### PR TITLE
[build] allow no boost

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,10 +440,6 @@ AC_DEFUN([OTBR_REQUIRE_HEADER],
 
 OTBR_REQUIRE_HEADER([stdint.h])
 OTBR_REQUIRE_HEADER([string.h])
-AC_LANG_PUSH(C++)
-OTBR_REQUIRE_HEADER([boost/scoped_ptr.hpp])
-OTBR_REQUIRE_HEADER([boost/shared_ptr.hpp])
-AC_LANG_POP(C++)
 
 #
 # Check for types and structures


### PR DESCRIPTION
This PR removes checking boost, so that if web is disabled, no need to have boost at all.