### PR TITLE
[agent] fix build on Android

### DIFF
--- a/.travis/check-android-build
+++ b/.travis/check-android-build
@@ -276,8 +276,10 @@ main()
     prepare_libmdnssd
 
     make showcommands otbr-agent
+    make showcommands otbr-agent.conf
 
     test -f out/target/product/generic_arm64/system/bin/otbr-agent
+    test -f out/target/product/generic_arm64/system/etc/dbus-1/system.d/otbr-agent.conf
 }
 
 main "$@"

--- a/Android.mk
+++ b/Android.mk
@@ -82,5 +82,7 @@ LOCAL_MODULE_TAGS := eng
 LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/dbus-1/system.d
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := src/agent/otbr-agent.conf
+$(LOCAL_PATH)/src/agent/otbr-agent.conf: $(LOCAL_PATH)/src/agent/otbr-agent.conf.in
+	sed 's/@OTBR_AGENT_USER@/root/g' $< > $@
 
 include $(BUILD_PREBUILT)


### PR DESCRIPTION
This PR fixes build otbr-agent.conf on Android system, also added this
into travis tests.