### PR TITLE
[test] fix android build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       run: script/test build check
     - name: Codecov
       uses: codecov/codecov-action@v1
-    
+
   rest-check:
     runs-on: ubuntu-18.04
     strategy:

--- a/tests/scripts/check-android-build
+++ b/tests/scripts/check-android-build
@@ -196,10 +196,11 @@ prepare_openthread()
     mv "${SRC_DIR}"/../../third_party/openthread/repo external/openthread
     cat >>buildspec.mk <<EOF
 
-USE_OTBR_DAEMON := 1  
+USE_OTBR_DAEMON := 1
 OPENTHREAD_PROJECT_CFLAGS := \
-    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\" \
-    -DOPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE=1
+    -DOPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE=1 \
+    -DOPENTHREAD_CONFIG_FILE=\<openthread-config-android.h\> \
+    -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\"
 EOF
 }
 


### PR DESCRIPTION
OPENTHREAD_CONFIG_FILE is now defined in OPENTHREAD_PROJECT_CFLAGS in
OpenThread. This PR adds the definition to fix android build check.