### PR TITLE
[codecov] fix codecov drop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       uses: codecov/codecov-action@v1
 
   rest-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         rest: ["rest-off", ""]


### PR DESCRIPTION
Fixes #653

Seems codecov does not work on ubuntu-20.04 here. The actual cause is not found yet. 
Revert one job to use `ubuntu-18.04` to fix codecov issue. 