### PR TITLE
[web] unify start environment name

### DIFF
--- a/src/web/otbr-web.init.in
+++ b/src/web/otbr-web.init.in
@@ -29,7 +29,7 @@
 # Provides:          otbr-web
 # Required-Start:    wpantund otbr-agent
 # Required-Stop:
-# Should-Start:      
+# Should-Start:
 # Should-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
@@ -54,7 +54,7 @@ if [ -f $OTBR_WEB_CONF ]; then
     . $OTBR_WEB_CONF
 fi
 
-start_web() 
+start_web()
 {
     if [ -e $PIDFILE ]; then
         if $0 status > /dev/null ; then

--- a/src/web/otbr-web.service.in
+++ b/src/web/otbr-web.service.in
@@ -5,7 +5,7 @@ ConditionPathExists=@sbindir@/otbr-web
 
 [Service]
 EnvironmentFile=-@sysconfdir@/default/otbr-web
-ExecStart=@sbindir@/otbr-web $BR_OPTS
+ExecStart=@sbindir@/otbr-web $OTBR_WEB_OPTS
 Restart=on-failure
 RestartSec=5
 RestartPreventExitStatus=SIGKILL


### PR DESCRIPTION
This PR unifies the environment name in `/etc/default/otbr-web` to be `OTBR_WEB_OPTS`.