### PR TITLE
[openwrt] fix otbr attempt to call global 'threadget' (a nil value)

### DIFF
--- a/src/openwrt/view/admin_thread/thread_setting.htm
+++ b/src/openwrt/view/admin_thread/thread_setting.htm
@@ -2,7 +2,6 @@
 	local ubus = require "ubus"
 	local sys = require "luci.sys"
 	local utl = require "luci.util"
-	local state = threadget("state").State
 
 	function connect_ubus(methods)
 		local result
@@ -17,6 +16,16 @@
 		return result
 	end
 
+	function threadget(action)
+		local result = connect_ubus(action)
+		
+		return result
+	end
+
+	local state = threadget("state").State
+
+
+
 	function addrlist()
 		local k, v
 		local l = { }
@@ -30,11 +39,7 @@
 		return l
 	end
 
-	function threadget(action)
-		local result = connect_ubus(action)
 
-		return result
-	end
 -%>
 <%+header%>
 


### PR DESCRIPTION
On OpenWrt 19.07,Modify the order to avoid call "connect_ubus" and "threadget" failed.
before:
![image](https://user-images.githubusercontent.com/20263334/97773936-e539ab80-1b8e-11eb-900e-a4b22eea8627.png)
![image](https://user-images.githubusercontent.com/20263334/97773940-ea96f600-1b8e-11eb-818f-b56da5e7d226.png)
fix:
![image](https://user-images.githubusercontent.com/20263334/97773953-fda9c600-1b8e-11eb-8e78-4e080abaca06.png)
![image](https://user-images.githubusercontent.com/20263334/97773974-1a45fe00-1b8f-11eb-88bb-3829f608a722.png)
