### PR TITLE
[dbus] add watch enable check

### DIFF
--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -35,6 +35,7 @@
 #define OTBR_DBUS_AGENT_HPP_
 
 #include <functional>
+#include <set>
 #include <string>
 #include <sys/select.h>
 
@@ -97,7 +98,6 @@ public:
 private:
     static dbus_bool_t AddDBusWatch(struct DBusWatch *aWatch, void *aContext);
     static void        RemoveDBusWatch(struct DBusWatch *aWatch, void *aContext);
-    static void        ToggleDBusWatch(struct DBusWatch *aWatch, void *aContext);
 
     static const struct timeval kPollTimeout;
 
@@ -111,8 +111,7 @@ private:
      * This map is used to track DBusWatch-es.
      *
      */
-    using WatchMap = std::map<DBusWatch *, bool>;
-    WatchMap mWatches;
+    std::set<DBusWatch *> mWatches;
 };
 
 } // namespace DBus


### PR DESCRIPTION
 Some disabled watch will not be toggled causing writable file descriptor
 to be triggered infinitely. The toggle feature is optional in d-bus.
 This patch fixes this bug.