### PR TITLE
[travis-ci] fix install python

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -56,6 +56,7 @@ case $BUILD_TARGET in
 
     macOS)
         # On Travis, brew install fails when a package is already installed, so use reinstall here instead of ./script/bootstrap
+        brew unlink python@2 || true
         brew reinstall boost cmake cpputest dbus jsoncpp ninja
         OTBR_OPTIONS='-DOTBR_MDNS=OFF' ./script/test build
         ;;


### PR DESCRIPTION
unlink python2 before brew install, which fails for unable to link python as python3.