### PR TITLE
[tests] fix compiler warning on template specialization

### DIFF
--- a/tests/unit/test_dbus_message.cpp
+++ b/tests/unit/test_dbus_message.cpp
@@ -49,12 +49,18 @@ struct TestStruct
     std::string name;
 };
 
-template <> struct otbr::DBus::DBusTypeTrait<TestStruct>
+namespace otbr {
+namespace DBus {
+
+template <> struct DBusTypeTrait<TestStruct>
 {
     static constexpr const char *TYPE_AS_STRING =
         //{uint8, uint32, string}
         "(yus)";
 };
+
+} // namespace DBus
+} // namespace otbr
 
 bool operator==(const TestStruct &aLhs, const TestStruct &aRhs)
 {


### PR DESCRIPTION
Some compliers complain:
```
[2/7] Building CXX object tests/unit/CMakeFiles/otbr-test-unit.dir/test_dbus_message.cpp.o
FAILED: tests/unit/CMakeFiles/otbr-test-unit.dir/test_dbus_message.cpp.o 
/usr/bin/c++  -DMBEDTLS_CONFIG_FILE=\"/home/pi/ot-br-posix/third_party/openthread/mbedtls-config.h\" -DOTBR_ENABLE_DBUS_SERVER=1 -DPACKAGE_NAME=\"OPENTHREAD_BR\" -DPACKAGE_VERSION=\"0.2.0-c14ef63\" -I/usr/include/dbus-1.0 -I/usr/lib/arm-linux-gnueabihf/dbus-1.0/include -I../../include -I../../src -Ithird_party/openthread/repo/etc/cmake -I../../third_party/openthread/repo/etc/cmake -I../../third_party/openthread/repo/include -I../../third_party/openthread/repo/src/posix/platform/include -I../../third_party/openthread/repo/src -I../../third_party/openthread/repo/third_party/mbedtls/repo/include -Wall -Wextra -Werror -Wfatal-errors -Wno-missing-braces -std=c++11 -MD -MT tests/unit/CMakeFiles/otbr-test-unit.dir/test_dbus_message.cpp.o -MF tests/unit/CMakeFiles/otbr-test-unit.dir/test_dbus_message.cpp.o.d -o tests/unit/CMakeFiles/otbr-test-unit.dir/test_dbus_message.cpp.o -c ../../tests/unit/test_dbus_message.cpp
../../tests/unit/test_dbus_message.cpp:52:32: error: specialization of ‘template<class T> struct otbr::DBus::DBusTypeTrait’ in different namespace [-fpermissive]
 template <> struct otbr::DBus::DBusTypeTrait<TestStruct>
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.

```