### PR TITLE
[dbus] fix wrong error code when error happens

### DIFF
--- a/src/dbus/client/client_error.cpp
+++ b/src/dbus/client/client_error.cpp
@@ -97,8 +97,15 @@ ClientError CheckErrorMessage(DBusMessage *aMessage)
         std::string errorMsg;
         auto        args = std::tie(errorMsg);
 
-        VerifyOrExit(DBusMessageToTuple(*aMessage, args) == OTBR_ERROR_NONE, error = ClientError::ERROR_DBUS);
-        error = ConvertFromDBusErrorName(errorMsg);
+        if (dbus_message_get_type(aMessage) == DBUS_MESSAGE_TYPE_ERROR)
+        {
+            error = ConvertFromDBusErrorName(dbus_message_get_error_name(aMessage));
+        }
+        else
+        {
+            VerifyOrExit(DBusMessageToTuple(*aMessage, args) == OTBR_ERROR_NONE, error = ClientError::ERROR_DBUS);
+            error = ConvertFromDBusErrorName(errorMsg);
+        }
     }
 
 exit:

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -87,9 +87,10 @@ send "commissioner start\r\n"
 expect "Commissioner: active"
 send "commissioner joiner add * ABCDEF\r\n"
 expect "Done"
+expect "Joiner end"
+send "commissioner stop\r\n"
 wait
 EOF
-    sleep 5
     # The ot-cli-mtd node is used to test the child and neighbor table.
     expect <<EOF &
 spawn ot-cli-mtd 2

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -203,6 +203,7 @@ int main()
                             onMeshPrefix.mPreference = 0;
                             onMeshPrefix.mStable     = true;
 
+                            TEST_ASSERT(aErr == ClientError::ERROR_NONE);
                             TEST_ASSERT(api->GetChannel(channelResult) == OTBR_ERROR_NONE);
                             TEST_ASSERT(channelResult == channel);
                             TEST_ASSERT(api->GetExtPanId(extpanidCheck) == OTBR_ERROR_NONE);
@@ -217,7 +218,13 @@ int main()
                             TEST_ASSERT(api->AddOnMeshPrefix(onMeshPrefix) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->RemoveOnMeshPrefix(onMeshPrefix.mPrefix) == OTBR_ERROR_NONE);
 
-                            exit(static_cast<uint8_t>(aErr));
+                            api->FactoryReset(nullptr);
+                            TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", nullptr) ==
+                                        ClientError::OT_ERROR_NOT_FOUND);
+                            TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", [](ClientError aJoinError) {
+                                TEST_ASSERT(aJoinError == ClientError::OT_ERROR_NOT_FOUND);
+                                exit(0);
+                            }) == ClientError::ERROR_NONE);
                         });
                     });
     });

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -37,6 +37,7 @@ on_exit()
 
     sudo killall otbr-agent || true
     sudo killall expect || true
+    sudo killall ot-ctl || true
     sudo killall ot-cli-ftd || true
     sudo killall ot-cli-mtd || true
 
@@ -46,6 +47,15 @@ on_exit()
 main()
 {
     sudo "${CMAKE_BINARY_DIR}"/src/agent/otbr-agent -d 7 -v -I wpan0 "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1" &
+    sleep 1
+    sudo expect <<EOF &
+spawn ${CMAKE_BINARY_DIR}/third_party/openthread/repo/src/posix/ot-ctl
+send "ifconfig up\r\n"
+expect "Done"
+send "thread start\r\n"
+expect "Done"
+wait
+EOF
     trap on_exit EXIT
     sleep 5
     sudo python3 "${CMAKE_CURRENT_SOURCE_DIR}"/test_rest.py


### PR DESCRIPTION
The reply dbus message will not contain error code when error happens.
Currently all the error codes will be OTBR_ERROR_DBUS.
This CL checks separate DBusError to correctly handle the error codes
and adds corresponding tests.