### PR TITLE
[agent] add region support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -98,6 +98,7 @@ LOCAL_SRC_FILES := \
     src/agent/ncp_openthread.cpp \
     src/agent/thread_helper.cpp \
     src/common/logging.cpp \
+    src/common/region_code.cpp \
     src/dbus/common/dbus_message_dump.cpp \
     src/dbus/common/dbus_message_helper.cpp \
     src/dbus/common/dbus_message_helper_openthread.cpp \

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -97,7 +97,7 @@ static const struct option  kOptions[]   = {
     {"verbose", no_argument, nullptr, OTBR_OPT_VERBOSE},
     {"version", no_argument, nullptr, OTBR_OPT_VERSION},
     {"radio-version", no_argument, nullptr, OTBR_OPT_RADIO_VERSION},
-    {"region", required_argument, nullptr, OTBR_OPT_REGION},
+    {"reg", required_argument, nullptr, OTBR_OPT_REGION},
     {0, 0, 0, 0}};
 
 static void HandleSignal(int aSignal)

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -47,6 +47,7 @@
 #include "agent/ncp_openthread.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "common/region_code.hpp"
 #include "common/types.hpp"
 #if OTBR_ENABLE_REST_SERVER
 #include "rest/rest_web_server.hpp"
@@ -81,6 +82,7 @@ enum
     OTBR_OPT_VERSION        = 'V',
     OTBR_OPT_SHORTMAX       = 128,
     OTBR_OPT_RADIO_VERSION,
+    OTBR_OPT_REGION,
 };
 
 // Default poll timeout.
@@ -95,6 +97,7 @@ static const struct option  kOptions[]   = {
     {"verbose", no_argument, nullptr, OTBR_OPT_VERBOSE},
     {"version", no_argument, nullptr, OTBR_OPT_VERSION},
     {"radio-version", no_argument, nullptr, OTBR_OPT_RADIO_VERSION},
+    {"region", required_argument, nullptr, OTBR_OPT_REGION},
     {0, 0, 0, 0}};
 
 static void HandleSignal(int aSignal)
@@ -215,14 +218,16 @@ static void OnAllocateFailed(void)
 
 int main(int argc, char *argv[])
 {
-    int                    logLevel = OTBR_LOG_INFO;
-    int                    opt;
-    int                    ret                   = EXIT_SUCCESS;
-    const char *           interfaceName         = kDefaultInterfaceName;
-    const char *           backboneInterfaceName = "";
-    otbr::Ncp::Controller *ncp                   = nullptr;
-    bool                   verbose               = false;
-    bool                   printRadioVersion     = false;
+    int                              logLevel = OTBR_LOG_INFO;
+    int                              opt;
+    int                              ret                   = EXIT_SUCCESS;
+    const char *                     interfaceName         = kDefaultInterfaceName;
+    const char *                     backboneInterfaceName = "";
+    otbr::Ncp::Controller *          ncp                   = nullptr;
+    otbr::Ncp::ControllerOpenThread *ncpOpenThread         = nullptr;
+    bool                             verbose               = false;
+    bool                             printRadioVersion     = false;
+    otbr::RegionCode                 regionCode            = otbr::kRegionUnknown;
 
     std::set_new_handler(OnAllocateFailed);
 
@@ -267,6 +272,10 @@ int main(int argc, char *argv[])
             printRadioVersion = true;
             break;
 
+        case OTBR_OPT_REGION:
+            regionCode = otbr::StringToRegionCode(optarg);
+            break;
+
         default:
             PrintHelp(argv[0]);
             ExitNow(ret = EXIT_FAILURE);
@@ -278,13 +287,18 @@ int main(int argc, char *argv[])
     otbrLog(OTBR_LOG_INFO, "Running %s", OTBR_PACKAGE_VERSION);
     VerifyOrExit(optind < argc, ret = EXIT_FAILURE);
 
-    ncp = otbr::Ncp::Controller::Create(interfaceName, argv[optind], backboneInterfaceName);
+    ncp           = otbr::Ncp::Controller::Create(interfaceName, argv[optind], backboneInterfaceName);
+    ncpOpenThread = reinterpret_cast<ControllerOpenThread *>(ncp);
     VerifyOrExit(ncp != nullptr, ret = EXIT_FAILURE);
 
     otbrLog(OTBR_LOG_INFO, "Thread interface %s", interfaceName);
 #if OTBR_ENABLE_BACKBONE_ROUTER
     otbrLog(OTBR_LOG_INFO, "Backbone interface %s", backboneInterfaceName);
 #endif
+    otbrLog(OTBR_LOG_INFO, "Backbone interface %s",
+            backboneInterfaceName == nullptr ? "(null)" : backboneInterfaceName);
+    otbrLog(OTBR_LOG_INFO, "Region %s", otbr::RegionCodeToString(regionCode));
+    ncpOpenThread->SetRegionCode(regionCode);
 
     {
         otbr::AgentInstance instance(ncp);
@@ -298,16 +312,12 @@ int main(int argc, char *argv[])
 
         if (printRadioVersion)
         {
-            ControllerOpenThread *ncpOpenThread = reinterpret_cast<ControllerOpenThread *>(ncp);
-
             PrintRadioVersion(ncpOpenThread->GetInstance());
             ExitNow(ret = EXIT_SUCCESS);
         }
 
 #if OTBR_ENABLE_OPENWRT
-        ControllerOpenThread *ncpThread = reinterpret_cast<ControllerOpenThread *>(ncp);
-
-        UbusServerInit(ncpThread, &sThreadMutex);
+        UbusServerInit(ncpOpenThread, &sThreadMutex);
         std::thread(UbusServerRun).detach();
 #endif
         SuccessOrExit(ret = Mainloop(instance, interfaceName));

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -196,7 +196,7 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
 
 static void PrintHelp(const char *aProgramName)
 {
-    fprintf(stderr, "Usage: %s [-I interfaceName] [-d DEBUG_LEVEL] [-v] RADIO_URL\n", aProgramName);
+    fprintf(stderr, "Usage: %s [--reg region] [-I interfaceName] [-d DEBUG_LEVEL] [-v] RADIO_URL\n", aProgramName);
     fprintf(stderr, "%s", otSysGetRadioUrlHelpString());
 }
 
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
     otbr::Ncp::ControllerOpenThread *ncpOpenThread         = nullptr;
     bool                             verbose               = false;
     bool                             printRadioVersion     = false;
-    otbr::RegionCode                 regionCode            = otbr::kRegionUnknown;
+    std::string                      regionCode;
 
     std::set_new_handler(OnAllocateFailed);
 
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
             break;
 
         case OTBR_OPT_REGION:
-            regionCode = otbr::StringToRegionCode(optarg);
+            regionCode = optarg;
             break;
 
         default:
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
     VerifyOrExit(optind < argc, ret = EXIT_FAILURE);
 
     ncp           = otbr::Ncp::Controller::Create(interfaceName, argv[optind], backboneInterfaceName);
-    ncpOpenThread = reinterpret_cast<ControllerOpenThread *>(ncp);
+    ncpOpenThread = static_cast<ControllerOpenThread *>(ncp);
     VerifyOrExit(ncp != nullptr, ret = EXIT_FAILURE);
 
     otbrLog(OTBR_LOG_INFO, "Thread interface %s", interfaceName);
@@ -297,7 +297,10 @@ int main(int argc, char *argv[])
 #endif
     otbrLog(OTBR_LOG_INFO, "Backbone interface %s",
             backboneInterfaceName == nullptr ? "(null)" : backboneInterfaceName);
-    otbrLog(OTBR_LOG_INFO, "Region %s", otbr::RegionCodeToString(regionCode));
+    if (!regionCode.empty())
+    {
+        otbrLog(OTBR_LOG_INFO, "Region %s", regionCode.c_str());
+    }
     ncpOpenThread->SetRegionCode(regionCode);
 
     {

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -43,6 +43,7 @@
 
 #include "ncp.hpp"
 #include "agent/thread_helper.hpp"
+#include "common/region_code.hpp"
 
 namespace otbr {
 namespace Ncp {
@@ -87,6 +88,22 @@ public:
      *
      */
     otbr::agent::ThreadHelper *GetThreadHelper(void) { return mThreadHelper.get(); }
+
+    /**
+     * This method sets the region code.
+     *
+     * @param[in]   aCode   The region code.
+     *
+     */
+    void SetRegionCode(RegionCode aCode) { mRegionCode = aCode; }
+
+    /**
+     * This method gets the region code.
+     *
+     * @retval  The region code.
+     *
+     */
+    RegionCode GetRegionCode(void) { return mRegionCode; }
 
     /**
      * This method updates the fd_set to poll.
@@ -169,6 +186,7 @@ private:
     std::multimap<std::chrono::steady_clock::time_point, std::function<void(void)>> mTimers;
     bool                                                                            mTriedAttach;
     std::vector<std::function<void(void)>>                                          mResetHandlers;
+    RegionCode                                                                      mRegionCode;
 };
 
 } // namespace Ncp

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -95,7 +95,7 @@ public:
      * @param[in]   aCode   The region code.
      *
      */
-    void SetRegionCode(RegionCode aCode) { mRegionCode = aCode; }
+    void SetRegionCode(const std::string &aCode) { mRegionCode = aCode; }
 
     /**
      * This method gets the region code.
@@ -103,7 +103,7 @@ public:
      * @retval  The region code.
      *
      */
-    RegionCode GetRegionCode(void) { return mRegionCode; }
+    std::string GetRegionCode(void) { return mRegionCode; }
 
     /**
      * This method updates the fd_set to poll.
@@ -186,7 +186,7 @@ private:
     std::multimap<std::chrono::steady_clock::time_point, std::function<void(void)>> mTimers;
     bool                                                                            mTriedAttach;
     std::vector<std::function<void(void)>>                                          mResetHandlers;
-    RegionCode                                                                      mRegionCode;
+    std::string                                                                     mRegionCode;
 };
 
 } // namespace Ncp

--- a/src/agent/thread_helper.cpp
+++ b/src/agent/thread_helper.cpp
@@ -187,8 +187,8 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
     otExtendedPanId extPanId;
     otMasterKey     masterKey;
     otPskc          pskc;
-    uint32_t        preferredChannelMask = GetSupportedChannelMaskForRegion(mNcp->GetRegionCode());
-    uint32_t        supportedChannelMask = GetPreferredChannelMaskForRegion(mNcp->GetRegionCode());
+    uint32_t        preferredChannelMask = GetPreferredChannelMaskForRegion(mNcp->GetRegionCode());
+    uint32_t        supportedChannelMask = GetSupportedChannelMaskForRegion(mNcp->GetRegionCode());
     uint32_t        channelMask;
     uint8_t         channel;
 

--- a/src/agent/thread_helper.cpp
+++ b/src/agent/thread_helper.cpp
@@ -45,6 +45,7 @@
 #include "common/byteswap.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "common/region_code.hpp"
 
 namespace otbr {
 namespace agent {
@@ -186,6 +187,8 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
     otExtendedPanId extPanId;
     otMasterKey     masterKey;
     otPskc          pskc;
+    uint32_t        preferredChannelMask = GetSupportedChannelMaskForRegion(mNcp->GetRegionCode());
+    uint32_t        supportedChannelMask = GetPreferredChannelMaskForRegion(mNcp->GetRegionCode());
     uint32_t        channelMask;
     uint8_t         channel;
 
@@ -241,11 +244,11 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
     SuccessOrExit(error = otThreadSetExtendedPanId(mInstance, &extPanId));
     SuccessOrExit(error = otThreadSetMasterKey(mInstance, &masterKey));
 
-    channelMask = otPlatRadioGetPreferredChannelMask(mInstance) & aChannelMask;
+    channelMask = otLinkGetSupportedChannelMask(mInstance) & preferredChannelMask & aChannelMask;
 
     if (channelMask == 0)
     {
-        channelMask = otLinkGetSupportedChannelMask(mInstance) & aChannelMask;
+        channelMask = otLinkGetSupportedChannelMask(mInstance) & supportedChannelMask & aChannelMask;
     }
     VerifyOrExit(channelMask != 0, otbrLog(OTBR_LOG_WARNING, "Invalid channel mask"), error = OT_ERROR_INVALID_ARGS);
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,6 +29,7 @@
 add_library(otbr-common
     logging.cpp
     types.cpp
+    region_code.cpp
 )
 
 target_link_libraries(otbr-common

--- a/src/common/region_code.cpp
+++ b/src/common/region_code.cpp
@@ -28,102 +28,40 @@
 
 #include "region_code.hpp"
 
-#include <string.h>
-#include <utility>
-
-#include "common/logging.hpp"
-
 namespace {
 
-enum : uint32_t
-{
-    kChannelMask11To24 = 0x1fff800,
-    kChannelMask11To25 = 0x3fff800,
-    kChannelMask11To26 = 0x7fff800,
-};
-}
+constexpr uint32_t kChannelMask11To24 = 0x1fff800;
+constexpr uint32_t kChannelMask11To25 = 0x3fff800;
+constexpr uint32_t kChannelMask11To26 = 0x7fff800;
+
+constexpr char kRegionCodeUS[] = "US";
+constexpr char kRegionCodeCA[] = "CA";
+
+} // namespace
 
 namespace otbr {
 
-static const std::pair<RegionCode, const char *> sRegionCodeNames[] = {
-    {kRegionWW, "WW"},
-    {kRegionCA, "CA"},
-    {kRegionUS, "US"},
-};
-
-RegionCode StringToRegionCode(const char *aRegionString)
+uint32_t GetSupportedChannelMaskForRegion(const std::string &aRegionCode)
 {
-    RegionCode code  = kRegionUnknown;
-    bool       found = false;
+    uint32_t mask = kChannelMask11To26;
 
-    for (const auto &p : sRegionCodeNames)
+    // US or CA
+    if (aRegionCode == kRegionCodeUS || aRegionCode == kRegionCodeCA)
     {
-        if (!strcmp(aRegionString, p.second))
-        {
-            code  = p.first;
-            found = true;
-        }
-    }
-
-    if (!found)
-    {
-        otbrLog(OTBR_LOG_WARNING, "Unknown region %s", aRegionString);
-    }
-    return code;
-}
-
-const char *RegionCodeToString(RegionCode aRegionCode)
-{
-    const char *name  = "Unknown";
-    bool        found = false;
-
-    for (const auto &p : sRegionCodeNames)
-    {
-        if (aRegionCode == p.first)
-        {
-            name  = p.second;
-            found = true;
-        }
-    }
-
-    if (!found)
-    {
-        otbrLog(OTBR_LOG_WARNING, "Unknown region code %d", static_cast<int>(aRegionCode));
-    }
-    return name;
-}
-
-uint32_t GetSupportedChannelMaskForRegion(RegionCode aRegionCode)
-{
-    uint32_t mask;
-
-    switch (aRegionCode)
-    {
-    case kRegionCA:
-    case kRegionUS:
         mask = kChannelMask11To25;
-        break;
-    default:
-        mask = kChannelMask11To26;
-        break;
     }
 
     return mask;
 }
 
-uint32_t GetPreferredChannelMaskForRegion(RegionCode aRegionCode)
+uint32_t GetPreferredChannelMaskForRegion(const std::string &aRegionCode)
 {
-    uint32_t mask;
+    uint32_t mask = kChannelMask11To26;
 
-    switch (aRegionCode)
+    // US or CA
+    if (aRegionCode == kRegionCodeUS || aRegionCode == kRegionCodeCA)
     {
-    case kRegionCA:
-    case kRegionUS:
         mask = kChannelMask11To24;
-        break;
-    default:
-        mask = kChannelMask11To26;
-        break;
     }
 
     return mask;

--- a/src/common/region_code.cpp
+++ b/src/common/region_code.cpp
@@ -1,0 +1,132 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "region_code.hpp"
+
+#include <string.h>
+#include <utility>
+
+#include "common/logging.hpp"
+
+namespace {
+
+enum : uint32_t
+{
+    kChannelMask11To24 = 0x1fff800,
+    kChannelMask11To25 = 0x3fff800,
+    kChannelMask11To26 = 0x7fff800,
+};
+}
+
+namespace otbr {
+
+static const std::pair<RegionCode, const char *> sRegionCodeNames[] = {
+    {kRegionWW, "WW"},
+    {kRegionCA, "CA"},
+    {kRegionUS, "US"},
+};
+
+RegionCode StringToRegionCode(const char *aRegionString)
+{
+    RegionCode code  = kRegionUnknown;
+    bool       found = false;
+
+    for (const auto &p : sRegionCodeNames)
+    {
+        if (!strcmp(aRegionString, p.second))
+        {
+            code  = p.first;
+            found = true;
+        }
+    }
+
+    if (!found)
+    {
+        otbrLog(OTBR_LOG_WARNING, "Unknown region %s", aRegionString);
+    }
+    return code;
+}
+
+const char *RegionCodeToString(RegionCode aRegionCode)
+{
+    const char *name  = "Unknown";
+    bool        found = false;
+
+    for (const auto &p : sRegionCodeNames)
+    {
+        if (aRegionCode == p.first)
+        {
+            name  = p.second;
+            found = true;
+        }
+    }
+
+    if (!found)
+    {
+        otbrLog(OTBR_LOG_WARNING, "Unknown region code %d", static_cast<int>(aRegionCode));
+    }
+    return name;
+}
+
+uint32_t GetSupportedChannelMaskForRegion(RegionCode aRegionCode)
+{
+    uint32_t mask;
+
+    switch (aRegionCode)
+    {
+    case kRegionCA:
+    case kRegionUS:
+        mask = kChannelMask11To25;
+        break;
+    default:
+        mask = kChannelMask11To26;
+        break;
+    }
+
+    return mask;
+}
+
+uint32_t GetPreferredChannelMaskForRegion(RegionCode aRegionCode)
+{
+    uint32_t mask;
+
+    switch (aRegionCode)
+    {
+    case kRegionCA:
+    case kRegionUS:
+        mask = kChannelMask11To24;
+        break;
+    default:
+        mask = kChannelMask11To26;
+        break;
+    }
+
+    return mask;
+}
+
+} // namespace otbr

--- a/src/common/region_code.hpp
+++ b/src/common/region_code.hpp
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_COMMON_REGION_CODE_HPP_
+#define OTBR_COMMON_REGION_CODE_HPP_
+
+#include <stdint.h>
+
+namespace otbr {
+
+enum RegionCode
+{
+    kRegionWW      = 0, // < World wide
+    kRegionCA      = 1, // < Canada
+    kRegionUS      = 2, // < United States
+    kRegionUnknown = 3, // < Unknown
+};
+
+RegionCode StringToRegionCode(const char *aRegionString);
+
+const char *RegionCodeToString(RegionCode aRegionCode);
+
+uint32_t GetSupportedChannelMaskForRegion(RegionCode aRegionCode);
+
+uint32_t GetPreferredChannelMaskForRegion(RegionCode aRegionCode);
+
+} // namespace otbr
+
+#endif // OTBR_COMMON_REGION_CODE_HPP_

--- a/src/common/region_code.hpp
+++ b/src/common/region_code.hpp
@@ -29,25 +29,29 @@
 #ifndef OTBR_COMMON_REGION_CODE_HPP_
 #define OTBR_COMMON_REGION_CODE_HPP_
 
-#include <stdint.h>
+#include <string>
 
 namespace otbr {
 
-enum RegionCode
-{
-    kRegionWW      = 0, // < World wide
-    kRegionCA      = 1, // < Canada
-    kRegionUS      = 2, // < United States
-    kRegionUnknown = 3, // < Unknown
-};
+/**
+ * This method returns the supported channel mask for a region code.
+ *
+ *
+ * @param[in] aRegionCode   The region code.
+ * @returns The supported channel mask.
+ *
+ */
+uint32_t GetSupportedChannelMaskForRegion(const std::string &aRegionCode);
 
-RegionCode StringToRegionCode(const char *aRegionString);
-
-const char *RegionCodeToString(RegionCode aRegionCode);
-
-uint32_t GetSupportedChannelMaskForRegion(RegionCode aRegionCode);
-
-uint32_t GetPreferredChannelMaskForRegion(RegionCode aRegionCode);
+/**
+ * This method returns the preferred channel mask for a region code.
+ *
+ * @param[in] aRegionCode   The region code.
+ *
+ * @returns The preferred channel mask.
+ *
+ */
+uint32_t GetPreferredChannelMaskForRegion(const std::string &aRegionCode);
 
 } // namespace otbr
 

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -374,6 +374,11 @@ ClientError ThreadApiDBus::SetLinkMode(const LinkModeConfig &aConfig)
     return SetProperty(OTBR_DBUS_PROPERTY_LINK_MODE, aConfig);
 }
 
+ClientError ThreadApiDBus::SetRegion(const std::string &aRegion)
+{
+    return SetProperty(OTBR_DBUS_PROPERTY_REGION, aRegion);
+}
+
 ClientError ThreadApiDBus::GetLinkMode(LinkModeConfig &aConfig)
 {
     return GetProperty(OTBR_DBUS_PROPERTY_LINK_MODE, aConfig);
@@ -508,6 +513,11 @@ ClientError ThreadApiDBus::GetRadioTxPower(int8_t &aTxPower)
 ClientError ThreadApiDBus::GetExternalRoutes(std::vector<ExternalRoute> &aExternalRoutes)
 {
     return GetProperty(OTBR_DBUS_PROPERTY_EXTERNAL_ROUTES, aExternalRoutes);
+}
+
+ClientError ThreadApiDBus::GetRegion(std::string &aRegion)
+{
+    return GetProperty(OTBR_DBUS_PROPERTY_REGION, aRegion);
 }
 
 std::string ThreadApiDBus::GetInterfaceName(void)

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -268,6 +268,17 @@ public:
     ClientError SetLinkMode(const LinkModeConfig &aConfig);
 
     /**
+     * This method sets the region.
+     *
+     * @param[in]   aRegion   The region, can be CA, US or WW.
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_DBUS dbus encode/decode error
+     *
+     */
+    ClientError SetRegion(const std::string &aRegion);
+
+    /**
      * This method gets the link operating mode.
      *
      * @param[out]  aConfig   The operating mode config.
@@ -579,6 +590,17 @@ public:
      *
      */
     ClientError GetExternalRoutes(std::vector<ExternalRoute> &aExternalRoutes);
+
+    /**
+     * This method gets the region.
+     *
+     * @param[out]  aRegion    The region, can be CA, US or WW.
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_DBUS dbus encode/decode error
+     *
+     */
+    ClientError GetRegion(std::string &aRegion);
 
     /**
      * This method returns the network interface name the client is bound to.

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -79,6 +79,7 @@
 #define OTBR_DBUS_PROPERTY_INSTANT_RSSI "InstantRssi"
 #define OTBR_DBUS_PROPERTY_RADIO_TX_POWER "RadioTxPower"
 #define OTBR_DBUS_PROPERTY_EXTERNAL_ROUTES "ExternalRoutes"
+#define OTBR_DBUS_PROPERTY_REGION "Region"
 
 #define OTBR_ROLE_NAME_DISABLED "disabled"
 #define OTBR_ROLE_NAME_DETACHED "detached"

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -497,13 +497,10 @@ exit:
 
 otError DBusThreadObject::SetRegionHandler(DBusMessageIter &aIter)
 {
-    std::string regionName;
-    RegionCode  regionCode;
+    std::string regionCode;
     otError     error = OT_ERROR_NONE;
 
-    VerifyOrExit(DBusMessageExtractFromVariant(&aIter, regionName) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
-    regionCode = StringToRegionCode(regionName.c_str());
-    VerifyOrExit(regionCode != kRegionUnknown, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(DBusMessageExtractFromVariant(&aIter, regionCode) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
     mNcp->SetRegionCode(regionCode);
 
 exit:
@@ -985,8 +982,8 @@ exit:
 
 otError DBusThreadObject::GetRegionHandler(DBusMessageIter &aIter)
 {
-    otError     error      = OT_ERROR_NONE;
-    std::string regionName = RegionCodeToString(mNcp->GetRegionCode());
+    otError     error = OT_ERROR_NONE;
+    std::string regionName(mNcp->GetRegionCode());
 
     VerifyOrExit(DBusMessageEncodeToVariant(&aIter, regionName) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -40,6 +40,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/byteswap.hpp"
+#include "common/region_code.hpp"
 #include "dbus/common/constants.hpp"
 #include "dbus/server/dbus_agent.hpp"
 #include "dbus/server/dbus_thread_object.hpp"
@@ -139,6 +140,9 @@ otbrError DBusThreadObject::Init(void)
                                std::bind(&DBusThreadObject::SetLegacyUlaPrefixHandler, this, _1));
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_LINK_MODE,
                                std::bind(&DBusThreadObject::SetLinkModeHandler, this, _1));
+    RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_REGION,
+                               std::bind(&DBusThreadObject::SetRegionHandler, this, _1));
+
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_LINK_MODE,
                                std::bind(&DBusThreadObject::GetLinkModeHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
@@ -192,6 +196,8 @@ otbrError DBusThreadObject::Init(void)
                                std::bind(&DBusThreadObject::GetRadioTxPowerHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_EXTERNAL_ROUTES,
                                std::bind(&DBusThreadObject::GetExternalRoutesHandler, this, _1));
+    RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_REGION,
+                               std::bind(&DBusThreadObject::GetRegionHandler, this, _1));
 
     return error;
 }
@@ -489,6 +495,21 @@ exit:
     return error;
 }
 
+otError DBusThreadObject::SetRegionHandler(DBusMessageIter &aIter)
+{
+    std::string regionName;
+    RegionCode  regionCode;
+    otError     error = OT_ERROR_NONE;
+
+    VerifyOrExit(DBusMessageExtractFromVariant(&aIter, regionName) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
+    regionCode = StringToRegionCode(regionName.c_str());
+    VerifyOrExit(regionCode != kRegionUnknown, error = OT_ERROR_INVALID_ARGS);
+    mNcp->SetRegionCode(regionCode);
+
+exit:
+    return error;
+}
+
 otError DBusThreadObject::GetLinkModeHandler(DBusMessageIter &aIter)
 {
     auto             threadHelper = mNcp->GetThreadHelper();
@@ -663,8 +684,9 @@ exit:
 otError DBusThreadObject::GetSupportedChannelMaskHandler(DBusMessageIter &aIter)
 {
     auto     threadHelper = mNcp->GetThreadHelper();
-    uint32_t channelMask  = otLinkGetSupportedChannelMask(threadHelper->GetInstance());
-    otError  error        = OT_ERROR_NONE;
+    uint32_t channelMask  = otLinkGetSupportedChannelMask(threadHelper->GetInstance()) &
+                           GetSupportedChannelMaskForRegion(mNcp->GetRegionCode());
+    otError error = OT_ERROR_NONE;
 
     VerifyOrExit(DBusMessageEncodeToVariant(&aIter, channelMask) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
@@ -956,6 +978,17 @@ otError DBusThreadObject::GetExternalRoutesHandler(DBusMessageIter &aIter)
 
     VerifyOrExit(DBusMessageEncodeToVariant(&aIter, externalRouteTable) == OTBR_ERROR_NONE,
                  error = OT_ERROR_INVALID_ARGS);
+
+exit:
+    return error;
+}
+
+otError DBusThreadObject::GetRegionHandler(DBusMessageIter &aIter)
+{
+    otError     error      = OT_ERROR_NONE;
+    std::string regionName = RegionCodeToString(mNcp->GetRegionCode());
+
+    VerifyOrExit(DBusMessageEncodeToVariant(&aIter, regionName) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
 exit:
     return error;

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -86,6 +86,7 @@ private:
     otError SetMeshLocalPrefixHandler(DBusMessageIter &aIter);
     otError SetLegacyUlaPrefixHandler(DBusMessageIter &aIter);
     otError SetLinkModeHandler(DBusMessageIter &aIter);
+    otError SetRegionHandler(DBusMessageIter &aIter);
 
     otError GetLinkModeHandler(DBusMessageIter &aIter);
     otError GetDeviceRoleHandler(DBusMessageIter &aIter);
@@ -113,6 +114,7 @@ private:
     otError GetInstantRssiHandler(DBusMessageIter &aIter);
     otError GetRadioTxPowerHandler(DBusMessageIter &aIter);
     otError GetExternalRoutesHandler(DBusMessageIter &aIter);
+    otError GetRegionHandler(DBusMessageIter &aIter);
 
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
 

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -334,6 +334,10 @@
     <property name="ExternalRoutes" type="((ayy)qybb)" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
+
+    <property name="Region" type="s" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
   </interface>
 
   <interface name="org.freedesktop.DBus.Properties">

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -53,8 +53,8 @@ main()
     sudo rm -rf tmp
     sudo install -m 644 "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent.conf /etc/dbus-1/system.d/"${OTBR_DBUS_SERVER_CONF}"
     sudo service dbus reload
-    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d7 -I wpan0 --radio-version "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" | grep "OPENTHREAD"
     sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
+    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent --region WW -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
     trap on_exit EXIT
     sleep 5
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -54,7 +54,7 @@ main()
     sudo install -m 644 "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent.conf /etc/dbus-1/system.d/"${OTBR_DBUS_SERVER_CONF}"
     sudo service dbus reload
     sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
-    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent --region WW -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
+    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent --reg WW -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
     trap on_exit EXIT
     sleep 5
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -53,7 +53,7 @@ main()
     sudo rm -rf tmp
     sudo install -m 644 "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent.conf /etc/dbus-1/system.d/"${OTBR_DBUS_SERVER_CONF}"
     sudo service dbus reload
-    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
+    sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d7 -I wpan0 --radio-version "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" | grep "OPENTHREAD"
     sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent --reg WW -d7 -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
     trap on_exit EXIT
     sleep 5

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -117,6 +117,8 @@ int main()
         std::vector<uint8_t> masterKey = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                           0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
         uint16_t             channel   = 11;
+        std::string          region;
+        uint32_t             channelMask;
 
         for (auto &&result : aResult)
         {
@@ -129,6 +131,18 @@ int main()
 
         cfg.mDeviceType = true;
         api->SetLinkMode(cfg);
+
+        api->SetRegion("US");
+        api->GetRegion(region);
+        TEST_ASSERT(region == "US");
+        api->GetSupportedChannelMask(channelMask);
+        TEST_ASSERT((channelMask & (1 << 26)) == 0);
+
+        api->SetRegion("WW");
+        api->GetRegion(region);
+        TEST_ASSERT(region == "WW");
+        api->GetSupportedChannelMask(channelMask);
+        TEST_ASSERT((channelMask & (1 << 26)) != 0);
 
         api->Attach("Test", 0x3456, extpanid, masterKey, {}, 1 << channel,
                     [&api, channel, extpanid](ClientError aError) {


### PR DESCRIPTION
The PR adds region support which will determine the preferred channels
and the allowed channels when forming or joining a Thread network.

- Add region and channel mask logic.
- Add region to command line arguments.
- Add d-bus get and set api.