### PR TITLE
[test] fix dbus client checks

### DIFF
--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -120,8 +120,8 @@ int main()
             if (aError == OTBR_ERROR_NONE)
             {
                 std::string                           name;
-                uint64_t                              extAddress;
-                uint16_t                              rloc16;
+                uint64_t                              extAddress = 0;
+                uint16_t                              rloc16     = 0xffff;
                 uint8_t                               routerId;
                 std::vector<uint8_t>                  networkData;
                 std::vector<uint8_t>                  stableNetworkData;
@@ -161,9 +161,8 @@ int main()
                 assert(api->RemoveOnMeshPrefix(onMeshPrefix.mPrefix) == OTBR_ERROR_NONE);
                 api->FactoryReset(nullptr);
                 assert(api->GetNetworkName(name) == OTBR_ERROR_NONE);
-                assert(rloc16 != 0);
+                assert(rloc16 != 0xffff);
                 assert(extAddress != 0);
-                assert(partitionId != 0);
                 assert(routerId == leaderData.mLeaderRouterId);
                 assert(!networkData.empty());
                 assert(childTable.empty());


### PR DESCRIPTION
The rloc16 value can be zero, use 0xffff for an invalid value instead.