### PR TITLE
[ncp] fix the default return value of RequestEvent

### DIFF
--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -140,7 +140,7 @@ bool ControllerOpenThread::IsResetRequested(void)
 
 otbrError ControllerOpenThread::RequestEvent(int aEvent)
 {
-    otbrError ret = OTBR_ERROR_ERRNO;
+    otbrError ret = OTBR_ERROR_NONE;
 
     switch (aEvent)
     {


### PR DESCRIPTION
This PR fix the bug that the default return value of `ControllerOpenThread::RequestEvent` should be `OTBR_ERROR_NONE` rather than `OTBR_ERROR_ERRNO`.