### PR TITLE
[agent] full reset using execvp

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <assert.h>
 #include <openthread/logging.h>
 #include <openthread/platform/radio.h>
 
@@ -83,6 +84,11 @@ enum
     OTBR_OPT_RADIO_VERSION,
 };
 
+static jmp_buf sResetJump;
+static bool    sShouldTerminate = false;
+
+void __gcov_flush();
+
 // Default poll timeout.
 static const struct timeval kPollTimeout = {10, 0};
 static const struct option  kOptions[]   = {
@@ -97,13 +103,16 @@ static const struct option  kOptions[]   = {
 
 static void HandleSignal(int aSignal)
 {
+    sShouldTerminate = true;
     signal(aSignal, SIG_DFL);
 }
 
 static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
 {
-    int                   error         = EXIT_FAILURE;
+    int                   error         = EXIT_SUCCESS;
     ControllerOpenThread &ncpOpenThread = static_cast<ControllerOpenThread &>(aInstance.GetNcp());
+
+    OT_UNUSED_VARIABLE(ncpOpenThread);
 
 #if OTBR_ENABLE_DBUS_SERVER
     std::unique_ptr<DBusAgent> dbusAgent = std::unique_ptr<DBusAgent>(new DBusAgent(aInterfaceName, &ncpOpenThread));
@@ -119,7 +128,7 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
     // allow quitting elegantly
     signal(SIGTERM, HandleSignal);
 
-    while (true)
+    while (!sShouldTerminate)
     {
         otSysMainloopContext mainloop;
         int                  rval;
@@ -150,12 +159,6 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
         rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
                       &mainloop.mTimeout);
 
-        if (ncpOpenThread.IsResetRequested())
-        {
-            ncpOpenThread.Reset();
-            continue;
-        }
-
         if (rval >= 0)
         {
 #if OTBR_ENABLE_OPENWRT
@@ -173,13 +176,13 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
             dbusAgent->Process(mainloop.mReadFdSet, mainloop.mWriteFdSet, mainloop.mErrorFdSet);
 #endif
         }
-        else
+        else if (errno != EINTR)
         {
 #if OTBR_ENABLE_OPENWRT
             sThreadMutex.lock();
 #endif
             error = OTBR_ERROR_ERRNO;
-            otbrLog(OTBR_LOG_ERR, "select() failed", strerror(errno));
+            otbrLog(OTBR_LOG_ERR, "select() failed: %s", strerror(errno));
             break;
         }
     }
@@ -209,7 +212,7 @@ static void OnAllocateFailed(void)
     exit(1);
 }
 
-int main(int argc, char *argv[])
+static int realmain(int argc, char *argv[])
 {
     int                              logLevel = OTBR_LOG_INFO;
     int                              opt;
@@ -302,4 +305,29 @@ int main(int argc, char *argv[])
 
 exit:
     return ret;
+}
+
+void otPlatReset(otInstance *aInstance)
+{
+    gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
+
+    otInstanceFinalize(aInstance);
+    otSysDeinit();
+
+    longjmp(sResetJump, 1);
+    assert(false);
+}
+
+int main(int argc, char *argv[])
+{
+    if (setjmp(sResetJump))
+    {
+        alarm(0);
+#if OPENTHREAD_ENABLE_COVERAGE
+        __gcov_flush();
+#endif
+        execvp(argv[0], argv);
+    }
+
+    return realmain(argc, argv);
 }

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -109,21 +109,6 @@ public:
     virtual void Process(const otSysMainloopContext &aMainloop) = 0;
 
     /**
-     * This method reest the Ncp Controller.
-     *
-     */
-    virtual void Reset(void) = 0;
-
-    /**
-     * This method return whether reset is requested.
-     *
-     * @retval  TRUE  reset is requested.
-     * @retval  FALSE reset isn't requested.
-     *
-     */
-    virtual bool IsResetRequested(void) = 0;
-
-    /**
      * This method request the event.
      *
      * @param[in]   aEvent  The event id to request.

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -53,7 +53,6 @@
 #include <ot-legacy-pairing-ext.h>
 #endif
 
-static bool sReset;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::seconds;
@@ -66,7 +65,6 @@ ControllerOpenThread::ControllerOpenThread(const char *aInterfaceName,
                                            const char *aRadioUrl,
                                            const char *aBackboneInterfaceName)
     : mInstance(nullptr)
-    , mTriedAttach(false)
 {
     memset(&mConfig, 0, sizeof(mConfig));
 
@@ -241,30 +239,10 @@ void ControllerOpenThread::Process(const otSysMainloopContext &aMainloop)
         mTimers.erase(mTimers.begin());
     }
 
-    if (!mTriedAttach && mThreadHelper->TryResumeNetwork() == OT_ERROR_NONE)
+    if (getenv("OTBR_NO_AUTO_ATTACH") == nullptr && mThreadHelper->TryResumeNetwork() == OT_ERROR_NONE)
     {
-        mTriedAttach = true;
+        setenv("OTBR_NO_AUTO_ATTACH", "1", 0);
     }
-}
-
-void ControllerOpenThread::Reset(void)
-{
-    gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
-
-    otInstanceFinalize(mInstance);
-    otSysDeinit();
-    Init();
-    for (auto &handler : mResetHandlers)
-    {
-        handler();
-    }
-    mTriedAttach = false;
-    sReset       = false;
-}
-
-bool ControllerOpenThread::IsResetRequested(void)
-{
-    return sReset;
 }
 
 otbrError ControllerOpenThread::RequestEvent(int aEvent)
@@ -413,10 +391,3 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 
 } // namespace Ncp
 } // namespace otbr
-
-void otPlatReset(otInstance *aInstance)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    sReset = true;
-}

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -106,21 +106,6 @@ public:
     void Process(const otSysMainloopContext &aMainloop) override;
 
     /**
-     * This method reset the NCP controller.
-     *
-     */
-    void Reset(void) override;
-
-    /**
-     * This method return whether reset is requested.
-     *
-     * @retval  TRUE  reset is requested.
-     * @retval  FALSE reset isn't requested.
-     *
-     */
-    bool IsResetRequested(void) override;
-
-    /**
      * This method request the event.
      *
      * @param[in]   aEvent  The event id to request.
@@ -179,7 +164,6 @@ private:
     otPlatformConfig                                                                mConfig;
     std::unique_ptr<otbr::agent::ThreadHelper>                                      mThreadHelper;
     std::multimap<std::chrono::steady_clock::time_point, std::function<void(void)>> mTimers;
-    bool                                                                            mTriedAttach;
     std::vector<std::function<void(void)>>                                          mResetHandlers;
 };
 

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -291,13 +291,12 @@ void DBusThreadObject::FactoryResetHandler(DBusRequest &aRequest)
 {
     aRequest.ReplyOtResult(OT_ERROR_NONE);
     otInstanceFactoryReset(mNcp->GetThreadHelper()->GetInstance());
-    mNcp->Reset();
 }
 
 void DBusThreadObject::ResetHandler(DBusRequest &aRequest)
 {
-    mNcp->Reset();
     aRequest.ReplyOtResult(OT_ERROR_NONE);
+    otInstanceReset(mNcp->GetThreadHelper()->GetInstance());
 }
 
 void DBusThreadObject::JoinerStartHandler(DBusRequest &aRequest)

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -32,6 +32,8 @@
 
 #include <fcntl.h>
 
+#include "utils/socket_utils.hpp"
+
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::steady_clock;
@@ -57,23 +59,14 @@ RestWebServer *RestWebServer::GetRestWebServer(ControllerOpenThread *aNcp)
     return sServer;
 }
 
-otbrError RestWebServer::Init(void)
+void RestWebServer::Init(void)
 {
-    otbrError error = OTBR_ERROR_NONE;
-
     mResource.Init();
-
-    error = InitializeListenFd();
-
-    return error;
+    InitializeListenFd();
 }
 
 void RestWebServer::UpdateFdSet(otSysMainloopContext &aMainloop)
 {
-    if (mListenFd == -1)
-    {
-        VerifyOrExit(InitializeListenFd() == OTBR_ERROR_NONE);
-    }
     FD_SET(mListenFd, &aMainloop.mReadFdSet);
     aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mListenFd);
 
@@ -82,7 +75,6 @@ void RestWebServer::UpdateFdSet(otSysMainloopContext &aMainloop)
         Connection *connection = it->second.get();
         connection->UpdateFdSet(aMainloop);
     }
-exit:
 
     return;
 }
@@ -132,7 +124,7 @@ otbrError RestWebServer::UpdateConnections(fd_set &aReadFdSet)
     return error;
 }
 
-otbrError RestWebServer::InitializeListenFd(void)
+void RestWebServer::InitializeListenFd(void)
 {
     otbrError   error = OTBR_ERROR_NONE;
     std::string errorMessage;
@@ -144,7 +136,7 @@ otbrError RestWebServer::InitializeListenFd(void)
     mAddress.sin_addr.s_addr = INADDR_ANY;
     mAddress.sin_port        = htons(kPortNumber);
 
-    mListenFd = socket(AF_INET, SOCK_STREAM, 0);
+    mListenFd = SocketWithCloseExec(AF_INET, SOCK_STREAM, 0, kSocketNonBlock);
     VerifyOrExit(mListenFd != -1, err = errno, error = OTBR_ERROR_REST, errorMessage = "socket");
 
     ret = setsockopt(mListenFd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&optval), sizeof(optval));
@@ -156,21 +148,14 @@ otbrError RestWebServer::InitializeListenFd(void)
     ret = listen(mListenFd, 5);
     VerifyOrExit(ret >= 0, err = errno, error = OTBR_ERROR_REST, errorMessage = "listen");
 
-    ret = SetFdNonblocking(mListenFd);
-    VerifyOrExit(ret, err = errno, error = OTBR_ERROR_REST, errorMessage = " set nonblock");
-
 exit:
+
     if (error != OTBR_ERROR_NONE)
     {
-        if (mListenFd != -1)
-        {
-            close(mListenFd);
-            mListenFd = -1;
-        }
-        otbrLog(OTBR_LOG_ERR, "otbr rest server init error %s : %s", errorMessage.c_str(), strerror(err));
+        otbrLog(OTBR_LOG_ERR, "InitializeListenFd error %s : %s", errorMessage.c_str(), strerror(err));
     }
 
-    return error;
+    VerifyOrDie(error == OTBR_ERROR_NONE, "otbr rest server init error");
 }
 
 otbrError RestWebServer::Accept(int aListenFd)

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -62,9 +62,6 @@ public:
     /**
      * This method initializes the REST server.
      *
-     * @retval  OTBR_ERROR_NONE     REST server initialized successfully.
-     * @retval  OTBR_ERROR_REST     Failed due to rest error .
-     *
      */
     void Init(void);
 

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -66,7 +66,7 @@ public:
      * @retval  OTBR_ERROR_REST     Failed due to rest error .
      *
      */
-    otbrError Init(void);
+    void Init(void);
 
     /**
      * This method updates the file descriptor sets and timeout for mainloop.
@@ -89,7 +89,7 @@ private:
     otbrError UpdateConnections(fd_set &aReadFdSet);
     void      CreateNewConnection(int32_t &aFd);
     otbrError Accept(int32_t aListenFd);
-    otbrError InitializeListenFd(void);
+    void      InitializeListenFd(void);
     bool      SetFdNonblocking(int32_t fd);
 
     // Resource handler

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(otbr-utils
     event_emitter.cpp
     hex.cpp
     pskc.cpp
+    socket_utils.cpp
     steering_data.cpp
     strcpy_utils.cpp
     system_utils.cpp

--- a/src/utils/socket_utils.cpp
+++ b/src/utils/socket_utils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/src/utils/socket_utils.cpp
+++ b/src/utils/socket_utils.cpp
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "utils/socket_utils.hpp"
+
+#include "common/code_utils.hpp"
+
+int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption)
+{
+    int rval = 0;
+    int fd   = -1;
+
+#ifdef __APPLE__
+    VerifyOrExit((fd = socket(aDomain, aType, aProtocol)) != -1, perror("socket(SOCK_CLOEXEC)"));
+
+    VerifyOrExit((rval = fcntl(fd, F_GETFD, 0)) != -1, perror("fcntl(F_GETFD)"));
+    rval |= aBlockOption == kSocketNonBlock ? O_NONBLOCK | FD_CLOEXEC : FD_CLOEXEC;
+    VerifyOrExit((rval = fcntl(fd, F_SETFD, rval)) != -1, perror("fcntl(F_SETFD)"));
+#else
+    aType |= aBlockOption == kSocketNonBlock ? SOCK_CLOEXEC | SOCK_NONBLOCK : SOCK_CLOEXEC;
+    VerifyOrExit((fd = socket(aDomain, aType, aProtocol)) != -1, perror("socket(SOCK_CLOEXEC)"));
+#endif
+
+exit:
+    if (rval == -1)
+    {
+        VerifyOrDie(close(fd) == 0, "close(fd) failed");
+        fd = -1;
+    }
+
+    return fd;
+}

--- a/src/utils/socket_utils.hpp
+++ b/src/utils/socket_utils.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -40,10 +40,23 @@
 
 enum SocketBlockOption
 {
-    kSocketBlock,
-    kSocketNonBlock,
+    kSocketBlock,    ///< The socket is blocking.
+    kSocketNonBlock, ///< The socket is non-blocking.
 };
 
+/**
+ * This function creates a socket with SOCK_CLOEXEC flag set.
+ *
+ * @param[in]   aDomain       The communication domain.
+ * @param[in]   aType         The semantics of communication.
+ * @param[in]   aProtocol     The protocol to use.
+ * @param[in]   aBlockOption  Whether to add nonblock flags.
+ *
+ * @returns The file descriptor of the created socket.
+ *
+ * @retval  -1  Failed to create socket.
+ *
+ */
 int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption);
 
 #endif // OTBR_UTILS_SOCKET_UTILS_HPP_

--- a/src/utils/socket_utils.hpp
+++ b/src/utils/socket_utils.hpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_UTILS_SOCKET_UTILS_HPP_
+#define OTBR_UTILS_SOCKET_UTILS_HPP_
+
+#include "openthread-br/config.h"
+
+#include "common/code_utils.hpp"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+enum SocketBlockOption
+{
+    kSocketBlock,
+    kSocketNonBlock,
+};
+
+int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption);
+
+#endif // OTBR_UTILS_SOCKET_UTILS_HPP_

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -58,6 +58,7 @@ main()
     trap on_exit EXIT
     sleep 5
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
+    sleep 1
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         org.freedesktop.DBus.Introspectable.Introspect | grep JoinerStart
@@ -115,6 +116,7 @@ EOF
         string:ABCDEF string:mock string:mock \
         string:mock string:mock string:mock
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
+    sleep 1
     sudo "${CMAKE_BINARY_DIR}"/tests/dbus/otbr-test-dbus-client
 }
 

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -175,6 +175,7 @@ int main()
                             TEST_ASSERT(api->GetRadioTxPower(txPower) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetActiveDatasetTlvs(activeDataset) == OTBR_ERROR_NONE);
                             api->FactoryReset(nullptr);
+                            sleep(1);
                             TEST_ASSERT(api->GetNetworkName(name) == OTBR_ERROR_NONE);
                             TEST_ASSERT(rloc16 != 0xffff);
                             TEST_ASSERT(extAddress != 0);
@@ -219,6 +220,7 @@ int main()
                             TEST_ASSERT(api->RemoveOnMeshPrefix(onMeshPrefix.mPrefix) == OTBR_ERROR_NONE);
 
                             api->FactoryReset(nullptr);
+                            sleep(1);
                             TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", nullptr) ==
                                         ClientError::OT_ERROR_NOT_FOUND);
                             TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", [](ClientError aJoinError) {


### PR DESCRIPTION
Premature reset has causing a number of bugs.

This commit fix the bugs and avoid potential future bugs by resetting otbr-agent using `execvp`, which will bootstrap the whole process completely. 