### PR TITLE
[commissioner] add resign

### DIFF
--- a/src/commissioner/commissioner.hpp
+++ b/src/commissioner/commissioner.hpp
@@ -113,7 +113,7 @@ public:
      * @returns inner commisioner state is not kStateInvalid
      *
      */
-    bool IsValid(void) const { return mCommissionState != kStateInvalid; }
+    bool IsValid(void) const { return mCommissionState != CommissionState::kStateInvalid; }
 
     /**
      * This method returns whether the commissioner petition succeeded
@@ -121,7 +121,7 @@ public:
      * @returns inner commisioner state is kStateAccepted
      *
      */
-    bool IsCommissionerAccepted(void) const { return mCommissionState == kStateAccepted; }
+    bool IsCommissionerAccepted(void) const { return mCommissionState == CommissionState::kStateAccepted; }
 
     /**
      * This method initialize the dtls session
@@ -151,14 +151,6 @@ public:
     void CommissionerPetition(void);
 
     /**
-     * This method sends commissioner set coap request
-     *
-     * @param[in]    aSteeringData      steering data to filter joiner, overrrides data from constructor
-     *
-     */
-    void CommissionerSet(const SteeringData &aSteeringData);
-
-    /**
      * This method gets number of nodes joined through commissioner
      *
      * @returns number of JOIN_FIN.rsp messages sent
@@ -169,7 +161,21 @@ public:
     ~Commissioner();
 
 private:
-    enum CommissionState
+    /**
+     * This method sends commissioner set coap request
+     *
+     * @param[in]    aSteeringData      steering data to filter joiner, overrrides data from constructor
+     *
+     */
+    void CommissionerSet(const SteeringData &aSteeringData);
+
+    /**
+     * This method gracefully resign as commissioner
+     *
+     */
+    void Resign(void);
+
+    enum class CommissionState
     {
         kStateInvalid = 0, ///< uninitialized, encounter network error or petition exceeds max retry
         kStateConnected,   ///< dtls connection setup done
@@ -181,7 +187,7 @@ private:
     Commissioner &operator=(const Commissioner &);
 
     int  DtlsHandShake(const sockaddr_in &aAgentAddr);
-    void CommissionerKeepAlive(void);
+    void CommissionerKeepAlive(uint8_t aState);
 
     static ssize_t SendCoap(const uint8_t *aBuffer,
                             uint16_t       aLength,
@@ -211,6 +217,7 @@ private:
     mbedtls_ssl_config           mSslConf;
     mbedtls_timing_delay_context mTimer;
     bool                         mDtlsInitDone;
+    bool                         mIsCommissioner;
 
     Coap::Agent *  mCoapAgent;
     uint16_t       mCoapToken;

--- a/src/commissioner/commissioner.hpp
+++ b/src/commissioner/commissioner.hpp
@@ -113,7 +113,7 @@ public:
      * @returns inner commisioner state is not kStateInvalid
      *
      */
-    bool IsValid(void) const { return mCommissionState != CommissionState::kStateInvalid; }
+    bool IsValid(void) const { return mCommissionerState != CommissionerState::kStateInvalid; }
 
     /**
      * This method returns whether the commissioner petition succeeded
@@ -121,7 +121,7 @@ public:
      * @returns inner commisioner state is kStateAccepted
      *
      */
-    bool IsCommissionerAccepted(void) const { return mCommissionState == CommissionState::kStateAccepted; }
+    bool IsCommissionerAccepted(void) const { return mCommissionerState == CommissionerState::kStateAccepted; }
 
     /**
      * This method initialize the dtls session
@@ -156,9 +156,9 @@ public:
      * @returns number of JOIN_FIN.rsp messages sent
      *
      */
-    int GetNumFinalizedJoiners(void);
+    int GetNumFinalizedJoiners(void) const;
 
-    ~Commissioner();
+    ~Commissioner(void);
 
 private:
     /**
@@ -170,24 +170,24 @@ private:
     void CommissionerSet(const SteeringData &aSteeringData);
 
     /**
-     * This method gracefully resign as commissioner
+     * This method gracefully resigns as commissioner
      *
      */
     void Resign(void);
 
-    enum class CommissionState
+    enum class CommissionerState
     {
         kStateInvalid = 0, ///< uninitialized, encounter network error or petition exceeds max retry
         kStateConnected,   ///< dtls connection setup done
         kStateAccepted,    ///< commissioner petition succeeded
         kStateRejected,    ///< rejected by leader, still retrying petition
-    } mCommissionState;
+    } mCommissionerState;
 
     Commissioner(const Commissioner &);
     Commissioner &operator=(const Commissioner &);
 
     int  DtlsHandShake(const sockaddr_in &aAgentAddr);
-    void CommissionerKeepAlive(uint8_t aState);
+    void SendCommissionerKeepAlive(int8_t aState);
 
     static ssize_t SendCoap(const uint8_t *aBuffer,
                             uint16_t       aLength,
@@ -217,7 +217,6 @@ private:
     mbedtls_ssl_config           mSslConf;
     mbedtls_timing_delay_context mTimer;
     bool                         mDtlsInitDone;
-    bool                         mIsCommissioner;
 
     Coap::Agent *  mCoapAgent;
     uint16_t       mCoapToken;

--- a/src/common/tlv.hpp
+++ b/src/common/tlv.hpp
@@ -128,6 +128,9 @@ public:
 
     /**
      * This method sets uint16_t as the value.
+     *
+     * @param[in]    aValue         uint16_t value
+     *
      */
     void SetValue(uint16_t aValue)
     {
@@ -141,11 +144,26 @@ public:
 
     /**
      * This method sets uint8_t as the value.
+     *
+     * @param[in]    aValue         uint8_t value
+     *
      */
     void SetValue(uint8_t aValue)
     {
         SetLength(sizeof(aValue), false);
         *static_cast<uint8_t *>(GetValue()) = aValue;
+    }
+
+    /**
+     * This method sets int8_t as the value.
+     *
+     * @param[in]    aValue         int8_t value
+     *
+     */
+    void SetValue(int8_t aValue)
+    {
+        SetLength(sizeof(aValue), false);
+        *static_cast<int8_t *>(GetValue()) = aValue;
     }
 
     /**


### PR DESCRIPTION
Add resign to allow other commissioners to petition in deconstruction.
Also made `CommissionerState` an `enum class` to prevent accidental misuse.