### PR TITLE
[cmake] move minimum version to 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 3.11.4)
+cmake_minimum_required(VERSION 3.10.2)
 project(openthread-br VERSION 0.2.0)
 
 

--- a/src/dbus/common/CMakeLists.txt
+++ b/src/dbus/common/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(otbr-dbus-common PUBLIC
     otbr-common
     openthread-ftd
     openthread-posix
-    ${DBUS_LINK_LIBRARIES}
+    $<$<BOOL:${DBUS_LIBRARY_DIRS}>:-L$<JOIN:${DBUS_LIBRARY_DIRS}," -L">>
+    ${DBUS_LIBRARIES}
 )
 

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -46,7 +46,8 @@ target_include_directories(otbr-web PRIVATE
     ${PROJECT_SOURCE_DIR}/third_party/Simple-web-server/repo
 )
 target_link_libraries(otbr-web PRIVATE
-    ${JSONCPP_LINK_LIBRARIES}
+    $<$<BOOL:${JSONCPP_LIBRARY_DIRS}>:-L$<JOIN:${JSONCPP_LIBRARY_DIRS}," -L">>
+    ${JSONCPP_LIBRARIES}
     otbr-common
     otbr-utils
     openthread-ftd

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -40,7 +40,8 @@ target_include_directories(otbr-test-unit PRIVATE
 target_link_libraries(otbr-test-unit
     $<$<BOOL:${OTBR_DBUS}>:otbr-dbus-common>
     $<$<STREQUAL:${OTBR_MDNS},"mDNSResponder">:otbr-mdns>
-    ${CPPUTEST_LINK_LIBRARIES}
+    $<$<BOOL:${CPPUTEST_LIBRARY_DIRS}>:-L$<JOIN:${CPPUTEST_LIBRARY_DIRS}," -L">>
+    ${CPPUTEST_LIBRARIES}
     mbedtls
     otbr-common
     otbr-utils


### PR DESCRIPTION
To support automated armv7 docker builds.