### PR TITLE
[github-actions] add OT1.2 Backbone CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Build
       run: script/test package
 
-  ot12-backbone:
+  thread-1-2-backbone:
     runs-on: ubuntu-18.04
     env:
       PACKET_VERIFICATION: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
     - name: Build
       run: script/test package
 
-  ot12-backbone-ci:
+  ot12-backbone:
     runs-on: ubuntu-18.04
     env:
       PACKET_VERIFICATION: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,3 +152,49 @@ jobs:
         cmake --version | grep 3.10.3
     - name: Build
       run: script/test package
+
+  ot12-backbone-ci:
+    runs-on: ubuntu-18.04
+    env:
+      PACKET_VERIFICATION: 1
+      REFERENCE_DEVICE: 1
+      THREAD_VERSION: 1.2
+      INTER_OP: 1
+      VIRTUAL_TIME: 0
+      PYTHONUNBUFFERED: 1
+      OTBR_COVERAGE: 1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build OTBR Docker Image
+        run: |
+          otbr_options="-DOTBR_BACKBONE_ROUTER=ON -DOT_DUA=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON"
+          otbr_image_name="otbr-ot12-backbone-ci"
+          docker build -t "${otbr_image_name}" -f etc/docker/Dockerfile . --build-arg REFERENCE_DEVICE=1 --build-arg OT_BACKBONE_CI=1 --build-arg OTBR_OPTIONS="${otbr_options}"
+      - name: Bootstrap OpenThread Test
+        run: |
+          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+          sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat
+          python3 -m pip install -r third_party/openthread/repo/tests/scripts/thread-cert/requirements.txt
+      - name: Build OpenThread
+        run: |
+          (cd third_party/openthread/repo && ./script/test build)
+      - name: Get Thread-Wireshark
+        run: |
+          (cd third_party/openthread/repo && ./script/test get_thread_wireshark)
+      - name: Run Test
+        run: |
+          export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e OTBR_COVERAGE"
+          echo "CI_ENV=${CI_ENV}"
+          (cd third_party/openthread/repo && sudo -E ./script/test cert_bbr ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false))
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: thread-1-2-backbone-results
+          path: |
+            third_party/openthread/repo/*.pcap
+            third_party/openthread/repo/*.json
+            third_party/openthread/repo/*.log
+      - name: Codecov
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
This PR adds the OpenThread 1.2 Backbone CI (same test of https://github.com/openthread/openthread/pull/5489) to OTBR .

 - [x] Verified that Codecov Uploading in Docker works:
  ![image](https://user-images.githubusercontent.com/52448427/93749493-92361580-fc2c-11ea-8e88-775748774969.png)
 - [x] Update OpenThread to latest master.
