### PR TITLE
[code-utils] remove client dependency of toolchain.h

### DIFF
--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -29,8 +29,6 @@
 #ifndef OTBR_COMMON_CODE_UTILS_HPP_
 #define OTBR_COMMON_CODE_UTILS_HPP_
 
-#include <openthread/platform/toolchain.h>
-
 /**
  *  This aligns the pointer to @p aAlignType.
  *
@@ -145,7 +143,57 @@
 #define OTBR_NOOP
 #define OTBR_UNUSED_VARIABLE(variable) ((void)(variable))
 
-#define OTBR_TOOL_PACKED_BEGIN OT_TOOL_PACKED_BEGIN
-#define OTBR_TOOL_PACKED_END OT_TOOL_PACKED_END
+/**
+ * @def OTBR_TOOL_PACKED_BEGIN
+ *
+ * Compiler-specific indication that a class or struct must be byte packed.
+ *
+ */
+
+/**
+ * @def OTBR_TOOL_PACKED_END
+ *
+ * Compiler-specific indication at the end of a byte packed class or struct.
+ *
+ */
+
+// =========== TOOLCHAIN SELECTION : START ===========
+
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM) || defined(__TI_ARM__)
+
+// https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html
+// http://www.keil.com/support/man/docs/armcc/armcc_chr1359124973480.htm
+
+#define OTBR_TOOL_PACKED_BEGIN
+#define OTBR_TOOL_PACKED_END __attribute__((packed))
+
+#elif defined(__ICCARM__) || defined(__ICC8051__)
+
+// http://supp.iar.com/FilesPublic/UPDINFO/004916/arm/doc/EWARM_DevelopmentGuide.ENU.pdf
+
+#include "intrinsics.h"
+
+#define OTBR_TOOL_PACKED_BEGIN __packed
+#define OTBR_TOOL_PACKED_END
+
+#elif defined(__SDCC)
+
+// Structures are packed by default in sdcc, as it primarily targets 8-bit MCUs.
+
+#define OTBR_TOOL_PACKED_BEGIN
+#define OTBR_TOOL_PACKED_END
+
+#else
+
+#error "Error: No valid Toolchain specified"
+
+// Symbols for Doxygen
+
+#define OTBR_TOOL_PACKED_BEGIN
+#define OTBR_TOOL_PACKED_END
+
+#endif
+
+// =========== TOOLCHAIN SELECTION : END ===========
 
 #endif // OTBR_COMMON_CODE_UTILS_HPP_


### PR DESCRIPTION
This removes the dependency of `openthread/platform/toolchain.h` from `common/code_utils.hpp`, for the same reason as <https://github.com/openthread/ot-br-posix/pull/601>.