### PR TITLE
[web] fix OTBR-REST build fail in GCC 4.8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        rest: ["rest", ""]
+        rest: ["rest-off", ""]
     env:
       BUILD_TARGET: check
       OTBR_REST: ${{ matrix.rest }}

--- a/script/test
+++ b/script/test
@@ -147,7 +147,10 @@ do_prepare()
     if [[ ${OTBR_COVERAGE} == 1 ]]; then
         otbr_options+=("-DOTBR_COVERAGE=ON")
     fi
-    if [[ ${OTBR_REST} == "rest" ]]; then
+
+    if [[ ${OTBR_REST} == "rest-off" ]]; then
+        otbr_options+=("-DOTBR_REST=OFF")
+    else
         otbr_options+=("-DOTBR_REST=ON")
     fi
 }
@@ -158,7 +161,6 @@ do_package()
         "-DBUILD_TESTING=OFF"
         "-DCMAKE_INSTALL_PREFIX=/usr"
         "-DCMAKE_BUILD_TYPE=Release"
-        "-DOTBR_REST=ON"
         "-DOTBR_WEB=ON"
         ${otbr_options[@]+"${otbr_options[@]}"}
     )

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -49,18 +49,10 @@
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_PREFIX "/networks/current/prefix"
 
 #define OT_REST_HTTP_STATUS_200 "200 OK"
-#define OT_REST_HTTP_STATUS_201 "201 Created"
-#define OT_REST_HTTP_STATUS_202 "202 Accepted"
-#define OT_REST_HTTP_STATUS_204 "204 No Content"
-#define OT_REST_HTTP_STATUS_400 "400 Bad Request"
 #define OT_REST_HTTP_STATUS_404 "404 Not Found"
 #define OT_REST_HTTP_STATUS_405 "405 Method Not Allowed"
 #define OT_REST_HTTP_STATUS_408 "408 Request Timeout"
-#define OT_REST_HTTP_STATUS_411 "411 Length Required"
-#define OT_REST_HTTP_STATUS_415 "415 Unsupported Media Type"
 #define OT_REST_HTTP_STATUS_500 "500 Internal Server Error"
-#define OT_REST_HTTP_STATUS_501 "501 Not Implemented"
-#define OT_REST_HTTP_STATUS_505 "505 HTTP Version Not Supported"
 
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -93,18 +85,6 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     case HttpStatusCode::kStatusOk:
         httpStatus = OT_REST_HTTP_STATUS_200;
         break;
-    case HttpStatusCode::kStatusCreated:
-        httpStatus = OT_REST_HTTP_STATUS_201;
-        break;
-    case HttpStatusCode::kStatusAccepted:
-        httpStatus = OT_REST_HTTP_STATUS_202;
-        break;
-    case HttpStatusCode::kStatusNoContent:
-        httpStatus = OT_REST_HTTP_STATUS_204;
-        break;
-    case HttpStatusCode::kStatusBadRequest:
-        httpStatus = OT_REST_HTTP_STATUS_400;
-        break;
     case HttpStatusCode::kStatusResourceNotFound:
         httpStatus = OT_REST_HTTP_STATUS_404;
         break;
@@ -114,20 +94,8 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     case HttpStatusCode::kStatusRequestTimeout:
         httpStatus = OT_REST_HTTP_STATUS_408;
         break;
-    case HttpStatusCode::kStatusLengthRequired:
-        httpStatus = OT_REST_HTTP_STATUS_411;
-        break;
-    case HttpStatusCode::kStatusUnsupportedMediaType:
-        httpStatus = OT_REST_HTTP_STATUS_415;
-        break;
     case HttpStatusCode::kStatusInternalServerError:
         httpStatus = OT_REST_HTTP_STATUS_500;
-        break;
-    case HttpStatusCode::kStatusNotImplemented:
-        httpStatus = OT_REST_HTTP_STATUS_501;
-        break;
-    case HttpStatusCode::kStatusHttpVersionNotSupported:
-        httpStatus = OT_REST_HTTP_STATUS_505;
         break;
     }
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -148,8 +148,7 @@ private:
     std::unordered_map<std::string, ResourceHandler>         mResourceMap;
     std::unordered_map<std::string, ResourceCallbackHandler> mResourceCallbackMap;
 
-    std::unordered_map<HttpStatusCode, std::string> mResponseCodeMap;
-    std::unordered_map<std::string, DiagInfo>       mDiagSet;
+    std::unordered_map<std::string, DiagInfo> mDiagSet;
 };
 
 } // namespace rest

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -58,19 +58,11 @@ enum class HttpMethod : std::uint8_t
 
 enum class HttpStatusCode : std::uint16_t
 {
-    kStatusOk                      = 200,
-    kStatusCreated                 = 201,
-    kStatusAccepted                = 202,
-    kStatusNoContent               = 204,
-    kStatusBadRequest              = 400,
-    kStatusResourceNotFound        = 404,
-    kStatusMethodNotAllowed        = 405,
-    kStatusRequestTimeout          = 408,
-    kStatusLengthRequired          = 411,
-    kStatusUnsupportedMediaType    = 415,
-    kStatusInternalServerError     = 500,
-    kStatusNotImplemented          = 501,
-    kStatusHttpVersionNotSupported = 505
+    kStatusOk                  = 200,
+    kStatusResourceNotFound    = 404,
+    kStatusMethodNotAllowed    = 405,
+    kStatusRequestTimeout      = 408,
+    kStatusInternalServerError = 500,
 };
 
 enum class PostError : std::uint8_t


### PR DESCRIPTION
As discussed in #587 ,  we avoid using `std::hash` in OTBR-REST. 

Build check did not disclose this issue because OTBR-REST is not set as default enabled in test,  we also fix this in this PR. 