### PR TITLE
[openwrt] fix startup script no effect

### DIFF
--- a/src/openwrt/otbr-agent.init.in
+++ b/src/openwrt/otbr-agent.init.in
@@ -1,3 +1,4 @@
+#!/bin/sh /etc/rc.common
 #
 #  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
@@ -26,7 +27,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-#!/bin/sh /etc/rc.common
 
 START=90
 
@@ -34,6 +34,6 @@ USE_PROCD=1
 
 start_service() {
 	procd_open_instance
-	procd_set_param command @CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent 'spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
+	procd_set_param command @CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 	procd_close_instance
 }

--- a/src/openwrt/otbr-agent.init.in
+++ b/src/openwrt/otbr-agent.init.in
@@ -34,6 +34,6 @@ USE_PROCD=1
 
 start_service() {
 	procd_open_instance
-	procd_set_param command @CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
+	procd_set_param command @CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent 'spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
 	procd_close_instance
 }

--- a/src/openwrt/view/admin_thread/thread_setting.htm
+++ b/src/openwrt/view/admin_thread/thread_setting.htm
@@ -2,7 +2,6 @@
 	local ubus = require "ubus"
 	local sys = require "luci.sys"
 	local utl = require "luci.util"
-	local state = threadget("state").State
 
 	function connect_ubus(methods)
 		local result
@@ -17,6 +16,16 @@
 		return result
 	end
 
+	function threadget(action)
+		local result = connect_ubus(action)
+		
+		return result
+	end
+
+	local state = threadget("state").State
+
+
+
 	function addrlist()
 		local k, v
 		local l = { }
@@ -30,11 +39,7 @@
 		return l
 	end
 
-	function threadget(action)
-		local result = connect_ubus(action)
 
-		return result
-	end
 -%>
 <%+header%>
 


### PR DESCRIPTION
The statement script needs to be on the first line, otherwise executing "/etc/init.d/otbr-agent start" has no effect.