### PR TITLE
[build] use openthread-br/config.h 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -73,6 +73,7 @@ LOCAL_MODULE_TAGS := eng
 LOCAL_SHARED_LIBRARIES := libdbus
 
 LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/include \
     $(LOCAL_PATH)/src \
     $(LOCAL_PATH)/third_party/wpantund \
     $(LOCAL_PATH)/third_party/wpantund/repo/src \

--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,7 @@ AC_CONFIG_MACRO_DIR([third_party/openthread/repo/third_party/nlbuild-autotools/r
 # Tell autoconf what file the package is using to aggregate C preprocessor
 # defines.
 #
-AC_CONFIG_HEADERS([include/otbr-config.h])
+AC_CONFIG_HEADERS([include/openthread-br/autoconf-config.h])
 
 #
 # Figure out what the canonical build, host and target tuples are.

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -28,4 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+nobase_include_HEADERS = \
+    openthread-br/config.h \
+    $(NULL)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/include/openthread-br/config.h
+++ b/include/openthread-br/config.h
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_CONFIG_H_
+#define OTBR_CONFIG_H_
+
+#if HAVE_CONFIG_H
+#include "autoconf-config.h"
+#elif defined(OTBR_CONFIG_FILE)
+#include OTBR_CONFIG_FILE
+#endif
+
+#endif // OTBR_CONFIG_H_

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -60,6 +60,7 @@ otbr_agent_LDFLAGS = \
     $(NULL)
 
 otbr_agent_CPPFLAGS         = \
+    -I$(top_srcdir)/include   \
     -I$(top_srcdir)/src       \
     -I$(top_srcdir)/third_party/openthread/repo/src/core                     \
     $(OPENTHREAD_CPPFLAGS)    \
@@ -115,6 +116,7 @@ libotbr_agent_la_LDFLAGS = \
     $(NULL)
 
 libotbr_agent_la_CPPFLAGS                                                  = \
+    -I$(top_srcdir)/include                                                  \
     -I$(top_srcdir)/src                                                      \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -26,9 +26,7 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if HAVE_CONFIG_H
-#include "otbr-config.h"
-#endif
+#include <openthread-br/config.h>
 
 #include <mutex>
 #include <thread>

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -34,9 +34,7 @@
 #ifndef NCP_HPP_
 #define NCP_HPP_
 
-#if HAVE_CONFIG_H
-#include "otbr-config.h"
-#endif
+#include <openthread-br/config.h>
 
 #include <netinet/in.h>
 #include <stddef.h>

--- a/src/commissioner/Makefile.am
+++ b/src/commissioner/Makefile.am
@@ -51,6 +51,7 @@ libotbr_commissioner_la_SOURCES                       = \
     $(NULL)
 
 libotbr_commissioner_la_CPPFLAGS                      = \
+    -I$(top_srcdir)/include                             \
     -I$(top_srcdir)/src                                 \
     -I$(top_srcdir)/src/web                             \
     $(MBEDTLS_CPPFLAGS)                                 \
@@ -76,6 +77,7 @@ otbr_commissioner_LDADD                               = \
     $(NULL)
 
 otbr_commissioner_CPPFLAGS                            = \
+    -I$(top_srcdir)/include                             \
     $(libotbr_commissioner_la_CPPFLAGS)                 \
     $(NULL)
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -66,6 +66,7 @@ libotbr_coap_la_SOURCES                               = \
     $(NULL)
 
 libotbr_coap_la_CPPFLAGS                              = \
+    -I$(top_srcdir)/include                             \
     -I$(top_builddir)/third_party/libcoap/repo          \
     -I$(top_builddir)/third_party/libcoap/repo/include  \
     -I$(top_srcdir)/third_party/libcoap/repo            \
@@ -82,6 +83,7 @@ libotbr_dtls_la_SOURCES                               = \
     $(NULL)
 
 libotbr_dtls_la_CPPFLAGS                              = \
+    -I$(top_srcdir)/include                             \
     $(MBEDTLS_CPPFLAGS)                                 \
     $(NULL)
 

--- a/src/dbus/Makefile.am
+++ b/src/dbus/Makefile.am
@@ -44,6 +44,7 @@ libotbr_dbus_la_SOURCES   = \
 
 libotbr_dbus_la_CPPFLAGS                                   = \
     -I$(top_srcdir)                                          \
+    -I$(top_srcdir)/include                                  \
     -I$(top_srcdir)/src                                      \
     -I$(top_srcdir)/third_party/openthread/repo/src/         \
     -I$(top_srcdir)/third_party/openthread/repo/include/     \

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -41,6 +41,7 @@ libutils_la_SOURCES = \
     $(NULL)
 
 libutils_la_CPPFLAGS                                    = \
+    -I$(top_srcdir)/include                               \
     -I$(top_srcdir)/src                                   \
     -I$(top_srcdir)/third_party/mbedtls/repo/include      \
     $(MBEDTLS_CPPFLAGS)                                   \

--- a/src/web/Makefile.am
+++ b/src/web/Makefile.am
@@ -50,6 +50,7 @@ otbr_web_LDFLAGS                                           = \
     $(NULL)
 
 otbr_web_CPPFLAGS                                          = \
+    -I$(top_srcdir)/include                                  \
     $(libotbr_web_la_CPPFLAGS)                               \
     $(NULL)
 
@@ -99,6 +100,7 @@ libotbr_web_la_LDFLAGS                                          = \
     $(NULL)
 
 libotbr_web_la_CPPFLAGS                                         = \
+    -I$(top_srcdir)/include                                       \
     -I$(top_srcdir)/src                                           \
     -I$(top_srcdir)/src/wpan-controller                           \
     -I$(top_srcdir)/src/web-service                               \

--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -32,7 +32,7 @@
  */
 #define OT_HTTP_PORT 80
 
-#include "otbr-config.h"
+#include <openthread-br/config.h>
 
 #include <errno.h>
 #include <signal.h>

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -34,9 +34,7 @@
 #ifndef WPAN_SERVICE
 #define WPAN_SERVICE
 
-#if HAVE_CONFIG_H
-#include "otbr-config.h"
-#endif
+#include <openthread-br/config.h>
 
 #include <stdint.h>
 #include <stdio.h>

--- a/tests/dbus/Makefile.am
+++ b/tests/dbus/Makefile.am
@@ -40,6 +40,7 @@ otbr_test_dbus_server_CXXFLAGS = \
 
 otbr_test_dbus_server_CPPFLAGS = \
     -I$(top_srcdir) \
+    -I$(top_srcdir)/include \
     -I$(top_srcdir)/src \
     -I$(top_srcdir)/third_party/openthread/repo/src/ \
     -I$(top_srcdir)/third_party/openthread/repo/include/ \

--- a/tests/mdns/Makefile.am
+++ b/tests/mdns/Makefile.am
@@ -35,6 +35,7 @@ otbr_test_mdns_SOURCES                                 = \
     $(NULL)
 
 otbr_test_mdns_CPPFLAGS                                = \
+    -I$(top_srcdir)/include                              \
     -I$(top_srcdir)/src                                  \
     $(NULL)
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -48,6 +48,7 @@ unittest_SOURCES          += \
 endif
 
 unittest_CPPFLAGS                                             = \
+    -I$(top_srcdir)/include                                     \
     -I$(top_srcdir)/src                                         \
     -I$(top_srcdir)/src/agent                                   \
     -I$(top_srcdir)/src/web                                     \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -37,6 +37,7 @@ pskc_SOURCES                                              = \
     $(NULL)
 
 pskc_CPPFLAGS                                             = \
+    -I$(top_srcdir)/include                                 \
     -I$(top_srcdir)/src                                     \
     -I$(top_srcdir)/src/agent                               \
     -I$(top_srcdir)/src/web                                 \
@@ -57,6 +58,7 @@ steering_data_SOURCES                                     = \
     $(NULL)
 
 steering_data_CPPFLAGS                                    = \
+    -I$(top_srcdir)/include                                 \
     -I$(top_srcdir)/src                                     \
     -I$(top_srcdir)/src/agent                               \
     $(MBEDTLS_CPPFLAGS)                                     \


### PR DESCRIPTION
Check if there is autoconf header file inside openthread-br/config.h to
make code clean.