### PR TITLE
network-manager depends on dnsmasq

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -68,7 +68,7 @@ install_packages_apt()
     }
 
     # network-manager
-    without NETWORK_MANAGER || sudo apt-get install --no-install-recommends -y network-manager
+    without NETWORK_MANAGER || sudo apt-get install --no-install-recommends -y dnsmasq network-manager
 
     # dhcpcd5
     without DHCPV6_PD || {


### PR DESCRIPTION
network-manager depends on dnsmasq to setup BorderRouter-AP for Raspi 3B

before, ./script/setup fails with following in /var/log/syslog:
Jun 16 01:47:51 raspberrypi NetworkManager[390]: <error> [1592268471.6993] device (wlan0): share: (wlan0) failed to start dnsmasq: Could not find "dnsmasq" binary

after: 
Jun 16 05:05:27 raspberrypi NetworkManager[390]: <info>  [1592280327.7592] dnsmasq-manager: starting dnsmasq...