### PR TITLE
[logging] do not log to stderr by default

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -174,7 +174,7 @@ void BorderAgent::HandleMdnsState(Mdns::State aState)
         PublishService();
         break;
     default:
-        otbrLog(OTBR_LOG_WARNING, "Mdns service not available!");
+        otbrLog(OTBR_LOG_WARNING, "MDNS service not available!");
         break;
     }
 }
@@ -206,7 +206,7 @@ void BorderAgent::SendToCommissioner(void *aContext, int aEvent, va_list aArgume
         VerifyOrExit(sent == static_cast<ssize_t>(length), perror("send to commissioner"));
     }
 
-    otbrLog(OTBR_LOG_INFO, "Sent to commissioner");
+    otbrLog(OTBR_LOG_DEBUG, "Sent to commissioner");
 
 exit:
     return;
@@ -278,8 +278,6 @@ void BorderAgent::StartPublishService(void)
 {
     VerifyOrExit(mNetworkName[0] != '\0');
 
-    otbrLog(OTBR_LOG_INFO, "Start publishing service");
-
     if (mPublisher->IsStarted())
     {
         PublishService();
@@ -290,7 +288,7 @@ void BorderAgent::StartPublishService(void)
     }
 
 exit:
-    return;
+    otbrLog(OTBR_LOG_INFO, "Start publishing service");
 }
 
 void BorderAgent::StopPublishService(void)

--- a/src/agent/mdns_avahi.cpp
+++ b/src/agent/mdns_avahi.cpp
@@ -472,7 +472,7 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
         break;
 
     case AVAHI_CLIENT_CONNECTING:
-        otbrLog(OTBR_LOG_DEBUG, "Connecting to avahi server...");
+        otbrLog(OTBR_LOG_DEBUG, "Connecting to avahi server");
         break;
 
     default:
@@ -534,7 +534,7 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
         if (!strncmp(it->mName, aName, sizeof(it->mName)) && !strncmp(it->mType, aType, sizeof(it->mType)) &&
             it->mPort == aPort)
         {
-            otbrLog(OTBR_LOG_INFO, "MDNS updating service %s...", aName);
+            otbrLog(OTBR_LOG_INFO, "MDNS update service %s", aName);
             error = avahi_entry_group_update_service_txt_strlst(
                 mGroup, AVAHI_IF_UNSPEC, mProtocol, static_cast<AvahiPublishFlags>(0), aName, aType, mDomain, last);
             SuccessOrExit(error);
@@ -543,7 +543,7 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
         }
     }
 
-    otbrLog(OTBR_LOG_INFO, "MDNS creating service %s...", aName);
+    otbrLog(OTBR_LOG_INFO, "MDNS create service %s", aName);
     error = avahi_entry_group_add_service_strlst(mGroup, AVAHI_IF_UNSPEC, mProtocol, static_cast<AvahiPublishFlags>(0),
                                                  aName, aType, mDomain, mHost, aPort, last);
     SuccessOrExit(error);

--- a/src/agent/mdns_mdnssd.cpp
+++ b/src/agent/mdns_mdnssd.cpp
@@ -202,7 +202,7 @@ void PublisherMDnsSd::Stop(void)
 
     for (Services::iterator it = mServices.begin(); it != mServices.end(); ++it)
     {
-        otbrLog(OTBR_LOG_INFO, "MDNS remove service %s...", it->mName);
+        otbrLog(OTBR_LOG_INFO, "MDNS remove service %s", it->mName);
         DNSServiceRefDeallocate(it->mService);
     }
 
@@ -260,7 +260,7 @@ void PublisherMDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSe
 
         if (error != kDNSServiceErr_NoError)
         {
-            otbrLog(OTBR_LOG_WARNING, "DNSServiceProcessResult returned %s", DNSErrorToString(error));
+            otbrLog(OTBR_LOG_WARNING, "DNSServiceProcessResult failed: %s", DNSErrorToString(error));
         }
     }
 }
@@ -369,7 +369,7 @@ otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, con
 
         if (cur + recordLength >= txt + sizeof(txt))
         {
-            otbrLog(OTBR_LOG_ERR, "Skip text record too much long:%s=%s", name, value);
+            otbrLog(OTBR_LOG_WARNING, "Skip text record too much long: %s=%s", name, value);
             continue;
         }
 

--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -99,7 +99,7 @@ DBusHandlerResult ControllerWpantund::HandlePropertyChangedSignal(DBusMessage &a
     VerifyOrExit(key != NULL, result = DBUS_HANDLER_RESULT_NOT_YET_HANDLED);
     dbus_message_iter_next(&iter);
 
-    otbrLog(OTBR_LOG_INFO, "NCP property %s changed.", key);
+    otbrLog(OTBR_LOG_DEBUG, "NCP property %s changed.", key);
     SuccessOrExit(OTBR_ERROR_NONE == ParseEvent(key, &iter));
 
     result = DBUS_HANDLER_RESULT_HANDLED;
@@ -199,7 +199,6 @@ otbrError ControllerWpantund::ParseEvent(const char *aKey, DBusMessageIter *aIte
             ExitNow(ret = OTBR_ERROR_DBUS);
         }
 
-        otbrLog(OTBR_LOG_INFO, "xpanid %llu...", xpanid);
         EventEmitter::Emit(kEventExtPanId, reinterpret_cast<uint8_t *>(&xpanid));
     }
 
@@ -356,7 +355,7 @@ exit:
 
     if (ret != OTBR_ERROR_NONE)
     {
-        otbrLog(OTBR_LOG_INFO, "UdpForwardSend failed: ", otbrErrorString(ret));
+        otbrLog(OTBR_LOG_WARNING, "UdpForwardSend failed: ", otbrErrorString(ret));
     }
 
     return ret;
@@ -473,13 +472,13 @@ otbrError ControllerWpantund::RequestEvent(int aEvent)
         key = kWPANTUNDProperty_NetworkPSKc;
         break;
     default:
-        otbrLog(OTBR_LOG_WARNING, "Unknown event %d", aEvent);
+        assert(false);
         break;
     }
 
     VerifyOrExit(key != NULL && mInterfaceDBusPath[0] != '\0', errno = EINVAL);
 
-    otbrLog(OTBR_LOG_DEBUG, "Requesting %s...", key);
+    otbrLog(OTBR_LOG_DEBUG, "Request event %s", key);
     VerifyOrExit((message = dbus_message_new_method_call(mInterfaceDBusName, mInterfaceDBusPath,
                                                          WPANTUND_DBUS_APIv1_INTERFACE, WPANTUND_IF_CMD_PROP_GET)) !=
                      NULL,

--- a/src/commissioner/main.cpp
+++ b/src/commissioner/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
 
     SuccessOrExit(error = ParseArgs(argc, argv, args));
 
-    otbrLogInit("Commissioner", args.mDebugLevel);
+    otbrLogInit("Commissioner", args.mDebugLevel, true);
     signal(SIGTERM, HandleSignal);
     signal(SIGINT, HandleSignal);
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -175,7 +175,7 @@ static void LogPrintf(const char *fmt, ...)
 }
 
 /** Initialize logging */
-void otbrLogInit(const char *aIdent, int aLevel)
+void otbrLogInit(const char *aIdent, int aLevel, bool aPrintStderr)
 {
     assert(aIdent);
     assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
@@ -186,7 +186,7 @@ void otbrLogInit(const char *aIdent, int aLevel)
     if (!sSyslogOpened)
     {
         sSyslogOpened = true;
-        openlog(aIdent, LOG_CONS | LOG_PID | LOG_PERROR, LOG_USER);
+        openlog(aIdent, (LOG_CONS | LOG_PID) | (aPrintStderr ? LOG_PERROR : 0), LOG_USER);
     }
     sLevel = aLevel;
 }

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -81,11 +81,12 @@ void otbrLogSetFilename(const char *aFilename);
 /**
  * This function initialize the logging service.
  *
- * @param[in]   aIdent  Identity of the logger.
- * @param[in]   aLevel  Log level of the logger.
+ * @param[in]   aIdent          Identity of the logger.
+ * @param[in]   aLevel          Log level of the logger.
+ * @param[in]   aPrintStderr    Whether to log to stderr.
  *
  */
-void otbrLogInit(const char *aIdent, int aLevel);
+void otbrLogInit(const char *aIdent, int aLevel, bool aPrintStderr);
 
 /**
  * This function log at level @p aLevel.

--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
         printf("http port not specified, using default %d\n", port);
     }
 
-    otbrLogInit(kSyslogIdent, logLevel);
+    otbrLogInit(kSyslogIdent, logLevel, true);
     otbrLog(OTBR_LOG_INFO, "border router web started on %s", interfaceName);
 
     server = new ot::Web::WebServer();

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    otbrLogInit("otbr-mdns", OTBR_LOG_DEBUG);
+    otbrLogInit("otbr-mdns", OTBR_LOG_DEBUG, true);
     // allow quitting elegantly
     signal(SIGTERM, RecoverSignal);
     switch (argv[1][0])

--- a/tests/scripts/meshcop
+++ b/tests/scripts/meshcop
@@ -370,16 +370,16 @@ ba_start()
   write_syslog "AGENT: starting"
 
   # check version
-  (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -v)
+  (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -V)
   # check invalid arguments
   (cd "${ORIGIN_PWD}" && ! sudo "${OTBR_AGENT_PATH}" -x)
 
   # we launch this in the background
   set -x
   if [[ "${NCP_CONTROLLER}" = openthread ]]; then
-    (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -I "${TUN_NAME}" -d 6 ${ot_radio} ${LEADER_NODE_ID}&)
+    (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -I "${TUN_NAME}" -v -d 6 ${ot_radio} ${LEADER_NODE_ID}&)
   else
-    (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -I "${TUN_NAME}" -d 6&)
+    (cd "${ORIGIN_PWD}" && sudo "${OTBR_AGENT_PATH}" -I "${TUN_NAME}" -v -d 6&)
   fi
   set +x
 

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -41,7 +41,7 @@ TEST(Logging, TestLoggingHigherLevel)
     char ident[20];
 
     sprintf(ident, "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO);
+    otbrLogInit(ident, OTBR_LOG_INFO, true);
     otbrLog(OTBR_LOG_DEBUG, "cool-higher");
     otbrLogDeinit();
     sleep(0);
@@ -56,7 +56,7 @@ TEST(Logging, TestLoggingEqualLevel)
     char ident[20];
 
     sprintf(ident, "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO);
+    otbrLogInit(ident, OTBR_LOG_INFO, true);
     otbrLog(OTBR_LOG_INFO, "cool-equal");
     otbrLogDeinit();
     sleep(0);
@@ -73,7 +73,7 @@ TEST(Logging, TestLoggingLowerLevel)
     char cmd[128];
 
     sprintf(ident, "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO);
+    otbrLogInit(ident, OTBR_LOG_INFO, true);
     otbrLog(OTBR_LOG_WARNING, "cool-lower");
     otbrLogDeinit();
     sleep(0);
@@ -88,7 +88,7 @@ TEST(Logging, TestLoggingDump)
     char cmd[128];
 
     sprintf(ident, "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_DEBUG);
+    otbrLogInit(ident, OTBR_LOG_DEBUG, true);
     const char s[] = "one super long string with lots of text";
     otbrDump(OTBR_LOG_INFO, "foobar", s, sizeof(s));
     otbrLogDeinit();


### PR DESCRIPTION
This PR changes the default logging behavior to not logging to console
without `-v`.