### PR TITLE
[android] fix deterministic -j1 build failure.

### DIFF
--- a/.travis/check-android-build
+++ b/.travis/check-android-build
@@ -269,6 +269,7 @@ prepare_libchrome_stub()
     SRC_DIR="$(cd "$(dirname "$0")" ; pwd -P)"
     mkdir -p external
     cp -r "${SRC_DIR}"/../etc/libchrome_stub external/libchrome
+    touch ${SRC_DIR}/../mdns_mojom_stub.c
 }
 
 prepare_openthread()

--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,7 @@ WITH_MDNS ?= mojo
 ifeq ($(WITH_MDNS),mojo)
 include $(CLEAR_VARS)
 
-LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
 LOCAL_MODULE := libmdns_mojom
 LOCAL_MODULE_TAGS := eng
 LOCAL_CPP_EXTENSION := .cc
@@ -62,7 +62,7 @@ MDNS_MOJOM_SRCS := $(gen_src)
 
 LOCAL_SHARED_LIBRARIES += libchrome libmojo
 
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)
 endif
 
 include $(CLEAR_VARS)
@@ -199,7 +199,8 @@ LOCAL_SRC_FILES += \
 # The generated header files are not in dependency chain.
 # Force dependency here
 LOCAL_ADDITIONAL_DEPENDENCIES += $(MDNS_MOJOM_SRCS)
-LOCAL_SHARED_LIBRARIES += libmdns_mojom libchrome libmojo
+LOCAL_STATIC_LIBRARIES += libmdns_mojom
+LOCAL_SHARED_LIBRARIES += libchrome libmojo
 endif
 endif
 

--- a/etc/libchrome_stub/generate_mojom_sources.mk
+++ b/etc/libchrome_stub/generate_mojom_sources.mk
@@ -1,0 +1,29 @@
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+LOCAL_SRC_FILES += mdns_mojom_stub.c


### PR DESCRIPTION
Generated mojo files should be in static libraries to ensure
the module is completely built before compilation of another module.