### PR TITLE
[setup] fix network manager and DNS setup

### DIFF
--- a/script/_dns64
+++ b/script/_dns64
@@ -85,6 +85,8 @@ dns64_install()
     [ -f /.dockerenv ] || sudo sh -c "echo \"nameserver $DNS64_NAMESERVER_ADDR\" >> $RESOLV_CONF_HEAD"
 
     if have systemctl; then
+        sudo systemctl stop dnsmasq || true
+        sudo systemctl disable dnsmasq || true
         sudo systemctl enable "${service_name}" || true
         sudo systemctl is-enabled "${service_name}" || die 'Failed to enable bind9!'
         sudo systemctl start "${service_name}" || die 'Failed to start bind9!'

--- a/script/_network_manager
+++ b/script/_network_manager
@@ -38,7 +38,7 @@ create_ap_connection()
     IFNAME=$(nmcli d | grep wifi | cut -d" " -f1)
 
     sudo nmcli c add type wifi ifname $IFNAME con-name ${AP_CONN} ssid ${AP_CONN}
-    sudo nmcli c modify ${AP_CONN} 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared ipv6.method ignore
+    sudo nmcli c modify ${AP_CONN} 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared ipv6.method auto
     sudo nmcli c modify ${AP_CONN} wifi-sec.key-mgmt wpa-psk
     sudo nmcli c modify ${AP_CONN} wifi-sec.proto rsn
     sudo nmcli c modify ${AP_CONN} wifi-sec.psk "12345678"


### PR DESCRIPTION
This fixes setup script by 2 modifications:
- Changes network manager `ipv6.method` to `auto` to make WiFi AP work.
- Stops and disables `dnsmasq` before starting `bind9` to fix the "port 53 in use" issue.