### PR TITLE
[utils] fix strcpy_safe behavior

### DIFF
--- a/src/utils/strcpy_utils.cpp
+++ b/src/utils/strcpy_utils.cpp
@@ -33,8 +33,8 @@ int strcpy_safe(char *aDest, size_t aDestSize, const char *aSrc)
 {
     int ret = 0;
     VerifyOrExit(aDest != NULL, ret = -1);
-    VerifyOrExit(aSrc != NULL, ret = -1, aDest[0] = 0);
-    VerifyOrExit(aDestSize > strnlen(aSrc, aDestSize), ret = -1, aDest[0] = 0);
+    VerifyOrExit(aSrc != NULL, ret = -1);
+    VerifyOrExit(aDestSize > strnlen(aSrc, aDestSize), ret = -1);
 
     strncpy(aDest, aSrc, aDestSize);
 

--- a/src/utils/strcpy_utils.hpp
+++ b/src/utils/strcpy_utils.hpp
@@ -36,14 +36,14 @@ extern "C" {
 #endif
 
 /**
- * This method is a safe version of strcpy always ensuring last byte to be 0
- * If strlen(aSrc) >= n, the string will be truncated
+ * This method is a safe version of strcpy. A source string longer than
+ * destination will be rejected.
  *
  * @param[out] aDest      dest string
  * @param[in]  aDestSize  size of dest string buffer
  * @param[in]  aSrc       src string
  *
- * @returns 0 on success, -1 on error
+ * @returns 0, succeed and string copied; -1, failed and `aDest` is not changed.
  *
  */
 int strcpy_safe(char *aDest, size_t aDestSize, const char *aSrc);


### PR DESCRIPTION
`aDest` is the output provided by caller. `aDest` should not be touched If this function returns a failure (-1). It is unexpected that a failed call has any side effect on the output.