### PR TITLE
[bootstrap] install dnsutils for reference device

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -88,7 +88,7 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y libjsoncpp1 libjsoncpp-dev
 
     # reference device
-    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd
+    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils
 
     # backbone-router
     without BACKBONE_ROUTER || sudo apt-get install --no-install-recommends -y iptables libnetfilter-queue1 libnetfilter-queue-dev


### PR DESCRIPTION
This commit installs the dnsutils package for reference device. 

The dnsutils package includes tools like `dig`, which can be used to test DNS servers on BR.