### PR TITLE
[raspbian] fix raspbian image expanding

### DIFF
--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -155,7 +155,7 @@ case "$(uname)" in
             (mkdir -p docker-rpi-emu \
                 && cd docker-rpi-emu \
                 && (git --git-dir=.git rev-parse --is-inside-work-tree || git --git-dir=.git init .) \
-                && git fetch --depth 1 https://github.com/ryankurte/docker-rpi-emu.git master \
+                && git fetch --depth 1 https://github.com/ryankurte/docker-rpi-emu.git pull/21/head \
                 && git checkout FETCH_HEAD)
 
             pip3 install git-archive-all


### PR DESCRIPTION
Raspbian image expanding by 1024MB was never successful in the Github Actions. 

This commit uses https://github.com/ryankurte/docker-rpi-emu/pull/21 to fix this issue.

### Question:
#532 failed on raspbian-check workflow constantly and requires this PR to pass all checks. Are we going to wait for https://github.com/ryankurte/docker-rpi-emu/pull/21 to be merged? Or can we merge this commit using https://github.com/ryankurte/docker-rpi-emu/pull/21 rather than docker-rpi-emu master? 

FYI: 

### Failed expanding output
```bash
+ sudo ./expand.sh /home/runner/.cache/tools/images/2018-04-18-raspbian-stretch-lite.img 1024
...
Number  Start   End     Size    Type     File system  Flags
 1      4194kB  49.4MB  45.2MB  primary  fat32        lba
 2      50.3MB  1862MB  1812MB  primary  ext4

Making new partition from 50.3MB to 2936MB
e2fsck 1.44.1 (24-Mar-2018)
e2fsck: need terminal for interactive repairs
resize2fs 1.44.1 (24-Mar-2018)
Please run 'e2fsck -f /dev/loop1' first.
```

### Successful expanding output
```bash
+ sudo ./expand.sh /home/runner/.cache/tools/images/2018-04-18-raspbian-stretch-lite.img 1024
...
Number  Start   End     Size    Type     File system  Flags
 1      4194kB  49.4MB  45.2MB  primary  fat32        lba
 2      50.3MB  1862MB  1812MB  primary  ext4

Making new partition from 50.3MB to 2936MB
rootfs: 39315/110656 files (0.1% non-contiguous), 256882/442368 blocks
resize2fs 1.44.1 (24-Mar-2018)
Resizing the filesystem on /dev/loop1 to 704512 (4k) blocks.
The filesystem on /dev/loop1 is now 704512 (4k) blocks long.
```