### PR TITLE
[flags] configure backbone network interface name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,12 @@ project(openthread-br VERSION 0.2.0)
 
 add_library(otbr-config INTERFACE)
 
-option(OTBR_DBUS          "Build DBus support" OFF)
-option(OTBR_OPENWRT       "Build OpenWrt support" OFF)
-option(OTBR_UNSECURE_JOIN "Enable unsecure joining" OFF)
-option(OTBR_WEB           "Build Web GUI" OFF)
-option(OTBR_REST          "Build Rest Server" OFF)
+option(OTBR_BACKBONE_ROUTER  "Build Backbone Router" OFF)
+option(OTBR_DBUS             "Build DBus support" OFF)
+option(OTBR_OPENWRT          "Build OpenWrt support" OFF)
+option(OTBR_UNSECURE_JOIN    "Enable unsecure joining" OFF)
+option(OTBR_WEB              "Build Web GUI" OFF)
+option(OTBR_REST             "Build Rest Server" OFF)
 
 
 if(NOT CMAKE_C_STANDARD)
@@ -90,6 +91,15 @@ endif()
 
 find_package(PkgConfig)
 include(GNUInstallDirs)
+
+if (OTBR_BACKBONE_ROUTER)
+    target_compile_definitions(otbr-config INTERFACE
+            OTBR_ENABLE_BACKBONE_ROUTER=1
+    )
+    set(OT_THREAD_VERSION 1.2)
+    set(OT_BACKBONE_ROUTER ON)
+    set(OT_SERVICE ON)
+endif()
 
 if(OTBR_DBUS)
     pkg_check_modules(DBUS REQUIRED dbus-1)

--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -43,6 +43,11 @@ function parse_args()
                 shift
                 shift
                 ;;
+            --backbone-interface | -B)
+                BACKBONE_INTERFACE_ARG="-B $2"
+                shift
+                shift
+                ;;
             --nat64-prefix)
                 NAT64_PREFIX=$2
                 shift
@@ -73,6 +78,7 @@ parse_args "$@"
 
 echo "RADIO_URL:" $RADIO_URL
 echo "TUN_INTERFACE_NAME:" $TUN_INTERFACE_NAME
+echo "BACKBONE_INTERFACE: $BACKBONE_INTERFACE_ARG"
 echo "NAT64_PREFIX:" $NAT64_PREFIX
 echo "AUTO_PREFIX_ROUTE:" $AUTO_PREFIX_ROUTE
 echo "AUTO_PREFIX_SLAAC:" $AUTO_PREFIX_SLAAC
@@ -82,7 +88,7 @@ NAT64_PREFIX=${NAT64_PREFIX/\//\\\/}
 sed -i "s/^prefix.*$/prefix $NAT64_PREFIX/" /etc/tayga.conf
 sed -i "s/dns64.*$/dns64 $NAT64_PREFIX {};/" /etc/bind/named.conf.options
 
-echo "OTBR_AGENT_OPTS=\"-I $TUN_INTERFACE_NAME -d7 $RADIO_URL\"" >/etc/default/otbr-agent
+echo "OTBR_AGENT_OPTS=\"-I $TUN_INTERFACE_NAME $BACKBONE_INTERFACE_ARG -d7 $RADIO_URL\"" >/etc/default/otbr-agent
 echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d7 -p 80\"" >/etc/default/otbr-web
 
 /app/script/server

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -131,11 +131,14 @@ public:
     /**
      * This method creates a NCP Controller.
      *
-     * @param[in]   aInterfaceName  A string of the NCP interface name.
-     * @param[in]   aRadioUrl       The URL describes the radio chip.
+     * @param[in]   aInterfaceName          A string of the NCP interface name.
+     * @param[in]   aRadioUrl               The URL describes the radio chip.
+     * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
      *
      */
-    static Controller *Create(const char *aInterfaceName, const char *aRadioUrl);
+    static Controller *Create(const char *aInterfaceName,
+                              const char *aRadioUrl,
+                              const char *aBackboneInterfaceName = nullptr);
 
     /**
      * This method destroys a NCP Controller.

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -59,14 +59,17 @@ using std::chrono::steady_clock;
 namespace otbr {
 namespace Ncp {
 
-ControllerOpenThread::ControllerOpenThread(const char *aInterfaceName, const char *aRadioUrl)
+ControllerOpenThread::ControllerOpenThread(const char *aInterfaceName,
+                                           const char *aRadioUrl,
+                                           const char *aBackboneInterfaceName)
     : mTriedAttach(false)
 {
     memset(&mConfig, 0, sizeof(mConfig));
 
-    mConfig.mInterfaceName = aInterfaceName;
-    mConfig.mRadioUrl      = aRadioUrl;
-    mConfig.mSpeedUpFactor = 1;
+    mConfig.mInterfaceName         = aInterfaceName;
+    mConfig.mBackboneInterfaceName = aBackboneInterfaceName;
+    mConfig.mRadioUrl              = aRadioUrl;
+    mConfig.mSpeedUpFactor         = 1;
 }
 
 ControllerOpenThread::~ControllerOpenThread(void)
@@ -303,9 +306,9 @@ void ControllerOpenThread::RegisterResetHandler(std::function<void(void)> aHandl
     mResetHandlers.emplace_back(std::move(aHandler));
 }
 
-Controller *Controller::Create(const char *aInterfaceName, const char *aRadioUrl)
+Controller *Controller::Create(const char *aInterfaceName, const char *aRadioUrl, const char *aBackboneInterfaceName)
 {
-    return new ControllerOpenThread(aInterfaceName, aRadioUrl);
+    return new ControllerOpenThread(aInterfaceName, aRadioUrl, aBackboneInterfaceName);
 }
 
 /*

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -56,11 +56,12 @@ public:
     /**
      * This constructor initializes this object.
      *
-     * @param[in]   aInterfaceName  A string of the NCP interface name.
-     * @param[in]   aRadioUrl       The URL describes the radio chip.
+     * @param[in]   aInterfaceName          A string of the NCP interface name.
+     * @param[in]   aRadioUrl               The URL describes the radio chip.
+     * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
      *
      */
-    ControllerOpenThread(const char *aInterfaceName, const char *aRadioUrl);
+    ControllerOpenThread(const char *aInterfaceName, const char *aRadioUrl, const char *aBackboneInterfaceName);
 
     /**
      * This method initalize the NCP controller.


### PR DESCRIPTION
This PR adds the `-B <backbone-ifname>`  argument to `otbr-agent`. 

If this argument is not given, the backbone is not initialized. 