### PR TITLE
[platform] verify Network Manager with BeagleBone

### DIFF
--- a/examples/platforms/beagleboneblack/default
+++ b/examples/platforms/beagleboneblack/default
@@ -27,18 +27,14 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-# We need to extend the default SUDO timeout
-# otherwise we have to enter sudo passwords multiple times :-(
-
 # shellcheck disable=SC2034
-SUDO_EXTEND_TIME=true
+SUDO_EXTEND_TIME=false
 
-# the beaglebone black does not have enough ram to build
-# so we enable a swapfile
-SWAP_REQUIRED=true
+SWAP_REQUIRED=false
 
-# NAT64 we have not tested ...
-NAT64=0
-DNS64=0
-DHCPV6_PD=0
-NETWORK_MANAGER=0
+NAT64=1
+DNS64=1
+DHCPV6_PD=1
+NETWORK_MANAGER=1
+# disabled unless specifically added for the device
+NETWORK_MANAGER_WIFI=0

--- a/script/_dhcpv6_pd
+++ b/script/_dhcpv6_pd
@@ -53,7 +53,7 @@ NCP_STATE_NOTIFIER_SERVICE="/etc/systemd/system/${NCP_STATE_NOTIFIER_SERVICE_NAM
 
 DHCPCD_RELOADER="${NCP_STATE_DISPATCHER}/dhcpcd_reloader"
 
-without DHCPV6_PD || test "$PLATFORM" = raspbian || test "$PLATFORM" = ubuntu || die "DHCPv6-PD is not tested under $PLATFORM."
+without DHCPV6_PD || test "$PLATFORM" = beagleboneblack || test "$PLATFORM" = raspbian || test "$PLATFORM" = ubuntu || die "DHCPv6-PD is not tested under $PLATFORM."
 
 create_dhcpcd_conf_with_dhcpv6_pd()
 {
@@ -114,7 +114,7 @@ ia_pd 3/::/63 $WPAN_INTERFACE/1
 
 EOF
 
-    if [ "$PLATFORM" = "raspbian" ]; then
+    if [ "$PLATFORM" = "raspbian" ] || with NETWORK_MANAGER_WIFI; then
         sudo tee -a ${DHCPCD_CONF} <<EOF
 interface $WLAN_INTERFACE
 iaid 4

--- a/script/_dns64
+++ b/script/_dns64
@@ -38,10 +38,12 @@ DNS64_CONF="dns64 $(echo $NAT64_PREFIX | tr \"/\" \"/\") { clients { thread; }; 
 
 # Currently solution was verified only on raspbian and ubuntu.
 #
-without NAT64 || test "$PLATFORM" = ubuntu || test "$PLATFORM" = raspbian || die "dns64 is not tested under $PLATFORM."
+without NAT64 || test "$PLATFORM" = ubuntu || test "$PLATFORM" = beagleboneblack || test "$PLATFORM" = raspbian || die "dns64 is not tested under $PLATFORM."
 
 if [ "$PLATFORM" = raspbian ]; then
     RESOLV_CONF_HEAD=/etc/resolv.conf.head
+elif [ "$PLATFORM" = beagleboneblack ]; then
+    RESOLV_CONF_HEAD=/etc/resolvconf/resolv.conf.d/head
 elif [ "$PLATFORM" = ubuntu ]; then
     RESOLV_CONF_HEAD=/etc/resolvconf/resolv.conf.d/head
 fi
@@ -49,6 +51,8 @@ fi
 dns64_update_resolvconf()
 {
     if [ "$PLATFORM" = ubuntu ]; then
+        sudo resolvconf -u || true
+    elif [ "$PLATFORM" = beagleboneblack ]; then
         sudo resolvconf -u || true
     elif [ "$PLATFORM" = raspbian ]; then
         if systemctl is-enabled NetworkManager; then

--- a/script/_initrc
+++ b/script/_initrc
@@ -91,18 +91,16 @@ if [[ ! ${PLATFORM+x} ]]; then
         # Note: 'model' is a binary file with no newline
         PLATFORM=beagleboneblack
     else
-        PLATFORM=
+        case "${OSTYPE}" in
+            darwin*)
+                PLATFORM=macOS
+                ;;
+            *)
+                have_or_die lsb_release
+                PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+                ;;
+        esac
     fi
-
-    case "${OSTYPE}" in
-        darwin*)
-            PLATFORM=macOS
-            ;;
-        *)
-            have_or_die lsb_release
-            PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
-            ;;
-    esac
 fi
 echo "Current platform is $PLATFORM"
 

--- a/script/_nat64
+++ b/script/_nat64
@@ -156,6 +156,7 @@ nat64_start()
         service tayga start || die 'Failed to start tayga'
     elif have systemctl; then
         sudo systemctl start tayga || die 'Failed to start tayga!'
+        sudo systemctl enable tayga || die 'Failed to enable tayga!'
         sudo systemctl start otbr-nat44 || die 'Failed to start NAT44!'
     fi
 }

--- a/script/_network_manager
+++ b/script/_network_manager
@@ -46,7 +46,7 @@ create_ap_connection()
 
 create_eth_connection()
 {
-    IFNAME=$(nmcli d | grep ethernet | cut -d" " -f1)
+    IFNAME=$(nmcli d | grep ethernet | cut -d" " -f1 | grep -v usb)
 
     sudo nmcli c add type ethernet ifname "${IFNAME}" con-name ${ETH_CONN}
     sudo nmcli c modify ${ETH_CONN} ipv6.method ignore
@@ -344,7 +344,7 @@ network_manager_install()
     sudo systemctl enable NetworkManager || die "Failed to enable NetworkManager."
 
     # Create AP connection only on raspbian platform.
-    if [ "$PLATFORM" = raspbian ]; then
+    if [ "$PLATFORM" = raspbian ] || with NETWORK_MANAGER_WIFI; then
         create_ap_helper_script
         sudo chmod a+x ${AP_HELPER_SCRIPT}
 
@@ -361,7 +361,7 @@ network_manager_install()
 
     sleep 15
 
-    if [ "$PLATFORM" = raspbian ]; then
+    if [ "$PLATFORM" = raspbian ] || with NETWORK_MANAGER_WIFI; then
         sudo nmcli c up ${AP_CONN}
     fi
 
@@ -382,7 +382,7 @@ network_manager_uninstall()
         sudo systemctl start NetworkManager
     fi
 
-    if [ "$PLATFORM" = raspbian ]; then
+    if [ "$PLATFORM" = raspbian ] || with NETWORK_MANAGER_WIFI; then
         sudo nmcli c down ${AP_CONN} || true
         sudo nmcli c delete ${AP_CONN} || true
     fi


### PR DESCRIPTION
This allows building for BeagleBone in the same fashion as RasPi.

BeagleBone uses connaman by default for network management. The [BeagleBone Black build guide](https://openthread.io/guides/border-router/beaglebone-black) should be updated to explain how to replace connman with Network Manager.