### PR TITLE
[dbus] fix handler registration under external reset

### DIFF
--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -213,6 +213,10 @@ void ControllerOpenThread::Reset(void)
     otInstanceFinalize(mInstance);
     otSysDeinit();
     Init();
+    for (auto &handler : mResetHandlers)
+    {
+        handler();
+    }
     sReset = false;
 }
 
@@ -277,6 +281,11 @@ void ControllerOpenThread::PostTimerTask(std::chrono::steady_clock::time_point a
                                          const std::function<void(void)> &     aTask)
 {
     mTimers.insert({aTimePoint, aTask});
+}
+
+void ControllerOpenThread::RegisterResetHandler(std::function<void(void)> aHandler)
+{
+    mResetHandlers.emplace_back(std::move(aHandler));
 }
 
 Controller *Controller::Create(const char *aInterfaceName, const char *aRadioUrl)

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -128,7 +128,22 @@ public:
      */
     otbrError RequestEvent(int aEvent) override;
 
+    /**
+     * This method posts a task to the timer
+     *
+     * @param[in]   aTimePoint  The timepoint to trigger the task.
+     * @param[in]   aTask       The task function.
+     *
+     */
     void PostTimerTask(std::chrono::steady_clock::time_point aTimePoint, const std::function<void(void)> &aTask);
+
+    /**
+     * This method registers a reset handler.
+     *
+     * @param[in]   aHandler  The handler function.
+     *
+     */
+    void RegisterResetHandler(std::function<void(void)> aHandler);
 
     ~ControllerOpenThread(void) override;
 
@@ -145,6 +160,7 @@ private:
     std::unique_ptr<otbr::agent::ThreadHelper>                                      mThreadHelper;
     std::multimap<std::chrono::steady_clock::time_point, std::function<void(void)>> mTimers;
     bool                                                                            mTriedAttach;
+    std::vector<std::function<void(void)>>                                          mResetHandlers;
 };
 
 } // namespace Ncp

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -101,6 +101,7 @@ otbrError DBusThreadObject::Init(void)
     auto      threadHelper = mNcp->GetThreadHelper();
 
     threadHelper->AddDeviceRoleHandler(std::bind(&DBusThreadObject::DeviceRoleHandler, this, _1));
+    mNcp->RegisterResetHandler(std::bind(&DBusThreadObject::NcpResetHandler, this));
 
     RegisterMethod(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_SCAN_METHOD,
                    std::bind(&DBusThreadObject::ScanHandler, this, _1));
@@ -196,6 +197,13 @@ void DBusThreadObject::DeviceRoleHandler(otDeviceRole aDeviceRole)
     SignalPropertyChanged(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE, GetDeviceRoleName(aDeviceRole));
 }
 
+void DBusThreadObject::NcpResetHandler(void)
+{
+    mNcp->GetThreadHelper()->AddDeviceRoleHandler(std::bind(&DBusThreadObject::DeviceRoleHandler, this, _1));
+    SignalPropertyChanged(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
+                          GetDeviceRoleName(OT_DEVICE_ROLE_DISABLED));
+}
+
 void DBusThreadObject::ScanHandler(DBusRequest &aRequest)
 {
     auto threadHelper = mNcp->GetThreadHelper();
@@ -267,18 +275,11 @@ void DBusThreadObject::FactoryResetHandler(DBusRequest &aRequest)
     aRequest.ReplyOtResult(OT_ERROR_NONE);
     otInstanceFactoryReset(mNcp->GetThreadHelper()->GetInstance());
     mNcp->Reset();
-    mNcp->GetThreadHelper()->AddDeviceRoleHandler(std::bind(&DBusThreadObject::DeviceRoleHandler, this, _1));
-    SignalPropertyChanged(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
-                          GetDeviceRoleName(OT_DEVICE_ROLE_DISABLED));
 }
 
 void DBusThreadObject::ResetHandler(DBusRequest &aRequest)
 {
     mNcp->Reset();
-    mNcp->GetThreadHelper()->AddDeviceRoleHandler(std::bind(&DBusThreadObject::DeviceRoleHandler, this, _1));
-    SignalPropertyChanged(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
-                          GetDeviceRoleName(OT_DEVICE_ROLE_DISABLED));
-
     aRequest.ReplyOtResult(OT_ERROR_NONE);
 }
 

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -66,6 +66,7 @@ public:
 
 private:
     void DeviceRoleHandler(otDeviceRole aDeviceRole);
+    void NcpResetHandler(void);
 
     void ScanHandler(DBusRequest &aRequest);
     void AttachHandler(DBusRequest &aRequest);


### PR DESCRIPTION
This change allows the dbus agent to send device role changed signals under unexpected external resets. (e.g. ot-ctl factoryreset and internal OpenThread resets)