### PR TITLE
[avahi] check if mGroup is nil before commit

### DIFF
--- a/src/agent/mdns_avahi.cpp
+++ b/src/agent/mdns_avahi.cpp
@@ -442,7 +442,10 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
         mState = kStateReady;
         CreateGroup(aClient);
         mStateHandler(mContext, mState);
-        avahi_entry_group_commit(mGroup);
+        if (mGroup)
+        {
+            avahi_entry_group_commit(mGroup);
+        }
         break;
 
     case AVAHI_CLIENT_FAILURE:


### PR DESCRIPTION
member method [CreateGroup](https://github.com/openthread/ot-br-posix/blob/affbbdb34b2c6743b1e83a1fd5ef50cf6e93d6ac/src/agent/mdns_avahi.cpp#L420) has no guarantee of success.