### PR TITLE
[mDNS] mDNS implementation using mojo interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
       os: linux
     - env: BUILD_TARGET="android-check" VERBOSE=1
       os: linux
+    - env: BUILD_TARGET="mdns-mojo-check" VERBOSE=1
+      os: linux
     - env: BUILD_TARGET="posix-check" VERBOSE=1 WITH_MDNS=mDNSResponder
       compiler: clang
       os: linux

--- a/Android.mk
+++ b/Android.mk
@@ -28,6 +28,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
+ifeq ($(WITH_MDNS),mojo)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE_CLASS := SHARED_LIBRARIES
@@ -45,7 +46,7 @@ LOCAL_CFLAGS += -Wall -Wextra -Wno-unused-parameter
 LOCAL_CPPFLAGS += -std=c++14
 
 LOCAL_MOJOM_FILES := \
-    public/chromecast/mojom/mdns.mojom \
+    third_party/chromecast/mojom/mdns.mojom \
     $(NULL)
 
 LOCAL_MOJOM_TYPEMAP_FILES :=
@@ -60,6 +61,7 @@ MDNS_MOJOM_SRCS := $(gen_src)
 LOCAL_SHARED_LIBRARIES += libchrome libmojo
 
 include $(BUILD_SHARED_LIBRARY)
+endif
 
 include $(CLEAR_VARS)
 
@@ -67,7 +69,6 @@ LOCAL_MODULE_CLASS := EXECUTABLES
 LOCAL_MODULE := otbr-agent
 LOCAL_MODULE_TAGS := eng
 LOCAL_SHARED_LIBRARIES := libdbus
-WITH_MDNS := mojo
 
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/src \
@@ -109,10 +110,10 @@ LOCAL_SRC_FILES += \
     $(NULL)
 
 LOCAL_SHARED_LIBRARIES += libmdnssd
-else ifeq($(WITH_MDNS),mojo)
-
+else
+ifeq ($(WITH_MDNS),mojo)
 LOCAL_CFLAGS += \
-    -DOTBR_ENABLE_MOJO=1 \
+    -DOTBR_ENABLE_MDNS_MOJO=1 \
     $(NULL)
 
 LOCAL_SRC_FILES += \
@@ -121,8 +122,9 @@ LOCAL_SRC_FILES += \
 
 # The generated header files are not in dependency chain.
 # Force dependency here
-LOCAL_ADDITIONAL_DEPENDENCIES += $(MDNS_MOJOM_GEN_SRCS)
+LOCAL_ADDITIONAL_DEPENDENCIES += $(MDNS_MOJOM_SRCS)
 LOCAL_SHARED_LIBRARIES += libmdns_mojom libchrome libmojo
+endif
 endif
 
 include $(BUILD_EXECUTABLE)

--- a/Android.mk
+++ b/Android.mk
@@ -26,12 +26,48 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-LOCAL_PATH:= $(call my-dir)
+LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE:= otbr-agent
+LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+LOCAL_MODULE := libmdns_mojom
 LOCAL_MODULE_TAGS := eng
+LOCAL_CPP_EXTENSION := .cc
+
+LOCAL_C_INCLUDES := \
+    external/libchrome \
+    external/gtest/include \
+    $(NULL)
+
+LOCAL_CFLAGS += -Wall -Wextra -Wno-unused-parameter
+
+LOCAL_CPPFLAGS += -std=c++14
+
+LOCAL_MOJOM_FILES := \
+    public/chromecast/mojom/mdns.mojom \
+    $(NULL)
+
+LOCAL_MOJOM_TYPEMAP_FILES :=
+
+LIB_MOJO_ROOT := external/libchrome
+LOCAL_SOURCE_ROOT := $(LOCAL_PATH)
+
+include external/libchrome/generate_mojom_sources.mk
+
+MDNS_MOJOM_SRCS := $(gen_src)
+
+LOCAL_SHARED_LIBRARIES += libchrome libmojo
+
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_MODULE := otbr-agent
+LOCAL_MODULE_TAGS := eng
+LOCAL_SHARED_LIBRARIES := libdbus
+WITH_MDNS := mojo
 
 LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/src \
@@ -43,12 +79,17 @@ LOCAL_C_INCLUDES := \
     $(LOCAL_PATH)/third_party/wpantund/repo/src/wpanctl \
     $(LOCAL_PATH)/third_party/wpantund/repo/third_party/assert-macros \
     $(LOCAL_PATH)/third_party/wpantund/repo/third_party/openthread/src/ncp \
+    external/libchrome \
+    external/gtest/include \
     $(NULL)
 
-LOCAL_CFLAGS := \
+LOCAL_CFLAGS += -Wall -Wextra -Wno-unused-parameter
+LOCAL_CFLAGS += \
     -DPACKAGE_VERSION=\"0.01.00\" \
     -DOTBR_ENABLE_NCP_WPANTUND=1 \
     $(NULL)
+
+LOCAL_CPPFLAGS += -std=c++14
 
 LOCAL_SRC_FILES := \
     third_party/wpantund/repo/src/util/string-utils.c \
@@ -62,25 +103,37 @@ LOCAL_SRC_FILES := \
     src/utils/hex.cpp \
     $(NULL)
 
-LOCAL_SHARED_LIBRARIES := libdbus
-
 ifeq ($(WITH_MDNS),mDNSResponder)
 LOCAL_SRC_FILES += \
     src/agent/mdns_mdnssd.cpp \
     $(NULL)
 
 LOCAL_SHARED_LIBRARIES += libmdnssd
+else ifeq($(WITH_MDNS),mojo)
+
+LOCAL_CFLAGS += \
+    -DOTBR_ENABLE_MOJO=1 \
+    $(NULL)
+
+LOCAL_SRC_FILES += \
+    src/agent/mdns_mojo.cpp \
+    $(NULL)
+
+# The generated header files are not in dependency chain.
+# Force dependency here
+LOCAL_ADDITIONAL_DEPENDENCIES += $(MDNS_MOJOM_GEN_SRCS)
+LOCAL_SHARED_LIBRARIES += libmdns_mojom libchrome libmojo
 endif
 
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)
 
+LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE := otbr-agent.conf
 LOCAL_MODULE_TAGS := eng
 
 LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/dbus-1/system.d
-LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := src/agent/otbr-agent.conf
 $(LOCAL_PATH)/src/agent/otbr-agent.conf: $(LOCAL_PATH)/src/agent/otbr-agent.conf.in
 	sed 's/@OTBR_AGENT_USER@/root/g' $< > $@

--- a/public/chromecast/mojom/mdns.mojom
+++ b/public/chromecast/mojom/mdns.mojom
@@ -1,0 +1,113 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module chromecast.mojom;
+
+// Public mojo Interface for exposing partial multicast management.
+
+enum MdnsResult {
+  // Operation was successfully completed.
+  SUCCESS,
+  // The specified service could not be found as a valid service registered
+  // to the responder, i.e. the service was never registered or has already
+  // been unregistered.
+  NOT_FOUND,
+  // The specified service is a duplicate or similar enough to another service
+  // that would cause conflicts if it became registered with the responder.
+  DUPLICATE_SERVICE,
+  // The specified service could not be used to create a service record.
+  CANNOT_CREATE_RECORDS,
+  // The specified service was given one or more invalid TXT records.
+  INVALID_TEXT,
+  // The specified service was given one or more invalid parameters for the
+  // operation.
+  INVALID_PARAMS,
+};
+
+// Describes an initial instance publication or query response.
+struct MdnsPublication {
+  uint16 port;
+  bool can_cache;
+  array<string>? text;
+  uint32 ptr_ttl_seconds = 4500; // default 75 minutes
+  uint32 srv_ttl_seconds = 120; // default 2 minutes
+  uint32 txt_ttl_seconds = 4500; // default 75 minutes
+};
+
+interface MdnsDynamicServiceResponder {
+  // Updates the status of the instance publication.
+  UpdateStatus(MdnsResult error);
+
+  // Provides instance information for initial announcements and query responses
+  // relating to the service instance specified in
+  // |Responder.RegisterDynamicServiceInstance|.
+  // |query| indicates whether data is requested for an initial announcement
+  // (false) or in response to a query (true). If the publication relates to a
+  // subtype of the service, |subtype| contains the subtype, otherwise it is
+  // null. If |publication| is null, no announcement or response is transmitted.
+  // Strings in |text| are transmitted in the TXT record.
+  GetPublication(bool query, string subtype) => (MdnsPublication? publication);
+};
+
+interface MdnsResponder {
+  // Registers service instance with the responder.
+  RegisterServiceInstance(string service_name,
+                          string service_transport,
+                          string instance_name,
+                          int32 port,
+                          array<string>? text) => (MdnsResult error);
+
+  // Registers service instance with the responder, with user specific behavior
+  // in announcement and query reply, such as dynamic subtype filtering.
+  // Use GetPublication to get initial announcements if |initializer| is null.
+  RegisterDynamicServiceInstance(string service_name,
+                                 string instance_name,
+                                 MdnsDynamicServiceResponder responder,
+                                 MdnsPublication initializer);
+
+  // Unregisters currently registered service instance from responder.
+  UnregisterServiceInstance(string service_name,
+                            string instance_name) => (MdnsResult error);
+
+  // Initiates announcement of a service instance currently being registered.
+  // Typically used when records change for services registered by a call to
+  // |RegisterDynamicServiceInstance|.
+  ReannounceInstance(string service_name,
+                     string instance_name);
+
+  // Updates the entries in the TXT record. If the service is still probing
+  // then it will reprobe with new records. If the service is already running
+  // then it will reannounce soon.
+  UpdateTxtRecord(string service_name,
+                  string instance_name,
+                  array<string> text) => (MdnsResult error);
+
+  // Updates the entries in the SRV record. If the service is still probing
+  // then it will reprobe with new records. If the service is already running
+  // then it will reannounce soon.
+  UpdateSrvRecord(string service_name,
+                  string instance_name,
+                  int32 port,
+                  int32 priority,
+                  int32 weight) => (MdnsResult error);
+
+  // Updates the list of known subtypes. This new list of subtypes will
+  // replace the old list, although goodbye records will only be sent for
+  // removed subtypes and announcement records will only be sent for newly
+  // added subtypes.
+  // For Dynamic Service, if a query matches a fixed subtype for a service
+  // it will immediately respond with cached data. The service will only
+  // fallback to GetPublication if no fixed subtypes matched the query.
+  UpdateSubtypes(string service_name,
+                 string instance_name,
+                 array<string> fixed_subtypes) => (MdnsResult error);
+
+  // Clear the cache to a Dynamic Service. If the cached publication relates to
+  // a subtype of the service, |subtype| contains the subtype, otherwise it is
+  // null.
+  ClearPublicationCache(string service_name,
+                        string instance_name,
+                        string subtype);
+};
+

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -77,7 +77,7 @@ enum
 };
 
 BorderAgent::BorderAgent(Ncp::Controller *aNcp)
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     : mPublisher(Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, HandleMdnsState, this))
 #else
     : mPublisher(NULL)
@@ -98,7 +98,7 @@ void BorderAgent::Init(void)
 #if OTBR_ENABLE_NCP_WPANTUND
     mNcp->On(Ncp::kEventUdpForwardStream, SendToCommissioner, this);
 #endif
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     mNcp->On(Ncp::kEventExtPanId, HandleExtPanId, this);
     mNcp->On(Ncp::kEventNetworkName, HandleNetworkName, this);
 #endif
@@ -130,11 +130,11 @@ otbrError BorderAgent::Start(void)
                  error = OTBR_ERROR_ERRNO);
 #endif
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventNetworkName));
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventExtPanId));
     StartPublishService();
-#endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
 
     // Suppress unused warning of label exit
     ExitNow();
@@ -154,7 +154,7 @@ void BorderAgent::Stop(void)
     }
 #endif // OTBR_ENABLE_NCP_WPANTUND
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     StopPublishService();
 #endif
 }
@@ -312,7 +312,7 @@ void BorderAgent::SetNetworkName(const char *aNetworkName)
 {
     strncpy(mNetworkName, aNetworkName, sizeof(mNetworkName) - 1);
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     if (mThreadStarted)
     {
         // Restart publisher to publish new service name.
@@ -325,7 +325,7 @@ void BorderAgent::SetNetworkName(const char *aNetworkName)
 void BorderAgent::SetExtPanId(const uint8_t *aExtPanId)
 {
     memcpy(mExtPanId, aExtPanId, sizeof(mExtPanId));
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
     if (mThreadStarted)
     {
         StartPublishService();

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -77,7 +77,7 @@ enum
 };
 
 BorderAgent::BorderAgent(Ncp::Controller *aNcp)
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     : mPublisher(Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, HandleMdnsState, this))
 #else
     : mPublisher(NULL)
@@ -98,7 +98,7 @@ void BorderAgent::Init(void)
 #if OTBR_ENABLE_NCP_WPANTUND
     mNcp->On(Ncp::kEventUdpForwardStream, SendToCommissioner, this);
 #endif
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     mNcp->On(Ncp::kEventExtPanId, HandleExtPanId, this);
     mNcp->On(Ncp::kEventNetworkName, HandleNetworkName, this);
 #endif
@@ -130,11 +130,11 @@ otbrError BorderAgent::Start(void)
                  error = OTBR_ERROR_ERRNO);
 #endif
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventNetworkName));
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventExtPanId));
     StartPublishService();
-#endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
 
     // Suppress unused warning of label exit
     ExitNow();
@@ -154,7 +154,7 @@ void BorderAgent::Stop(void)
     }
 #endif // OTBR_ENABLE_NCP_WPANTUND
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     StopPublishService();
 #endif
 }
@@ -312,7 +312,7 @@ void BorderAgent::SetNetworkName(const char *aNetworkName)
 {
     strncpy(mNetworkName, aNetworkName, sizeof(mNetworkName) - 1);
 
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     if (mThreadStarted)
     {
         // Restart publisher to publish new service name.
@@ -325,7 +325,7 @@ void BorderAgent::SetNetworkName(const char *aNetworkName)
 void BorderAgent::SetExtPanId(const uint8_t *aExtPanId)
 {
     memcpy(mExtPanId, aExtPanId, sizeof(mExtPanId));
-#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MOJO
+#if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     if (mThreadStarted)
     {
         StartPublishService();

--- a/src/agent/mdns_mojo.cpp
+++ b/src/agent/mdns_mojo.cpp
@@ -1,0 +1,215 @@
+#include <base/at_exit.h>
+#include <base/bind.h>
+#include <base/bind_helpers.h>
+#include <base/command_line.h>
+#include <base/logging.h>
+#include <base/task_scheduler/post_task.h>
+#include <mojo/core/embedder/embedder.h>
+#include <mojo/core/embedder/scoped_ipc_support.h>
+
+#include <functional>
+
+#include "agent/mdns_mojo.hpp"
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+namespace ot {
+namespace BorderRouter {
+namespace Mdns {
+
+void MdnsMojoPublisher::LaunchMojoThreads()
+{
+    otbrLog(OTBR_LOG_INFO, "chromeTask");
+    base::CommandLine::Init(0, NULL);
+    base::AtExitManager exit_manager;
+
+    base::MessageLoopForIO main_loop;
+    base::RunLoop          run_loop;
+
+    mojo::core::Init();
+    mojo::core::ScopedIPCSupport ipc_support(main_loop.task_runner(),
+                                             mojo::core::ScopedIPCSupport::ShutdownPolicy::CLEAN);
+
+    mMojoTaskRunner = main_loop.task_runner();
+    mMojoTaskRunner->PostTask(FROM_HERE, base::BindOnce(&MdnsMojoPublisher::ConnectToMojo, base::Unretained(this)));
+    run_loop.Run();
+}
+
+MdnsMojoPublisher::MdnsMojoPublisher(StateHandler aHandler, void *aContext)
+    : mConnector(nullptr)
+    , mStateHandler(aHandler)
+    , mContext(aContext)
+    , mStarted(false)
+{
+    mLaunchThread = std::make_unique<std::thread>(&MdnsMojoPublisher::LaunchMojoThreads, this);
+}
+
+void MdnsMojoPublisher::ConnectToMojo()
+{
+    otbrLog(OTBR_LOG_INFO, "Connecting to Mojo");
+    chromecast::external_mojo::ExternalConnector::Connect(
+        chromecast::external_mojo::GetBrokerPath(),
+        base::BindOnce(&MdnsMojoPublisher::mMojoConnectCb, base::Unretained(this)));
+}
+
+void MdnsMojoPublisher::mMojoConnectCb(std::unique_ptr<chromecast::external_mojo::ExternalConnector> aConnector)
+{
+    if (aConnector)
+    {
+        otbrLog(OTBR_LOG_INFO, "Mojo connected");
+        aConnector->set_connection_error_callback(
+            base::BindOnce(&MdnsMojoPublisher::mMojoDisconnectedCb, base::Unretained(this)));
+        aConnector->BindInterface("chromecast", &mResponder);
+        mConnector = std::move(aConnector);
+        Start();
+    }
+    else
+    {
+        mMojoTaskRunner->PostTask(FROM_HERE, base::BindOnce(&MdnsMojoPublisher::ConnectToMojo, base::Unretained(this)));
+    }
+}
+
+void MdnsMojoPublisher::mMojoDisconnectedCb()
+{
+    mConnector = nullptr;
+}
+
+otbrError MdnsMojoPublisher::Start()
+{
+    otbrError err = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mConnector != nullptr, err = OTBR_ERROR_MDNS);
+
+    mStarted = true;
+    mStateHandler(mContext, kStateReady);
+exit:
+    return err;
+}
+
+bool MdnsMojoPublisher::IsStarted() const
+{
+    return mStarted;
+}
+
+void MdnsMojoPublisher::Stop()
+{
+    mMojoTaskRunner->PostTask(FROM_HERE, base::BindOnce(&MdnsMojoPublisher::StopPublishTask, base::Unretained(this)));
+}
+
+void MdnsMojoPublisher::StopPublishTask(void)
+{
+    if (!mLastServiceName.empty())
+    {
+        mResponder->UnregisterServiceInstance(mLastServiceName, mLastInstanceName, base::DoNothing());
+    }
+    mLastServiceName.clear();
+    mLastInstanceName.clear();
+}
+
+otbrError MdnsMojoPublisher::PublishService(uint16_t aPort, const char *aName, const char *aType, ...)
+{
+    otbrError                err = OTBR_ERROR_NONE;
+    std::vector<std::string> text;
+    va_list                  args;
+
+    va_start(args, aType);
+
+    VerifyOrExit(mConnector != nullptr, err = OTBR_ERROR_MDNS);
+    for (const char *name = va_arg(args, const char *); name; name = va_arg(args, const char *))
+    {
+        const char *value = va_arg(args, const char *);
+
+        text.emplace_back(std::string(name) + "=" + std::string(value));
+    }
+    mMojoTaskRunner->PostTask(FROM_HERE, base::BindOnce(&MdnsMojoPublisher::PublishServiceTask, base::Unretained(this),
+                                                        aPort, aType, aName, text));
+
+exit:
+    va_end(args);
+    return err;
+}
+
+void MdnsMojoPublisher::PublishServiceTask(uint16_t                        aPort,
+                                           const std::string &             aType,
+                                           const std::string &             aInstanceName,
+                                           const std::vector<std::string> &aText)
+{
+    std::string            serviceName;
+    std::string            serviceProtocol;
+    std::string::size_type split = aType.rfind('.');
+
+    // Remove the last trailing dot since the cast mdns will add one
+    if (split + 1 == aType.length())
+    {
+        split = aType.rfind('.', split - 1);
+    }
+
+    VerifyOrExit(split != std::string::npos);
+
+    serviceName     = aType.substr(0, split);
+    serviceProtocol = aType.substr(split + 1, std::string::npos);
+
+    VerifyOrExit(!serviceName.empty() && !serviceProtocol.empty());
+
+    // Remove the last trailing dot since the cast mdns will add one
+    if (serviceProtocol.back() == '.')
+    {
+        serviceProtocol.erase(serviceProtocol.size() - 1);
+    }
+
+    mResponder->UnregisterServiceInstance(serviceName, aInstanceName, base::DoNothing());
+    if (!mLastServiceName.empty())
+    {
+        mResponder->UnregisterServiceInstance(mLastServiceName, mLastInstanceName, base::DoNothing());
+    }
+
+    otbrLog(OTBR_LOG_INFO, "service name %s, protocol %s, instance %s", serviceName.c_str(), serviceProtocol.c_str(),
+            aInstanceName.c_str());
+    mResponder->RegisterServiceInstance(serviceName, serviceProtocol, aInstanceName, aPort, aText,
+                                        base::BindOnce([](chromecast::mojom::MdnsResult r) {
+                                            otbrLog(OTBR_LOG_INFO, "register result %d", static_cast<int32_t>(r));
+                                        }));
+    mLastServiceName  = serviceName;
+    mLastInstanceName = aInstanceName;
+
+exit:
+    return;
+}
+
+void MdnsMojoPublisher::UpdateFdSet(fd_set & aReadFdSet,
+                                    fd_set & aWriteFdSet,
+                                    fd_set & aErrorFdSet,
+                                    int &    aMaxFd,
+                                    timeval &aTimeout)
+{
+    (void)aReadFdSet;
+    (void)aWriteFdSet;
+    (void)aErrorFdSet;
+    (void)aMaxFd;
+    (void)aTimeout;
+}
+
+void MdnsMojoPublisher::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+{
+    (void)aReadFdSet;
+    (void)aWriteFdSet;
+    (void)aErrorFdSet;
+}
+
+Publisher *Publisher::Create(int aFamily, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext)
+{
+    (void)aFamily;
+    (void)aHost;
+    (void)aDomain;
+
+    return new MdnsMojoPublisher(aHandler, aContext);
+}
+
+void Publisher::Destroy(Publisher *aPublisher)
+{
+    delete aPublisher;
+}
+
+} // namespace Mdns
+} // namespace BorderRouter
+} // namespace ot

--- a/src/agent/mdns_mojo.hpp
+++ b/src/agent/mdns_mojo.hpp
@@ -1,0 +1,162 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are
+ * met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for MDNS service based on avahi.
+ */
+
+#ifndef MDNS_MOJO_HPP__
+#define MDNS_MOJO_HPP__
+
+#include <base/macros.h>
+#include <base/message_loop/message_loop.h>
+#include <base/message_loop/message_pump_for_io.h>
+#include <base/task_scheduler/post_task.h>
+#include <chromecast/external_mojo/public/cpp/common.h>
+#include <chromecast/external_mojo/public/cpp/external_connector.h>
+
+#include <mutex>
+#include <thread>
+
+#include "agent/mdns.hpp"
+#include "public/chromecast/mojom/mdns.mojom.h"
+
+namespace ot {
+namespace BorderRouter {
+namespace Mdns {
+
+class MdnsMojoPublisher : public Publisher
+{
+public:
+    MdnsMojoPublisher(StateHandler aHandler, void *aContext);
+
+    /**
+     * This method starts the MDNS service.
+     *
+     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     *
+     */
+    otbrError Start(void) override;
+
+    /**
+     * This method stops the MDNS service.
+     *
+     */
+    void Stop(void) override;
+
+    /**
+     * This method checks if publisher has been started.
+     *
+     * @retval true     Already started.
+     * @retval false    Not started.
+     *
+     */
+    bool IsStarted(void) const override;
+
+    /**
+     * This method publishes or updates a service.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     * @param[in]   aPort               The port number of this service.
+     * @param[in]   ...                 Pointers to null-terminated string of key
+     * and value for text record. The last argument must be NULL.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) override;
+
+    /**
+     * This method performs the MDNS processing.
+     *
+     * @param[in]   aReadFdSet          A reference to fd_set ready for reading.
+     * @param[in]   aWriteFdSet         A reference to fd_set ready for writing.
+     * @param[in]   aErrorFdSet         A reference to fd_set with error occurred.
+     *
+     */
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) override;
+
+    /**
+     * This method updates the fd_set and timeout for mainloop.
+     *
+     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
+     * @param[inout]    aWriteFdSet     A reference to fd_set for polling read.
+     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
+     * @param[inout]    aMaxFd          A reference to the current max fd in @p
+     * aReadFdSet and @p aWriteFdSet.
+     * @param[inout]    aTimeout        A reference to the timeout. Update this
+     * value if the MDNS service has pending process in less than its current
+     * value.
+     *
+     */
+    void UpdateFdSet(fd_set & aReadFdSet,
+                     fd_set & aWriteFdSet,
+                     fd_set & aErrorFdSet,
+                     int &    aMaxFd,
+                     timeval &aTimeout) override;
+
+private:
+    void PublishServiceTask(uint16_t                        aPort,
+                            const std::string &             aType,
+                            const std::string &             aInstanceName,
+                            const std::vector<std::string> &aText);
+
+    void StopPublishTask(void);
+
+    void LaunchMojoThreads(void);
+    void ConnectToMojo(void);
+    void mMojoConnectCb(std::unique_ptr<chromecast::external_mojo::ExternalConnector> aConnector);
+    void mMojoDisconnectedCb(void);
+    void mRegisterServiceCb(chromecast::mojom::MdnsResult aResult);
+
+    scoped_refptr<base::SingleThreadTaskRunner>                   mMojoTaskRunner;
+    std::unique_ptr<std::thread>                                  mLaunchThread;
+    std::unique_ptr<chromecast::external_mojo::ExternalConnector> mConnector;
+    chromecast::mojom::MdnsResponderPtr                           mResponder;
+
+    std::string mLastServiceName;
+    std::string mLastInstanceName;
+
+    StateHandler mStateHandler;
+    void *       mContext;
+    bool         mStarted;
+
+    MdnsMojoPublisher(const MdnsMojoPublisher &);
+    MdnsMojoPublisher &operator=(const MdnsMojoPublisher &);
+};
+
+} // namespace Mdns
+} // namespace BorderRouter
+} // namespace ot
+
+#endif

--- a/tests/mdns/mdns_mojo_test/BUILD.gn
+++ b/tests/mdns/mdns_mojo_test/BUILD.gn
@@ -1,6 +1,4 @@
-#!/bin/sh
-#
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2019, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -25,68 +23,54 @@
 #  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
-#
 
-set -e
-set -x
+import("//build/config/nacl/config.gni")
+import("//testing/libfuzzer/fuzzer_test.gni")
+import("//testing/test.gni")
 
-TOOLS_HOME=$HOME/.cache/tools
+executable("mdns_mojo_client") {
+  testonly = true
+  sources = [
+    "client.cpp",
+    "mdns_mojo.cpp",
+    "mdns_mojo.hpp",
+    "mdns.hpp",
+    "common/code_utils.hpp",
+    "common/types.hpp",
+  ]
 
-die() {
-	echo " *** ERROR: " $*
-	exit 1
+  defines = [
+    "TEST_IN_CHROMIUM"
+  ]
+
+  deps = [
+    "//mdns_mojo_test/public/mojom",
+    "//base",
+    "//mojo/core/embedder",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/platform",
+    "//mojo/public/cpp/system",
+    "//chromecast/external_mojo/external_service_support:external_service",
+    "//chromecast/external_mojo/public/cpp:common",
+    "//chromecast/external_mojo/public/mojom",
+  ]
 }
 
-case $BUILD_TARGET in
-android-check)
-    (cd .. && "${TRAVIS_BUILD_DIR}/.travis/check-android-build")
-    ;;
+executable("mdns_mojo_stub_service") {
+  testonly = true
+  sources = [
+    "stub_mojo_service.cpp",
+  ]
 
-mdns-mojo-check)
-    ./tests/mdns/test-mojo
-    ;;
-
-pretty-check)
-    export PATH=$TOOLS_HOME/usr/bin:$PATH
-    ./bootstrap && ./configure && make pretty-check || die
-    ;;
-
-posix-check)
-    CPPFLAGS="$CFLAGS -I$TOOLS_HOME/usr/include" LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib" .travis/check-posix
-    ;;
-
-meshcop)
-    if gcc-5 --version; then
-      export CC=gcc-5
-      export CXX=g++-5
-    fi
-
-    ./bootstrap
-    ./script/test build
-
-    OT_CLI="ot-cli-mtd" ./script/test meshcop
-    OT_CLI="ot-cli-ftd" ./script/test meshcop
-    COMMISSIONER_WEB=1 ./script/test meshcop
-    NCP_CONTROLLER=openthread ./script/test clean build meshcop
-    ;;
-
-scan-build)
-    .travis/check-scan-build
-    ;;
-
-script-check)
-    .travis/check-scripts
-    ;;
-
-raspbian-gcc)
-    IMAGE_FILE=$TOOLS_HOME/images/$IMAGE_NAME.img .travis/check-raspbian
-    ;;
-
-docker-check)
-    .travis/check-docker
-    ;;
-
-*)
-    die
-    ;;
-esac
+  deps = [
+    "//mdns_mojo_test/public/mojom",
+    "//base",
+    "//mojo/core/embedder",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/platform",
+    "//mojo/public/cpp/system",
+    "//chromecast/external_mojo/external_service_support:external_service",
+    "//chromecast/external_mojo/public/cpp:common",
+    "//chromecast/external_mojo/public/mojom",
+  ]
+}

--- a/tests/mdns/mdns_mojo_test/client.cpp
+++ b/tests/mdns/mdns_mojo_test/client.cpp
@@ -1,0 +1,57 @@
+/*
+ *    Copyright (c) 2019, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes stub service for MDNS client based on mojo.
+ */
+
+#include <unistd.h>
+
+#include "mdns_mojo.hpp"
+
+static ot::BorderRouter::Mdns::Publisher *sPublisher;
+static bool                               published = false;
+
+void PublishHandler(void *aContext, ot::BorderRouter::Mdns::State aState)
+{
+    sPublisher->PublishService(49191, "test", "_meshcop._udp", nullptr);
+    published = true;
+}
+
+int main(void)
+{
+    sPublisher = ot::BorderRouter::Mdns::Publisher::Create(0, nullptr, nullptr, PublishHandler, nullptr);
+    while (!published)
+        ;
+    sleep(1);
+    sPublisher->Stop();
+    sleep(1);
+    ot::BorderRouter::Mdns::Publisher::Destroy(sPublisher);
+    return 0;
+}

--- a/tests/mdns/mdns_mojo_test/public/mojom/BUILD.gn
+++ b/tests/mdns/mdns_mojo_test/public/mojom/BUILD.gn
@@ -1,6 +1,4 @@
-#!/bin/sh
-#
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2019, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -25,68 +23,15 @@
 #  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
-#
 
-set -e
-set -x
+import("//mojo/public/tools/bindings/mojom.gni")
 
-TOOLS_HOME=$HOME/.cache/tools
+mojom("mojom") {
+  sources = [
+    "mdns.mojom",
+  ]
 
-die() {
-	echo " *** ERROR: " $*
-	exit 1
+  deps = [
+    "//mojo/public/mojom/base",
+  ]
 }
-
-case $BUILD_TARGET in
-android-check)
-    (cd .. && "${TRAVIS_BUILD_DIR}/.travis/check-android-build")
-    ;;
-
-mdns-mojo-check)
-    ./tests/mdns/test-mojo
-    ;;
-
-pretty-check)
-    export PATH=$TOOLS_HOME/usr/bin:$PATH
-    ./bootstrap && ./configure && make pretty-check || die
-    ;;
-
-posix-check)
-    CPPFLAGS="$CFLAGS -I$TOOLS_HOME/usr/include" LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib" .travis/check-posix
-    ;;
-
-meshcop)
-    if gcc-5 --version; then
-      export CC=gcc-5
-      export CXX=g++-5
-    fi
-
-    ./bootstrap
-    ./script/test build
-
-    OT_CLI="ot-cli-mtd" ./script/test meshcop
-    OT_CLI="ot-cli-ftd" ./script/test meshcop
-    COMMISSIONER_WEB=1 ./script/test meshcop
-    NCP_CONTROLLER=openthread ./script/test clean build meshcop
-    ;;
-
-scan-build)
-    .travis/check-scan-build
-    ;;
-
-script-check)
-    .travis/check-scripts
-    ;;
-
-raspbian-gcc)
-    IMAGE_FILE=$TOOLS_HOME/images/$IMAGE_NAME.img .travis/check-raspbian
-    ;;
-
-docker-check)
-    .travis/check-docker
-    ;;
-
-*)
-    die
-    ;;
-esac

--- a/tests/mdns/mdns_mojo_test/stub_mojo_service.cpp
+++ b/tests/mdns/mdns_mojo_test/stub_mojo_service.cpp
@@ -1,0 +1,200 @@
+/*
+ *    Copyright (c) 2019, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes stub service for MDNS client based on mojo.
+ */
+
+#include <base/at_exit.h>
+#include <base/bind.h>
+#include <base/bind_helpers.h>
+#include <base/command_line.h>
+#include <base/logging.h>
+#include <base/message_loop/message_loop.h>
+#include <base/message_loop/message_pump_for_io.h>
+#include <base/run_loop.h>
+#include <chromecast/external_mojo/external_service_support/external_connector.h>
+#include <chromecast/external_mojo/external_service_support/external_service.h>
+#include <chromecast/external_mojo/public/cpp/common.h>
+#include <mojo/core/embedder/embedder.h>
+#include <mojo/core/embedder/scoped_ipc_support.h>
+#include <mojo/public/cpp/bindings/binding_set.h>
+
+#include <utility>
+
+#include "mdns_mojo_test/public/mojom/mdns.mojom.h"
+
+class StubMdnsMojomResponder;
+
+struct GlobalState
+{
+    std::unique_ptr<chromecast::external_service_support::ExternalConnector> connector;
+    std::unique_ptr<chromecast::external_service_support::ExternalService>   service;
+    std::unique_ptr<StubMdnsMojomResponder>                                  responder;
+};
+
+class StubMdnsMojomResponder : public chromecast::mojom::MdnsResponder
+{
+public:
+    StubMdnsMojomResponder() {}
+
+    void AddBinding(chromecast::mojom::MdnsResponderRequest aRequest)
+    {
+        mBindings.AddBinding(this, std::move(aRequest));
+    }
+
+    void RegisterServiceInstance(const std::string &                             aServiceName,
+                                 const std::string &                             aServiceTransport,
+                                 const std::string &                             aInstanceName,
+                                 int32_t                                         aPort,
+                                 const base::Optional<std::vector<std::string>> &aText,
+                                 RegisterServiceInstanceCallback                 aCallback) override
+    {
+        (void)aServiceName;
+        (void)aServiceTransport;
+        (void)aInstanceName;
+        (void)aPort;
+        (void)aCallback;
+
+        std::move(aCallback).Run(chromecast::mojom::MdnsResult::SUCCESS);
+    }
+
+    void RegisterDynamicServiceInstance(const std::string &                               aServiceName,
+                                        const std::string &                               aInstanceName,
+                                        chromecast::mojom::MdnsDynamicServiceResponderPtr aResponder,
+                                        chromecast::mojom::MdnsPublicationPtr             aInitializer) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+        (void)aResponder;
+        (void)aInitializer;
+    }
+
+    void UnregisterServiceInstance(const std::string &               aServiceName,
+                                   const std::string &               aInstanceName,
+                                   UnregisterServiceInstanceCallback aCallback) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+
+        std::move(aCallback).Run(chromecast::mojom::MdnsResult::SUCCESS);
+    }
+
+    void ReannounceInstance(const std::string &aServiceName, const std::string &aInstanceName) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+    }
+
+    void UpdateTxtRecord(const std::string &             aServiceName,
+                         const std::string &             aInstanceName,
+                         const std::vector<std::string> &aText,
+                         UpdateTxtRecordCallback         aCallback) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+        (void)aText;
+
+        std::move(aCallback).Run(chromecast::mojom::MdnsResult::SUCCESS);
+    }
+
+    void UpdateSrvRecord(const std::string &     aServiceName,
+                         const std::string &     aInstanceName,
+                         int32_t                 aPort,
+                         int32_t                 aPriority,
+                         int32_t                 aWeight,
+                         UpdateSrvRecordCallback aCallback) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+        (void)aPort;
+        (void)aPriority;
+        (void)aWeight;
+
+        std::move(aCallback).Run(chromecast::mojom::MdnsResult::SUCCESS);
+    }
+
+    void UpdateSubtypes(const std::string &             aServiceName,
+                        const std::string &             aInstanceName,
+                        const std::vector<std::string> &aFixedSubtypes,
+                        UpdateSubtypesCallback          aCallback) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+        (void)aFixedSubtypes;
+
+        std::move(aCallback).Run(chromecast::mojom::MdnsResult::SUCCESS);
+    }
+
+    void ClearPublicationCache(const std::string &aServiceName,
+                               const std::string &aInstanceName,
+                               const std::string &aSubType) override
+    {
+        (void)aServiceName;
+        (void)aInstanceName;
+        (void)aSubType;
+    }
+
+private:
+    mojo::BindingSet<chromecast::mojom::MdnsResponder> mBindings;
+
+    DISALLOW_COPY_AND_ASSIGN(StubMdnsMojomResponder);
+};
+
+void OnConnected(GlobalState *                                                            aState,
+                 std::unique_ptr<chromecast::external_service_support::ExternalConnector> aConnector)
+{
+    aState->connector = std::move(aConnector);
+    aState->service   = std::make_unique<chromecast::external_service_support::ExternalService>();
+    aState->responder = std::make_unique<StubMdnsMojomResponder>();
+    aState->service->AddInterface(
+        base::BindRepeating(&StubMdnsMojomResponder::AddBinding, base::Unretained(aState->responder.get())));
+    aState->connector->RegisterService("chromecast", aState->service.get());
+}
+
+int main()
+{
+    GlobalState state;
+
+    base::CommandLine::Init(0, NULL);
+    base::AtExitManager exitManager;
+
+    base::MessageLoopForIO mainLoop;
+    base::RunLoop          runLoop;
+
+    mojo::core::Init();
+    mojo::core::ScopedIPCSupport ipcSupport(mainLoop.task_runner(),
+                                            mojo::core::ScopedIPCSupport::ShutdownPolicy::CLEAN);
+
+    chromecast::external_service_support::ExternalConnector::Connect(chromecast::external_mojo::GetBrokerPath(),
+                                                                     base::BindOnce(OnConnected, &state));
+    runLoop.Run();
+
+    return 0;
+}

--- a/tests/mdns/test-mojo
+++ b/tests/mdns/test-mojo
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+# Test build and run mdns using mojo
+#
+
+set -x
+set -e
+
+
+main() 
+{
+    OTBR_DIR=${OTBR_DIR:-$(pwd)}
+    BUILD_DIR=${OTBR_DIR}/build/chromium
+    CHROMIUM_DIR=${BUILD_DIR}/chromium
+
+    if [ -f "${BUILD_DIR}" ] || [ -d "${BUILD_DIR}" ]; then
+        rm -rf "${BUILD_DIR}"
+    fi
+    mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
+
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git --depth=1
+
+    export PATH="${BUILD_DIR}/depot_tools:${PATH}"
+
+    mkdir -p "${CHROMIUM_DIR}" && cd "${CHROMIUM_DIR}"
+    fetch --nohooks --no-history chromium
+
+    # sync test code
+    MOJO_TEST_SRC_DIR=${CHROMIUM_DIR}/src/mdns_mojo_test
+    cp -r "${OTBR_DIR}/tests/mdns/mdns_mojo_test" "${CHROMIUM_DIR}/src/"
+    ln -s "${OTBR_DIR}/third_party/chromecast/mojom/mdns.mojom" "${MOJO_TEST_SRC_DIR}/public/mojom/mdns.mojom"
+    ln -s "${OTBR_DIR}/src/agent/mdns.hpp" "${MOJO_TEST_SRC_DIR}/mdns.hpp"
+    ln -s "${OTBR_DIR}/src/agent/mdns_mojo.hpp" "${MOJO_TEST_SRC_DIR}/mdns_mojo.hpp"
+    ln -s "${OTBR_DIR}/src/agent/mdns_mojo.cpp" "${MOJO_TEST_SRC_DIR}/mdns_mojo.cpp"
+    ln -s "${OTBR_DIR}/src/common" "${MOJO_TEST_SRC_DIR}/common"
+
+    cd /etc/apt/sources.list.d && sudo rm -rf cassandra.list* couchdb.list* mongodb-3.4.list* rabbitmq_rabbitmq-server.list* chris-lea-redis-server.list* github_git-lfs.list*
+    cd "${CHROMIUM_DIR}/src"
+    # Required to install seperately on travis
+    sudo apt-get -y install gcc-multilib g++-multilib
+    sudo ./build/install-build-deps.sh
+    gclient runhooks
+
+    sed -i -e '/"\/\/url:url_unittests",/a \    "\/\/mdns_mojo_test:mdns_mojo_client",\n    "\/\/mdns_mojo_test:mdns_mojo_stub_service",' "${CHROMIUM_DIR}/src/BUILD.gn"
+
+    gn gen out/Default
+    autoninja -C out/Default mdns_mojo_test:mdns_mojo_client mdns_mojo_test:mdns_mojo_stub_service chromecast/external_mojo/external_service_support:standalone_mojo_broker
+
+    ./out/Default/standalone_mojo_broker &
+    BROKER_PID=$!
+    ./out/Default/mdns_mojo_stub_service &
+    SERVICE_PID=$!
+    ./out/Default/mdns_mojo_client
+    kill -INT "${BROKER_PID}"
+    kill -INT "${SERVICE_PID}"
+}
+
+main "$@"

--- a/third_party/chromecast/mojom/mdns.mojom
+++ b/third_party/chromecast/mojom/mdns.mojom
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 


### PR DESCRIPTION
On chromecast devices, the mdns is implemented by the chromecast application. This change calls the mojo RPC interface to publish services.
