### PR TITLE
[beaglebone] disable nginx and apache

### DIFF
--- a/script/_disable_services
+++ b/script/_disable_services
@@ -42,7 +42,7 @@ bbb_disable_services()
 
     for service in $SERVICE_LIST
     do
-        if [[ $(sudo systemctl is-active $service) != "inactive" ]];
+        if [ $(sudo systemctl is-active $service) != "inactive" ];
         then
             for action in stop disable
             do

--- a/script/_disable_services
+++ b/script/_disable_services
@@ -34,7 +34,7 @@
 bbb_disable_services()
 {
     SERVICE_LIST=""
-    SERVICE_LIST="${SERVICE_LIST} apache2 "
+    SERVICE_LIST="${SERVICE_LIST} nginx "
     SERVICE_LIST="${SERVICE_LIST} bonescript.socket"
     SERVICE_LIST="${SERVICE_LIST} bonescript.service"
     SERVICE_LIST="${SERVICE_LIST} bonescript-autorun.service"

--- a/script/_disable_services
+++ b/script/_disable_services
@@ -34,17 +34,21 @@
 bbb_disable_services()
 {
     SERVICE_LIST=""
-    SERVICE_LIST="${SERVICE_LIST} nginx "
+    SERVICE_LIST="${SERVICE_LIST} apache2 " # Debian jessie
+    SERVICE_LIST="${SERVICE_LIST} nginx "   # Debian stretch
     SERVICE_LIST="${SERVICE_LIST} bonescript.socket"
     SERVICE_LIST="${SERVICE_LIST} bonescript.service"
     SERVICE_LIST="${SERVICE_LIST} bonescript-autorun.service"
 
     for service in $SERVICE_LIST
     do
-        for action in stop disable
-        do
-            sudo systemctl $action $service
-        done
+        if [[ $(sudo systemctl is-active $service) != "inactive" ]];
+        then
+            for action in stop disable
+            do
+                sudo systemctl $action $service
+            done
+        fi
     done
 }
 


### PR DESCRIPTION
The BeagleBone Debian distribution has changed from Jessie to Strecth.
One of the changes in that migration was moving the server for the
Cloud9 IDE to nginx from apache.

One of the scripts called by the setup disables running webservers to
allow the OpenThread Border Router to run it's own server. This updates
the disable script to point to the current webserver on the BeagleBone.