### PR TITLE
[scripts] fix ninja build log permissions

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -59,6 +59,7 @@ otbr_install()
     (mkdir -p "${OTBR_TOP_BUILDDIR}" \
         && cd "${OTBR_TOP_BUILDDIR}" \
         && cmake -GNinja "${OTBR_TOP_SRCDIR}" "${otbr_options[@]}" \
+        && (sudo chown $USER:$USER .ninja_* || true) \
         && ninja \
         && sudo ninja install)
 


### PR DESCRIPTION
Sometimes OTBR failed to build with ninja:
```
-- Build files have been written to: /home/pi/ot-br-posix/build/otbr
+ ninja
ninja: error: opening build log: Permission denied
```

This PR makes sure ninja has permission to access the log files (i.e. .ninja_log and .ninja_deps)