### PR TITLE
[plat] set gPlatResetReason for software reset

### DIFF
--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -250,6 +250,8 @@ void ControllerOpenThread::Process(const otSysMainloopContext &aMainloop)
 
 void ControllerOpenThread::Reset(void)
 {
+    gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
+
     otInstanceFinalize(mInstance);
     otSysDeinit();
     Init();
@@ -450,5 +452,6 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 void otPlatReset(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
+
     sReset = true;
 }


### PR DESCRIPTION
https://github.com/openthread/openthread/pull/5466 allows ot-ctl to reconnect to otbr-agent or ot-daemon seamlessly. 
However, otbr-agent didn't set `gPlatResetReason` correctly thus this feature is not working for otbr-agent. 
This commit fix this issue. 