### PR TITLE
[mdns] add joiner advertisement support

### DIFF
--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -34,7 +34,11 @@
 #ifndef OTBR_AGENT_BORDER_AGENT_HPP_
 #define OTBR_AGENT_BORDER_AGENT_HPP_
 
+#include <list>
+
 #include <stdint.h>
+
+#include <openthread/thread.h>
 
 #include "agent/ncp.hpp"
 #include "mdns/mdns.hpp"
@@ -124,13 +128,17 @@ private:
     void SetExtPanId(const uint8_t *aExtPanId);
     void SetThreadVersion(uint16_t aThreadVersion);
     void HandleThreadState(bool aStarted);
+    void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo);
     void HandlePSKc(const uint8_t *aPSKc);
 
     static void HandlePSKc(void *aContext, int aEvent, va_list aArguments);
     static void HandleThreadState(void *aContext, int aEvent, va_list aArguments);
+    static void HandleDiscoveryRequest(void *aContext, int aEvent, va_list aArguments);
     static void HandleNetworkName(void *aContext, int aEvent, va_list aArguments);
     static void HandleExtPanId(void *aContext, int aEvent, va_list aArguments);
     static void HandleThreadVersion(void *aContext, int aEvent, va_list aArguments);
+
+    static std::vector<uint8_t> SerializeDiscoveryInfo(const otThreadDiscoveryRequestInfo &aInfo);
 
     Mdns::Publisher *mPublisher;
     Ncp::Controller *mNcp;
@@ -141,6 +149,8 @@ private:
     char     mNetworkName[kSizeNetworkName + 1];
     bool     mThreadStarted;
     bool     mPSKcInitialized;
+
+    std::list<otThreadDiscoveryRequestInfo> mDiscoveryInfos;
 };
 
 /**

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -68,6 +68,7 @@ enum
     kEventThreadState,      ///< Thread State.
     kEventThreadVersion,    ///< Thread Version.
     kEventUdpForwardStream, ///< UDP forward stream arrived.
+    kEventDiscoveryRequest, ///< Joiner discovery request arrived.
 };
 
 /**

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -108,6 +108,10 @@ otbrError ControllerOpenThread::Init(void)
 
     mInstance = otSysInit(&mConfig);
     otCliUartInit(mInstance);
+
+    // Override the Discovery Request handler in CLI.
+    otThreadSetDiscoveryRequestCallback(mInstance, HandleDiscoveryRequest, this);
+
 #if OTBR_ENABLE_LEGACY
     otLegacyInit();
 #endif
@@ -164,6 +168,18 @@ void ControllerOpenThread::HandleStateChanged(otChangedFlags aFlags)
     }
 
     mThreadHelper->StateChangedCallback(aFlags);
+}
+
+void ControllerOpenThread::HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo *aDiscoveryInfo)
+{
+    if (aDiscoveryInfo != NULL)
+    {
+        EventEmitter::Emit(kEventDiscoveryRequest, *aDiscoveryInfo);
+    }
+    else
+    {
+        otbrLog(OTBR_LOG_WARNING, "joiner discovery request is null");
+    }
 }
 
 static struct timeval ToTimeVal(const microseconds &aTime)

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -154,6 +154,12 @@ private:
     }
     void HandleStateChanged(otChangedFlags aFlags);
 
+    static void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo *aDiscoveryInfo, void *aContext)
+    {
+        static_cast<ControllerOpenThread *>(aContext)->HandleDiscoveryRequest(aDiscoveryInfo);
+    }
+    void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo *aDiscoveryInfo);
+
     otInstance *mInstance;
 
     otPlatformConfig                                                                mConfig;

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -34,6 +34,11 @@
 #ifndef OTBR_AGENT_MDNS_HPP_
 #define OTBR_AGENT_MDNS_HPP_
 
+#include <list>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <sys/select.h>
 
 #include "common/types.hpp"
@@ -77,6 +82,8 @@ typedef void (*StateHandler)(void *aContext, State aState);
 class Publisher
 {
 public:
+    using TxtRecordList = std::list<std::pair<std::string, std::vector<uint8_t>>>;
+
     /**
      * This method starts the MDNS service.
      *
@@ -104,17 +111,19 @@ public:
     /**
      * This method publishes or updates a service.
      *
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
-     * @param[in]   ...                 Pointers to null-terminated string of key and value for text record.
-     *                                  The last argument must be nullptr.
+     * @param[in]   aTxtRecords         The TXT key-value pair list.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    virtual otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) = 0;
+    virtual otbrError PublishService(uint16_t             aPort,
+                                     const char *         aName,
+                                     const char *         aType,
+                                     const TxtRecordList &aTxtRecords) = 0;
 
     /**
      * This method performs the MDNS processing.

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -497,7 +497,10 @@ void PublisherAvahi::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet
     mPoller.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
 }
 
-otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, const char *aType, ...)
+otbrError PublisherAvahi::PublishService(uint16_t             aPort,
+                                         const char *         aName,
+                                         const char *         aType,
+                                         const TxtRecordList &aTxtRecords)
 {
     otbrError ret   = OTBR_ERROR_ERRNO;
     int       error = 0;
@@ -508,16 +511,15 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
     va_list          args;
     size_t           used = 0;
 
-    va_start(args, aType);
-
     VerifyOrExit(mState == kStateReady, errno = EAGAIN);
     VerifyOrExit(mGroup != nullptr, ret = OTBR_ERROR_MDNS);
 
-    for (const char *name = va_arg(args, const char *); name; name = va_arg(args, const char *))
+    for (const auto record : aTxtRecords)
     {
-        int         rval;
-        const char *value       = va_arg(args, const char *);
-        size_t      valueLength = va_arg(args, size_t);
+        int            rval;
+        const char *   name        = record.first.c_str();
+        const uint8_t *value       = record.second.data();
+        size_t         valueLength = record.second.size();
         // +1 for the size of "=", avahi doesn't need '\0' at the end of the entry
         size_t needed = sizeof(AvahiStringList) - sizeof(AvahiStringList::text) + strlen(name) + valueLength + 1;
 

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -203,24 +203,24 @@ public:
      */
     PublisherAvahi(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext);
 
-    ~PublisherAvahi(void);
+    ~PublisherAvahi(void) override;
 
     /**
      * This method publishes or updates a service.
      *
-     * @note only text record can be updated.
-     *
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
-     * @param[in]   ...                 Pointers to null-terminated string of key and value for text record.
-     *                                  The last argument must be nullptr.
+     * @param[in]   aTxtRecords         The TXT key-value pair list.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...);
+    otbrError PublishService(uint16_t             aPort,
+                             const char *         aName,
+                             const char *         aType,
+                             const TxtRecordList &aTxtRecords) override;
 
     /**
      * This method starts the MDNS service.
@@ -229,7 +229,7 @@ public:
      * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
      *
      */
-    otbrError Start(void);
+    otbrError Start(void) override;
 
     /**
      * This method checks if publisher has been started.
@@ -238,13 +238,13 @@ public:
      * @retval false    Not started.
      *
      */
-    bool IsStarted(void) const;
+    bool IsStarted(void) const override;
 
     /**
      * This method stops the MDNS service.
      *
      */
-    void Stop(void);
+    void Stop(void) override;
 
     /**
      * This method performs avahi poll processing.
@@ -254,7 +254,7 @@ public:
      * @param[in]   aErrorFdSet         A reference to error file descriptors.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) override;
 
     /**
      * This method updates the fd_set and timeout for mainloop.
@@ -266,7 +266,11 @@ public:
      * @param[inout]    aTimeout        A reference to the timeout.
      *
      */
-    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout);
+    void UpdateFdSet(fd_set & aReadFdSet,
+                     fd_set & aWriteFdSet,
+                     fd_set & aErrorFdSet,
+                     int &    aMaxFd,
+                     timeval &aTimeout) override;
 
 private:
     enum

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -344,23 +344,24 @@ exit:
     return;
 }
 
-otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, const char *aType, ...)
+otbrError PublisherMDnsSd::PublishService(uint16_t             aPort,
+                                          const char *         aName,
+                                          const char *         aType,
+                                          const TxtRecordList &aTxtRecords)
 {
     otbrError     ret   = OTBR_ERROR_NONE;
     int           error = 0;
-    va_list       args;
     uint8_t       txt[kMaxSizeOfTxtRecord];
     uint8_t *     cur        = txt;
     DNSServiceRef serviceRef = nullptr;
 
-    va_start(args, aType);
-
-    for (const char *name = va_arg(args, const char *); name; name = va_arg(args, const char *))
+    for (const auto &record : aTxtRecords)
     {
-        const char * value        = va_arg(args, const char *);
-        const size_t nameLength   = strlen(name);
-        const size_t valueLength  = va_arg(args, size_t);
-        size_t       recordLength = nameLength + 1 + valueLength;
+        const char *   name         = record.first.c_str();
+        const size_t   nameLength   = record.first.size();
+        const uint8_t *value        = record.second.data();
+        const size_t   valueLength  = record.second.size();
+        size_t         recordLength = nameLength + 1 + valueLength;
 
         assert(nameLength > 0 && valueLength > 0 && recordLength < kMaxTextRecordSize);
 
@@ -383,8 +384,6 @@ otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, con
         memcpy(cur, value, valueLength);
         cur += valueLength;
     }
-
-    va_end(args);
 
     for (Services::iterator it = mServices.begin(); it != mServices.end(); ++it)
     {

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -65,24 +65,24 @@ public:
      */
     PublisherMDnsSd(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext);
 
-    ~PublisherMDnsSd(void);
+    ~PublisherMDnsSd(void) override;
 
     /**
      * This method publishes or updates a service.
      *
-     * @note only text record can be updated.
-     *
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
-     * @param[in]   ...                 Pointers to null-terminated string of key and value for text record.
-     *                                  The last argument must be nullptr.
+     * @param[in]   aTxtRecords         The TXT key-value pair list.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...);
+    otbrError PublishService(uint16_t             aPort,
+                             const char *         aName,
+                             const char *         aType,
+                             const TxtRecordList &aTxtRecords) override;
 
     /**
      * This method starts the MDNS service.
@@ -91,7 +91,7 @@ public:
      * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
      *
      */
-    otbrError Start(void);
+    otbrError Start(void) override;
 
     /**
      * This method checks if publisher has been started.
@@ -100,13 +100,13 @@ public:
      * @retval false    Not started.
      *
      */
-    bool IsStarted(void) const;
+    bool IsStarted(void) const override;
 
     /**
      * This method stops the MDNS service.
      *
      */
-    void Stop(void);
+    void Stop(void) override;
 
     /**
      * This method performs avahi poll processing.
@@ -116,7 +116,7 @@ public:
      * @param[in]   aErrorFdSet         A reference to error file descriptors.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) override;
 
     /**
      * This method updates the fd_set and timeout for mainloop.
@@ -128,7 +128,11 @@ public:
      * @param[inout]    aTimeout        A reference to the timeout.
      *
      */
-    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout);
+    void UpdateFdSet(fd_set & aReadFdSet,
+                     fd_set & aWriteFdSet,
+                     fd_set & aErrorFdSet,
+                     int &    aMaxFd,
+                     timeval &aTimeout) override;
 
 private:
     void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef);

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -87,9 +87,12 @@ void PublishSingleService(void *aContext, Mdns::State aState)
     assert(aContext == &sContext);
     if (aState == Mdns::kStateReady)
     {
-        otbrError err = sContext.mPublisher->PublishService(12345, "SingleService", "_meshcop._udp.", "nn", "cool",
-                                                            sizeof("cool") - 1, "xp", reinterpret_cast<char *>(&xpanid),
-                                                            sizeof(xpanid), nullptr);
+        Mdns::Publisher::TxtRecordList txtRecords{
+            {"nn", std::vector<uint8_t>{'c', 'o', 'o', 'l'}},
+            {"xp", std::vector<uint8_t>{xpanid, xpanid + sizeof(xpanid)}},
+        };
+
+        otbrError err = sContext.mPublisher->PublishService(12345, "SingleService", "_meshcop._udp.", txtRecords);
 
         assert(err == OTBR_ERROR_NONE);
     }
@@ -102,14 +105,19 @@ void PublishMultipleServices(void *aContext, Mdns::State aState)
     assert(aContext == &sContext);
     if (aState == Mdns::kStateReady)
     {
-        otbrError err = sContext.mPublisher->PublishService(12345, "MultipleService1", "_meshcop._udp.", "nn", "cool1",
-                                                            sizeof("cool1") - 1, "xp",
-                                                            reinterpret_cast<char *>(&xpanid), sizeof(xpanid), nullptr);
+        Mdns::Publisher::TxtRecordList txtRecords{
+            {"nn", std::vector<uint8_t>{'c', 'o', 'o', 'l', '1'}},
+            {"xp", std::vector<uint8_t>{xpanid, xpanid + sizeof(xpanid)}},
+        };
 
+        otbrError err = sContext.mPublisher->PublishService(12345, "MultipleService1", "_meshcop._udp.", txtRecords);
         assert(err == OTBR_ERROR_NONE);
-        err = sContext.mPublisher->PublishService(12345, "MultipleService2", "_meshcop._udp.", "nn", "cool2",
-                                                  sizeof("cool1") - 1, "xp", reinterpret_cast<char *>(&xpanid),
-                                                  sizeof(xpanid), nullptr);
+
+        txtRecords = Mdns::Publisher::TxtRecordList{
+            {"nn", std::vector<uint8_t>{'c', 'o', 'o', 'l', '2'}},
+            {"xp", std::vector<uint8_t>{xpanid, xpanid + sizeof(xpanid)}},
+        };
+        err = sContext.mPublisher->PublishService(12345, "MultipleService2", "_meshcop._udp.", txtRecords);
         assert(err == OTBR_ERROR_NONE);
     }
 }
@@ -126,15 +134,19 @@ void PublishUpdateServices(void *aContext, Mdns::State aState)
 
         if (!sContext.mUpdate)
         {
-            err = sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.", "nn", "cool",
-                                                      sizeof("cool") - 1, "xp", reinterpret_cast<char *>(&xpanidOld),
-                                                      sizeof(xpanidOld), nullptr);
+            Mdns::Publisher::TxtRecordList txtRecords{
+                {"nn", std::vector<uint8_t>{'c', 'o', 'o', 'l'}},
+                {"xp", std::vector<uint8_t>{xpanidOld, xpanidOld + sizeof(xpanidOld)}},
+            };
+            err = sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.", txtRecords);
         }
         else
         {
-            err = sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.", "nn", "coolcool",
-                                                      sizeof("coolcool") - 1, "xp",
-                                                      reinterpret_cast<char *>(&xpanidNew), sizeof(xpanidNew), nullptr);
+            Mdns::Publisher::TxtRecordList txtRecords{
+                {"nn", std::vector<uint8_t>{'c', 'o', 'o', 'l', 'c', 'o', 'o', 'l'}},
+                {"xp", std::vector<uint8_t>{xpanidNew, xpanidNew + sizeof(xpanidNew)}},
+            };
+            err = sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.", txtRecords);
         }
         assert(err == OTBR_ERROR_NONE);
     }


### PR DESCRIPTION
This PR adds joiner advertisement info in mDNS response.

TODO
- [ ] remove joiner advertisement info after timeout. Depends on https://github.com/openthread/ot-br-posix/pull/543.
- [ ] reset `third_party/OpenThread` HEAD after merging https://github.com/openthread/openthread/pull/5381.