### PR TITLE
[setup] allow specify cmake options via OS env

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -53,10 +53,7 @@ otbr_install()
     local otbr_options=()
 
     if [[ ${OTBR_OPTIONS} ]]; then
-        oIFS=$IFS
-        IFS=" "
         read -r -a otbr_options <<< "${OTBR_OPTIONS}"
-        IFS=$oIFS
     fi
 
     otbr_options=(

--- a/script/_otbr
+++ b/script/_otbr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -29,6 +29,7 @@
 
 readonly OTBR_TOP_BUILDDIR="${BUILD_DIR}/otbr"
 readonly OTBR_TOP_SRCDIR="$PWD"
+readonly OTBR_OPTIONS="${OTBR_OPTIONS:-}"
 
 otbr_uninstall()
 {
@@ -49,11 +50,21 @@ otbr_uninstall()
 
 otbr_install()
 {
-    local otbr_options=(
+    local otbr_options=()
+
+    if [[ ${OTBR_OPTIONS} ]]; then
+        oIFS=$IFS
+        IFS=" "
+        read -r -a otbr_options <<< "${OTBR_OPTIONS}"
+        IFS=$oIFS
+    fi
+
+    otbr_options=(
         "-DBUILD_TESTING=OFF"
         "-DCMAKE_INSTALL_PREFIX=/usr"
         "-DOTBR_DBUS=ON"
         "-DOTBR_WEB=ON"
+        "${otbr_options[@]}"
     )
 
     (mkdir -p "${OTBR_TOP_BUILDDIR}" \


### PR DESCRIPTION
This PR allows developers to specify extra cmake options for `script/setup` using env `OTBR_OPTIONS`.