### PR TITLE
[dbus] add active dataset api

### DIFF
--- a/src/agent/thread_helper.cpp
+++ b/src/agent/thread_helper.cpp
@@ -268,6 +268,30 @@ exit:
     }
 }
 
+void ThreadHelper::Attach(ResultHandler aHandler)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = OT_ERROR_INVALID_STATE);
+    mAttachHandler = aHandler;
+
+    if (!otIp6IsEnabled(mInstance))
+    {
+        SuccessOrExit(error = otIp6SetEnabled(mInstance, true));
+    }
+    SuccessOrExit(error = otThreadSetEnabled(mInstance, true));
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (aHandler)
+        {
+            aHandler(error);
+        }
+        mAttachHandler = nullptr;
+    }
+}
+
 otError ThreadHelper::Reset(void)
 {
     mDeviceRoleHandlers.clear();

--- a/src/agent/thread_helper.hpp
+++ b/src/agent/thread_helper.hpp
@@ -120,6 +120,17 @@ public:
                 ResultHandler               aHandler);
 
     /**
+     * This method attaches the device to the Thread network.
+     *
+     * @note The joiner start and the attach proccesses are exclusive, and the
+     *       network parameter will be set through the active dataset.
+     *
+     * @param[in]   aHandler        The attach result handler.
+     *
+     */
+    void Attach(ResultHandler aHandler);
+
+    /**
      * This method resets the OpenThread stack.
      *
      * @returns The error value of underlying OpenThread api calls.

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -228,6 +228,30 @@ exit:
     return error;
 }
 
+ClientError ThreadApiDBus::Attach(const OtResultHandler &aHandler)
+{
+    ClientError error = ClientError::ERROR_NONE;
+
+    VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = ClientError::OT_ERROR_INVALID_STATE);
+    mAttachHandler = aHandler;
+
+    if (aHandler)
+    {
+        error = CallDBusMethodAsync(OTBR_DBUS_ATTACH_METHOD,
+                                    &ThreadApiDBus::sHandleDBusPendingCall<&ThreadApiDBus::AttachPendingCallHandler>);
+    }
+    else
+    {
+        error = CallDBusMethodSync(OTBR_DBUS_ATTACH_METHOD);
+    }
+    if (error != ClientError::ERROR_NONE)
+    {
+        mAttachHandler = nullptr;
+    }
+exit:
+    return error;
+}
+
 void ThreadApiDBus::AttachPendingCallHandler(DBusPendingCall *aPending)
 {
     ClientError       ret = ClientError::OT_ERROR_FAILED;
@@ -369,6 +393,11 @@ ClientError ThreadApiDBus::SetLegacyUlaPrefix(const std::array<uint8_t, OTBR_IP6
     return SetProperty(OTBR_DBUS_PROPERTY_LEGACY_ULA_PREFIX, aPrefix);
 }
 
+ClientError ThreadApiDBus::SetActiveDatasetTlvs(const std::vector<uint8_t> &aDataset)
+{
+    return SetProperty(OTBR_DBUS_PROPERTY_ACTIVE_DATASET_TLVS, aDataset);
+}
+
 ClientError ThreadApiDBus::SetLinkMode(const LinkModeConfig &aConfig)
 {
     return SetProperty(OTBR_DBUS_PROPERTY_LINK_MODE, aConfig);
@@ -508,6 +537,11 @@ ClientError ThreadApiDBus::GetRadioTxPower(int8_t &aTxPower)
 ClientError ThreadApiDBus::GetExternalRoutes(std::vector<ExternalRoute> &aExternalRoutes)
 {
     return GetProperty(OTBR_DBUS_PROPERTY_EXTERNAL_ROUTES, aExternalRoutes);
+}
+
+ClientError ThreadApiDBus::GetActiveDatasetTlvs(std::vector<uint8_t> &aDataset)
+{
+    return GetProperty(OTBR_DBUS_PROPERTY_ACTIVE_DATASET_TLVS, aDataset);
 }
 
 std::string ThreadApiDBus::GetInterfaceName(void)

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -126,6 +126,21 @@ public:
                        const OtResultHandler &     aHandler);
 
     /**
+     * This method attaches the device to the Thread network.
+     *
+     * The network parameters will be set with the active dataset under this
+     * circumstance.
+     *
+     * @param[in]   aHandler        The attach result handler.
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_DBUS dbus encode/decode error
+     * @retval ...        OpenThread defined error value otherwise
+     *
+     */
+    ClientError Attach(const OtResultHandler &aHandler);
+
+    /**
      * This method performs a factory reset.
      *
      * @param[in]   aHandler        The reset result handler.
@@ -254,6 +269,18 @@ public:
      *
      */
     ClientError SetLegacyUlaPrefix(const std::array<uint8_t, OTBR_IP6_PREFIX_SIZE> &aPrefix);
+
+    /**
+     * This method sets the active operational dataset.
+     *
+     * @param[out]  aDataset    The active operational dataset
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_DBUS dbus encode/decode error
+     * @retval ...        OpenThread defined error value otherwise
+     *
+     */
+    ClientError SetActiveDatasetTlvs(const std::vector<uint8_t> &aDataset);
 
     /**
      * This method sets the link operating mode.
@@ -579,6 +606,18 @@ public:
      *
      */
     ClientError GetExternalRoutes(std::vector<ExternalRoute> &aExternalRoutes);
+
+    /**
+     * This method gets the active operational dataset
+     *
+     * @param[out]  aDataset    The active operational dataset
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_DBUS dbus encode/decode error
+     * @retval ...        OpenThread defined error value otherwise
+     *
+     */
+    ClientError GetActiveDatasetTlvs(std::vector<uint8_t> &aDataset);
 
     /**
      * This method returns the network interface name the client is bound to.

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -79,6 +79,7 @@
 #define OTBR_DBUS_PROPERTY_INSTANT_RSSI "InstantRssi"
 #define OTBR_DBUS_PROPERTY_RADIO_TX_POWER "RadioTxPower"
 #define OTBR_DBUS_PROPERTY_EXTERNAL_ROUTES "ExternalRoutes"
+#define OTBR_DBUS_PROPERTY_ACTIVE_DATASET_TLVS "ActiveDatasetTlvs"
 
 #define OTBR_ROLE_NAME_DISABLED "disabled"
 #define OTBR_ROLE_NAME_DETACHED "detached"

--- a/src/dbus/common/dbus_message_helper.cpp
+++ b/src/dbus/common/dbus_message_helper.cpp
@@ -177,5 +177,16 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::vector<int64_t> &
     return DBusMessageEncodePrimitive(aIter, aValue);
 }
 
+bool IsDBusMessageEmpty(DBusMessage &aMessage)
+{
+    DBusMessageIter iter;
+
+    if (!dbus_message_iter_init(&aMessage, &iter))
+    {
+        return true;
+    }
+    return dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_INVALID;
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -583,6 +583,8 @@ otbrError DBusMessageToTuple(UniqueDBusMessage const &aMessage, std::tuple<Field
     return DBusMessageToTuple(*aMessage.get(), aValues);
 }
 
+bool IsDBusMessageEmpty(DBusMessage &aMessage);
+
 } // namespace DBus
 } // namespace otbr
 

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -86,6 +86,7 @@ private:
     otError SetMeshLocalPrefixHandler(DBusMessageIter &aIter);
     otError SetLegacyUlaPrefixHandler(DBusMessageIter &aIter);
     otError SetLinkModeHandler(DBusMessageIter &aIter);
+    otError SetActiveDatasetTlvsHandler(DBusMessageIter &aIter);
 
     otError GetLinkModeHandler(DBusMessageIter &aIter);
     otError GetDeviceRoleHandler(DBusMessageIter &aIter);
@@ -113,6 +114,7 @@ private:
     otError GetInstantRssiHandler(DBusMessageIter &aIter);
     otError GetRadioTxPowerHandler(DBusMessageIter &aIter);
     otError GetExternalRoutesHandler(DBusMessageIter &aIter);
+    otError GetActiveDatasetTlvsHandler(DBusMessageIter &aIter);
 
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
 

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -31,6 +31,9 @@
       <arg name="channel_mask" type="u"/>
     </method>
 
+    <method name="Attach">
+    </method>
+
     <method name="PermitUnsecureJoin">
       <arg name="port" type="q"/>
       <arg name="timeout" type="u"/>
@@ -332,6 +335,10 @@
       }
     -->
     <property name="ExternalRoutes" type="((ayy)qybb)" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
+    <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
   </interface>

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -134,7 +134,9 @@ int main()
                     [&api, channel, extpanid](ClientError aError) {
                         printf("Attach result %d\n", static_cast<int>(aError));
                         sleep(10);
-                        uint64_t extpanidCheck;
+                        uint64_t             extpanidCheck;
+                        std::vector<uint8_t> activeDataset;
+
                         if (aError == OTBR_ERROR_NONE)
                         {
                             std::string                           name;
@@ -166,6 +168,7 @@ int main()
                             TEST_ASSERT(api->GetPartitionId(partitionId) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetInstantRssi(rssi) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetRadioTxPower(txPower) == OTBR_ERROR_NONE);
+                            TEST_ASSERT(api->GetActiveDatasetTlvs(activeDataset) == OTBR_ERROR_NONE);
                             api->FactoryReset(nullptr);
                             TEST_ASSERT(api->GetNetworkName(name) == OTBR_ERROR_NONE);
                             TEST_ASSERT(rloc16 != 0xffff);
@@ -178,10 +181,13 @@ int main()
                         {
                             exit(-1);
                         }
-                        api->Attach("Test", 0x5678, extpanid, {}, {}, UINT32_MAX, [&api](ClientError aErr) {
+                        TEST_ASSERT(api->SetActiveDatasetTlvs(activeDataset) == OTBR_ERROR_NONE);
+                        api->Attach([&api, channel, extpanid](ClientError aErr) {
                             uint8_t                routerId;
                             otbr::DBus::LeaderData leaderData;
                             uint8_t                leaderWeight;
+                            uint16_t               channelResult;
+                            uint64_t               extpanidCheck;
                             Ip6Prefix              prefix;
                             OnMeshPrefix           onMeshPrefix = {};
 
@@ -191,6 +197,11 @@ int main()
                             onMeshPrefix.mPrefix     = prefix;
                             onMeshPrefix.mPreference = 0;
                             onMeshPrefix.mStable     = true;
+
+                            TEST_ASSERT(api->GetChannel(channelResult) == OTBR_ERROR_NONE);
+                            TEST_ASSERT(channelResult == channel);
+                            TEST_ASSERT(api->GetExtPanId(extpanidCheck) == OTBR_ERROR_NONE);
+                            TEST_ASSERT(extpanidCheck == extpanid);
 
                             TEST_ASSERT(api->GetLocalLeaderWeight(leaderWeight) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetLeaderData(leaderData) == OTBR_ERROR_NONE);


### PR DESCRIPTION
This change allows users to get and set the active dataset via the dbus
api. It also adds an `Attach` interface to allow users to start the
Thread network without specifying network parameters.