### PR TITLE
[docker] compact docker image size

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -51,10 +51,9 @@ ENV OTBR_DOCKER_REQS sudo
 ENV OTBR_DOCKER_DEPS git ca-certificates
 
 # Required and installed during build (script/bootstrap), could be removed
-ENV OTBR_BUILD_DEPS \
-  apt-utils \
-  build-essential \
-  psmisc
+ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-certificates \
+  libreadline-dev libncurses-dev libcpputest-dev libdbus-1-dev libavahi-common-dev \
+  libavahi-client-dev libboost-dev libboost-filesystem-dev libboost-system-dev libjsoncpp-dev
 
 # Required for OpenThread Backbone CI
 ENV OTBR_OT_BACKBONE_CI_DEPS curl ca-certificates

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -53,7 +53,7 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y libdbus-1-dev
 
     # mDNS
-    sudo apt-get install --no-install-recommends -y libavahi-common-dev libavahi-client-dev avahi-daemon
+    sudo apt-get install --no-install-recommends -y libavahi-client3 libavahi-common-dev libavahi-client-dev avahi-daemon
 
     # Boost
     sudo apt-get install --no-install-recommends -y libboost-dev libboost-filesystem-dev libboost-system-dev
@@ -85,7 +85,7 @@ install_packages_apt()
     }
 
     # libjsoncpp
-    sudo apt-get install --no-install-recommends -y libjsoncpp-dev
+    sudo apt-get install --no-install-recommends -y libjsoncpp1 libjsoncpp-dev
 }
 
 install_packages_opkg()


### PR DESCRIPTION
This PR further compacts Docker image size by removing packages for building but not useful in runtime. 

This PR reduces the otbr docker image size from 572MB to 452MB.