### PR TITLE
[test] increase the waiting time in dbus tests

### DIFF
--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -99,7 +99,7 @@ send "commissioner joiner add * ABCDEF\r\n"
 expect "Done"
 wait
 EOF
-    sleep 7
+    sleep 15
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.JoinerStart \


### PR DESCRIPTION
We found failed cases where the Thread network has not been formed yet.
Increase the timeout to make it more stable.