### PR TITLE
[mdns] include thread version in query response

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -136,6 +136,8 @@ otbrError BorderAgent::Start(void)
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventNetworkName));
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventExtPanId));
+
+// Currently supports only NCP_OPENTHREAD
 #if OTBR_ENABLE_NCP_OPENTHREAD
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventThreadVersion));
 #endif // OTBR_ENABLE_NCP_OPENTHREAD

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -429,7 +429,7 @@ void BorderAgent::HandleThreadVersion(void *aContext, int aEvent, va_list aArgum
     assert(aEvent == Ncp::kEventThreadVersion);
 
     // `uint16_t` has been promoted to `int`.
-    uint16_t threadVersion = va_arg(aArguments, int);
+    uint16_t threadVersion = static_cast<uint16_t>(va_arg(aArguments, int));
     static_cast<BorderAgent *>(aContext)->SetThreadVersion(threadVersion);
 }
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -136,7 +136,9 @@ otbrError BorderAgent::Start(void)
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventNetworkName));
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventExtPanId));
+#if OTBR_ENABLE_NCP_OPENTHREAD
     SuccessOrExit(error = mNcp->RequestEvent(Ncp::kEventThreadVersion));
+#endif // OTBR_ENABLE_NCP_OPENTHREAD
     StartPublishService();
 #endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -276,6 +276,19 @@ exit:
     return;
 }
 
+static const char *ThreadVersionToString(uint16_t aThreadVersion)
+{
+    switch (aThreadVersion)
+    {
+    case 2:
+        return "1.1.1";
+    case 3:
+        return "1.2.0";
+    default:
+        return "";
+    }
+}
+
 void BorderAgent::PublishService(void)
 {
     char xpanid[sizeof(mExtPanId) * 2 + 1];
@@ -435,19 +448,6 @@ void BorderAgent::HandleThreadVersion(void *aContext, int aEvent, va_list aArgum
     // `uint16_t` has been promoted to `int`.
     uint16_t threadVersion = static_cast<uint16_t>(va_arg(aArguments, int));
     static_cast<BorderAgent *>(aContext)->SetThreadVersion(threadVersion);
-}
-
-const char *BorderAgent::ThreadVersionToString(uint16_t aThreadVersion)
-{
-    switch (aThreadVersion)
-    {
-    case 2:
-        return "1.1.1";
-    case 3:
-        return "1.2.0";
-    default:
-        return "";
-    }
 }
 
 } // namespace BorderRouter

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -145,8 +145,8 @@ private:
     int mSocket;
 #endif
     uint8_t  mExtPanId[kSizeExtPanId];
-    char     mNetworkName[kSizeNetworkName + 1];
     uint16_t mThreadVersion;
+    char     mNetworkName[kSizeNetworkName + 1];
     bool     mThreadStarted;
     bool     mPSKcInitialized;
 };

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -128,13 +128,16 @@ private:
 
     void SetNetworkName(const char *aNetworkName);
     void SetExtPanId(const uint8_t *aExtPanId);
+    void SetThreadVersion(uint16_t aThreadVersion);
     void HandleThreadState(bool aStarted);
     void HandlePSKc(const uint8_t *aPSKc);
 
-    static void HandlePSKc(void *aContext, int aEvent, va_list aArguments);
-    static void HandleThreadState(void *aContext, int aEvent, va_list aArguments);
-    static void HandleNetworkName(void *aContext, int aEvent, va_list aArguments);
-    static void HandleExtPanId(void *aContext, int aEvent, va_list aArguments);
+    static void        HandlePSKc(void *aContext, int aEvent, va_list aArguments);
+    static void        HandleThreadState(void *aContext, int aEvent, va_list aArguments);
+    static void        HandleNetworkName(void *aContext, int aEvent, va_list aArguments);
+    static void        HandleExtPanId(void *aContext, int aEvent, va_list aArguments);
+    static void        HandleThreadVersion(void *aContext, int aEvent, va_list aArguments);
+    static const char *ThreadVersionToString(uint16_t aThreadVersion);
 
     Mdns::Publisher *mPublisher;
     Ncp::Controller *mNcp;
@@ -142,10 +145,11 @@ private:
 #if OTBR_ENABLE_NCP_WPANTUND
     int mSocket;
 #endif
-    uint8_t mExtPanId[kSizeExtPanId];
-    char    mNetworkName[kSizeNetworkName + 1];
-    bool    mThreadStarted;
-    bool    mPSKcInitialized;
+    uint8_t  mExtPanId[kSizeExtPanId];
+    char     mNetworkName[kSizeNetworkName + 1];
+    uint16_t mThreadVersion;
+    bool     mThreadStarted;
+    bool     mPSKcInitialized;
 };
 
 /**

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -132,12 +132,11 @@ private:
     void HandleThreadState(bool aStarted);
     void HandlePSKc(const uint8_t *aPSKc);
 
-    static void        HandlePSKc(void *aContext, int aEvent, va_list aArguments);
-    static void        HandleThreadState(void *aContext, int aEvent, va_list aArguments);
-    static void        HandleNetworkName(void *aContext, int aEvent, va_list aArguments);
-    static void        HandleExtPanId(void *aContext, int aEvent, va_list aArguments);
-    static void        HandleThreadVersion(void *aContext, int aEvent, va_list aArguments);
-    static const char *ThreadVersionToString(uint16_t aThreadVersion);
+    static void HandlePSKc(void *aContext, int aEvent, va_list aArguments);
+    static void HandleThreadState(void *aContext, int aEvent, va_list aArguments);
+    static void HandleNetworkName(void *aContext, int aEvent, va_list aArguments);
+    static void HandleExtPanId(void *aContext, int aEvent, va_list aArguments);
+    static void HandleThreadVersion(void *aContext, int aEvent, va_list aArguments);
 
     Mdns::Publisher *mPublisher;
     Ncp::Controller *mNcp;

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -73,6 +73,7 @@ enum
     kEventNetworkName,      ///< Network name arrived.
     kEventPSKc,             ///< PSKc arrived.
     kEventThreadState,      ///< Thread State.
+    kEventThreadVersion,    ///< Thread Version.
     kEventUdpForwardStream, ///< UDP forward stream arrived.
 };
 

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -140,7 +140,7 @@ bool ControllerOpenThread::IsResetRequested(void)
 
 otbrError ControllerOpenThread::RequestEvent(int aEvent)
 {
-    otbrError ret = OTBR_ERROR_ERRNO;
+    otbrError ret = OTBR_ERROR_NONE;
 
     switch (aEvent)
     {
@@ -175,6 +175,11 @@ otbrError ControllerOpenThread::RequestEvent(int aEvent)
     case kEventPSKc:
     {
         EventEmitter::Emit(kEventPSKc, otThreadGetPskc(mInstance));
+        break;
+    }
+    case kEventThreadVersion:
+    {
+        EventEmitter::Emit(kEventThreadVersion, otGetThreadVersion());
         break;
     }
     default:

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -179,7 +179,7 @@ otbrError ControllerOpenThread::RequestEvent(int aEvent)
     }
     case kEventThreadVersion:
     {
-        EventEmitter::Emit(kEventThreadVersion, otGetThreadVersion());
+        EventEmitter::Emit(kEventThreadVersion, otThreadGetVersion());
         break;
     }
     default:


### PR DESCRIPTION
This PR includes the `Thread Version` is a DNS query response. According to the spec, `Thread Version` is **required**.

Currently supports only `ncp=openthread`.

Dependent PR: [4225](https://github.com/openthread/openthread/pull/4225).

This PR updated submodule openthread to include the dependent PR.