### PR TITLE
[mojo] update mojo connect and receive api call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 
 sudo: required
-dist: trusty
 
 cache:
   directories:
@@ -16,10 +15,13 @@ matrix:
   include:
     - env: BUILD_TARGET="raspbian-gcc" VERBOSE=1 IMAGE_NAME=2017-04-10-raspbian-jessie-lite IMAGE_URL=http://director.downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-04-10/2017-04-10-raspbian-jessie-lite.zip
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="raspbian-gcc" VERBOSE=1 IMAGE_NAME=2018-04-18-raspbian-stretch-lite IMAGE_URL=http://director.downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-04-19/2018-04-18-raspbian-stretch-lite.zip
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="meshcop" VERBOSE=1
       os: linux
+      dist: trusty
       addons:
         apt:
           sources:
@@ -29,35 +31,47 @@ matrix:
             - g++-5
     - env: BUILD_TARGET="docker-check" VERBOSE=1
       os: linux
+      dist: trusty
       compiler: gcc
     - env: BUILD_TARGET="script-check"
       compiler: gcc
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="scan-build"
       os: linux
+      dist: trusty
       compiler: clang
     - env: BUILD_TARGET="android-check" VERBOSE=1 WITH_MDNS=mDNSResponder
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="android-check" VERBOSE=1 WITH_MDNS=""
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="android-check" VERBOSE=1
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="mdns-mojo-check" VERBOSE=1
       os: linux
+      dist: bionic
     - env: BUILD_TARGET="posix-check" VERBOSE=1 WITH_MDNS=mDNSResponder
       compiler: clang
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="posix-check" VERBOSE=1
       compiler: clang
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="posix-check" VERBOSE=1 WITH_MDNS=mDNSResponder
       compiler: gcc
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="posix-check" VERBOSE=1
       compiler: gcc
       os: linux
+      dist: trusty
     - env: BUILD_TARGET="pretty-check"
       os: linux
+      dist: trusty
       addons:
         apt:
           sources:

--- a/src/agent/mdns_mojo.hpp
+++ b/src/agent/mdns_mojo.hpp
@@ -37,16 +37,16 @@
 #include <base/macros.h>
 #include <base/message_loop/message_loop.h>
 #include <base/message_loop/message_pump_for_io.h>
+#include <chromecast/external_mojo/public/cpp/common.h>
+
 #ifndef TEST_IN_CHROMIUM
 #include <base/task_scheduler/post_task.h>
-#else
-#include <base/task/post_task.h>
-#endif
-#include <chromecast/external_mojo/public/cpp/common.h>
-#ifndef TEST_IN_CHROMIUM
 #include <chromecast/external_mojo/public/cpp/external_connector.h>
 #else
+#include <base/task/post_task.h>
 #include <chromecast/external_mojo/external_service_support/external_connector.h>
+#include <mojo/public/cpp/bindings/receiver.h>
+#include <mojo/public/cpp/bindings/remote.h>
 #endif
 
 #include <memory>
@@ -78,7 +78,8 @@ public:
     /**
      * The constructor to MdnsMojoPublisher
      *
-     * @param[in]   aHandler    The callback function for mojo connect state change
+     * @param[in]   aHandler    The callback function for mojo connect state
+     * change
      * @param[in]   aContext    The context for callback function
      *
      */
@@ -179,7 +180,12 @@ private:
     std::unique_ptr<std::thread>                          mMojoCoreThread;
     base::Closure                                         mMojoCoreThreadQuitClosure;
     std::unique_ptr<MOJO_CONNECTOR_NS::ExternalConnector> mConnector;
-    chromecast::mojom::MdnsResponderPtr                   mResponder;
+
+#ifndef TEST_IN_CHROMIUM
+    chromecast::mojom::MdnsResponderPtr mResponder;
+#else
+    mojo::Remote<chromecast::mojom::MdnsResponder> mResponder;
+#endif
 
     std::vector<std::pair<std::string, std::string>> mPublishedServices;
 

--- a/third_party/chromecast/mojom/mdns.mojom
+++ b/third_party/chromecast/mojom/mdns.mojom
@@ -25,31 +25,6 @@ enum MdnsResult {
   INVALID_PARAMS,
 };
 
-// Describes an initial instance publication or query response.
-struct MdnsPublication {
-  uint16 port;
-  bool can_cache;
-  array<string>? text;
-  uint32 ptr_ttl_seconds = 4500; // default 75 minutes
-  uint32 srv_ttl_seconds = 120; // default 2 minutes
-  uint32 txt_ttl_seconds = 4500; // default 75 minutes
-};
-
-interface MdnsDynamicServiceResponder {
-  // Updates the status of the instance publication.
-  UpdateStatus(MdnsResult error);
-
-  // Provides instance information for initial announcements and query responses
-  // relating to the service instance specified in
-  // |Responder.RegisterDynamicServiceInstance|.
-  // |query| indicates whether data is requested for an initial announcement
-  // (false) or in response to a query (true). If the publication relates to a
-  // subtype of the service, |subtype| contains the subtype, otherwise it is
-  // null. If |publication| is null, no announcement or response is transmitted.
-  // Strings in |text| are transmitted in the TXT record.
-  GetPublication(bool query, string subtype) => (MdnsPublication? publication);
-};
-
 interface MdnsResponder {
   // Registers service instance with the responder.
   RegisterServiceInstance(string service_name,
@@ -57,14 +32,6 @@ interface MdnsResponder {
                           string instance_name,
                           int32 port,
                           array<string>? text) => (MdnsResult error);
-
-  // Registers service instance with the responder, with user specific behavior
-  // in announcement and query reply, such as dynamic subtype filtering.
-  // Use GetPublication to get initial announcements if |initializer| is null.
-  RegisterDynamicServiceInstance(string service_name,
-                                 string instance_name,
-                                 MdnsDynamicServiceResponder responder,
-                                 MdnsPublication initializer);
 
   // Unregisters currently registered service instance from responder.
   UnregisterServiceInstance(string service_name,


### PR DESCRIPTION
The connect and receive api has been recently updated in chrominum.
Update accordingly.

The code divergence in libchrome and chromium forcing us to use different types and function names when linking to these libraries. I'm working with the chromium team to resolve this issue.