### PR TITLE
[dockerfile] add ARG `OT_BACKBONE_CI`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,12 @@ jobs:
 
   buildx:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - build_args: ""
+            push: yes
+          - build_args: "--build-arg OT_BACKBONE_CI=1"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -63,6 +69,7 @@ jobs:
           --build-arg VERSION=${VERSION} \
           --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
           --build-arg VCS_REF=${GITHUB_SHA::8} \
+          ${{ matrix.build_args }} \
           ${TAGS} --file etc/docker/Dockerfile .
 
     - name: Docker Buildx (build)
@@ -70,7 +77,7 @@ jobs:
         docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
 
     - name: Docker Login
-      if: success() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request'
+      if: success() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request' && matrix.push
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -78,16 +85,16 @@ jobs:
         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
 
     - name: Docker Buildx (push)
-      if: success() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request'
+      if: success() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request' && matrix.push
       run: |
         docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
 
     - name: Docker Check Manifest
-      if: always() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request'
+      if: always() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request' && matrix.push
       run: |
         docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
 
     - name: Clear
-      if: always() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request'
+      if: always() && github.repository == 'openthread/ot-br-posix' && github.event_name != 'pull_request' && matrix.push
       run: |
         rm -f ${HOME}/.docker/config.json

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -27,8 +27,10 @@
 
 FROM ubuntu:bionic
 
-
+ARG OT_BACKBONE_CI
 ARG OTBR_OPTIONS
+
+ENV OT_BACKBONE_CI=${OT_BACKBONE_CI}
 ENV OTBR_OPTIONS=${OTBR_OPTIONS}
 ENV DEBIAN_FRONTEND noninteractive
 ENV PLATFORM ubuntu
@@ -52,6 +54,9 @@ ENV OTBR_BUILD_DEPS \
   build-essential \
   psmisc
 
+# Required for OpenThread Backbone CI
+ENV OTBR_OT_BACKBONE_CI_DEPS curl ca-certificates
+
 # Required and installed during build (script/bootstrap) when RELEASE=1, could be removed
 ENV OTBR_NORELEASE_DEPS \
   cmake \
@@ -64,16 +69,19 @@ RUN apt-get update \
   && ./script/bootstrap \
   && ./script/setup \
   && chmod 644 /etc/bind/named.conf.options \
-  && mv ./script /tmp \
-  && mv ./etc /tmp \
-  && find . -delete \
-  && rm -rf /usr/include \
-  && mv /tmp/script . \
-  && mv /tmp/etc . \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $OTBR_DOCKER_DEPS \
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $OTBR_BUILD_DEPS  \
-  && ([ "${RELEASE}" = 1 ] ||  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false "$OTBR_NORELEASE_DEPS";) \
-  && rm -rf /var/lib/apt/lists/*
+  && [ "${OT_BACKBONE_CI}" = "1" ] || ( \
+    mv ./script /tmp \
+    && mv ./etc /tmp \
+    && find . -delete \
+    && rm -rf /usr/include \
+    && mv /tmp/script . \
+    && mv /tmp/etc . \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $OTBR_DOCKER_DEPS \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $OTBR_BUILD_DEPS  \
+    && ([ "${RELEASE}" = 1 ] ||  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false "$OTBR_NORELEASE_DEPS";) \
+    && rm -rf /var/lib/apt/lists/* \
+  ) \
+  && [ "${OT_BACKBONE_CI}" != "1" ] || apt-get install --no-install-recommends -y $OTBR_OT_BACKBONE_CI_DEPS
 
 ENTRYPOINT ["/app/etc/docker/docker_entrypoint.sh"]
 


### PR DESCRIPTION
This PR adds a new argument `OT_BACKBONE_CI` to the Dockerfile.

[OpenThread 1.2 Backbone CI](https://github.com/openthread/openthread/pull/5489) can use `OT_BACKBONE_CI=1` to build the Docker image for testing purpose:
- Install additional packages: `curl, ca-certificates`
- Does not remove source and build files in `/app` directory
- Does not remove unused packages and APT cache files
