### PR TITLE
Fix improper uses of strncpy

### DIFF
--- a/src/agent/mdns_avahi.cpp
+++ b/src/agent/mdns_avahi.cpp
@@ -550,8 +550,10 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
 
     {
         Service service;
-        strncpy(service.mName, aName, sizeof(service.mName));
-        strncpy(service.mType, aType, sizeof(service.mType));
+        if(strlcpy(service.mName, aName, sizeof(service.mName)) >= sizeof(service.mName))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for service.mName");
+        if(strlcpy(service.mType, aType, sizeof(service.mType)) >= sizeof(service.mType))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for service.mType");
         service.mPort = aPort;
         mServices.push_back(service);
     }

--- a/src/agent/mdns_mdnssd.cpp
+++ b/src/agent/mdns_mdnssd.cpp
@@ -337,8 +337,10 @@ void PublisherMDnsSd::RecordService(const char *aName, const char *aType, DNSSer
     {
         Service service;
 
-        strncpy(service.mName, aName, sizeof(service.mName));
-        strncpy(service.mType, aType, sizeof(service.mType));
+        if(strlcpy(service.mName, aName, sizeof(service.mName)) >= sizeof(service.mName))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for service.mName");
+        if(strlcpy(service.mType, aType, sizeof(service.mType)) >= sizeof(service.mType))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for service.mType");
         service.mService = aServiceRef;
         mServices.push_back(service);
     }

--- a/src/commissioner/addr_utils.cpp
+++ b/src/commissioner/addr_utils.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "addr_utils.hpp"
+#include "common/logging.hpp"
 
 #include <string.h>
 
@@ -53,7 +54,8 @@ char *GetIPString(const struct sockaddr *aAddr, char *aOutBuf, size_t aLength)
         break;
 
     default:
-        strncpy(aOutBuf, "Unknown AF", aLength);
+        if(strlcpy(aOutBuf, "Unknown AF", aLength) >= aLength)
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for aOutBuf");
         return NULL;
     }
 

--- a/src/commissioner/commissioner.cpp
+++ b/src/commissioner/commissioner.cpp
@@ -65,7 +65,8 @@ static void MBedDebugPrint(void *aCtx, int aLevel, const char *aFile, int aLine,
      */
     char *cp;
 
-    strncpy(buf, aStr, sizeof(buf));
+    if(strlcpy(buf, aStr, sizeof(buf)) >= sizeof(buf))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for buf");
     cp = strchr(buf, '\n');
     if (cp)
     {

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -143,7 +143,7 @@ public:
      * @param[in]  aIfName  The pointer to the interface name of wpantund.
      *
      */
-    void SetInterfaceName(const char *aIfName) { strncpy(mIfName, aIfName, sizeof(mIfName)); }
+    void SetInterfaceName(const char *aIfName) { if(strlcpy(mIfName, aIfName, sizeof(mIfName)) >= sizeof(mIfName)) otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mIfName"); }
 
     /**
      * This method gets status of wpan service.

--- a/src/web/wpan-controller/dbus_base.cpp
+++ b/src/web/wpan-controller/dbus_base.cpp
@@ -157,7 +157,8 @@ void DBusBase::SetDestination(const char *aDestination)
 
     dbus_error_init(&error);
     VerifyOrExit(aDestination != NULL, ret = kWpantundStatus_InvalidArgument);
-    strncpy(mDestination, aDestination, sizeof(mDestination));
+    if(strlcpy(mDestination, aDestination, sizeof(mDestination)) >= sizeof(mDestination))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mDestination");
 exit:
     if (ret != kWpantundStatus_Ok)
     {
@@ -178,7 +179,8 @@ void DBusBase::SetInterface(const char *aIface)
 
     dbus_error_init(&error);
     VerifyOrExit(aIface != NULL, ret = kWpantundStatus_InvalidArgument);
-    strncpy(mIface, aIface, sizeof(mIface));
+    if(strlcpy(mIface, aIface, sizeof(mIface)) >= sizeof(mIface))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mIface");
 exit:
     if (ret != kWpantundStatus_Ok)
     {
@@ -203,7 +205,8 @@ void DBusBase::SetInterfaceName(const char *aInterfaceName)
 
     dbus_error_init(&error);
     VerifyOrExit(aInterfaceName != NULL, ret = kWpantundStatus_InvalidArgument);
-    strncpy(mInterfaceName, aInterfaceName, sizeof(mInterfaceName));
+    if(strlcpy(mInterfaceName, aInterfaceName, sizeof(mInterfaceName)) >= sizeof(mInterfaceName))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mInterfaceName");
 exit:
     if (ret != kWpantundStatus_Ok)
     {
@@ -223,7 +226,8 @@ void DBusBase::SetPath(const char *aPath)
 
     dbus_error_init(&error);
     VerifyOrExit(aPath != NULL, ret = kWpantundStatus_InvalidArgument);
-    strncpy(mPath, aPath, sizeof(mPath));
+    if(strlcpy(mPath, aPath, sizeof(mPath)) >= sizeof(mPath))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mPath");
 exit:
     if (ret != kWpantundStatus_Ok)
     {
@@ -243,7 +247,8 @@ void DBusBase::SetDBusName(const char *aDBusName)
 
     dbus_error_init(&error);
     VerifyOrExit(aDBusName != NULL, ret = kWpantundStatus_InvalidDBusName);
-    strncpy(mDBusName, aDBusName, sizeof(mDBusName));
+    if(strlcpy(mDBusName, aDBusName, sizeof(mDBusName)) >= sizeof(mDBusName))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mDBusName");
 exit:
     if (ret != kWpantundStatus_Ok)
     {

--- a/src/web/wpan-controller/dbus_gateway.hpp
+++ b/src/web/wpan-controller/dbus_gateway.hpp
@@ -59,8 +59,8 @@ public:
     void SetPrefix(const char *aPrefix) { mPrefix = aPrefix; }
     void SetAddressString(const char *aAddressString)
     {
-        strncpy(mAddressString, aAddressString, strlen(aAddressString));
-        mAddressString[strlen(aAddressString)] = '\0';
+        if(strlcpy(mAddressString, aAddressString, sizeof(mAddressString)) >= sizeof(mAddressString))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mAddressString");
     }
     void SetPrefixBytes(uint8_t *aPrefixBytes) { memcpy(mPrefixBytes, aPrefixBytes, sizeof(mPrefixBytes)); }
     void SetAddr(uint8_t *aAddr) { mAddr = aAddr; }

--- a/src/web/wpan-controller/dbus_get.cpp
+++ b/src/web/wpan-controller/dbus_get.cpp
@@ -229,7 +229,8 @@ int DBusGet::GetAllPropertyNames(void)
     {
         char *pName;
         dbus_message_iter_get_basic(&listIter, &pName);
-        strncpy(mPropertyList[propCnt].name, pName, sizeof(mPropertyList[propCnt].name));
+        if(strlcpy(mPropertyList[propCnt].name, pName, sizeof(mPropertyList[propCnt].name)) >= sizeof(mPropertyList[propCnt].name))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected");
         propCnt++;
     }
     return propCnt;
@@ -239,7 +240,8 @@ void DBusGet::GetAllPropertyValues(int propCnt)
 {
     for (int i = 0; i < propCnt; i++)
     {
-        strncpy(mPropertyList[i].value, GetPropertyValue(mPropertyList[i].name), sizeof(mPropertyList[i].value));
+        if(strlcpy(mPropertyList[i].value, GetPropertyValue(mPropertyList[i].name), sizeof(mPropertyList[i].value)) >= sizeof(mPropertyList[i].value))
+            otbrLog(OTBR_LOG_ERR, "Buffer truncation detected");
     }
 }
 

--- a/src/web/wpan-controller/dbus_ifname.cpp
+++ b/src/web/wpan-controller/dbus_ifname.cpp
@@ -73,7 +73,8 @@ int DBusIfname::ProcessReply(void)
         if ((NULL != aItemInterfaceName) && (NULL != aItemDBusName) &&
             (strcmp(aItemInterfaceName, mInterfaceName) == 0))
         {
-            strncpy(mDBusName, aItemDBusName, DBUS_MAXIMUM_NAME_LENGTH);
+            if(strlcpy(mDBusName, aItemDBusName, DBUS_MAXIMUM_NAME_LENGTH) >= DBUS_MAXIMUM_NAME_LENGTH)
+                otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mDBusName");
             break;
         }
     }

--- a/src/web/wpan-controller/wpan_controller.cpp
+++ b/src/web/wpan-controller/wpan_controller.cpp
@@ -242,7 +242,8 @@ exit:
 
 void WPANController::SetInterfaceName(const char *aIfName)
 {
-    strncpy(mIfName, aIfName, sizeof(mIfName));
+    if(strlcpy(mIfName, aIfName, sizeof(mIfName)) >= sizeof(mIfName))
+        otbrLog(OTBR_LOG_ERR, "Buffer truncation detected for mIfName");
 }
 
 } // namespace Dbus

--- a/third_party/wpantund/repo/src/wpanctl/wpanctl-utils.c
+++ b/third_party/wpantund/repo/src/wpanctl/wpanctl-utils.c
@@ -471,7 +471,9 @@ lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name)
 				&& (NULL != item_dbus_name)
 				&& (strcmp(item_interface_name, interface_name) == 0)
 			) {
-				strncpy(dbus_bus_name, item_dbus_name, DBUS_MAXIMUM_NAME_LENGTH);
+				if(strlcpy(dbus_bus_name, item_dbus_name, DBUS_MAXIMUM_NAME_LENGTH) >= DBUS_MAXIMUM_NAME_LENGTH)
+                                    fprintf(stderr,
+				            "Buffer truncation detected for dbus_bus_name\n");
 				ret = 0;
 				break;
 			}


### PR DESCRIPTION
This addresses bug #243. In many places stncpy was used unsafely in
way that wouldn't null terminate buffers. strlcpy is a safer
replacement. Additionally, I've added error logging to note there's
a real issue with the code.

Signed-off-by: Andy Doan <andy@foundries.io>