### PR TITLE
[dbus] separate client/server error helpers

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -81,11 +81,11 @@ LOCAL_C_INCLUDES := \
     $(NULL)
 
 LOCAL_SRC_FILES = \
+    src/dbus/client/client_error.cpp \
     src/dbus/client/thread_api_dbus.cpp \
     src/dbus/common/dbus_message_helper.cpp \
     src/dbus/common/dbus_message_helper_openthread.cpp \
     src/dbus/common/error.cpp \
-    src/dbus/common/error_helper.cpp \
     $(NULL)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS := \
@@ -144,10 +144,10 @@ LOCAL_SRC_FILES += \
     src/dbus/common/dbus_message_helper.cpp \
     src/dbus/common/dbus_message_helper_openthread.cpp \
     src/dbus/common/error.cpp \
-    src/dbus/common/error_helper.cpp \
     src/dbus/server/dbus_agent.cpp \
     src/dbus/server/dbus_object.cpp \
     src/dbus/server/dbus_thread_object.cpp \
+    src/dbus/server/error_helper.cpp \
     $(NULL)
 
 LOCAL_STATIC_LIBRARIES += \

--- a/src/dbus/client/Makefile.am
+++ b/src/dbus/client/Makefile.am
@@ -31,6 +31,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 noinst_LTLIBRARIES = libotbr-dbus-client.la
 
 libotbr_dbus_client_la_SOURCES = \
+    client_error.cpp             \
     thread_api_dbus.cpp          \
     $(NULL)
 
@@ -56,6 +57,7 @@ libotbr_dbus_client_la_CXXFLAGS = \
     $(NULL)
 
 noinst_HEADERS        = \
+    client_error.hpp    \
     thread_api_dbus.hpp \
     $(NULL)
 

--- a/src/dbus/client/client_error.cpp
+++ b/src/dbus/client/client_error.cpp
@@ -1,0 +1,109 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "client_error.hpp"
+
+#include "common/code_utils.hpp"
+#include "dbus/common/dbus_message_helper.hpp"
+
+#define OTBR_OPENTHREAD_ERROR_PREFIX "io.openthread.Error"
+
+namespace otbr {
+namespace DBus {
+
+static const std::pair<ClientError, const char *> sErrorNames[] = {
+    {ClientError::ERROR_NONE, OTBR_OPENTHREAD_ERROR_PREFIX ".OK"},
+    {ClientError::OT_ERROR_GENERIC, OTBR_OPENTHREAD_ERROR_PREFIX ".Generic"},
+    {ClientError::OT_ERROR_FAILED, OTBR_OPENTHREAD_ERROR_PREFIX ".Failed"},
+    {ClientError::OT_ERROR_DROP, OTBR_OPENTHREAD_ERROR_PREFIX ".Drop"},
+    {ClientError::OT_ERROR_NO_BUFS, OTBR_OPENTHREAD_ERROR_PREFIX ".NoBufs"},
+    {ClientError::OT_ERROR_NO_ROUTE, OTBR_OPENTHREAD_ERROR_PREFIX ".NoRoute"},
+    {ClientError::OT_ERROR_BUSY, OTBR_OPENTHREAD_ERROR_PREFIX ".Busy"},
+    {ClientError::OT_ERROR_PARSE, OTBR_OPENTHREAD_ERROR_PREFIX ".Parse"},
+    {ClientError::OT_ERROR_INVALID_ARGS, OTBR_OPENTHREAD_ERROR_PREFIX ".InvalidArgs"},
+    {ClientError::OT_ERROR_SECURITY, OTBR_OPENTHREAD_ERROR_PREFIX ".Security"},
+    {ClientError::OT_ERROR_ADDRESS_QUERY, OTBR_OPENTHREAD_ERROR_PREFIX ".AddressQuery"},
+    {ClientError::OT_ERROR_NO_ADDRESS, OTBR_OPENTHREAD_ERROR_PREFIX ".NoAddress"},
+    {ClientError::OT_ERROR_ABORT, OTBR_OPENTHREAD_ERROR_PREFIX ".Abort"},
+    {ClientError::OT_ERROR_NOT_IMPLEMENTED, OTBR_OPENTHREAD_ERROR_PREFIX ".NotImplemented"},
+    {ClientError::OT_ERROR_INVALID_STATE, OTBR_OPENTHREAD_ERROR_PREFIX ".InvalidState"},
+    {ClientError::OT_ERROR_NO_ACK, OTBR_OPENTHREAD_ERROR_PREFIX ".NoAck"},
+    {ClientError::OT_ERROR_CHANNEL_ACCESS_FAILURE, OTBR_OPENTHREAD_ERROR_PREFIX ".ChannelAccessFailure"},
+    {ClientError::OT_ERROR_DETACHED, OTBR_OPENTHREAD_ERROR_PREFIX ".Detached"},
+    {ClientError::OT_ERROR_FCS, OTBR_OPENTHREAD_ERROR_PREFIX ".FcsErr"},
+    {ClientError::OT_ERROR_NO_FRAME_RECEIVED, OTBR_OPENTHREAD_ERROR_PREFIX ".NoFrameReceived"},
+    {ClientError::OT_ERROR_UNKNOWN_NEIGHBOR, OTBR_OPENTHREAD_ERROR_PREFIX ".UnknownNeighbor"},
+    {ClientError::OT_ERROR_INVALID_SOURCE_ADDRESS, OTBR_OPENTHREAD_ERROR_PREFIX ".InvalidSourceAddress"},
+    {ClientError::OT_ERROR_ADDRESS_FILTERED, OTBR_OPENTHREAD_ERROR_PREFIX ".AddressFiltered"},
+    {ClientError::OT_ERROR_DESTINATION_ADDRESS_FILTERED, OTBR_OPENTHREAD_ERROR_PREFIX ".DestinationAddressFiltered"},
+    {ClientError::OT_ERROR_NOT_FOUND, OTBR_OPENTHREAD_ERROR_PREFIX ".NotFound"},
+    {ClientError::OT_ERROR_ALREADY, OTBR_OPENTHREAD_ERROR_PREFIX ".Already"},
+    {ClientError::OT_ERROR_IP6_ADDRESS_CREATION_FAILURE, OTBR_OPENTHREAD_ERROR_PREFIX ".Ipv6AddressCreationFailure"},
+    {ClientError::OT_ERROR_NOT_CAPABLE, OTBR_OPENTHREAD_ERROR_PREFIX ".NotCapable"},
+    {ClientError::OT_ERROR_RESPONSE_TIMEOUT, OTBR_OPENTHREAD_ERROR_PREFIX ".ResponseTimeout"},
+    {ClientError::OT_ERROR_DUPLICATED, OTBR_OPENTHREAD_ERROR_PREFIX ".Duplicated"},
+    {ClientError::OT_ERROR_REASSEMBLY_TIMEOUT, OTBR_OPENTHREAD_ERROR_PREFIX ".ReassemblyTimeout"},
+    {ClientError::OT_ERROR_NOT_TMF, OTBR_OPENTHREAD_ERROR_PREFIX ".NotTmf"},
+    {ClientError::OT_ERROR_NOT_LOWPAN_DATA_FRAME, OTBR_OPENTHREAD_ERROR_PREFIX ".NonLowpanDatatFrame"},
+    {ClientError::OT_ERROR_LINK_MARGIN_LOW, OTBR_OPENTHREAD_ERROR_PREFIX ".LinkMarginLow"},
+};
+
+ClientError ConvertFromDBusErrorName(const std::string &aErrorName)
+{
+    ClientError error = ClientError::ERROR_NONE;
+
+    for (const auto &p : sErrorNames)
+    {
+        if (p.second == aErrorName)
+        {
+            error = static_cast<ClientError>(p.first);
+            break;
+        }
+    }
+    return error;
+}
+
+ClientError CheckErrorMessage(DBusMessage *aMessage)
+{
+    ClientError error = ClientError::ERROR_NONE;
+
+    if (dbus_message_get_type(aMessage) == DBUS_MESSAGE_TYPE_ERROR)
+    {
+        std::string errorMsg;
+        auto        args = std::tie(errorMsg);
+
+        VerifyOrExit(DBusMessageToTuple(*aMessage, args) == OTBR_ERROR_NONE, error = ClientError::ERROR_DBUS);
+        error = ConvertFromDBusErrorName(errorMsg);
+    }
+
+exit:
+    return error;
+}
+
+} // namespace DBus
+} // namespace otbr

--- a/src/dbus/client/client_error.hpp
+++ b/src/dbus/client/client_error.hpp
@@ -26,28 +26,17 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OTBR_DBUS_COMMON_ERROR_HELPER_HPP_
-#define OTBR_DBUS_COMMON_ERROR_HELPER_HPP_
+#ifndef OTBR_DBUS_CLIENT_CLIENT_ERROR_HPP_
+#define OTBR_DBUS_CLIENT_CLIENT_ERROR_HPP_
 
 #include <string>
 
 #include <dbus/dbus.h>
-#include <openthread/error.h>
 
 #include "dbus/common/error.hpp"
 
 namespace otbr {
 namespace DBus {
-
-/**
- * This function returns the string representation of an otError.
- *
- * @param[in] aError  The otError value.
- *
- * @returns The string representation of an otError.
- *
- */
-const char *ConvertToDBusErrorName(otError aError);
 
 /**
  * This function converts an error string to client error.
@@ -73,4 +62,4 @@ ClientError CheckErrorMessage(DBusMessage *aMessage);
 } // namespace DBus
 } // namespace otbr
 
-#endif // OTBR_DBUS_COMMON_ERROR_HELPER_HPP_
+#endif // OTBR_DBUS_CLIENT_CLIENT_ERROR_HPP_

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -30,11 +30,11 @@
 #include <string.h>
 
 #include "common/code_utils.hpp"
+#include "dbus/client/client_error.hpp"
 #include "dbus/client/thread_api_dbus.hpp"
 #include "dbus/common/constants.hpp"
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
-#include "dbus/common/error_helper.hpp"
 
 namespace otbr {
 namespace DBus {

--- a/src/dbus/common/Makefile.am
+++ b/src/dbus/common/Makefile.am
@@ -34,7 +34,6 @@ noinst_LTLIBRARIES = libotbr-dbus-common.la
 libotbr_dbus_common_la_SOURCES       = \
     dbus_message_helper.cpp            \
     error.cpp                          \
-    error_helper.cpp                   \
     dbus_message_helper_openthread.cpp \
     $(NULL)
 
@@ -65,7 +64,6 @@ noinst_HEADERS            = \
     dbus_message_helper.hpp \
     dbus_resources.hpp      \
     error.hpp               \
-    error_helper.hpp        \
     types.hpp               \
     $(NULL)
 

--- a/src/dbus/server/Makefile.am
+++ b/src/dbus/server/Makefile.am
@@ -39,6 +39,7 @@ libotbr_dbus_server_la_CXXFLAGS   = \
 
 libotbr_dbus_server_la_SOURCES       = \
     dbus_object.cpp                    \
+    error_helper.cpp                   \
     $(NULL)
 
 if OTBR_ENABLE_NCP_OPENTHREAD
@@ -73,6 +74,7 @@ noinst_HEADERS            = \
     dbus_object.hpp         \
     dbus_request.hpp        \
     dbus_thread_object.hpp  \
+    error_helper.hpp        \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/dbus/server/dbus_request.hpp
+++ b/src/dbus/server/dbus_request.hpp
@@ -30,7 +30,7 @@
 
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
-#include "dbus/common/error_helper.hpp"
+#include "dbus/server/error_helper.hpp"
 
 namespace otbr {
 namespace DBus {

--- a/src/dbus/server/error_helper.cpp
+++ b/src/dbus/server/error_helper.cpp
@@ -26,7 +26,7 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "dbus/common/error_helper.hpp"
+#include "dbus/server/error_helper.hpp"
 #include "common/code_utils.hpp"
 #include "dbus/common/dbus_message_helper.hpp"
 
@@ -85,38 +85,6 @@ const char *ConvertToDBusErrorName(otError aError)
         }
     }
     return name;
-}
-
-ClientError ConvertFromDBusErrorName(const std::string &aErrorName)
-{
-    ClientError err = ClientError::ERROR_NONE;
-
-    for (const auto &p : sErrorNames)
-    {
-        if (p.second == aErrorName)
-        {
-            err = static_cast<ClientError>(p.first);
-            break;
-        }
-    }
-    return err;
-}
-
-ClientError CheckErrorMessage(DBusMessage *aMessage)
-{
-    ClientError err = ClientError::ERROR_NONE;
-
-    if (dbus_message_get_type(aMessage) == DBUS_MESSAGE_TYPE_ERROR)
-    {
-        std::string errMsg;
-        auto        args = std::tie(errMsg);
-
-        VerifyOrExit(DBusMessageToTuple(*aMessage, args) == OTBR_ERROR_NONE, err = ClientError::ERROR_DBUS);
-        err = ConvertFromDBusErrorName(errMsg);
-    }
-
-exit:
-    return err;
 }
 
 } // namespace DBus

--- a/src/dbus/server/error_helper.hpp
+++ b/src/dbus/server/error_helper.hpp
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_DBUS_SERVER_ERROR_HELPER_HPP_
+#define OTBR_DBUS_SERVER_ERROR_HELPER_HPP_
+
+#include <string>
+
+#include <dbus/dbus.h>
+#include <openthread/error.h>
+
+#include "dbus/common/error.hpp"
+
+namespace otbr {
+namespace DBus {
+
+/**
+ * This function returns the string representation of an otError.
+ *
+ * @param[in] aError  The otError value.
+ *
+ * @returns The string representation of an otError.
+ *
+ */
+const char *ConvertToDBusErrorName(otError aError);
+
+} // namespace DBus
+} // namespace otbr
+
+#endif // OTBR_DBUS_SERVER_ERROR_HELPER_HPP_


### PR DESCRIPTION
This removes users' dependency on OpenThread headers when compiling the
otbr-dbus-client library.