### PR TITLE
[common] remove client dependency of OpenThread header

### DIFF
--- a/src/backbone_router/backbone_agent.cpp
+++ b/src/backbone_router/backbone_agent.cpp
@@ -109,15 +109,15 @@ void BackboneAgent::HandleBackboneRouterMulticastListenerEvent(otBackboneRouterM
                                                                const otIp6Address &                   aAddress)
 {
     otbrLog(OTBR_LOG_INFO, "BackboneAgent: Multicast Listener event: %d, address: %s, state: %s", aEvent,
-            Ip6Address(aAddress).ToString().c_str(), StateToString(mBackboneRouterState));
+            Ip6Address(aAddress.mFields.m8).ToString().c_str(), StateToString(mBackboneRouterState));
 
     switch (aEvent)
     {
     case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED:
-        mSMCRouteManager.Add(Ip6Address(aAddress));
+        mSMCRouteManager.Add(Ip6Address(aAddress.mFields.m8));
         break;
     case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED:
-        mSMCRouteManager.Remove(Ip6Address(aAddress));
+        mSMCRouteManager.Remove(Ip6Address(aAddress.mFields.m8));
         break;
     }
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -35,14 +35,9 @@
 
 namespace otbr {
 
-Ip6Address::Ip6Address(const otIp6Address &aAddress)
+Ip6Address::Ip6Address(const uint8_t (&aAddress)[16])
 {
-    static_assert(sizeof(*this) == sizeof(aAddress), "wrong Ip6Address size");
-
-    m32[0] = aAddress.mFields.m32[0];
-    m32[1] = aAddress.mFields.m32[1];
-    m32[2] = aAddress.mFields.m32[2];
-    m32[3] = aAddress.mFields.m32[3];
+    memcpy(m8, aAddress, sizeof(m8));
 }
 
 std::string Ip6Address::ToString() const

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -41,8 +41,6 @@
 #include <string>
 #include <vector>
 
-#include <openthread/ip6.h>
-
 #ifndef IN6ADDR_ANY
 /**
  * Any IPv6 address literal.
@@ -114,12 +112,12 @@ public:
     }
 
     /**
-     * Constructor with an Thread Ip6 address.
+     * Constructor with an Ip6 address.
      *
-     * @param[in]   aAddress    The Thread Ip6 address.
+     * @param[in]   aAddress    The Ip6 address.
      *
      */
-    Ip6Address(const otIp6Address &aAddress);
+    Ip6Address(const uint8_t (&aAddress)[16]);
 
     /**
      * This method overloads `<` operator and compares if the Ip6 address is smaller than the other address.


### PR DESCRIPTION
This removes the dependency of `openthread/ip6.h` from `common/types.hpp`.