### PR TITLE
[web] fix option require error in otbr-web

### DIFF
--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     int         opt;
     uint16_t    port = OT_HTTP_PORT;
 
-    while ((opt = getopt(argc, argv, "d:I:p:v:a:")) != -1)
+    while ((opt = getopt(argc, argv, "d:I:p:va:")) != -1)
     {
         switch (opt)
         {


### PR DESCRIPTION
As explained in #450, an option require error appears when we check version number of otbr-web.

The typo is fixed and now `-v` option could correctly print version information.

