### PR TITLE
[mdns] add mDNS API to publish & un-publish custom host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,10 @@ tests/unit/unittest
 # Vim auto complete helper
 .ycm_extra_conf.py
 
+# CLion
+.idea
+cmake-build*
+
 # Thread local storage
 ./tmp/
 *.data

--- a/.gitignore
+++ b/.gitignore
@@ -105,10 +105,6 @@ tests/unit/unittest
 # Vim auto complete helper
 .ycm_extra_conf.py
 
-# CLion
-.idea
-cmake-build*
-
 # Thread local storage
 ./tmp/
 *.data

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -224,7 +224,7 @@ void BorderAgent::PublishService(void)
 
     assert(mThreadVersion != 0);
     // clang-format off
-    mPublisher->PublishService(nullptr, kBorderAgentUdpPort, mNetworkName, kBorderAgentServiceType,
+    mPublisher->PublishService(/* aHostName */ nullptr, kBorderAgentUdpPort, mNetworkName, kBorderAgentServiceType,
         "nn", mNetworkName, strlen(mNetworkName),
         "xp", &mExtPanId, sizeof(mExtPanId),
         "tv", versionString, strlen(versionString),

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -83,7 +83,7 @@ enum
 
 BorderAgent::BorderAgent(Ncp::Controller *aNcp)
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
-    : mPublisher(Mdns::Publisher::Create(AF_UNSPEC, nullptr, nullptr, HandleMdnsState, this))
+    : mPublisher(Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, HandleMdnsState, this))
 #else
     : mPublisher(nullptr)
 #endif
@@ -224,7 +224,7 @@ void BorderAgent::PublishService(void)
 
     assert(mThreadVersion != 0);
     // clang-format off
-    mPublisher->PublishService(kBorderAgentUdpPort, mNetworkName, kBorderAgentServiceType,
+    mPublisher->PublishService(nullptr, kBorderAgentUdpPort, mNetworkName, kBorderAgentServiceType,
         "nn", mNetworkName, strlen(mNetworkName),
         "xp", &mExtPanId, sizeof(mExtPanId),
         "tv", versionString, strlen(versionString),

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -104,6 +104,10 @@ public:
     /**
      * This method publishes or updates a service.
      *
+     * @param[in]   aHostName           The name of the host which this service resides on. If NULL is provided,
+     *                                  this service resides on local host and it is the implementation to provide
+     *                                  specific host name. Otherwise, the caller MUST publish the host with method
+     *                                  PublishHost.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      * @param[in]   aPort               The port number of this service.
@@ -114,7 +118,51 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    virtual otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) = 0;
+    virtual otbrError PublishService(const char *aHostName,
+                                     uint16_t    aPort,
+                                     const char *aName,
+                                     const char *aType,
+                                     ...) = 0;
+
+    /**
+     * This method un-publishes a service.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    virtual otbrError UnpublishService(const char *aName, const char *aType) = 0;
+
+    /**
+     * This method publishes or updates a host.
+     *
+     * Publishing a host is advertising an A/AAAA RR for the host name. This method should be called
+     * before a service with non-null host name is published.
+     *
+     * @param[in]  aName           The name of the host.
+     * @param[in]  aAddress        The address of the host.
+     * @param[in]  aAddressLength  The length of @p aAddress.
+     *
+     * @retval  OTBR_ERROR_NONE          Successfully published or updated the host.
+     * @retval  OTBR_ERROR_INVALID_ARGS  The arguments are not valid.
+     * @retval  OTBR_ERROR_ERRNO         Failed to publish or update the host.
+     *
+     */
+    virtual otbrError PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength) = 0;
+
+    /**
+     * This method un-publishes a host.
+     *
+     * @param[in]  aName  A host name.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     *
+     */
+    virtual otbrError UnpublishHost(const char *aName) = 0;
 
     /**
      * This method performs the MDNS processing.
@@ -149,22 +197,17 @@ public:
      * This function creates a MDNS publisher.
      *
      * @param[in]   aProtocol           Protocol to use for publishing. AF_INET6, AF_INET or AF_UNSPEC.
-     * @param[in]   aHost               The host where these services is residing on.
-     * @param[in]   aDomain             The domain to register in.
+     * @param[in]   aDomain             The domain to register in. May be nullptr.
      * @param[in]   aHandler            The function to be called when this service state changed.
      * @param[in]   aContext            A pointer to application-specific context.
      *
      * @returns A pointer to the newly created MDNS publisher.
      *
      */
-    static Publisher *Create(int          aProtocol,
-                             const char * aHost,
-                             const char * aDomain,
-                             StateHandler aHandler,
-                             void *       aContext);
+    static Publisher *Create(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
     /**
-     * This function destroies the MDNS publisher.
+     * This function destroys the MDNS publisher.
      *
      * @param[in]   aPublisher          A pointer to the publisher.
      *

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -130,8 +130,8 @@ public:
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the service.
      *
      */
     virtual otbrError UnpublishService(const char *aName, const char *aType) = 0;
@@ -158,8 +158,8 @@ public:
      *
      * @param[in]  aName  A host name.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the host.
      *
      */
     virtual otbrError UnpublishHost(const char *aName) = 0;
@@ -197,7 +197,7 @@ public:
      * This function creates a MDNS publisher.
      *
      * @param[in]   aProtocol           Protocol to use for publishing. AF_INET6, AF_INET or AF_UNSPEC.
-     * @param[in]   aDomain             The domain to register in. May be nullptr.
+     * @param[in]   aDomain             The domain to register in. Set nullptr to use default mDNS domain ("local.").
      * @param[in]   aHandler            The function to be called when this service state changed.
      * @param[in]   aContext            A pointer to application-specific context.
      *

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -583,26 +583,32 @@ exit:
 
 otbrError PublisherAvahi::UnpublishService(const char *aName, const char *aType)
 {
-    (void)aName;
-    (void)aType;
+    OTBR_UNUSED_VARIABLE(aName);
+    OTBR_UNUSED_VARIABLE(aType);
 
-    return OTBR_ERROR_NOT_IMPLEMENTED;
+    VerifyOrDie(false, "UnpublishService is not implemented with avahi");
+
+    return OTBR_ERROR_NONE;
 }
 
 otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
 {
-    (void)aName;
-    (void)aAddress;
-    (void)aAddressLength;
+    OTBR_UNUSED_VARIABLE(aName);
+    OTBR_UNUSED_VARIABLE(aAddress);
+    OTBR_UNUSED_VARIABLE(aAddressLength);
 
-    return OTBR_ERROR_NOT_IMPLEMENTED;
+    VerifyOrDie(false, "PublishHost is not implemented with avahi");
+
+    return OTBR_ERROR_NONE;
 }
 
 otbrError PublisherAvahi::UnpublishHost(const char *aName)
 {
-    (void)aName;
+    OTBR_UNUSED_VARIABLE(aName);
 
-    return OTBR_ERROR_NOT_IMPLEMENTED;
+    VerifyOrDie(false, "UnpublishHost is not implemented with avahi");
+
+    return OTBR_ERROR_NONE;
 }
 
 Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -305,16 +305,11 @@ void Poller::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const 
     }
 }
 
-PublisherAvahi::PublisherAvahi(int          aProtocol,
-                               const char * aHost,
-                               const char * aDomain,
-                               StateHandler aHandler,
-                               void *       aContext)
+PublisherAvahi::PublisherAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
     : mClient(nullptr)
     , mGroup(nullptr)
     , mProtocol(aProtocol == AF_INET6 ? AVAHI_PROTO_INET6
                                       : aProtocol == AF_INET ? AVAHI_PROTO_INET : AVAHI_PROTO_UNSPEC)
-    , mHost(aHost)
     , mDomain(aDomain)
     , mState(kStateIdle)
     , mStateHandler(aHandler)
@@ -497,7 +492,11 @@ void PublisherAvahi::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet
     mPoller.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
 }
 
-otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, const char *aType, ...)
+otbrError PublisherAvahi::PublishService(const char *aHostName,
+                                         uint16_t    aPort,
+                                         const char *aName,
+                                         const char *aType,
+                                         ...)
 {
     otbrError ret   = OTBR_ERROR_ERRNO;
     int       error = 0;
@@ -510,6 +509,7 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
 
     va_start(args, aType);
 
+    VerifyOrExit(aHostName == nullptr, ret = OTBR_ERROR_NOT_IMPLEMENTED);
     VerifyOrExit(mState == kStateReady, errno = EAGAIN);
     VerifyOrExit(mGroup != nullptr, ret = OTBR_ERROR_MDNS);
 
@@ -551,7 +551,7 @@ otbrError PublisherAvahi::PublishService(uint16_t aPort, const char *aName, cons
 
     otbrLog(OTBR_LOG_INFO, "MDNS create service %s", aName);
     error = avahi_entry_group_add_service_strlst(mGroup, AVAHI_IF_UNSPEC, mProtocol, static_cast<AvahiPublishFlags>(0),
-                                                 aName, aType, mDomain, mHost, aPort, last);
+                                                 aName, aType, mDomain, aHostName, aPort, last);
     SuccessOrExit(error);
 
     {
@@ -581,9 +581,33 @@ exit:
     return ret;
 }
 
-Publisher *Publisher::Create(int aFamily, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext)
+otbrError PublisherAvahi::UnpublishService(const char *aName, const char *aType)
 {
-    return new PublisherAvahi(aFamily, aHost, aDomain, aHandler, aContext);
+    (void)aName;
+    (void)aType;
+
+    return OTBR_ERROR_NOT_IMPLEMENTED;
+}
+
+otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
+{
+    (void)aName;
+    (void)aAddress;
+    (void)aAddressLength;
+
+    return OTBR_ERROR_NOT_IMPLEMENTED;
+}
+
+otbrError PublisherAvahi::UnpublishHost(const char *aName)
+{
+    (void)aName;
+
+    return OTBR_ERROR_NOT_IMPLEMENTED;
+}
+
+Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
+{
+    return new PublisherAvahi(aFamily, aDomain, aHandler, aContext);
 }
 
 void Publisher::Destroy(Publisher *aPublisher)

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -228,8 +228,8 @@ public:
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the service.
      *
      */
     otbrError UnpublishService(const char *aName, const char *aType) override;
@@ -255,8 +255,8 @@ public:
      *
      * @param[in]  aName  A host name.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the host.
      *
      * @note  All services reside on this host should be un-published by UnpublishService.
      *

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -194,22 +194,22 @@ public:
      * The constructor to initialize a Publisher.
      *
      * @param[in]   aProtocol           The protocol used for publishing. IPv4, IPv6 or both.
-     * @param[in]   aHost               The name of host residing the services to be published.
-                                        nullptr to use default.
      * @param[in]   aDomain             The domain of the host. nullptr to use default.
      * @param[in]   aHandler            The function to be called when state changes.
      * @param[in]   aContext            A pointer to application-specific context.
      *
      */
-    PublisherAvahi(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext);
+    PublisherAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
     ~PublisherAvahi(void) override;
 
     /**
      * This method publishes or updates a service.
      *
-     * @note only text record can be updated.
-     *
+     * @param[in]   aHostName           The name of the host which this service resides on. If NULL is provided,
+     *                                  this service resides on local host and it is the implementation to provide
+     *                                  specific host name. Otherwise, the caller MUST publish the host with method
+     *                                  PublishHost.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      * @param[in]   aPort               The port number of this service.
@@ -220,7 +220,48 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) override;
+    otbrError PublishService(const char *aHostName, uint16_t aPort, const char *aName, const char *aType, ...) override;
+
+    /**
+     * This method un-publishes a service.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    otbrError UnpublishService(const char *aName, const char *aType) override;
+
+    /**
+     * This method publishes or updates a host.
+     *
+     * Publishing a host is advertising an AAAA RR for the host name. This method should be called
+     * before a service with non-null host name is published.
+     *
+     * @param[in]  aName           The name of the host.
+     * @param[in]  aAddress        The address of the host.
+     * @param[in]  aAddressLength  The length of @p aAddress.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     *
+     */
+    otbrError PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength) override;
+
+    /**
+     * This method un-publishes a host.
+     *
+     * @param[in]  aName  A host name.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     *
+     * @note  All services reside on this host should be un-published by UnpublishService.
+     *
+     */
+    otbrError UnpublishHost(const char *aName) override;
 
     /**
      * This method starts the MDNS service.
@@ -303,7 +344,6 @@ private:
     AvahiEntryGroup *mGroup;
     Poller           mPoller;
     int              mProtocol;
-    const char *     mHost;
     const char *     mDomain;
     State            mState;
     StateHandler     mStateHandler;

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -476,6 +476,9 @@ otbrError PublisherMDnsSd::PublishHost(const char *aName, const uint8_t *aAddres
     DNSRecordRef hostRecord;
     Host         newHost;
 
+    // Supports only IPv6 for now, may support IPv4 in the future.
+    VerifyOrExit(aAddressLength == OTBR_IP6_ADDRESS_SIZE, error = OTBR_ERROR_INVALID_ARGS);
+
     SuccessOrExit(ret = MakeFullName(fullName, sizeof(fullName), aName));
 
     if (mHostsConnection == nullptr)
@@ -550,8 +553,8 @@ void PublisherMDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnect
                                                DNSServiceFlags     aFlags,
                                                DNSServiceErrorType aErrorCode)
 {
-    (void)aHostsConnection;
-    (void)aFlags;
+    OTBR_UNUSED_VARIABLE(aHostsConnection);
+    OTBR_UNUSED_VARIABLE(aFlags);
 
     auto host =
         std::find_if(mHosts.begin(), mHosts.end(), [&](const Host &aHost) { return aHost.mRecord == aHostRecord; });

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -33,6 +33,8 @@
 
 #include "mdns/mdns_mdnssd.hpp"
 
+#include <algorithm>
+
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
@@ -162,12 +164,8 @@ static const char *DNSErrorToString(DNSServiceErrorType aError)
     }
 }
 
-PublisherMDnsSd::PublisherMDnsSd(int          aProtocol,
-                                 const char * aHost,
-                                 const char * aDomain,
-                                 StateHandler aHandler,
-                                 void *       aContext)
-    : mHost(aHost)
+PublisherMDnsSd::PublisherMDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
+    : mHostsConnection(nullptr)
     , mDomain(aDomain)
     , mState(kStateIdle)
     , mStateHandler(aHandler)
@@ -205,6 +203,16 @@ void PublisherMDnsSd::Stop(void)
 
     mServices.clear();
 
+    if (mHostsConnection != nullptr)
+    {
+        otbrLog(OTBR_LOG_INFO, "MDNS remove all hosts");
+
+        // This effectively removes all hosts registered on this connection.
+        DNSServiceRefDeallocate(mHostsConnection);
+        mHostsConnection = nullptr;
+        mHosts.clear();
+    }
+
 exit:
     return;
 }
@@ -232,6 +240,20 @@ void PublisherMDnsSd::UpdateFdSet(fd_set & aReadFdSet,
             aMaxFd = fd;
         }
     }
+
+    if (mHostsConnection != nullptr)
+    {
+        int fd = DNSServiceRefSockFD(mHostsConnection);
+
+        assert(fd != -1);
+
+        FD_SET(fd, &aReadFdSet);
+
+        if (fd > aMaxFd)
+        {
+            aMaxFd = fd;
+        }
+    }
 }
 
 void PublisherMDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
@@ -248,6 +270,16 @@ void PublisherMDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSe
         if (FD_ISSET(fd, &aReadFdSet))
         {
             readyServices.push_back(it->mService);
+        }
+    }
+
+    if (mHostsConnection != nullptr)
+    {
+        int fd = DNSServiceRefSockFD(mHostsConnection);
+
+        if (FD_ISSET(fd, &aReadFdSet))
+        {
+            readyServices.push_back(mHostsConnection);
         }
     }
 
@@ -309,7 +341,7 @@ void PublisherMDnsSd::DiscardService(const char *aName, const char *aType, DNSSe
     {
         if (!strncmp(it->mName, aName, sizeof(it->mName)) && !strncmp(it->mType, aType, sizeof(it->mType)))
         {
-            assert(aServiceRef == it->mService);
+            assert(aServiceRef == nullptr || aServiceRef == it->mService);
             mServices.erase(it);
             DNSServiceRefDeallocate(aServiceRef);
             aServiceRef = nullptr;
@@ -344,7 +376,11 @@ exit:
     return;
 }
 
-otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, const char *aType, ...)
+otbrError PublisherMDnsSd::PublishService(const char *aHostName,
+                                          uint16_t    aPort,
+                                          const char *aName,
+                                          const char *aType,
+                                          ...)
 {
     otbrError     ret   = OTBR_ERROR_NONE;
     int           error = 0;
@@ -352,6 +388,17 @@ otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, con
     uint8_t       txt[kMaxSizeOfTxtRecord];
     uint8_t *     cur        = txt;
     DNSServiceRef serviceRef = nullptr;
+    char          fullHostName[kMaxSizeOfDomain];
+
+    if (aHostName != nullptr)
+    {
+        auto host = std::find_if(mHosts.begin(), mHosts.end(),
+                                 [&](const Host &aHost) { return strcmp(aHost.mName, aHostName) == 0; });
+
+        // Make sure that the host has been published.
+        VerifyOrExit(host != mHosts.end(), ret = OTBR_ERROR_INVALID_ARGS);
+        SuccessOrExit(error = MakeFullName(fullHostName, sizeof(fullHostName), aHostName));
+    }
 
     va_start(args, aType);
 
@@ -396,9 +443,9 @@ otbrError PublisherMDnsSd::PublishService(uint16_t aPort, const char *aName, con
         }
     }
 
-    SuccessOrExit(error = DNSServiceRegister(&serviceRef, 0, kDNSServiceInterfaceIndexAny, aName, aType, mDomain, mHost,
-                                             htons(aPort), static_cast<uint16_t>(cur - txt), txt,
-                                             HandleServiceRegisterResult, this));
+    SuccessOrExit(error = DNSServiceRegister(&serviceRef, 0, kDNSServiceInterfaceIndexAny, aName, aType, mDomain,
+                                             (aHostName != nullptr) ? fullHostName : nullptr, htons(aPort),
+                                             static_cast<uint16_t>(cur - txt), txt, HandleServiceRegisterResult, this));
     if (serviceRef != nullptr)
     {
         RecordService(aName, aType, serviceRef);
@@ -415,9 +462,133 @@ exit:
     return ret;
 }
 
-Publisher *Publisher::Create(int aFamily, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext)
+otbrError PublisherMDnsSd::UnpublishService(const char *aName, const char *aType)
 {
-    return new PublisherMDnsSd(aFamily, aHost, aDomain, aHandler, aContext);
+    DiscardService(aName, aType);
+    return OTBR_ERROR_NONE;
+}
+
+otbrError PublisherMDnsSd::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
+{
+    otbrError    ret   = OTBR_ERROR_NONE;
+    int          error = 0;
+    char         fullName[kMaxSizeOfDomain];
+    DNSRecordRef hostRecord;
+    Host         newHost;
+
+    SuccessOrExit(ret = MakeFullName(fullName, sizeof(fullName), aName));
+
+    if (mHostsConnection == nullptr)
+    {
+        SuccessOrExit(error = DNSServiceCreateConnection(&mHostsConnection));
+    }
+
+    for (const auto &host : mHosts)
+    {
+        if (strcmp(aName, host.mName) == 0)
+        {
+            otbrLog(OTBR_LOG_INFO, "mDNS update host %s", aName);
+            SuccessOrExit(error = DNSServiceUpdateRecord(mHostsConnection, host.mRecord, /* flags */ 0, aAddressLength,
+                                                         aAddress, /* ttl */ 0));
+            ExitNow();
+        }
+    }
+
+    SuccessOrExit(error = DNSServiceRegisterRecord(mHostsConnection, &hostRecord, kDNSServiceFlagsUnique,
+                                                   kDNSServiceInterfaceIndexAny, fullName, kDNSServiceType_AAAA,
+                                                   kDNSServiceClass_IN, aAddressLength, aAddress, /* ttl */ 0,
+                                                   HandleRegisterHostResult, this));
+    strcpy(newHost.mName, aName);
+    newHost.mRecord = hostRecord;
+    mHosts.push_back(newHost);
+
+exit:
+    if (error != kDNSServiceErr_NoError)
+    {
+        ret = OTBR_ERROR_MDNS;
+        otbrLog(OTBR_LOG_ERR, "Failed to publish/update host %s for mdnssd error: %s!", aName, DNSErrorToString(error));
+    }
+    return ret;
+}
+
+otbrError PublisherMDnsSd::UnpublishHost(const char *aName)
+{
+    otbrError ret   = OTBR_ERROR_NONE;
+    int       error = 0;
+
+    auto host =
+        std::find_if(mHosts.begin(), mHosts.end(), [&](const Host &aHost) { return strcmp(aHost.mName, aName) == 0; });
+    if (host == mHosts.end())
+    {
+        ExitNow();
+    }
+
+    SuccessOrExit(error = DNSServiceRemoveRecord(mHostsConnection, host->mRecord, /* flags */ 0));
+    mHosts.erase(host);
+
+exit:
+    if (error != kDNSServiceErr_NoError)
+    {
+        ret = OTBR_ERROR_MDNS;
+        otbrLog(OTBR_LOG_ERR, "Failed to un-publish host %s for mdnssd error: %s!", aName, DNSErrorToString(error));
+    }
+    return ret;
+}
+
+void PublisherMDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                               DNSRecordRef        aHostRecord,
+                                               DNSServiceFlags     aFlags,
+                                               DNSServiceErrorType aErrorCode,
+                                               void *              aContext)
+{
+    static_cast<PublisherMDnsSd *>(aContext)->HandleRegisterHostResult(aHostsConnection, aHostRecord, aFlags,
+                                                                       aErrorCode);
+}
+
+void PublisherMDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                               DNSRecordRef        aHostRecord,
+                                               DNSServiceFlags     aFlags,
+                                               DNSServiceErrorType aErrorCode)
+{
+    (void)aHostsConnection;
+    (void)aFlags;
+
+    auto host =
+        std::find_if(mHosts.begin(), mHosts.end(), [&](const Host &aHost) { return aHost.mRecord == aHostRecord; });
+    assert(host != mHosts.end());
+
+    if (aErrorCode == kDNSServiceErr_NoError)
+    {
+        otbrLog(OTBR_LOG_INFO, "Successfully registered host %s", host->mName);
+    }
+    else
+    {
+        otbrLog(OTBR_LOG_WARNING, "Failed to register host %s for mdnssd error: %s", host->mName,
+                DNSErrorToString(aErrorCode));
+    }
+}
+
+otbrError PublisherMDnsSd::MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName)
+{
+    otbrError   error      = OTBR_ERROR_NONE;
+    size_t      nameLength = strlen(aName);
+    const char *domain     = (mDomain == nullptr) ? "local." : mDomain;
+
+    VerifyOrExit(nameLength <= kMaxSizeOfHost, error = OTBR_ERROR_INVALID_ARGS);
+
+    assert(aFullNameLength >= nameLength + sizeof(".") + strlen(domain));
+
+    strcpy(aFullName, aName);
+    strcpy(aFullName + nameLength, ".");
+    strcpy(aFullName + nameLength + 1, domain);
+
+exit:
+    return error;
+}
+
+Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
+{
+    return new PublisherMDnsSd(aFamily, aDomain, aHandler, aContext);
 }
 
 void Publisher::Destroy(Publisher *aPublisher)

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -90,8 +90,8 @@ public:
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the service.
      *
      */
     otbrError UnpublishService(const char *aName, const char *aType) override;
@@ -117,8 +117,8 @@ public:
      *
      * @param[in]  aName  A host name.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     * @retval  OTBR_ERROR_NONE     Successfully un-published the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the host.
      *
      * @note  All services reside on this host should be un-published by UnpublishService.
      *

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -56,22 +56,22 @@ public:
      * The constructor to initialize a Publisher.
      *
      * @param[in]   aProtocol           The protocol used for publishing. IPv4, IPv6 or both.
-     * @param[in]   aHost               The name of host residing the services to be published.
-                                        nullptr to use default.
      * @param[in]   aDomain             The domain of the host. nullptr to use default.
      * @param[in]   aHandler            The function to be called when state changes.
      * @param[in]   aContext            A pointer to application-specific context.
      *
      */
-    PublisherMDnsSd(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext);
+    PublisherMDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
     ~PublisherMDnsSd(void) override;
 
     /**
      * This method publishes or updates a service.
      *
-     * @note only text record can be updated.
-     *
+     * @param[in]   aHostName           The name of the host which this service resides on. If NULL is provided,
+     *                                  this service resides on local host and it is the implementation to provide
+     *                                  specific host name. Otherwise, the caller MUST publish the host with method
+     *                                  PublishHost.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
      * @param[in]   aPort               The port number of this service.
@@ -82,7 +82,48 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) override;
+    otbrError PublishService(const char *aHostName, uint16_t aPort, const char *aName, const char *aType, ...) override;
+
+    /**
+     * This method un-publishes a service.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    otbrError UnpublishService(const char *aName, const char *aType) override;
+
+    /**
+     * This method publishes or updates a host.
+     *
+     * Publishing a host is advertising an AAAA RR for the host name. This method should be called
+     * before a service with non-null host name is published.
+     *
+     * @param[in]  aName           The name of the host.
+     * @param[in]  aAddress        The address of the host.
+     * @param[in]  aAddressLength  The length of @p aAddress.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     *
+     */
+    otbrError PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength) override;
+
+    /**
+     * This method un-publishes a host.
+     *
+     * @param[in]  aName  A host name.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the host.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the host.
+     *
+     * @note  All services reside on this host should be un-published by UnpublishService.
+     *
+     */
+    otbrError UnpublishHost(const char *aName) override;
 
     /**
      * This method starts the MDNS service.
@@ -135,7 +176,7 @@ public:
                      timeval &aTimeout) override;
 
 private:
-    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
+    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = nullptr);
     void RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
 
     static void HandleServiceRegisterResult(DNSServiceRef         aService,
@@ -151,6 +192,17 @@ private:
                                             const char *          aName,
                                             const char *          aType,
                                             const char *          aDomain);
+    static void HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                         DNSRecordRef        aHostRecord,
+                                         DNSServiceFlags     aFlags,
+                                         DNSServiceErrorType aErrorCode,
+                                         void *              aContext);
+    void        HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                         DNSRecordRef        aHostRecord,
+                                         DNSServiceFlags     aFlags,
+                                         DNSServiceErrorType aErrorCode);
+
+    otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
 
     enum
     {
@@ -169,14 +221,22 @@ private:
         DNSServiceRef mService;
     };
 
-    typedef std::vector<Service> Services;
+    struct Host
+    {
+        char         mName[kMaxSizeOfServiceName];
+        DNSRecordRef mRecord;
+    };
 
-    Services     mServices;
-    const char * mHost;
-    const char * mDomain;
-    State        mState;
-    StateHandler mStateHandler;
-    void *       mContext;
+    typedef std::vector<Service> Services;
+    typedef std::vector<Host>    Hosts;
+
+    Services      mServices;
+    Hosts         mHosts;
+    DNSServiceRef mHostsConnection;
+    const char *  mDomain;
+    State         mState;
+    StateHandler  mStateHandler;
+    void *        mContext;
 };
 
 /**

--- a/tests/mdns/CMakeLists.txt
+++ b/tests/mdns/CMakeLists.txt
@@ -33,7 +33,6 @@ add_executable(otbr-test-mdns
 target_link_libraries(otbr-test-mdns PRIVATE
     otbr-config
     otbr-mdns
-    openthread-ftd
 )
 
 add_test(

--- a/tests/mdns/test-multiple-custom-hosts
+++ b/tests/mdns/test-multiple-custom-hosts
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 #  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
@@ -26,46 +27,29 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(otbr-test-mdns
-    main.cpp
-)
+#
+# This script tests publishing single service with custom host name & address.
+#
 
-target_link_libraries(otbr-test-mdns PRIVATE
-    otbr-config
-    otbr-mdns
-)
+# shellcheck source=tests/mdns/test_init
+. "$(dirname "$0")/test_init"
 
-add_test(
-    NAME mdns-single
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single
-)
+main()
+{
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
+        start_publisher mc
 
-add_test(
-    NAME mdns-multiple
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple
-)
+        dns_sd_check MultipleService11 _meshcop._udp 'custom-host-1.local.'
+        dns_sd_check MultipleService12 _meshcop._udp 'custom-host-1.local.'
+        dns_sd_check_host 'custom-host-1.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
 
-add_test(
-    NAME mdns-update
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-update
-)
+        dns_sd_check MultipleService21 _meshcop._udp 'custom-host-2.local.'
+        dns_sd_check MultipleService22 _meshcop._udp 'custom-host-2.local.'
+        dns_sd_check_host 'custom-host-2.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
+    else
+        #TODO:
+        echo "not implemented yet"
+    fi
+}
 
-add_test(
-    NAME mdns-stop
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-stop
-)
-
-add_test(
-    NAME mdns-single-custom-host
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single-custom-host
-)
-
-add_test(
-    NAME mdns-multiple-custom-hosts
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple-custom-hosts
-)
-
-set_tests_properties(mdns-single mdns-multiple mdns-update mdns-stop mdns-single-custom-host mdns-multiple-custom-hosts
-    PROPERTIES
-        ENVIRONMENT "OTBR_MDNS=${OTBR_MDNS};OTBR_TEST_MDNS=$<TARGET_FILE:otbr-test-mdns>"
-)
+main "$@"

--- a/tests/mdns/test-single-custom-host
+++ b/tests/mdns/test-single-custom-host
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 #  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
@@ -26,46 +27,24 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(otbr-test-mdns
-    main.cpp
-)
+#
+# This script tests publishing single service with custom host name & address.
+#
 
-target_link_libraries(otbr-test-mdns PRIVATE
-    otbr-config
-    otbr-mdns
-)
+# shellcheck source=tests/mdns/test_init
+. "$(dirname "$0")/test_init"
 
-add_test(
-    NAME mdns-single
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single
-)
+main()
+{
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
+        start_publisher sc
 
-add_test(
-    NAME mdns-multiple
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple
-)
+        dns_sd_check SingleService _meshcop._udp 'custom-host.local.'
+        dns_sd_check_host 'custom-host.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
+    else
+        #TODO:
+        echo "not implemented yet"
+    fi
+}
 
-add_test(
-    NAME mdns-update
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-update
-)
-
-add_test(
-    NAME mdns-stop
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-stop
-)
-
-add_test(
-    NAME mdns-single-custom-host
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single-custom-host
-)
-
-add_test(
-    NAME mdns-multiple-custom-hosts
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple-custom-hosts
-)
-
-set_tests_properties(mdns-single mdns-multiple mdns-update mdns-stop mdns-single-custom-host mdns-multiple-custom-hosts
-    PROPERTIES
-        ENVIRONMENT "OTBR_MDNS=${OTBR_MDNS};OTBR_TEST_MDNS=$<TARGET_FILE:otbr-test-mdns>"
-)
+main "$@"

--- a/tests/mdns/test_init
+++ b/tests/mdns/test_init
@@ -98,6 +98,29 @@ dns_sd_check()
 }
 
 #######################################
+# Check if a host is regisered
+#
+# Arguments:
+#   $1  hostname
+#   $2  address
+#
+# Returns:
+#   0           Registered
+#   otherwise   Not registered
+#######################################
+dns_sd_check_host()
+{
+    # dns-sd will not exit
+    dns-sd -G v6 "$1" >"${DNS_SD_RESULT}" 2>&1 &
+    DNS_SD_PID=$!
+    sleep 1
+    kill "${DNS_SD_PID}"
+
+    cat "${DNS_SD_RESULT}"
+    grep "$2" "${DNS_SD_RESULT}"
+}
+
+#######################################
 # Check if a service is regisered
 #
 # Arguments:


### PR DESCRIPTION
This PR adds the ability to publish a service with custom host name & address.

For a Duckhorn BR, we need to help advertise a service registered by a Thread device. the Service resides on the end device and has specific host name & address. To support it, this PR adds below changes:
1. add an additional `aHostName` param to the `PublishService` API to allow specifying a custom host name;
2. add API `UnpublishService` to un-publish a service when the Thread device de-registers it from the BR. We cannot simply stop the Publisher because there may be many services from different Thread end devices.
3. add API `PublishHost` to publish a host name & address pair. The service cannot be resolved if the host it points to doesn't have a valid address RR.
4. add API `UnpublishHost` to un-publish the a host name & address pair. We cannot simply stop the Publisher because there can be many hosts registered by different Thread end devices.
5. add mdnssd implementation of those new APIs.