### PR TITLE
[web] fix reflected XSS

### DIFF
--- a/src/web/web-service/web_server.cpp
+++ b/src/web/web-service/web_server.cpp
@@ -59,8 +59,8 @@
 
 namespace otbr {
 namespace Web {
-namespace {
-void EscapeHtml(std::string &content)
+
+static void EscapeHtml(std::string &content)
 {
     std::string output;
 
@@ -92,7 +92,6 @@ void EscapeHtml(std::string &content)
 
     output.swap(content);
 }
-} // namespace
 
 WebServer::WebServer(void)
     : mServer(new HttpServer())

--- a/src/web/web-service/web_server.cpp
+++ b/src/web/web-service/web_server.cpp
@@ -59,6 +59,40 @@
 
 namespace otbr {
 namespace Web {
+namespace {
+void EscapeHtml(std::string &content)
+{
+    std::string output;
+
+    output.reserve(content.size());
+    for (char c : content)
+    {
+        switch (c)
+        {
+        case '&':
+            output.append("&amp;");
+            break;
+        case '<':
+            output.append("&lt;");
+            break;
+        case '>':
+            output.append("&gt;");
+            break;
+        case '"':
+            output.append("&quot;");
+            break;
+        case '\'':
+            output.append("&apos;");
+            break;
+        default:
+            output.push_back(c);
+            break;
+        }
+    }
+
+    output.swap(content);
+}
+} // namespace
 
 WebServer::WebServer(void)
     : mServer(new HttpServer())
@@ -121,8 +155,10 @@ void WebServer::HandleHttpRequest(const char *aUrl, const char *aMethod, HttpReq
                       << OT_RESPONSE_PLACEHOLD << httpResponse;
         } catch (std::exception &e)
         {
+            std::string content = e.what();
+            EscapeHtml(content);
             *response << OT_RESPONSE_FAILURE_STATUS << OT_RESPONSE_HEADER_LENGTH << strlen(e.what())
-                      << OT_RESPONSE_PLACEHOLD << e.what();
+                      << OT_RESPONSE_PLACEHOLD << content;
         }
     };
 }
@@ -206,6 +242,7 @@ void WebServer::DefaultHttpResponse(void)
         } catch (const std::exception &e)
         {
             std::string content = "Could not open path `" + request->path + "`: " + e.what();
+            EscapeHtml(content);
             *response << OT_RESPONSE_FAILURE_STATUS << OT_RESPONSE_HEADER_LENGTH << content.length()
                       << OT_RESPONSE_PLACEHOLD << content;
         }


### PR DESCRIPTION
This PR fixes a reflected XSS vulnerability of `otbr-web`. The exception message may contain user inputs so needs to escape sensitive characters.

Reproducing:
1.  Start `otbr-web` service on `localhost`.
1.  Run:
    ```bash
    curl 'localhost/no_such_file.pl?"><script>alert(111);</script>'
    ```
    Then the response will contain executable scripts.