### PR TITLE
[docker] do not fail on submodule update failure

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -164,9 +164,10 @@ install_cpputest()
 main()
 {
     . $BEFORE_HOOK
+    # TODO remove `|| true` after docker hub builder gets its git upgraded
+    git submodule update --init --recursive || true
     install_packages
     with RELEASE || install_cpputest
-    git submodule update --init --recursive
     ./bootstrap
     . $AFTER_HOOK
 }


### PR DESCRIPTION
Docker Hub clones repositories with `--recursive`, and since it is using
a old version of git. The git file is pointing to absolute path. After
copying into docker, the path is incorrect.

This PR allows git submodule failure in `script/bootstrap`.