### PR TITLE
[Utils] Add concurrent queue class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,11 @@ src/commissioner/otbr-commissioner
 # libcoap build
 third_party/libcoap/repo/libcoap-1.map
 third_party/libcoap/repo/libcoap-1.sym
+
+# Test logs
+tests/unit/unittest
+*.log
+*.trs
+
+# Vim auto complete helper
+.ycm_extra_conf.py

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -51,12 +51,13 @@ libutils_la_LIBADD                                      = \
     $(top_builddir)/src/common/libotbr-logging.la         \
     $(NULL)
 
-noinst_HEADERS      = \
-    crc16.hpp         \
-    hex.hpp           \
-    pskc.hpp          \
-    steering_data.hpp \
-    strcpy_utils.hpp  \
+noinst_HEADERS                 = \
+    concurrent_queue.hpp         \
+    crc16.hpp                    \
+    hex.hpp                      \
+    pskc.hpp                     \
+    steering_data.hpp            \
+    strcpy_utils.hpp             \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/utils/concurrent_queue.hpp
+++ b/src/utils/concurrent_queue.hpp
@@ -1,0 +1,106 @@
+/*
+ *    Copyright (c) 2019, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the tempalte for a concurrent queue
+ */
+
+#ifndef OTBR_CONCURRENT_QUEUE_HPP_
+#define OTBR_CONCURRENT_QUEUE_HPP_
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+namespace ot {
+namespace utils {
+
+template <typename T> class ConcurrentQueue
+{
+public:
+    ConcurrentQueue() = default;
+
+    /**
+     * This method pushes an item into the queue
+     *
+     * @param[in]  aItem  The item to be pushed
+     *
+     */
+    template <typename R> void Push(R &&aItem)
+    {
+        std::lock_guard<std::mutex> l(mMutex);
+        mQueue.push(std::forward<R>(aItem));
+        mItemPushedEvent.notify_one();
+    }
+
+    /**
+     * This method pops an item from the queue
+     *
+     * @returns The item at the top, if the queue is empty, will block until
+     *          one itme is pushed.
+     *
+     */
+    T Pop(void)
+    {
+        std::unique_lock<std::mutex> lck(mMutex);
+        mItemPushedEvent.wait(lck, [this]() { return !mQueue.empty(); });
+
+        T val = std::move(mQueue.front());
+        mQueue.pop();
+        return val;
+    }
+
+    /**
+     * This method returns whether the queue is empty
+     *
+     * @returns Whether the queue is emtpy. Only when you are the only consumer
+     *          it is ensured that a call to Pop() won't block if Empty() returns
+     *          false.
+     *
+     */
+    bool Empty(void)
+    {
+        std::lock_guard<std::mutex> l(mMutex);
+        return mQueue.empty();
+    }
+
+private:
+    std::mutex              mMutex;
+    std::condition_variable mItemPushedEvent;
+    std::queue<T>           mQueue;
+};
+
+using TaskQueue = ConcurrentQueue<std::function<void(void)>>;
+
+}; // namespace utils
+}; // namespace ot
+
+#endif // OTBR_CONCURRENT_QUEUE_HPP_

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -38,6 +38,7 @@ unittest_SOURCES           = \
     test_event_emitter.cpp   \
     test_pskc.cpp            \
     test_logging.cpp         \
+    test_queue.cpp           \
     $(NULL)
 
 if OTBR_ENABLE_MDNS_MDNSSD

--- a/tests/unit/test_event_emitter.cpp
+++ b/tests/unit/test_event_emitter.cpp
@@ -26,11 +26,11 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <CppUTest/TestHarness.h>
-
 #include <stdarg.h>
 
 #include "common/event_emitter.hpp"
+
+#include <CppUTest/TestHarness.h>
 
 static int   sCounter = 0;
 static int   sEvent   = 0;

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -85,7 +85,7 @@ TEST(Logging, TestLoggingLowerLevel)
 TEST(Logging, TestLoggingDump)
 {
     char ident[120];
-    char cmd[128];
+    char cmd[256];
 
     sprintf(ident, "otbr-test-%ld", clock());
     otbrLogInit(ident, OTBR_LOG_DEBUG, true);

--- a/tests/unit/test_queue.cpp
+++ b/tests/unit/test_queue.cpp
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <thread>
+
+#include "utils/concurrent_queue.hpp"
+
+#include <CppUTest/TestHarness.h>
+
+TEST_GROUP(Queue){};
+
+TEST(Queue, TestQueue)
+{
+    ot::utils::TaskQueue            taskQueue;
+    ot::utils::ConcurrentQueue<int> valueQueue;
+
+    std::thread task([&taskQueue, &valueQueue]() {
+        for (int i = 0; i < 2; i++)
+        {
+            int val = valueQueue.Pop();
+            taskQueue.Push([val]() { printf("%d \n", val); });
+        }
+    });
+
+    for (int i = 0; i < 2; i++)
+    {
+        valueQueue.Push(i);
+        auto f = taskQueue.Pop();
+        f();
+    }
+
+    task.join();
+}


### PR DESCRIPTION
This PR includes the concurrent queue template and its unit test. It
also fixes some build errors in the unit test module.

The concurrent queue class will be the task queue between the IPC
modules and the OpenThread core stack.