### PR TITLE
[mbedtls] enable ECDSA support

### DIFF
--- a/third_party/openthread/mbedtls-config.h
+++ b/third_party/openthread/mbedtls-config.h
@@ -70,6 +70,15 @@
 #define MBEDTLS_SSL_SRV_C
 #define MBEDTLS_SSL_TLS_C
 
+// Enable ECDSA support
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECDSA_DETERMINISTIC
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PK_WRITE_C
+
 #define MBEDTLS_NET_C
 #define MBEDTLS_TIMING_C
 


### PR DESCRIPTION
The Mbedtls ECDSA implementation is required by SRP client&server to sign message and verify signature.
See also openthread changes https://github.com/openthread/openthread/blob/677e2f01ecd71733cc82597bab22a6312120845d/third_party/mbedtls/mbedtls-config.h#L103-L111
```c++
#if OPENTHREAD_CONFIG_ECDSA_ENABLE
#define MBEDTLS_BASE64_C
#define MBEDTLS_ECDH_C
#define MBEDTLS_ECDSA_C
#define MBEDTLS_ECDSA_DETERMINISTIC
#define MBEDTLS_OID_C
#define MBEDTLS_PEM_PARSE_C
#define MBEDTLS_PK_WRITE_C
#endif
```