### PR TITLE
[script] avoid bash extension

### DIFF
--- a/.travis/check-raspbian
+++ b/.travis/check-raspbian
@@ -72,8 +72,10 @@ EOF
         sudo git clone --depth 1 https://github.com/openthread/wpantund.git $IMAGE_DIR/home/pi/repo/._build/wpantund && \
         sudo cp -v $STAGE_DIR/check.sh $IMAGE_DIR/home/pi/check.sh &&  \
         sudo ./qemu-setup.sh $IMAGE_DIR &&                             \
-        sudo chroot $IMAGE_DIR /bin/bash /home/pi/check.sh &&          \
-        sudo ./qemu-cleanup.sh $IMAGE_DIR &&                           \
+        sudo chroot $IMAGE_DIR /bin/bash /home/pi/check.sh
+        sudo umount -lf $IMAGE_DIR/dev/pts || true
+        sudo ./qemu-cleanup.sh $IMAGE_DIR || true
+        sudo umount -lf $IMAGE_DIR/dev || true
         sudo ./unmount.sh $IMAGE_DIR)
 }
 

--- a/.travis/check-raspbian
+++ b/.travis/check-raspbian
@@ -59,6 +59,8 @@ main() {
         su -m -c 'script/bootstrap' pi
         su -m -c './configure --prefix=/usr' pi
         su -m -c 'make' pi
+        umount /sys
+        umount /proc
 EOF
 
     (cd docker-rpi-emu/scripts &&

--- a/.travis/check-raspbian
+++ b/.travis/check-raspbian
@@ -59,8 +59,8 @@ main() {
         su -m -c 'script/bootstrap' pi
         su -m -c './configure --prefix=/usr' pi
         su -m -c 'make' pi
-        umount /sys
-        umount /proc
+        umount -lf /sys
+        umount -lf /proc
 EOF
 
     (cd docker-rpi-emu/scripts &&

--- a/script/_initrc
+++ b/script/_initrc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -91,11 +91,16 @@ then
     cat /sys/firmware/devicetree/base/model | grep -s "BeagleBone Black" && PLATFORM=beagleboneblack
 fi
 
-if [[ "${OSTYPE}" = "darwin"* ]]; then
-    PLATFORM=macOS
-elif test -z "$PLATFORM"; then
-    have_or_die lsb_release
-    PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+if test -z "$PLATFORM"; then
+    case "${OSTYPE}" in
+        darwin*)
+            PLATFORM=macOS
+            ;;
+        *)
+            have_or_die lsb_release
+            PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+            ;;
+    esac
 fi
 echo "Current platform is $PLATFORM"
 


### PR DESCRIPTION
This PR removes dependency on `[[`, also fixed the broken travis test of **raspbian jessie**.