### PR TITLE
[web] unify MasterKey and NetworkKey

### DIFF
--- a/.travis/check-docker
+++ b/.travis/check-docker
@@ -85,7 +85,7 @@ main()
     local -r OT_NETWORK_NAME=OpenThreadDocker
 
     curl "${OTBR_WEB_URL}"/index.html | grep 'What is OpenThread'
-    curl --header "Content-Type: application/json" --request POST --data "{\"networkKey\":\"${OT_MASTER_KEY}\",\"prefix\":\"fd11:22::\",\"defaultRoute\":true,\"extPanId\":\"${OT_XPANID}\",\"panId\":\"${OT_PANID}\",\"passphrase\":\"${OT_AGENT_PASSPHRASE}\",\"channel\":${OT_CHANNEL},\"networkName\":\"${OT_NETWORK_NAME}\"}" "${OTBR_WEB_URL}"/form_network | grep "success"
+    curl --header "Content-Type: application/json" --request POST --data "{\"masterKey\":\"${OT_MASTER_KEY}\",\"prefix\":\"fd11:22::\",\"defaultRoute\":true,\"extPanId\":\"${OT_XPANID}\",\"panId\":\"${OT_PANID}\",\"passphrase\":\"${OT_AGENT_PASSPHRASE}\",\"channel\":${OT_CHANNEL},\"networkName\":\"${OT_NETWORK_NAME}\"}" "${OTBR_WEB_URL}"/form_network | grep "success"
 }
 
 main "$@"

--- a/src/web/web-service/frontend/index.html
+++ b/src/web/web-service/frontend/index.html
@@ -200,11 +200,11 @@
 
               <div layout="row">
                 <md-input-container flex="50">
-                  <label>Network Key</label>
-                  <input required minlength="32" maxlength="32" ng-pattern="/^[0-9a-fA-F]{32}$/" name="networkKey" ng-model="thread.networkKey">
-                  <div ng-messages="threadForm.networkKey.$error">
+                  <label>Master Key</label>
+                  <input required minlength="32" maxlength="32" ng-pattern="/^[0-9a-fA-F]{32}$/" name="masterKey" ng-model="thread.masterKey">
+                  <div ng-messages="threadForm.MasterKey.$error">
                     <div ng-message-exp="['required', 'minlength', 'maxlength', 'pattern']">
-                      Network Key must be 32 hexadecimal digits long.
+                      Master Key must be 32 hexadecimal digits long.
                     </div>
                   </div>
                 </md-input-container>
@@ -237,7 +237,7 @@
               </md-input-container>
               <div>
                 <md-button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" type="submit" ng-click="showConfirm($event, (threadForm.networkName.$valid && threadForm.extPanId.$valid &&
-                threadForm.panId.$valid && threadForm.passphrase.$valid && threadForm.networkKey.$valid &&
+                threadForm.panId.$valid && threadForm.passphrase.$valid && threadForm.masterKey.$valid &&
                 threadForm.channel.$valid && threadForm.prefix.$valid))">Form</md-button>
               </div>
             </form>

--- a/src/web/web-service/frontend/join.dialog.html
+++ b/src/web/web-service/frontend/join.dialog.html
@@ -11,11 +11,11 @@
         <h5>Are you sure you want to JOIN this Thread Network?</h5>
         <div layout="row">
           <md-input-container flex="80">
-            <label>Network Key</label>
-            <input required minlength="32" maxlength="32" ng-pattern="/^[0-9a-fA-F]{32}$/" name="networkKey" ng-model="thread.networkKey">
-            <div ng-messages="joinForm.networkKey.$error">
+            <label>Master Key</label>
+            <input required minlength="32" maxlength="32" ng-pattern="/^[0-9a-fA-F]{32}$/" name="masterKey" ng-model="thread.masterKey">
+            <div ng-messages="joinForm.masterKey.$error">
               <div ng-message-exp="['required', 'minlength', 'maxlength', 'pattern']">
-                Network Key must be hexadecimal digits and 32 characters long.
+                Master Key must be hexadecimal digits and 32 characters long.
               </div>
             </div>
           </md-input-container>
@@ -46,7 +46,7 @@
       Cancel
     </md-button>
     <!-- <span flex="40"></span> -->
-    <md-button md-autofocus flex class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-button show-modal" style="width: 90px; margin-left:30px;  margin-bottom: 15px" ng-click="join(joinForm.networkKey.$valid && joinForm.prefix.$valid)">
+    <md-button md-autofocus flex class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-button show-modal" style="width: 90px; margin-left:30px;  margin-bottom: 15px" ng-click="join(joinForm.masterKey.$valid && joinForm.prefix.$valid)">
       Join
     </md-button>
   </div>

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -88,7 +88,7 @@
             extPanId: '1111111122222222',
             panId: '0x1234',
             passphrase: '123456',
-            networkKey: '00112233445566778899aabbccddeeff',
+            masterKey: '00112233445566778899aabbccddeeff',
             channel: 15,
             prefix: 'fd11:22::',
             defaultRoute: true,
@@ -170,7 +170,7 @@
             var networkInfo = sharedProperties.getNetworkInfo();
             $scope.isDisplay = false;
             $scope.thread = {
-                networkKey: '00112233445566778899aabbccddeeff',
+                masterKey: '00112233445566778899aabbccddeeff',
                 prefix: 'fd11:22::',
                 defaultRoute: true,
             };
@@ -199,7 +199,7 @@
                 };
                 $scope.isDisplay = true;
                 var data = {
-                    networkKey: $scope.thread.networkKey,
+                    masterKey: $scope.thread.masterKey,
                     prefix: $scope.thread.prefix,
                     defaultRoute: $scope.thread.defaultRoute,
                     index: index,
@@ -248,7 +248,7 @@
                     $scope.thread.defaultRoute = false;
                 };
                 var data = {
-                    networkKey: $scope.thread.networkKey,
+                    masterKey: $scope.thread.masterKey,
                     prefix: $scope.thread.prefix,
                     defaultRoute: $scope.thread.defaultRoute,
                     extPanId: $scope.thread.extPanId,

--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -54,7 +54,7 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     Json::FastWriter            jsonWriter;
     std::string                 response;
     int                         index;
-    std::string                 networkKey;
+    std::string                 masterKey;
     std::string                 prefix;
     bool                        defaultRoute;
     int                         ret = kWpanStatus_Ok;
@@ -64,7 +64,7 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
 
     VerifyOrExit(reader.parse(aJoinRequest.c_str(), root) == true, ret = kWpanStatus_ParseRequestFailed);
     index        = root["index"].asUInt();
-    networkKey   = root["networkKey"].asString();
+    masterKey    = root["masterKey"].asString();
     prefix       = root["prefix"].asString();
     defaultRoute = root["defaultRoute"].asBool();
 
@@ -74,7 +74,7 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     }
 
     VerifyOrExit(client.FactoryReset(), ret = kWpanStatus_LeaveFailed);
-    VerifyOrExit(client.Execute("masterkey %s", networkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(client.Execute("masterkey %s", masterKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(client.Execute("networkname %s", mNetworks[index].mNetworkName) != nullptr,
                  ret = kWpanStatus_SetFailed);
     VerifyOrExit(client.Execute("channel %u", mNetworks[index].mChannel) != nullptr, ret = kWpanStatus_SetFailed);
@@ -109,7 +109,7 @@ std::string WpanService::HandleFormNetworkRequest(const std::string &aFormReques
     otbr::Psk::Pskc             psk;
     char                        pskcStr[OT_PSKC_MAX_LENGTH * 2 + 1];
     uint8_t                     extPanIdBytes[OT_EXTENDED_PANID_LENGTH];
-    std::string                 networkKey;
+    std::string                 masterKey;
     std::string                 prefix;
     uint16_t                    channel;
     std::string                 networkName;
@@ -124,7 +124,7 @@ std::string WpanService::HandleFormNetworkRequest(const std::string &aFormReques
 
     pskcStr[OT_PSKC_MAX_LENGTH * 2] = '\0'; // for manipulating with strlen
     VerifyOrExit(reader.parse(aFormRequest.c_str(), root) == true, ret = kWpanStatus_ParseRequestFailed);
-    networkKey   = root["networkKey"].asString();
+    masterKey    = root["masterKey"].asString();
     prefix       = root["prefix"].asString();
     channel      = root["channel"].asUInt();
     networkName  = root["networkName"].asString();
@@ -143,7 +143,7 @@ std::string WpanService::HandleFormNetworkRequest(const std::string &aFormReques
     }
 
     VerifyOrExit(client.FactoryReset(), ret = kWpanStatus_LeaveFailed);
-    VerifyOrExit(client.Execute("masterkey %s", networkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(client.Execute("masterkey %s", masterKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(client.Execute("networkname %s", networkName.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(client.Execute("channel %u", channel) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(client.Execute("extpanid %s", extPanId.c_str()) != nullptr, ret = kWpanStatus_SetFailed);

--- a/tests/scripts/meshcop
+++ b/tests/scripts/meshcop
@@ -309,7 +309,7 @@ network_form()
     readonly OT_MASTER_KEY="$(random_masterkey)"
     readonly OT_CHANNEL="$(random_channel)"
 
-    curl --header "Content-Type: application/json" --request POST --data "{\"networkKey\":\"${OT_MASTER_KEY}\",\"prefix\":\"fd11:22::\",\"defaultRoute\":true,\"extPanId\":\"${OT_XPANID}\",\"panId\":\"${OT_PANID}\",\"passphrase\":\"${OT_AGENT_PASSPHRASE}\",\"channel\":${OT_CHANNEL},\"networkName\":\"${OT_NETWORK_NAME}\"}" "${OTBR_WEB_URL}"/form_network | grep "success" || die "WEB: form failed"
+    curl --header "Content-Type: application/json" --request POST --data "{\"masterKey\":\"${OT_MASTER_KEY}\",\"prefix\":\"fd11:22::\",\"defaultRoute\":true,\"extPanId\":\"${OT_XPANID}\",\"panId\":\"${OT_PANID}\",\"passphrase\":\"${OT_AGENT_PASSPHRASE}\",\"channel\":${OT_CHANNEL},\"networkName\":\"${OT_NETWORK_NAME}\"}" "${OTBR_WEB_URL}"/form_network | grep "success" || die "WEB: form failed"
     sleep 15
     # verify mDNS is working as expected.
     local mdns_result="${TEST_BASE}"/mdns_result.log


### PR DESCRIPTION
As discussed in #545 , this PR changes all `NetworkKey` to `MasterKey` in Web module, so the naming of this terminology is consistent with the Thread Specification.