### PR TITLE
[WIP] add HIDL server support

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -79,7 +79,10 @@ cc_binary {
         "-Wall",
         "-Wextra",
         "-DOTBR_PACKAGE_VERSION=\"0.2.0\"",
+        "-DOTBR_ENABLE_HIDL_SERVER=1",
     ],
+
+    cppflags: ["-std=c++17"],
 
     srcs: [
         "src/agent/agent_instance.cpp",
@@ -89,13 +92,20 @@ cc_binary {
         "src/agent/ncp_openthread.cpp",
         "src/agent/thread_helper.cpp",
         "src/common/logging.cpp",
+        "src/common/ot_utils.cpp",
         "src/common/types.cpp",
+        "src/hidl/1.0/hidl_agent.cpp",
+        "src/hidl/1.0/hidl_settings.cpp",
+        "src/hidl/1.0/hidl_thread.cpp",
         "src/utils/event_emitter.cpp",
         "src/utils/hex.cpp",
         "src/utils/strcpy_utils.cpp",
     ],
 
     shared_libs: [
+        "android.hardware.thread@1.0",
+        "libhidlbase",
+        "libutils",
         "libcutils",
     ],
 

--- a/Android.mk
+++ b/Android.mk
@@ -114,6 +114,7 @@ LOCAL_SRC_FILES := \
     src/agent/ncp_openthread.cpp \
     src/agent/thread_helper.cpp \
     src/common/logging.cpp \
+    src/common/ot_utils.cpp \
     src/dbus/common/dbus_message_dump.cpp \
     src/dbus/common/dbus_message_helper.cpp \
     src/dbus/common/dbus_message_helper_openthread.cpp \

--- a/src/agent/thread_helper.cpp
+++ b/src/agent/thread_helper.cpp
@@ -45,6 +45,7 @@
 #include "common/byteswap.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "common/ot_utils.hpp"
 
 namespace otbr {
 namespace agent {
@@ -160,19 +161,6 @@ uint8_t ThreadHelper::RandomChannelFromChannelMask(uint32_t aChannelMask)
     return channels[std::uniform_int_distribution<unsigned int>(0, numValidChannels - 1)(mRandomDevice)];
 }
 
-static otExtendedPanId ToOtExtendedPanId(uint64_t aExtPanId)
-{
-    otExtendedPanId extPanId;
-    uint64_t        mask = UINT8_MAX;
-
-    for (size_t i = 0; i < sizeof(uint64_t); i++)
-    {
-        extPanId.m8[i] = static_cast<uint8_t>((aExtPanId >> ((sizeof(uint64_t) - i - 1) * 8)) & mask);
-    }
-
-    return extPanId;
-}
-
 void ThreadHelper::Attach(const std::string &         aNetworkName,
                           uint16_t                    aPanId,
                           uint64_t                    aExtPanId,
@@ -203,7 +191,7 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
 
     if (aExtPanId != UINT64_MAX)
     {
-        extPanId = ToOtExtendedPanId(aExtPanId);
+        extPanId = Uint64ToOtExtendedPanId(aExtPanId);
     }
     else
     {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -28,6 +28,7 @@
 
 add_library(otbr-common
     logging.cpp
+    ot_utils.cpp
     types.cpp
 )
 

--- a/src/common/ot_utils.cpp
+++ b/src/common/ot_utils.cpp
@@ -1,0 +1,83 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "common/ot_utils.hpp"
+
+namespace otbr {
+
+std::string DeviceRoleToString(otDeviceRole aRole)
+{
+    std::string roleName;
+
+    switch (aRole)
+    {
+    case OT_DEVICE_ROLE_DISABLED:
+        roleName = OTBR_ROLE_NAME_DISABLED;
+        break;
+    case OT_DEVICE_ROLE_DETACHED:
+        roleName = OTBR_ROLE_NAME_DETACHED;
+        break;
+    case OT_DEVICE_ROLE_CHILD:
+        roleName = OTBR_ROLE_NAME_CHILD;
+        break;
+    case OT_DEVICE_ROLE_ROUTER:
+        roleName = OTBR_ROLE_NAME_ROUTER;
+        break;
+    case OT_DEVICE_ROLE_LEADER:
+        roleName = OTBR_ROLE_NAME_LEADER;
+        break;
+    }
+
+    return roleName;
+}
+
+uint64_t ArrayToUint64(const uint8_t *aValue)
+{
+    uint64_t val = 0;
+
+    for (size_t i = 0; i < sizeof(uint64_t); i++)
+    {
+        val = (val << 8) | aValue[i];
+    }
+
+    return val;
+}
+
+otExtendedPanId Uint64ToOtExtendedPanId(uint64_t aExtPanId)
+{
+    otExtendedPanId extPanId;
+    uint64_t        mask = UINT8_MAX;
+
+    for (size_t i = 0; i < sizeof(uint64_t); i++)
+    {
+        extPanId.m8[i] = static_cast<uint8_t>((aExtPanId >> ((sizeof(uint64_t) - i - 1) * 8)) & mask);
+    }
+
+    return extPanId;
+}
+} // namespace otbr

--- a/src/common/ot_utils.hpp
+++ b/src/common/ot_utils.hpp
@@ -1,0 +1,82 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for OpenThread utils.
+ */
+
+#ifndef OTBR_COMMON_OT_UTILS_HPP_
+#define OTBR_COMMON_OT_UTILS_HPP_
+
+#include <string>
+
+#include <openthread/dataset.h>
+#include <openthread/thread.h>
+
+namespace otbr {
+
+#define OTBR_ROLE_NAME_DISABLED "disabled"
+#define OTBR_ROLE_NAME_DETACHED "detached"
+#define OTBR_ROLE_NAME_CHILD "child"
+#define OTBR_ROLE_NAME_ROUTER "router"
+#define OTBR_ROLE_NAME_LEADER "leader"
+
+/**
+ * This method converts the device role to string.
+ *
+ * @param[in] aRole  The Thread device role.
+ *
+ * @returns The device role string.
+ *
+ */
+std::string DeviceRoleToString(otDeviceRole aRole);
+
+/**
+ * This method converts the array to uint64_t.
+ *
+ * @param[in] aValue  A pointer to the array, the length of the array equals to 8 bytes.
+ *
+ * @returns The uint64_t value.
+ *
+ */
+uint64_t ArrayToUint64(const uint8_t *aValue);
+
+/**
+ * This method converts the extended pan ID in uint64_t to otExtendedPanId.
+ *
+ * @param[in] aExtPanId  The extended pan ID in uint64_t.
+ *
+ * @returns The otExtendedPanId value.
+ *
+ */
+otExtendedPanId Uint64ToOtExtendedPanId(uint64_t aExtPanId);
+
+} // namespace otbr
+
+#endif // OTBR_COMMON_OT_UTILS_HPP_

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -30,11 +30,32 @@
 #include <sstream>
 #include <sys/socket.h>
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#else
+#include <endian.h>
+#endif
+
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
+
+std::string HexToString(const uint8_t *aHex, uint16_t aLength)
+{
+    std::string str;
+    char        bytestr[3];
+
+    for (uint16_t i = 0; i < aLength; i++)
+    {
+        snprintf(bytestr, sizeof(bytestr), "%02x", aHex[i]);
+        str.append(bytestr);
+    }
+
+    return str;
+}
 
 Ip6Address::Ip6Address(const uint8_t (&aAddress)[16])
 {
@@ -114,13 +135,13 @@ std::string Ip6Prefix::ToString() const
     return strBuilder.str();
 }
 
-std::string MacAddress::ToString(void) const
+std::string Ip6NetworkPrefix::ToString() const
 {
-    char strbuf[sizeof(m8) * 3];
+    char strbuf[INET6_ADDRSTRLEN];
 
-    snprintf(strbuf, sizeof(strbuf), "%02x:%02x:%02x:%02x:%02x:%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5]);
+    snprintf(strbuf, sizeof(strbuf), "%x:%x:%x:%x::0/64", htobe16(m16[0]), htobe16(m16[1]), htobe16(m16[2]),
+             htobe16(m16[3]));
 
     return std::string(strbuf);
 }
-
 } // namespace otbr

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -63,6 +63,18 @@
 struct otIp6Prefix;
 
 /**
+ * Forward declaration for otExtAddress to avoid including <openthread/platform/radio.h>
+ *
+ */
+struct otExtAddress;
+
+/**
+ * Forward declaration for otExtendedPanId to avoid including <openthread/dataset.h>
+ *
+ */
+struct otExtendedPanId;
+
+/**
  * This enumeration represents error codes used throughout OpenThread Border Router.
  */
 enum otbrError
@@ -79,6 +91,7 @@ enum otbrError
     OTBR_ERROR_PARSE           = -8,  ///< Parse error.
     OTBR_ERROR_NOT_IMPLEMENTED = -9,  ///< Not implemented error.
     OTBR_ERROR_INVALID_ARGS    = -10, ///< Invalid arguments error.
+    OTBR_ERROR_HIDL            = -11, ///< HIDL error.
 };
 
 namespace otbr {
@@ -93,6 +106,17 @@ enum
 
 static constexpr char kSolicitedMulticastAddressPrefix[]   = "ff02::01:ff00:0";
 static constexpr char kLinkLocalAllNodesMulticastAddress[] = "ff02::01";
+
+/**
+ * This method converts the hex array to the string in hex format.
+ *
+ * @param[in]  aHex     A pointer to the hex array.
+ * @param[in]  aLength  The length of the hex array.
+ *
+ * @returns The string in hex format.
+ *
+ */
+std::string HexToString(const uint8_t *aHex, uint16_t aLength);
 
 /**
  * This class implements the Ipv6 address functionality.
@@ -269,6 +293,14 @@ public:
     Ip6Prefix(void) { Clear(); }
 
     /**
+     * Constructor with an Ip6 prefix.
+     *
+     * @param[in]   aAddress    The Ip6 prefix.
+     *
+     */
+    Ip6Prefix(const otIp6Prefix &aPrefix) { Set(aPrefix); }
+
+    /**
      * This method sets the Ip6 prefix to an `otIp6Prefix` value.
      *
      * @param[in] aPrefix  The `otIp6Prefix` value to set the Ip6 prefix.
@@ -303,6 +335,45 @@ public:
 } OTBR_TOOL_PACKED_END;
 
 /**
+ * This class implements the Ipv6 network prefix functionality.
+ *
+ */
+OTBR_TOOL_PACKED_BEGIN
+class Ip6NetworkPrefix
+{
+public:
+    /**
+     * Default constructor.
+     *
+     */
+    Ip6NetworkPrefix(void) { m64[0] = 0; }
+
+    /**
+     * Constructor with an 8-bytes prefix.
+     *
+     * @param[in] aPrefix  A pointer to the buffer containing the 8-bytes prefix.
+     *
+     */
+    Ip6NetworkPrefix(const uint8_t *aPrefix) { memcpy(m8, aPrefix, sizeof(*this)); }
+
+    /**
+     * This method returns the string representation for the Ip6 network prefix.
+     *
+     * @returns The string representation of the Ip6 network prefix.
+     *
+     */
+    std::string ToString(void) const;
+
+    union
+    {
+        uint8_t  m8[8];
+        uint16_t m16[4];
+        uint32_t m32[2];
+        uint64_t m64[1];
+    };
+} OTBR_TOOL_PACKED_END;
+
+/**
  * This class represents an ethernet MAC address.
  */
 OTBR_TOOL_PACKED_BEGIN
@@ -326,7 +397,7 @@ public:
      * @returns The string representation of the MAC address.
      *
      */
-    std::string ToString(void) const;
+    std::string ToString(void) const { return HexToString(m8, 6); }
 
     union
     {
@@ -335,6 +406,69 @@ public:
     };
 } OTBR_TOOL_PACKED_END;
 
+/**
+ * This class represents an extended MAC address.
+ */
+OTBR_TOOL_PACKED_BEGIN
+class ExtAddress
+{
+public:
+    /**
+     * Default constructor.
+     *
+     */
+    ExtAddress(void) { memset(m8, 0, sizeof(m8)); }
+
+    /**
+     * Constructor with an extended MAC address.
+     *
+     * @param[in]  aExtAddress  The extended MAC address.
+     *
+     */
+    ExtAddress(const otExtAddress &aExtAddress) { memcpy(reinterpret_cast<void *>(this), &aExtAddress, sizeof(*this)); }
+
+    /**
+     * This method returns the string representation for the Extended address.
+     *
+     * @returns The string representation of the Extended address.
+     *
+     */
+    std::string ToString(void) const { return HexToString(m8, 8); };
+
+    uint8_t m8[8];
+} OTBR_TOOL_PACKED_END;
+
+/**
+ * This class represents an extended Pan Id.
+ */
+OTBR_TOOL_PACKED_BEGIN
+class ExtPanId
+{
+public:
+    /**
+     * Default constructor.
+     *
+     */
+    ExtPanId(void) { memset(m8, 0, sizeof(m8)); }
+
+    /**
+     * Constructor with an extended Pan Id.
+     *
+     * @param[in] aExtPanId  The extended Pan Id.
+     *
+     */
+    ExtPanId(const otExtendedPanId &aExtPanId) { memcpy(reinterpret_cast<void *>(this), &aExtPanId, sizeof(*this)); }
+
+    /**
+     * This method returns the string representation for the extended Pan Id.
+     *
+     * @returns The string representation of the extended Pan Id.
+     *
+     */
+    std::string ToString(void) const { return HexToString(m8, 8); };
+
+    uint8_t m8[8];
+} OTBR_TOOL_PACKED_END;
 } // namespace otbr
 
 #endif // OTBR_COMMON_TYPES_HPP_

--- a/src/hidl/1.0/hidl_agent.cpp
+++ b/src/hidl/1.0/hidl_agent.cpp
@@ -1,0 +1,74 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hidl/1.0/hidl_agent.hpp"
+
+#include <hidl/HidlTransportSupport.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/types.hpp"
+
+namespace otbr {
+namespace Hidl {
+using android::hardware::handleTransportPoll;
+using android::hardware::setupTransportPolling;
+
+HidlAgent::HidlAgent(otbr::Ncp::ControllerOpenThread *aNcp)
+    : mThread(aNcp)
+    , mSettings()
+{
+    VerifyOrDie((mHidlFd = setupTransportPolling()) >= 0, "Setup HIDL transport for use with (e)poll failed");
+    mSettings.Init();
+}
+
+void HidlAgent::Init(void)
+{
+    mThread.Init();
+}
+
+void HidlAgent::UpdateFdSet(otSysMainloopContext &aMainloop) const
+{
+    FD_SET(mHidlFd, &aMainloop.mReadFdSet);
+    FD_SET(mHidlFd, &aMainloop.mWriteFdSet);
+
+    if (mHidlFd > aMainloop.mMaxFd)
+    {
+        aMainloop.mMaxFd = mHidlFd;
+    }
+}
+
+void HidlAgent::Process(const otSysMainloopContext &aMainloop)
+{
+    if (FD_ISSET(mHidlFd, &aMainloop.mReadFdSet) || FD_ISSET(mHidlFd, &aMainloop.mWriteFdSet))
+    {
+        handleTransportPoll(mHidlFd);
+    }
+}
+} // namespace Hidl
+} // namespace otbr

--- a/src/hidl/1.0/hidl_agent.hpp
+++ b/src/hidl/1.0/hidl_agent.hpp
@@ -1,0 +1,101 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <openthread-br/config.h>
+
+#include "agent/ncp_openthread.hpp"
+#include "hidl/1.0/hidl_settings.hpp"
+#include "hidl/1.0/hidl_thread.hpp"
+
+namespace otbr {
+namespace Hidl {
+
+/**
+ * This class implements the HIDL agent.
+ *
+ */
+struct HidlAgent
+{
+public:
+    /**
+     * The constructor of a HIDL object.
+     *
+     * Will use the default interfacename
+     *
+     * @param[in] aNcp  The ncp controller.
+     *
+     */
+    explicit HidlAgent(otbr::Ncp::ControllerOpenThread *aNcp);
+
+    /**
+     * This method performs initialization for the HIDL services.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method updates the file descriptor sets and timeout for mainloop.
+     *
+     * @param[inout] aMainloop  A reference to OpenThread mainloop context.
+     *
+     */
+    void UpdateFdSet(otSysMainloopContext &aMainloop) const;
+
+    /**
+     * This method performs processing.
+     *
+     * @param[in] aMainloop  A reference to OpenThread mainloop context.
+     *
+     */
+    void Process(const otSysMainloopContext &aMainloop);
+
+    /**
+     * This method returns a reference to HidlSettings object.
+     *
+     * @retval  A reference to HidlSettings object.
+     *
+     */
+    otbr::Hidl::HidlSettings &GetSettings(void) { return mSettings; }
+
+    /**
+     * This method returns a reference to HidlMdns object.
+     *
+     * @retval  A reference to HidlSettings object.
+     *
+     */
+    otbr::Hidl::HidlMdns &GetMdns(void) { return mMdns; }
+
+private:
+    int                      mHidlFd;
+    otbr::Hidl::HidlThread   mThread;
+    otbr::Hidl::HidlSettings mSettings;
+};
+} // namespace Hidl
+} // namespace otbr

--- a/src/hidl/1.0/hidl_death_recipient.hpp
+++ b/src/hidl/1.0/hidl_death_recipient.hpp
@@ -1,0 +1,74 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for MDNS HIDL interface.
+ */
+
+#pragma once
+
+#include <hidl/HidlSupport.h>
+
+namespace otbr {
+namespace Hidl {
+using ::android::sp;
+using ::android::hardware::hidl_death_recipient;
+using ::android::hidl::base::V1_0::IBase;
+
+typedef void (*ClientDiedCallback)(void *aContext);
+
+class ClientDeathRecipient : public hidl_death_recipient
+{
+public:
+    ClientDeathRecipient(ClientDiedCallback aCallback, void *aContext)
+        : mCallback(aCallback)
+        , mContext(aContext)
+        , mHasDied(true)
+    {
+    }
+
+    virtual void serviceDied(uint64_t /* cookie */, const android::wp<IBase> & /* service */)
+    {
+        if (mCallback != nullptr)
+        {
+            mCallback(mContext);
+        }
+    }
+
+    bool GetClientHasDied(void) const { return mHasDied; }
+    void SetClientHasDied(bool aHasDied) { mHasDied = aHasDied; }
+
+private:
+    ClientDiedCallback mCallback;
+    void *             mContext;
+    bool               mHasDied;
+};
+
+} // namespace Hidl
+} // namespace otbr

--- a/src/hidl/1.0/hidl_settings.cpp
+++ b/src/hidl/1.0/hidl_settings.cpp
@@ -1,0 +1,297 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements HIDL Settings interface.
+ */
+
+#include "hidl/1.0/hidl_settings.hpp"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <hidl/HidlTransportSupport.h>
+#include <openthread/platform/secure_settings.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+namespace otbr {
+namespace Hidl {
+using android::hardware::handleTransportPoll;
+using android::hardware::setupTransportPolling;
+
+HidlSettings::HidlSettings(void)
+    : mSettingsCallback(nullptr)
+{
+    VerifyOrDie((mHidlFd = setupTransportPolling()) >= 0, "Setup HIDL transport for use with (e)poll failed");
+}
+
+void HidlSettings::Init(void)
+{
+    otbrLog(OTBR_LOG_INFO, "Register HIDL Settings service");
+    VerifyOrDie(registerAsService() == android::NO_ERROR, "Register HIDL Settings service failed");
+
+    mDeathRecipient = new ClientDeathRecipient(sClientDeathCallback, this);
+    VerifyOrDie(mDeathRecipient != nullptr, "Create client death reciptient failed");
+}
+
+otbrError HidlSettings::WaitingForClientToStart(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+    fd_set    readFdSet;
+    fd_set    writeFdSet;
+
+    while (true)
+    {
+        FD_ZERO(&readFdSet);
+        FD_ZERO(&writeFdSet);
+        FD_SET(mHidlFd, &readFdSet);
+        FD_SET(mHidlFd, &writeFdSet);
+
+        if (select(mHidlFd + 1, &readFdSet, &writeFdSet, nullptr, nullptr) >= 0)
+        {
+            if (FD_ISSET(mHidlFd, &readFdSet) || FD_ISSET(mHidlFd, &writeFdSet))
+            {
+                handleTransportPoll(mHidlFd);
+            }
+
+            if (mSettingsCallback != nullptr)
+            {
+                break;
+            }
+        }
+        else
+        {
+            error = OTBR_ERROR_ERRNO;
+            break;
+        }
+    }
+
+    return error;
+}
+
+Return<void> HidlSettings::initialize(const sp<IThreadSettingsCallback> &aCallback)
+{
+    VerifyOrExit(aCallback != NULL);
+
+    mSettingsCallback = aCallback;
+
+    mDeathRecipient->SetClientHasDied(false);
+    mSettingsCallback->linkToDeath(mDeathRecipient, 2);
+
+    otbrLog(OTBR_LOG_INFO, "HIDL Settings interface initialized");
+
+exit:
+    return Void();
+}
+
+Return<void> HidlSettings::deinitialize(void)
+{
+    mSettingsCallback = nullptr;
+
+    if ((!mDeathRecipient->GetClientHasDied()) && (mSettingsCallback != nullptr))
+    {
+        mSettingsCallback->unlinkToDeath(mDeathRecipient);
+        mDeathRecipient->SetClientHasDied(true);
+    }
+
+    otbrLog(OTBR_LOG_INFO, "HIDL Settings interface deinitialized");
+
+    return Void();
+}
+
+otError HidlSettings::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(mSettingsCallback != nullptr, error = OT_ERROR_INVALID_STATE);
+
+    mSettingsCallback->onSettingsGet(aKey, aIndex, [&](ThreadError aError, const hidl_vec<uint8_t> &aValueVec) {
+        if ((error = static_cast<otError>(aError)) == OT_ERROR_NONE)
+        {
+            uint16_t length = aValueVec.size();
+
+            if (aValueLength != nullptr)
+            {
+                length        = (*aValueLength < length) ? *aValueLength : length;
+                *aValueLength = length;
+
+                if (aValue != nullptr)
+                {
+                    std::copy_n(aValueVec.begin(), length, aValue);
+                }
+            }
+        }
+    });
+
+exit:
+    return error;
+}
+
+otError HidlSettings::Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    ThreadError ret;
+    otError     error = OT_ERROR_NONE;
+
+    VerifyOrExit(mSettingsCallback != nullptr, error = OT_ERROR_INVALID_STATE);
+
+    ret   = mSettingsCallback->onSettingsSet(aKey,
+                                           hidl_vec<uint8_t>(reinterpret_cast<const uint8_t *>(aValue),
+                                                             reinterpret_cast<const uint8_t *>(aValue) + aValueLength));
+    error = static_cast<otError>(ret);
+
+exit:
+    return error;
+}
+
+otError HidlSettings::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    ThreadError ret;
+    otError     error = OT_ERROR_NONE;
+
+    VerifyOrExit(mSettingsCallback != nullptr, error = OT_ERROR_INVALID_STATE);
+
+    ret   = mSettingsCallback->onSettingsAdd(aKey,
+                                           hidl_vec<uint8_t>(reinterpret_cast<const uint8_t *>(aValue),
+                                                             reinterpret_cast<const uint8_t *>(aValue) + aValueLength));
+    error = static_cast<otError>(ret);
+
+exit:
+    return error;
+}
+
+otError HidlSettings::Delete(uint16_t aKey, int aIndex)
+{
+    ThreadError ret;
+    otError     error = OT_ERROR_NONE;
+
+    VerifyOrExit(mSettingsCallback != nullptr, error = OT_ERROR_INVALID_STATE);
+
+    ret   = mSettingsCallback->onSettingsDelete(aKey, aIndex);
+    error = static_cast<otError>(ret);
+
+exit:
+    return error;
+}
+
+void HidlSettings::Wipe(void)
+{
+    VerifyOrExit(mSettingsCallback != nullptr);
+
+    mSettingsCallback->onSettingsWipe();
+
+exit:
+    return;
+}
+
+} // namespace Hidl
+} // namespace otbr
+
+#include "hidl/1.0/hidl_agent.hpp"
+
+extern std::unique_ptr<otbr::Hidl::HidlAgent> gHidlAgent;
+
+void otPlatSecureSettingsInit(otInstance *aInstance)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+}
+
+void otPlatSecureSettingsDeinit(otInstance *aInstance)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+}
+
+otError otPlatSecureSettingsGet(otInstance *aInstance,
+                                uint16_t    aKey,
+                                int         aIndex,
+                                uint8_t *   aValue,
+                                uint16_t *  aValueLength)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+    VerifyOrExit(gHidlAgent != nullptr, error = OT_ERROR_INVALID_STATE);
+    error = gHidlAgent->GetSettings().Get(aKey, aIndex, aValue, aValueLength);
+
+exit:
+    return error;
+}
+
+otError otPlatSecureSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+    VerifyOrExit(gHidlAgent != nullptr, error = OT_ERROR_INVALID_STATE);
+    error = gHidlAgent->GetSettings().Set(aKey, aValue, aValueLength);
+
+exit:
+    return error;
+}
+
+otError otPlatSecureSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+    VerifyOrExit(gHidlAgent != nullptr, error = OT_ERROR_INVALID_STATE);
+    error = gHidlAgent->GetSettings().Add(aKey, aValue, aValueLength);
+
+exit:
+    return error;
+}
+
+otError otPlatSecureSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+    VerifyOrExit(gHidlAgent != nullptr, error = OT_ERROR_INVALID_STATE);
+    error = gHidlAgent->GetSettings().Delete(aKey, aIndex);
+
+exit:
+    return error;
+}
+
+void otPlatSecureSettingsWipe(otInstance *aInstance)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    VerifyOrExit(gHidlAgent != nullptr);
+    gHidlAgent->GetSettings().Wipe();
+
+exit:
+    return;
+}

--- a/src/hidl/1.0/hidl_settings.hpp
+++ b/src/hidl/1.0/hidl_settings.hpp
@@ -1,0 +1,181 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for HIDL Settings interface.
+ */
+
+#pragma once
+
+#include <openthread-br/config.h>
+
+#include <android/hardware/thread/1.0/IThreadSettings.h>
+#include <android/hardware/thread/1.0/IThreadSettingsCallback.h>
+#include <openthread/error.h>
+
+#include "common/types.hpp"
+#include "hidl/1.0/hidl_death_recipient.hpp"
+
+namespace otbr {
+namespace Hidl {
+using ::android::sp;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+using ::android::hardware::thread::V1_0::IThreadSettings;
+using ::android::hardware::thread::V1_0::IThreadSettingsCallback;
+using ::android::hardware::thread::V1_0::ThreadError;
+
+/**
+ * This class implements HIDL Settings interface.
+ *
+ */
+class HidlSettings : public IThreadSettings
+{
+public:
+    /**
+     * The constructor to initialize a HIDL Settings interface.
+     *
+     */
+    HidlSettings(void);
+
+    ~HidlSettings(void){};
+
+    /**
+     * This method performs initialization for the HIDL Settings service.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method waits for the HIDL settings client to start.
+     *
+     */
+    otbrError WaitingForClientToStart(void);
+
+    /**
+     * This method is called by the HIDL client to initalizes the Settings HIDL callback object.
+     *
+     */
+    Return<void> initialize(const sp<IThreadSettingsCallback> &aCallback) override;
+
+    /**
+     * This method is called by the HIDL client to deinitalizes the Settings HIDL callback object.
+     *
+     */
+    Return<void> deinitialize(void) override;
+
+    /**
+     * This method fetches the value identified by @p aKey.
+     *
+     * @param[in]     aKey          The key associated with the requested value.
+     * @param[in]     aIndex        The index of the specific item to get.
+     * @param[out]    aValue        A pointer to where the value of the setting should be written.
+     *                              May be nullptr if just testing for the presence or length of a key.
+     * @param[inout]  aValueLength  A pointer to the length of the value.
+     *                              When called, this should point to an integer containing the maximum bytes that
+     *                              can be written to @p aValue.
+     *                              At return, the actual length of the setting is written.
+     *                              May be nullptr if performing a presence check.
+     *
+     * @retval OT_ERROR_NONE           The value was fetched successfully.
+     * @retval OT_ERROR_NOT_FOUND      The key was not found.
+     * @retval OT_ERROR_INVALID_STATE  The HIDL client is not active.
+     *
+     */
+    otError Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength);
+
+    /**
+     * This method sets or replaces the value identified by @p aKey.
+     *
+     * If there was more than one value previously associated with @p aKey, then they are all deleted and replaced with
+     * this single entry.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval OT_ERROR_NONE           The value was changed.
+     * @retval OT_ERROR_NO_BUFS        Not enough space to store the value.
+     * @retval OT_ERROR_INVALID_STATE  The HIDL client is not active.
+     *
+     */
+    otError Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+    /**
+     * This method adds a value to @p aKey.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval OT_ERROR_NONE           The value was added.
+     * @retval OT_ERROR_NO_BUFS        Not enough space to store the value.
+     * @retval OT_ERROR_INVALID_STATE  The HIDL client is not active.
+     *
+     */
+    otError Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+    /**
+     * This method removes a value from @p aKey.
+     *
+     * @param[in] aKey    The key associated with the value.
+     * @param[in] aIndex  The index of the value to be removed.
+     *                    If set to -1, all values for @p aKey will be removed.
+     *
+     * @retval OT_ERROR_NONE           The given key and index was found and removed successfully.
+     * @retval OT_ERROR_NOT_FOUND      The given key or index was not found.
+     * @retval OT_ERROR_INVALID_STATE  The HIDL client is not active.
+     *
+     */
+    otError Delete(uint16_t aKey, int aIndex);
+
+    /**
+     * This method removes all values.
+     *
+     */
+    void Wipe(void);
+
+private:
+    static void sClientDeathCallback(void *aContext)
+    {
+        HidlSettings *hidlSettings = static_cast<HidlSettings *>(aContext);
+        hidlSettings->deinitialize();
+    }
+
+    int                         mHidlFd;
+    sp<IThreadSettingsCallback> mSettingsCallback;
+    sp<ClientDeathRecipient>    mDeathRecipient;
+};
+
+} // namespace Hidl
+} // namespace otbr

--- a/src/hidl/1.0/hidl_thread.cpp
+++ b/src/hidl/1.0/hidl_thread.cpp
@@ -1,0 +1,1012 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "hidl/1.0/hidl_thread.hpp"
+
+#include <hidl/HidlTransportSupport.h>
+#include <openthread/border_router.h>
+#include <openthread/thread_ftd.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/ot_utils.hpp"
+#include "common/types.hpp"
+
+#if OTBR_ENABLE_LEGACY
+#include <ot-legacy-pairing-ext.h>
+#endif
+
+namespace otbr {
+
+namespace Hidl {
+
+using android::hardware::handleTransportPoll;
+using android::hardware::setupTransportPolling;
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+HidlThread::HidlThread(otbr::Ncp::ControllerOpenThread *aNcp)
+    : mNcp(aNcp)
+    , mThreadCallback(nullptr)
+{
+    VerifyOrDie(setupTransportPolling() >= 0, "Setup HIDL transport for use with (e)poll failed");
+}
+
+void HidlThread::Init(void)
+{
+    otbrLog(OTBR_LOG_INFO, "Register HIDL Thread service");
+    VerifyOrDie(registerAsService() == android::NO_ERROR, "Register HIDL Thread service failed");
+
+    mDeathRecipient = new ClientDeathRecipient(sClientDeathCallback, this);
+    VerifyOrDie(mDeathRecipient != nullptr, "Create client death reciptient failed");
+}
+
+Return<void> HidlThread::initialize(const sp<IThreadCallback> &aCallback)
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    mThreadCallback = aCallback;
+
+    threadHelper->AddDeviceRoleHandler(std::bind(&HidlThread::DeviceRoleHandler, this, _1));
+    mNcp->RegisterResetHandler(std::bind(&HidlThread::NcpResetHandler, this));
+
+    mDeathRecipient->SetClientHasDied(false);
+    mThreadCallback->linkToDeath(mDeathRecipient, 1);
+
+    otbrLog(OTBR_LOG_INFO, "HIDL Thread interface initialized");
+
+    return Void();
+}
+
+Return<void> HidlThread::deinitialize(void)
+{
+    if ((!mDeathRecipient->GetClientHasDied()) && (mThreadCallback != nullptr))
+    {
+        mThreadCallback->unlinkToDeath(mDeathRecipient);
+        mDeathRecipient->SetClientHasDied(true);
+    }
+
+    mThreadCallback = nullptr;
+    otbrLog(OTBR_LOG_INFO, "HIDL Thread interface deinitialized");
+
+    return Void();
+}
+
+void HidlThread::DeviceRoleHandler(otDeviceRole aDeviceRole)
+{
+    if (mThreadCallback != nullptr)
+    {
+        mThreadCallback->onAddDeviceRole(static_cast<::android::hardware::thread::V1_0::DeviceRole>(aDeviceRole));
+    }
+}
+
+void HidlThread::NcpResetHandler(void)
+{
+    mNcp->GetThreadHelper()->AddDeviceRoleHandler(std::bind(&HidlThread::DeviceRoleHandler, this, _1));
+
+    if (mThreadCallback != nullptr)
+    {
+        mThreadCallback->onAddDeviceRole(
+            static_cast<::android::hardware::thread::V1_0::DeviceRole>(OT_DEVICE_ROLE_DISABLED));
+    }
+}
+
+Return<ThreadError> HidlThread::permitUnsecureJoin(uint16_t aPort, uint32_t aSeconds)
+{
+    OTBR_UNUSED_VARIABLE(aPort);
+    OTBR_UNUSED_VARIABLE(aSeconds);
+
+    ThreadError error = ThreadError::OT_ERROR_NOT_IMPLEMENTED;
+
+#ifdef OTBR_ENABLE_UNSECURE_JOIN
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    error = static_cast<ThreadError>(threadHelper->PermitUnsecureJoin(aPort, aSeconds));
+
+    otbrLog(OTBR_LOG_INFO, "permitUnsecureJoin: Port:%d, Seconds:%d", aPort, aSeconds);
+#endif
+
+    return error;
+}
+
+Return<ThreadError> HidlThread::scan()
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    threadHelper->Scan(std::bind(&HidlThread::ScanResultHandler, this, _1, _2));
+    otbrLog(OTBR_LOG_INFO, "Scan");
+
+    return ThreadError::ERROR_NONE;
+}
+
+void HidlThread::ScanResultHandler(otError aError, const std::vector<otActiveScanResult> &aResult)
+{
+    std::vector<::android::hardware::thread::V1_0::ActiveScanResult> results;
+
+    otbrLog(OTBR_LOG_INFO, "ScanResultHandler: Error:%d", aError);
+
+    VerifyOrExit(aError == OT_ERROR_NONE);
+    for (const auto &r : aResult)
+    {
+        ::android::hardware::thread::V1_0::ActiveScanResult result;
+
+        std::copy(r.mSteeringData.m8, r.mSteeringData.m8 + r.mSteeringData.mLength, result.mSteeringData.begin());
+
+        result.mExtAddress    = ArrayToUint64(r.mExtAddress.m8);
+        result.mExtendedPanId = ArrayToUint64(r.mExtendedPanId.m8);
+        result.mNetworkName   = r.mNetworkName.m8;
+        result.mPanId         = r.mPanId;
+        result.mJoinerUdpPort = r.mJoinerUdpPort;
+        result.mChannel       = r.mChannel;
+        result.mRssi          = r.mRssi;
+        result.mLqi           = r.mLqi;
+        result.mVersion       = r.mVersion;
+        result.mIsNative      = r.mIsNative;
+        result.mIsJoinable    = r.mIsJoinable;
+
+        otbrLog(OTBR_LOG_INFO,
+                "IsJoinable:%u, NetworkName:%-16s, ExtPanId:0x%s, PanId:0x%04x, ExtAddress:%s, Channel:%2u: "
+                "Rssi:%3u, Lqi:%3u",
+                r.mIsJoinable, r.mNetworkName.m8, otbr::ExtPanId(r.mExtendedPanId).ToString().c_str(), r.mPanId,
+                otbr::ExtAddress(r.mExtAddress).ToString().c_str(), r.mChannel, r.mRssi, r.mLqi);
+
+        results.emplace_back(result);
+    }
+
+exit:
+    if (mThreadCallback != nullptr)
+    {
+        mThreadCallback->onScan(static_cast<ThreadError>(aError), std::move(results));
+    }
+}
+
+Return<ThreadError> HidlThread::attach(const hidl_string &      aNetworkName,
+                                       uint16_t                 aPanId,
+                                       uint64_t                 aExtPanId,
+                                       const hidl_vec<uint8_t> &aMasterKey,
+                                       const hidl_vec<uint8_t> &aPSKc,
+                                       uint32_t                 aChannelMask)
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    otbrLog(OTBR_LOG_INFO,
+            "Attach: NetworkName:%s, PanId:0x%04x, ExtPanId:0x%s, MaskerKey:[Hiden], Pskc:[Hiden], "
+            "ChannelMask:0x%08x",
+            aNetworkName.c_str(), aPanId, otbr::ExtPanId(Uint64ToOtExtendedPanId(aExtPanId)).ToString().c_str(),
+            aChannelMask);
+
+    threadHelper->Attach(aNetworkName, aPanId, aExtPanId, aMasterKey, aPSKc, aChannelMask, [this](otError aError) {
+        if (mThreadCallback != nullptr)
+        {
+            otbrLog(OTBR_LOG_INFO, "onAttach: error=%d", aError);
+            mThreadCallback->onAttach(static_cast<ThreadError>(aError));
+        }
+    });
+
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::attachActiveDataset()
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    otbrLog(OTBR_LOG_INFO, "AttachActiveDataset");
+
+    threadHelper->Attach([this](otError aError) {
+        if (mThreadCallback != nullptr)
+        {
+            otbrLog(OTBR_LOG_INFO, "onAttach: error=%d", aError);
+            mThreadCallback->onAttach(static_cast<ThreadError>(aError));
+        }
+    });
+
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::factoryReset()
+{
+    otbrLog(OTBR_LOG_INFO, "FactoryReset");
+    otInstanceFactoryReset(mNcp->GetThreadHelper()->GetInstance());
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::reset()
+{
+    otbrLog(OTBR_LOG_INFO, "Reset");
+    mNcp->Reset();
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::joinerStart(const hidl_string &aPskd,
+                                            const hidl_string &aProvisioningUrl,
+                                            const hidl_string &aVendorName,
+                                            const hidl_string &aVendorModel,
+                                            const hidl_string &aVendorSwVersion,
+                                            const hidl_string &aVendorData)
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    otbrLog(OTBR_LOG_INFO,
+            "JoinerStart: Pskd:[Hiden], ProvisioningUrl:%s, VendorName:%s, VendorModel:%s, "
+            "VendorSwVersion:%s, VendorData:%s",
+            aProvisioningUrl.c_str(), aVendorName.c_str(), aVendorModel.c_str(), aVendorSwVersion.c_str(),
+            aVendorData.c_str());
+
+    threadHelper->JoinerStart(aPskd, aProvisioningUrl, aVendorName, aVendorModel, aVendorSwVersion, aVendorData,
+                              [this](otError aError) {
+                                  if (mThreadCallback != nullptr)
+                                  {
+                                      mThreadCallback->onJoinerStart(static_cast<ThreadError>(aError));
+                                  }
+                              });
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::joinerStop()
+{
+    auto threadHelper = mNcp->GetThreadHelper();
+
+    otJoinerStop(threadHelper->GetInstance());
+    otbrLog(OTBR_LOG_INFO, "JoinerStop");
+
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::addOnMeshPrefix(const ::android::hardware::thread::V1_0::OnMeshPrefix &aPrefix)
+{
+    auto                 threadHelper = mNcp->GetThreadHelper();
+    otError              error        = OT_ERROR_NONE;
+    otBorderRouterConfig config;
+
+    VerifyOrExit(aPrefix.mPrefix.mPrefix.size() <= OT_IP6_ADDRESS_SIZE, error = OT_ERROR_INVALID_ARGS);
+
+    std::copy(aPrefix.mPrefix.mPrefix.begin(), aPrefix.mPrefix.mPrefix.end(), &config.mPrefix.mPrefix.mFields.m8[0]);
+    config.mPrefix.mLength = aPrefix.mPrefix.mLength;
+    config.mPreference     = aPrefix.mPreference;
+    config.mSlaac          = aPrefix.mSlaac;
+    config.mDhcp           = aPrefix.mDhcp;
+    config.mConfigure      = aPrefix.mConfigure;
+    config.mDefaultRoute   = aPrefix.mDefaultRoute;
+    config.mOnMesh         = aPrefix.mOnMesh;
+    config.mStable         = aPrefix.mStable;
+
+    SuccessOrExit(error = otBorderRouterAddOnMeshPrefix(threadHelper->GetInstance(), &config));
+    SuccessOrExit(error = otBorderRouterRegister(threadHelper->GetInstance()));
+
+    otbrLog(OTBR_LOG_INFO,
+            "AddOnMeshPrefix: Prefix:%s, Preference:%u, Slaac:%u, Dhcp:%u, Configure:%u, DefaultRoute:%u, OnMesh:%u, "
+            "Stable:%u",
+            otbr::Ip6Prefix(config.mPrefix).ToString().c_str(), config.mPreference, config.mSlaac, config.mDhcp,
+            config.mConfigure, config.mDefaultRoute, config.mOnMesh, config.mStable);
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<ThreadError> HidlThread::removeOnMeshPrefix(const ::android::hardware::thread::V1_0::Ip6Prefix &aPrefix)
+{
+    auto        threadHelper = mNcp->GetThreadHelper();
+    otError     error        = OT_ERROR_NONE;
+    otIp6Prefix ip6Prefix;
+
+    VerifyOrExit(aPrefix.mPrefix.size() <= OT_IP6_ADDRESS_SIZE, error = OT_ERROR_INVALID_ARGS);
+
+    std::copy(aPrefix.mPrefix.begin(), aPrefix.mPrefix.end(), &ip6Prefix.mPrefix.mFields.m8[0]);
+    ip6Prefix.mLength = aPrefix.mLength;
+
+    SuccessOrExit(error = otBorderRouterRemoveOnMeshPrefix(threadHelper->GetInstance(), &ip6Prefix));
+    SuccessOrExit(error = otBorderRouterRegister(threadHelper->GetInstance()));
+
+    otbrLog(OTBR_LOG_INFO, "RemoveOnMeshPrefix: Prefix:%s", otbr::Ip6Prefix(ip6Prefix).ToString().c_str());
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<ThreadError> HidlThread::addExternalRoute(const ::android::hardware::thread::V1_0::ExternalRoute &aExternalRoute)
+{
+    auto                  threadHelper = mNcp->GetThreadHelper();
+    otError               error        = OT_ERROR_NONE;
+    otExternalRouteConfig otRoute;
+    otIp6Prefix &         prefix = otRoute.mPrefix;
+
+    VerifyOrExit(aExternalRoute.mPrefix.mPrefix.size() <= OT_IP6_ADDRESS_SIZE, error = OT_ERROR_INVALID_ARGS);
+
+    std::copy(aExternalRoute.mPrefix.mPrefix.begin(), aExternalRoute.mPrefix.mPrefix.end(),
+              &prefix.mPrefix.mFields.m8[0]);
+    prefix.mLength      = aExternalRoute.mPrefix.mLength;
+    otRoute.mPreference = aExternalRoute.mPreference;
+    otRoute.mStable     = aExternalRoute.mStable;
+
+    SuccessOrExit(error = otBorderRouterAddRoute(threadHelper->GetInstance(), &otRoute));
+    if (aExternalRoute.mStable)
+    {
+        SuccessOrExit(error = otBorderRouterRegister(threadHelper->GetInstance()));
+    }
+
+    otbrLog(OTBR_LOG_INFO, "AddExternalRoute: Prefix:%s, Preference:%u, Stable:%u",
+            otbr::Ip6Prefix(prefix).ToString().c_str(), otRoute.mPreference, otRoute.mStable);
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<ThreadError> HidlThread::removeExternalRoute(const ::android::hardware::thread::V1_0::Ip6Prefix &aPrefix)
+{
+    auto        threadHelper = mNcp->GetThreadHelper();
+    otError     error        = OT_ERROR_NONE;
+    otIp6Prefix ip6Prefix;
+
+    VerifyOrExit(aPrefix.mPrefix.size() <= OT_IP6_ADDRESS_SIZE, error = OT_ERROR_INVALID_ARGS);
+
+    std::copy(aPrefix.mPrefix.begin(), aPrefix.mPrefix.end(), &ip6Prefix.mPrefix.mFields.m8[0]);
+    ip6Prefix.mLength = aPrefix.mLength;
+
+    SuccessOrExit(error = otBorderRouterRemoveRoute(threadHelper->GetInstance(), &ip6Prefix));
+    SuccessOrExit(error = otBorderRouterRegister(threadHelper->GetInstance()));
+
+    otbrLog(OTBR_LOG_INFO, "RemoveExternalRoute: Prefix:%s", otbr::Ip6Prefix(ip6Prefix).ToString().c_str());
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<ThreadError> HidlThread::setMeshLocalPrefix(const hidl_array<uint8_t, 8> &aPrefix)
+{
+    auto              threadHelper = mNcp->GetThreadHelper();
+    otMeshLocalPrefix networkPrefix;
+
+    std::copy(&aPrefix[0], &aPrefix[OT_IP6_PREFIX_SIZE], std::begin(networkPrefix.m8));
+
+    otbrLog(OTBR_LOG_INFO, "SetMeshLocalPrefix: Prefix:%s",
+            otbr::Ip6NetworkPrefix(networkPrefix.m8).ToString().c_str());
+
+    return static_cast<ThreadError>(otThreadSetMeshLocalPrefix(threadHelper->GetInstance(), &networkPrefix));
+}
+
+Return<ThreadError> HidlThread::setLegacyUlaPrefix(const hidl_array<uint8_t, 8> &aPrefix)
+{
+    OTBR_UNUSED_VARIABLE(aPrefix);
+
+#if OTBR_ENABLE_LEGACY
+    otbrLog(OTBR_LOG_INFO, "SetLegacyUlaPrefix: Prefix:%s", otbr::Ip6NetworkPrefix(&aPrefix[0]).ToString().c_str());
+    otSetLegacyUlaPrefix(&aPrefix[0]);
+#endif
+
+    return ThreadError::ERROR_NONE;
+}
+
+Return<ThreadError> HidlThread::setLinkMode(const ::android::hardware::thread::V1_0::LinkModeConfig &aConfig)
+{
+    auto             threadHelper = mNcp->GetThreadHelper();
+    otError          error        = OT_ERROR_NONE;
+    otLinkModeConfig otCfg;
+
+    otCfg.mDeviceType   = aConfig.mDeviceType;
+    otCfg.mNetworkData  = aConfig.mNetworkData;
+    otCfg.mRxOnWhenIdle = aConfig.mRxOnWhenIdle;
+
+    VerifyOrExit((error = otThreadSetLinkMode(threadHelper->GetInstance(), otCfg)) == OT_ERROR_NONE);
+
+    otbrLog(OTBR_LOG_INFO, "SetLinkMode: DeviceType:%u, NetworkData:%u, RxOnWhenIdle:%u", otCfg.mDeviceType,
+            otCfg.mNetworkData, otCfg.mRxOnWhenIdle);
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<ThreadError> HidlThread::setRadioRegion(const hidl_string &region)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint16_t regionCode;
+    otError  error = OT_ERROR_NONE;
+
+    VerifyOrExit(region.size() == sizeof(uint16_t), error = OT_ERROR_INVALID_ARGS);
+    regionCode = region.c_str()[0] << 8 | region.c_str()[1];
+
+    SuccessOrExit(error = otPlatRadioSetRegion(threadHelper->GetInstance(), regionCode));
+
+    otbrLog(OTBR_LOG_INFO, "SetRegion: Region:%s", region.c_str());
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<void> HidlThread::getLinkMode(getLinkMode_cb _hidl_cb)
+{
+    auto                                              threadHelper = mNcp->GetThreadHelper();
+    otLinkModeConfig                                  otCfg        = otThreadGetLinkMode(threadHelper->GetInstance());
+    ::android::hardware::thread::V1_0::LinkModeConfig cfg;
+
+    cfg.mDeviceType   = otCfg.mDeviceType;
+    cfg.mNetworkData  = otCfg.mNetworkData;
+    cfg.mRxOnWhenIdle = otCfg.mRxOnWhenIdle;
+
+    otbrLog(OTBR_LOG_INFO, "GetLinkMode: DeviceType:%u, NetworkData:%u, RxOnWhenIdle:%u", otCfg.mDeviceType,
+            otCfg.mNetworkData, otCfg.mRxOnWhenIdle);
+
+    _hidl_cb(ThreadError::ERROR_NONE, cfg);
+
+    return Void();
+}
+
+Return<void> HidlThread::getDeviceRole(getDeviceRole_cb _hidl_cb)
+{
+    auto         threadHelper = mNcp->GetThreadHelper();
+    otDeviceRole role         = otThreadGetDeviceRole(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetDeviceRole: Role:%s", DeviceRoleToString(role).c_str());
+
+    _hidl_cb(ThreadError::ERROR_NONE, static_cast<::android::hardware::thread::V1_0::DeviceRole>(role));
+
+    return Void();
+}
+
+Return<void> HidlThread::getNetworkName(getNetworkName_cb _hidl_cb)
+{
+    auto        threadHelper = mNcp->GetThreadHelper();
+    std::string networkName  = otThreadGetNetworkName(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetNetworkName: NetworkName:%s", networkName.c_str());
+
+    _hidl_cb(ThreadError::ERROR_NONE, networkName);
+
+    return Void();
+}
+
+Return<void> HidlThread::getPanId(getPanId_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint16_t panId        = otLinkGetPanId(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetPanId: PanId:0x%04x", panId);
+
+    _hidl_cb(ThreadError::ERROR_NONE, panId);
+
+    return Void();
+}
+
+Return<void> HidlThread::getExtPanId(getExtPanId_cb _hidl_cb)
+{
+    auto                   threadHelper = mNcp->GetThreadHelper();
+    const otExtendedPanId *extPanId     = otThreadGetExtendedPanId(threadHelper->GetInstance());
+    uint64_t               extPanIdVal  = ArrayToUint64(extPanId->m8);
+
+    otbrLog(OTBR_LOG_INFO, "GetExtPanId: ExtPanId:0x%s", otbr::ExtPanId(*extPanId).ToString().c_str());
+    _hidl_cb(ThreadError::ERROR_NONE, extPanIdVal);
+
+    return Void();
+}
+
+Return<void> HidlThread::getChannel(getChannel_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint16_t channel      = otLinkGetChannel(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetChannel: Channel:%u", channel);
+    _hidl_cb(ThreadError::ERROR_NONE, channel);
+
+    return Void();
+}
+
+Return<void> HidlThread::getMasterKey(getMasterKey_cb _hidl_cb)
+{
+    auto                 threadHelper = mNcp->GetThreadHelper();
+    const otMasterKey *  masterKey    = otThreadGetMasterKey(threadHelper->GetInstance());
+    std::vector<uint8_t> keyVal(masterKey->m8, masterKey->m8 + sizeof(masterKey->m8));
+
+    otbrLog(OTBR_LOG_INFO, "GetMasterKey: MasterKey:[Hiden]");
+    _hidl_cb(ThreadError::ERROR_NONE, keyVal);
+
+    return Void();
+}
+
+Return<void> HidlThread::getCcaFailureRate(getCcaFailureRate_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint16_t failureRate  = otLinkGetCcaFailureRate(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetCcaFailureRate: FailureRate:%u", failureRate);
+    _hidl_cb(ThreadError::ERROR_NONE, failureRate);
+
+    return Void();
+}
+
+Return<void> HidlThread::getLinkCounters(getLinkCounters_cb _hidl_cb)
+{
+    auto                                           threadHelper = mNcp->GetThreadHelper();
+    const otMacCounters *                          otCounters   = otLinkGetCounters(threadHelper->GetInstance());
+    ::android::hardware::thread::V1_0::MacCounters counters;
+
+    counters.mTxTotal              = otCounters->mTxTotal;
+    counters.mTxUnicast            = otCounters->mTxUnicast;
+    counters.mTxBroadcast          = otCounters->mTxBroadcast;
+    counters.mTxAckRequested       = otCounters->mTxAckRequested;
+    counters.mTxAcked              = otCounters->mTxAcked;
+    counters.mTxNoAckRequested     = otCounters->mTxNoAckRequested;
+    counters.mTxData               = otCounters->mTxData;
+    counters.mTxDataPoll           = otCounters->mTxDataPoll;
+    counters.mTxBeacon             = otCounters->mTxBeacon;
+    counters.mTxBeaconRequest      = otCounters->mTxBeaconRequest;
+    counters.mTxOther              = otCounters->mTxOther;
+    counters.mTxRetry              = otCounters->mTxRetry;
+    counters.mTxErrCca             = otCounters->mTxErrCca;
+    counters.mTxErrAbort           = otCounters->mTxErrAbort;
+    counters.mTxErrBusyChannel     = otCounters->mTxErrBusyChannel;
+    counters.mRxTotal              = otCounters->mRxTotal;
+    counters.mRxUnicast            = otCounters->mTxUnicast;
+    counters.mRxBroadcast          = otCounters->mRxBroadcast;
+    counters.mRxData               = otCounters->mRxData;
+    counters.mRxDataPoll           = otCounters->mTxDataPoll;
+    counters.mRxBeacon             = otCounters->mRxBeacon;
+    counters.mRxBeaconRequest      = otCounters->mRxBeaconRequest;
+    counters.mRxOther              = otCounters->mRxOther;
+    counters.mRxAddressFiltered    = otCounters->mRxAddressFiltered;
+    counters.mRxDestAddrFiltered   = otCounters->mRxDestAddrFiltered;
+    counters.mRxDuplicated         = otCounters->mRxDuplicated;
+    counters.mRxErrNoFrame         = otCounters->mRxErrNoFrame;
+    counters.mRxErrUnknownNeighbor = otCounters->mRxErrUnknownNeighbor;
+    counters.mRxErrInvalidSrcAddr  = otCounters->mRxErrInvalidSrcAddr;
+    counters.mRxErrSec             = otCounters->mRxErrSec;
+    counters.mRxErrFcs             = otCounters->mRxErrFcs;
+    counters.mRxErrOther           = otCounters->mRxErrOther;
+
+    otbrLog(
+        OTBR_LOG_INFO,
+        "TxTotal:%u, TxUnicast:%u, TxBroadcast:%u, TxAckRequested:%u, TxAcked:%u, TxNoAckRequested: %u, TxData:%u, "
+        "TxDataPoll:%u, TxBeacon:%u, TxBeaconRequest:%u, TxOther:%u, TxRetry:%u, TxErrCca:%u, TxErrAbort:%u, "
+        "TxErrBusyChannel:%u, RxTotal:%u, RxUnicast:%u, RxBroadcast:%u, RxData:%u, RxDataPoll:%u, RxBeacon:%u, "
+        "RxBeaconRequest:%u, RxOther:%u, RxAddressFiltered:%u, RxDestAddrFiltered:%u, RxDuplicated:%u, "
+        "RxErrNoFrame:%u, RxErrNoUnknownNeighbor:%u, RxErrInvalidSrcAddr:%u, RxErrSec:%u, RxErrFcs:%u, RxErrOther:%u",
+        otCounters->mTxTotal, otCounters->mTxUnicast, otCounters->mTxBroadcast, otCounters->mTxAckRequested,
+        otCounters->mTxAcked, otCounters->mTxNoAckRequested, otCounters->mTxData, otCounters->mTxDataPoll,
+        otCounters->mTxBeacon, otCounters->mTxBeaconRequest, otCounters->mTxOther, otCounters->mTxRetry,
+        otCounters->mTxErrCca, otCounters->mTxErrAbort, otCounters->mTxErrBusyChannel, otCounters->mRxTotal,
+        otCounters->mTxUnicast, otCounters->mRxBroadcast, otCounters->mRxData, otCounters->mTxDataPoll,
+        otCounters->mRxBeacon, otCounters->mRxBeaconRequest, otCounters->mRxOther, otCounters->mRxAddressFiltered,
+        otCounters->mRxDestAddrFiltered, otCounters->mRxDuplicated, otCounters->mRxErrNoFrame,
+        otCounters->mRxErrUnknownNeighbor, otCounters->mRxErrInvalidSrcAddr, otCounters->mRxErrSec,
+        otCounters->mRxErrFcs, otCounters->mRxErrOther);
+
+    _hidl_cb(ThreadError::ERROR_NONE, counters);
+
+    return Void();
+}
+
+Return<void> HidlThread::getIp6Counters(getIp6Counters_cb _hidl_cb)
+{
+    auto                                          threadHelper = mNcp->GetThreadHelper();
+    const otIpCounters *                          otCounters   = otThreadGetIp6Counters(threadHelper->GetInstance());
+    ::android::hardware::thread::V1_0::IpCounters counters;
+
+    counters.mTxSuccess = otCounters->mTxSuccess;
+    counters.mTxFailure = otCounters->mTxFailure;
+    counters.mRxSuccess = otCounters->mRxSuccess;
+    counters.mRxFailure = otCounters->mRxFailure;
+
+    otbrLog(OTBR_LOG_INFO, "GetIp6Counters: TxSuccess:%u, TxFailure:%u, RxSuccess:%u, RxFailure:%u",
+            otCounters->mTxSuccess, otCounters->mTxFailure, otCounters->mRxSuccess, otCounters->mRxFailure);
+
+    _hidl_cb(ThreadError::ERROR_NONE, counters);
+
+    return Void();
+}
+
+Return<void> HidlThread::getSupportedChannelMask(getSupportedChannelMask_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint32_t channelMask  = otLinkGetSupportedChannelMask(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetSupportedChannelMask: ChannelMask:0x%08x", channelMask);
+
+    _hidl_cb(ThreadError::ERROR_NONE, channelMask);
+
+    return Void();
+}
+
+Return<void> HidlThread::getRloc16(getRloc16_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint16_t rloc16       = otThreadGetRloc16(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetRloc16: Rloc16:0x%04x", rloc16);
+
+    _hidl_cb(ThreadError::ERROR_NONE, rloc16);
+
+    return Void();
+}
+
+Return<void> HidlThread::getExtendedAddress(getExtendedAddress_cb _hidl_cb)
+{
+    auto                threadHelper    = mNcp->GetThreadHelper();
+    const otExtAddress *addr            = otLinkGetExtendedAddress(threadHelper->GetInstance());
+    uint64_t            extendedAddress = ArrayToUint64(addr->m8);
+
+    otbrLog(OTBR_LOG_INFO, "GetExtendedAddress: ExtAddr:%s", otbr::ExtAddress(*addr).ToString().c_str());
+
+    _hidl_cb(ThreadError::ERROR_NONE, extendedAddress);
+
+    return Void();
+}
+
+Return<void> HidlThread::getRouterId(getRouterId_cb _hidl_cb)
+{
+    otError      error        = OT_ERROR_NONE;
+    auto         threadHelper = mNcp->GetThreadHelper();
+    uint16_t     rloc16       = otThreadGetRloc16(threadHelper->GetInstance());
+    otRouterInfo info;
+
+    SuccessOrExit(error = otThreadGetRouterInfo(threadHelper->GetInstance(), rloc16, &info));
+
+    otbrLog(OTBR_LOG_INFO, "GetRouterId: RouterId:0x%02x", info.mRouterId);
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), info.mRouterId);
+
+    return Void();
+}
+
+Return<void> HidlThread::getLeaderData(getLeaderData_cb _hidl_cb)
+{
+    otError                                       error        = OT_ERROR_NONE;
+    auto                                          threadHelper = mNcp->GetThreadHelper();
+    struct otLeaderData                           data;
+    ::android::hardware::thread::V1_0::LeaderData leaderData;
+
+    SuccessOrExit(error = otThreadGetLeaderData(threadHelper->GetInstance(), &data));
+    leaderData.mPartitionId       = data.mPartitionId;
+    leaderData.mWeighting         = data.mWeighting;
+    leaderData.mDataVersion       = data.mDataVersion;
+    leaderData.mStableDataVersion = data.mStableDataVersion;
+    leaderData.mLeaderRouterId    = data.mLeaderRouterId;
+
+    otbrLog(OTBR_LOG_INFO,
+            "GetLeaderData: PartitionId:%u, Weighting:%u, DataVersion:%u, StableDataVersion:%u, LeaderRouterId:%u",
+            data.mPartitionId, data.mWeighting, data.mDataVersion, data.mStableDataVersion, data.mLeaderRouterId);
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), leaderData);
+
+    return Void();
+}
+
+Return<void> HidlThread::getNetworkData(getNetworkData_cb _hidl_cb)
+{
+    otError                 error               = OT_ERROR_NONE;
+    static constexpr size_t kNetworkDataMaxSize = 255;
+    auto                    threadHelper        = mNcp->GetThreadHelper();
+    uint8_t                 data[kNetworkDataMaxSize];
+    uint8_t                 len = sizeof(data);
+    std::vector<uint8_t>    networkData;
+
+    SuccessOrExit(error = otNetDataGet(threadHelper->GetInstance(), /*stable=*/false, data, &len));
+    networkData = std::vector<uint8_t>(&data[0], &data[len]);
+
+    otbrLog(OTBR_LOG_INFO, "GetNetworkData");
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), networkData);
+
+    return Void();
+}
+
+Return<void> HidlThread::getStableNetworkData(getStableNetworkData_cb _hidl_cb)
+{
+    otError                 error               = OT_ERROR_NONE;
+    static constexpr size_t kNetworkDataMaxSize = 255;
+    auto                    threadHelper        = mNcp->GetThreadHelper();
+    uint8_t                 data[kNetworkDataMaxSize];
+    uint8_t                 len = sizeof(data);
+    std::vector<uint8_t>    networkData;
+
+    SuccessOrExit(error = otNetDataGet(threadHelper->GetInstance(), /*stable=*/true, data, &len));
+    networkData = std::vector<uint8_t>(&data[0], &data[len]);
+
+    otbrLog(OTBR_LOG_INFO, "GetStableNetworkData");
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), networkData);
+
+    return Void();
+}
+
+Return<void> HidlThread::getLocalLeaderWeight(getLocalLeaderWeight_cb _hidl_cb)
+{
+    auto    threadHelper = mNcp->GetThreadHelper();
+    uint8_t weight       = otThreadGetLocalLeaderWeight(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetLocalLeaderWeight: Weight:%u", weight);
+
+    _hidl_cb(ThreadError::ERROR_NONE, weight);
+
+    return Void();
+}
+
+Return<void> HidlThread::getChannelMonitorSampleCount(getChannelMonitorSampleCount_cb _hidl_cb)
+{
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint32_t cnt          = otChannelMonitorGetSampleCount(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetChannelMonitorSampleCount: Count:%u", cnt);
+
+    _hidl_cb(ThreadError::ERROR_NONE, cnt);
+#else
+    _hidl_cb(ThreadError::OT_ERROR_NOT_IMPLEMENTED, 0);
+#endif
+
+    return Void();
+}
+
+Return<void> HidlThread::getChannelMonitorAllChannelQualities(getChannelMonitorAllChannelQualities_cb _hidl_cb)
+{
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+    auto              threadHelper = mNcp->GetThreadHelper();
+    uint32_t          channelMask  = otLinkGetSupportedChannelMask(threadHelper->GetInstance());
+    constexpr uint8_t kNumChannels = sizeof(channelMask) * 8; // 8 bit per byte
+    std::vector<::android::hardware::thread::V1_0::ChannelQuality> quality;
+
+    otbrLog(OTBR_LOG_INFO, "GetChannelMonitorAllChannelQualities: ChannelMask:0x%08x", channelMask);
+    for (uint8_t i = 0; i < kNumChannels; i++)
+    {
+        if (channelMask & (1U << i))
+        {
+            uint16_t occupancy = otChannelMonitorGetChannelOccupancy(threadHelper->GetInstance(), i);
+
+            quality.emplace_back(ChannelQuality{i, occupancy});
+            otbrLog(OTBR_LOG_INFO, "Channel: %d, Occupancy: %d", i, occupancy);
+        }
+    }
+
+    _hidl_cb(ThreadError::ERROR_NONE, quality);
+#else
+    _hidl_cb(ThreadError::OT_ERROR_NOT_IMPLEMENTED, std::vector<::android::hardware::thread::V1_0::ChannelQuality>());
+#endif
+
+    return Void();
+}
+
+Return<void> HidlThread::getChildTable(getChildTable_cb _hidl_cb)
+{
+    auto                                                      threadHelper = mNcp->GetThreadHelper();
+    uint16_t                                                  childIndex   = 0;
+    otChildInfo                                               childInfo;
+    std::vector<::android::hardware::thread::V1_0::ChildInfo> childTable;
+
+    otbrLog(OTBR_LOG_INFO, "GetChildTable:");
+
+    while (otThreadGetChildInfoByIndex(threadHelper->GetInstance(), childIndex, &childInfo) == OT_ERROR_NONE)
+    {
+        ::android::hardware::thread::V1_0::ChildInfo info;
+
+        info.mExtAddress         = ArrayToUint64(childInfo.mExtAddress.m8);
+        info.mTimeout            = childInfo.mTimeout;
+        info.mAge                = childInfo.mAge;
+        info.mChildId            = childInfo.mChildId;
+        info.mNetworkDataVersion = childInfo.mNetworkDataVersion;
+        info.mLinkQualityIn      = childInfo.mLinkQualityIn;
+        info.mAverageRssi        = childInfo.mAverageRssi;
+        info.mLastRssi           = childInfo.mLastRssi;
+        info.mFrameErrorRate     = childInfo.mFrameErrorRate;
+        info.mMessageErrorRate   = childInfo.mMessageErrorRate;
+        info.mRxOnWhenIdle       = childInfo.mRxOnWhenIdle;
+        info.mFullThreadDevice   = childInfo.mFullThreadDevice;
+        info.mFullNetworkData    = childInfo.mFullNetworkData;
+        info.mIsStateRestoring   = childInfo.mIsStateRestoring;
+        childTable.push_back(info);
+        childIndex++;
+
+        otbrLog(
+            OTBR_LOG_INFO,
+            "%d: ExtAddress:%s, Timeout:%u, Age:%u, ChildId:0x%04x, NetworkDataVersion:%u, "
+            "LinkQualityIn:%u, AverageRssi:%d, LastRssi:%d, FrameErrorRate:%u, MessageErrorRate:%u, RxOnWhenIdle:%u, "
+            "FullThreadDevice:%u, FullNetworkData:%u, IsStateRestoring:%u",
+            childIndex, otbr::ExtAddress(childInfo.mExtAddress).ToString().c_str(), childInfo.mTimeout, childInfo.mAge,
+            childInfo.mChildId, childInfo.mNetworkDataVersion, childInfo.mLinkQualityIn, childInfo.mAverageRssi,
+            childInfo.mLastRssi, childInfo.mFrameErrorRate, childInfo.mMessageErrorRate, childInfo.mRxOnWhenIdle,
+            childInfo.mFullThreadDevice, childInfo.mFullNetworkData, childInfo.mIsStateRestoring);
+    }
+
+    _hidl_cb(ThreadError::ERROR_NONE, childTable);
+
+    return Void();
+}
+
+Return<void> HidlThread::getNeighborTable(getNeighborTable_cb _hidl_cb)
+{
+    auto                                                         threadHelper = mNcp->GetThreadHelper();
+    otNeighborInfoIterator                                       iter         = OT_NEIGHBOR_INFO_ITERATOR_INIT;
+    otNeighborInfo                                               neighborInfo;
+    std::vector<::android::hardware::thread::V1_0::NeighborInfo> neighborTable;
+
+    otbrLog(OTBR_LOG_INFO, "GetNeighborTable:");
+
+    while (otThreadGetNextNeighborInfo(threadHelper->GetInstance(), &iter, &neighborInfo) == OT_ERROR_NONE)
+    {
+        ::android::hardware::thread::V1_0::NeighborInfo info;
+
+        info.mExtAddress       = ArrayToUint64(neighborInfo.mExtAddress.m8);
+        info.mAge              = neighborInfo.mAge;
+        info.mRloc16           = neighborInfo.mRloc16;
+        info.mLinkFrameCounter = neighborInfo.mLinkFrameCounter;
+        info.mMleFrameCounter  = neighborInfo.mMleFrameCounter;
+        info.mLinkQualityIn    = neighborInfo.mLinkQualityIn;
+        info.mAverageRssi      = neighborInfo.mAverageRssi;
+        info.mLastRssi         = neighborInfo.mLastRssi;
+        info.mFrameErrorRate   = neighborInfo.mFrameErrorRate;
+        info.mMessageErrorRate = neighborInfo.mMessageErrorRate;
+        info.mRxOnWhenIdle     = neighborInfo.mRxOnWhenIdle;
+        info.mFullThreadDevice = neighborInfo.mFullThreadDevice;
+        info.mFullNetworkData  = neighborInfo.mFullNetworkData;
+        info.mIsChild          = neighborInfo.mIsChild;
+        neighborTable.push_back(info);
+
+        otbrLog(
+            OTBR_LOG_INFO,
+            "ExtAddress:%s, Age:%u, Rloc16:0x%04x, LinkFrameCounter:%u, MleFrameCounter:%u"
+            "LinkQualityIn:%u, AverageRssi:%d, LastRssi:%d, FrameErrorRate:%u, MessageErrorRate:%u, RxOnWhenIdle:%u, "
+            "FullThreadDevice:%u, FullNetworkData:%u, IsChild:%u",
+            otbr::ExtAddress(neighborInfo.mExtAddress).ToString().c_str(), neighborInfo.mAge, neighborInfo.mRloc16,
+            neighborInfo.mLinkFrameCounter, neighborInfo.mMleFrameCounter, neighborInfo.mLinkQualityIn,
+            neighborInfo.mAverageRssi, neighborInfo.mLastRssi, neighborInfo.mFrameErrorRate,
+            neighborInfo.mMessageErrorRate, neighborInfo.mRxOnWhenIdle, neighborInfo.mFullThreadDevice,
+            neighborInfo.mFullNetworkData, neighborInfo.mIsChild);
+    }
+
+    _hidl_cb(ThreadError::ERROR_NONE, neighborTable);
+
+    return Void();
+}
+
+Return<void> HidlThread::getPartitionId(getPartitionId_cb _hidl_cb)
+{
+    auto     threadHelper = mNcp->GetThreadHelper();
+    uint32_t partitionId  = otThreadGetPartitionId(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetPartitionId: PartitionId:%u", partitionId);
+
+    _hidl_cb(ThreadError::ERROR_NONE, partitionId);
+
+    return Void();
+}
+
+Return<void> HidlThread::getInstantRssi(getInstantRssi_cb _hidl_cb)
+{
+    auto   threadHelper = mNcp->GetThreadHelper();
+    int8_t rssi         = otPlatRadioGetRssi(threadHelper->GetInstance());
+
+    otbrLog(OTBR_LOG_INFO, "GetInstantRssi: Rssi:%d", rssi);
+    _hidl_cb(ThreadError::ERROR_NONE, rssi);
+
+    return Void();
+}
+
+Return<void> HidlThread::getRadioTxPower(getRadioTxPower_cb _hidl_cb)
+{
+    auto    threadHelper = mNcp->GetThreadHelper();
+    otError error        = OT_ERROR_NONE;
+    int8_t  txPower;
+
+    SuccessOrExit(error = otPlatRadioGetTransmitPower(threadHelper->GetInstance(), &txPower));
+    otbrLog(OTBR_LOG_INFO, "GetRadioTxPower: TxPower:%d", txPower);
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), txPower);
+
+    return Void();
+}
+
+Return<void> HidlThread::getExternalRoutes(getExternalRoutes_cb _hidl_cb)
+{
+    otError                                                       error        = OT_ERROR_NONE;
+    auto                                                          threadHelper = mNcp->GetThreadHelper();
+    otNetworkDataIterator                                         iter         = OT_NETWORK_DATA_ITERATOR_INIT;
+    otExternalRouteConfig                                         config;
+    std::vector<::android::hardware::thread::V1_0::ExternalRoute> externalRouteTable;
+
+    otbrLog(OTBR_LOG_INFO, "GetExternalRoutes:");
+    while (otBorderRouterGetNextRoute(threadHelper->GetInstance(), &iter, &config) == OT_ERROR_NONE)
+    {
+        ::android::hardware::thread::V1_0::ExternalRoute route;
+
+        route.mPrefix.mPrefix.resize(OTBR_IP6_PREFIX_SIZE);
+        std::copy(&config.mPrefix.mPrefix.mFields.m8[0], &config.mPrefix.mPrefix.mFields.m8[OTBR_IP6_PREFIX_SIZE],
+                  std::begin(route.mPrefix.mPrefix));
+
+        route.mPrefix.mLength      = config.mPrefix.mLength;
+        route.mRloc16              = config.mRloc16;
+        route.mPreference          = config.mPreference;
+        route.mStable              = config.mStable;
+        route.mNextHopIsThisDevice = config.mNextHopIsThisDevice;
+        externalRouteTable.push_back(route);
+
+        otbrLog(OTBR_LOG_INFO, "Prefix:%s, Rloc16:0x%04x, Preference:%u, Stable:%u, NextHopIsThisDevice:%u",
+                otbr::Ip6Prefix(config.mPrefix).ToString().c_str(), config.mRloc16, config.mPreference, config.mStable,
+                config.mNextHopIsThisDevice);
+    }
+
+    _hidl_cb(static_cast<ThreadError>(error), externalRouteTable);
+
+    return Void();
+}
+
+Return<void> HidlThread::getRadioRegion(getRadioRegion_cb _hidl_cb)
+{
+    auto        threadHelper = mNcp->GetThreadHelper();
+    otError     error        = OT_ERROR_NONE;
+    std::string radioRegion;
+    uint16_t    regionCode;
+
+    SuccessOrExit(error = otPlatRadioGetRegion(threadHelper->GetInstance(), &regionCode));
+    radioRegion.resize(sizeof(uint16_t), '\0');
+    radioRegion[0] = static_cast<char>((regionCode >> 8) & 0xff);
+    radioRegion[1] = static_cast<char>(regionCode & 0xff);
+
+    otbrLog(OTBR_LOG_INFO, "GetRegion: Region:%s", radioRegion.c_str());
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), radioRegion);
+
+    return Void();
+}
+
+Return<ThreadError> HidlThread::setActiveDatasetTlvs(
+    const ::android::hardware::thread::V1_0::OperationalDatasetTlvs &aDataset)
+{
+    auto                     threadHelper = mNcp->GetThreadHelper();
+    otOperationalDatasetTlvs datasetTlvs;
+    otError                  error = OT_ERROR_NONE;
+
+    VerifyOrExit(aDataset.size() <= sizeof(datasetTlvs.mTlvs));
+    std::copy(std::begin(aDataset), std::end(aDataset), std::begin(datasetTlvs.mTlvs));
+    datasetTlvs.mLength = aDataset.size();
+    error               = otDatasetSetActiveTlvs(threadHelper->GetInstance(), &datasetTlvs);
+
+exit:
+    return static_cast<ThreadError>(error);
+}
+
+Return<void> HidlThread::getActiveDatasetTlvs(getActiveDatasetTlvs_cb _hidl_cb)
+{
+    ::android::hardware::thread::V1_0::OperationalDatasetTlvs dataset;
+    auto                                                      threadHelper = mNcp->GetThreadHelper();
+    otError                                                   error        = OT_ERROR_NONE;
+    otOperationalDatasetTlvs                                  datasetTlvs;
+
+    SuccessOrExit(error = otDatasetGetActiveTlvs(threadHelper->GetInstance(), &datasetTlvs));
+    dataset = hidl_vec<uint8_t>{std::begin(datasetTlvs.mTlvs), std::begin(datasetTlvs.mTlvs) + datasetTlvs.mLength};
+
+exit:
+    _hidl_cb(static_cast<ThreadError>(error), dataset);
+
+    return Void();
+}
+
+} // namespace Hidl
+} // namespace otbr

--- a/src/hidl/1.0/hidl_thread.hpp
+++ b/src/hidl/1.0/hidl_thread.hpp
@@ -1,0 +1,559 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <openthread-br/config.h>
+
+#include <android/hardware/thread/1.0/IThread.h>
+#include <android/hardware/thread/1.0/IThreadCallback.h>
+#include <android/hardware/thread/1.0/IThreadMdns.h>
+#include <hidl/MQDescriptor.h>
+#include <hidl/Status.h>
+#include <openthread/link.h>
+
+#include "agent/ncp_openthread.hpp"
+#include "hidl/1.0/hidl_death_recipient.hpp"
+
+namespace otbr {
+namespace Hidl {
+using ::android::sp;
+using ::android::hardware::hidl_array;
+using ::android::hardware::hidl_memory;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+using ::android::hardware::thread::V1_0::IThread;
+using ::android::hardware::thread::V1_0::IThreadCallback;
+using ::android::hardware::thread::V1_0::ThreadError;
+
+/**
+ * This class implements the HIDL Thread service.
+ *
+ */
+struct HidlThread : public IThread
+{
+public:
+    /**
+     * The constructor of a HIDL object.
+     *
+     * Will use the default interfacename
+     *
+     * @param[in] aNcp  The ncp controller.
+     *
+     */
+    explicit HidlThread(otbr::Ncp::ControllerOpenThread *aNcp);
+
+    /**
+     * This method performs initialization for the HIDL Thread service.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method initalizes the HIDL Thread callback object.
+     *
+     */
+    Return<void> initialize(const sp<IThreadCallback> &aCallback) override;
+
+    /**
+     * This method deinitalizes the HIDL Thread callback object.
+     *
+     */
+    Return<void> deinitialize(void) override;
+
+    /**
+     * This method permits unsecure join on port.
+     *
+     * @param[in] aPort     The port number.
+     * @param[in] aSeconds  The timeout to close the port, 0 for never close.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> permitUnsecureJoin(uint16_t aPort, uint32_t aSeconds) override;
+
+    /**
+     * This method performs a Thread network scan.
+     *
+     * Note: The callback function `IThreadCallback::onScan()` is called after the Active Scan has completed.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> scan() override;
+
+    /**
+     * This method attaches the device to the Thread network.
+     *
+     * Note: The callback function `IThreadCallback::onAttach()` is called after the attach process has completed.
+     *
+     * @param[in] aNetworkName  The network name.
+     * @param[in] aPanId        The pan id, UINT16_MAX for random.
+     * @param[in] aExtPanId     The extended pan id, UINT64_MAX for random.
+     * @param[in] aMasterKey    The master key, empty for random.
+     * @param[in] aPSKc         The pre-shared commissioner key, empty for random.
+     * @param[in] aChannelMask  A bitmask for valid channels, will random select one.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> attach(const hidl_string &      aNetworkName,
+                               uint16_t                 aPanId,
+                               uint64_t                 aExtPanId,
+                               const hidl_vec<uint8_t> &aMasterKey,
+                               const hidl_vec<uint8_t> &aPSKc,
+                               uint32_t                 aChannelMask) override;
+
+    /**
+     * This method attaches the device to the Thread network.
+     *
+     * The network parameters will be set with the active dataset under this
+     * circumstance.
+     *
+     * Note: The callback function `IThreadCallback::onAttach()` is called after the attach process has completed.
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_HIDL Hidl encode/decode error
+     * @retval ...        OpenThread defined error value otherwise
+     *
+     */
+    Return<ThreadError> attachActiveDataset() override;
+
+    /**
+     * This method performs a factory reset.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> factoryReset() override;
+
+    /**
+     * This method performs a soft reset.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> reset() override;
+
+    /**
+     * This method triggers a thread join process. The joiner start and the attach proccesses are exclusive.
+     *
+     * Note: The callback function `IThreadCallback::onJoinerStart()` is called after the join operation has completed.
+     *
+     * @param[in] aPskd             The pre-shared key for device.
+     * @param[in] aProvisioningUrl  The provision url.
+     * @param[in] aVendorName       The vendor name.
+     * @param[in] aVendorModel      The vendor model.
+     * @param[in] aVendorSwVersion  The vendor software version.
+     * @param[in] aVendorData       The vendor custom data.
+     * @param[in] aHandler          The join result handler.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> joinerStart(const hidl_string &aPskd,
+                                    const hidl_string &aProvisioningUrl,
+                                    const hidl_string &aVendorName,
+                                    const hidl_string &aVendorModel,
+                                    const hidl_string &aVendorSwVersion,
+                                    const hidl_string &aVendorData) override;
+
+    /**
+     * This method stops the joiner process.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> joinerStop() override;
+
+    /**
+     * This method adds a on-mesh address prefix.
+     *
+     * @param[in] aPrefix  The address prefix.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> addOnMeshPrefix(const ::android::hardware::thread::V1_0::OnMeshPrefix &aPrefix) override;
+
+    /**
+     * This method removes a on-mesh address prefix.
+     *
+     * @param[in] aPrefix  The address prefix.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> removeOnMeshPrefix(const ::android::hardware::thread::V1_0::Ip6Prefix &aPrefix) override;
+
+    /**
+     * This method adds an external route.
+     *
+     * @param[in] aExternalroute  The external route config.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> addExternalRoute(
+        const ::android::hardware::thread::V1_0::ExternalRoute &aExternalRoute) override;
+
+    /**
+     * This method removes an external route.
+     *
+     * @param[in] aPrefix  The route prefix.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> removeExternalRoute(const ::android::hardware::thread::V1_0::Ip6Prefix &aPrefix) override;
+
+    /**
+     * This method sets the mesh-local prefix.
+     *
+     * @param[in] aPrefix  The address prefix.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> setMeshLocalPrefix(const hidl_array<uint8_t, 8> &aPrefix) override;
+
+    /**
+     * This method sets the legacy prefix of ConnectIP.
+     *
+     * @param[in] aPrefix  The address prefix.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> setLegacyUlaPrefix(const hidl_array<uint8_t, 8> &aPrefix) override;
+
+    /**
+     * This method sets the active operational dataset.
+     *
+     * @param[in] aDataset  The active operational dataset
+     *
+     * @retval ERROR_NONE successfully performed the dbus function call
+     * @retval ERROR_HIDL Hidl encode/decode error
+     * @retval ...        OpenThread defined error value otherwise
+     *
+     */
+    Return<ThreadError> setActiveDatasetTlvs(
+        const ::android::hardware::thread::V1_0::OperationalDatasetTlvs &aDataset) override;
+
+    /**
+     * This method sets the link operating mode.
+     *
+     * @param[in] aConfig  The operating mode config.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> setLinkMode(const ::android::hardware::thread::V1_0::LinkModeConfig &aConfig) override;
+
+    /**
+     * This method sets the radio region.
+     *
+     * @param[in] aRegion  The region, can be CA, US or WW.
+     *
+     * @retval ERROR_NONE  Successfully performed the HIDL function call.
+     * @retval ERROR_HIDL  Hidl encode/decode error.
+     * @retval ...         OpenThread defined error value otherwise.
+     *
+     */
+    Return<ThreadError> setRadioRegion(const hidl_string &aRegion) override;
+
+    /**
+     * This method gets the link operating mode.
+     *
+     * @param[in] _hidl_cb  A pointer to the get link mode callback function.
+     */
+    Return<void> getLinkMode(getLinkMode_cb _hidl_cb) override;
+
+    /**
+     * This method gets the current device role.
+     *
+     * @param[in] _hidl_cb  A pointer to the get device role callback function.
+     *
+     */
+    Return<void> getDeviceRole(getDeviceRole_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network name.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network name callback function.
+     *
+     */
+    Return<void> getNetworkName(getNetworkName_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network pan id.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network pan id callback function.
+     *
+     */
+    Return<void> getPanId(getPanId_cb _hidl_cb) override;
+
+    /**
+     * This method gets the extended pan id.
+     *
+     * @param[in] _hidl_cb  A pointer to the get extended pan id callback function.
+     *
+     */
+    Return<void> getExtPanId(getExtPanId_cb _hidl_cb) override;
+
+    /**
+     * This method gets the channel.
+     *
+     * @param[in] _hidl_cb  A pointer to the get channel callback callback function.
+     *
+     */
+    Return<void> getChannel(getChannel_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network master key.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network master key callback function.
+     *
+     */
+    Return<void> getMasterKey(getMasterKey_cb _hidl_cb) override;
+
+    /**
+     * This method gets the Clear Channel Assessment failure rate.
+     *
+     * @param[in] _hidl_cb  A pointer to the get Clear Channel Assessment failure rate callback function.
+     *
+     */
+    Return<void> getCcaFailureRate(getCcaFailureRate_cb _hidl_cb) override;
+
+    /**
+     * This method gets the mac level statistics counters.
+     *
+     * @param[in] _hidl_cb  A pointer to the get mac level statistic counters callback function.
+     *
+     */
+    Return<void> getLinkCounters(getLinkCounters_cb _hidl_cb) override;
+
+    /**
+     * This method gets the ip level statistics counters.
+     *
+     * @param[in] _hidl_cb  A pointer to the get ip level statistic counters callback function.
+     *
+     */
+    Return<void> getIp6Counters(getIp6Counters_cb _hidl_cb) override;
+
+    /**
+     * This method gets the supported channel mask.
+     *
+     * @param[in] _hidl_cb  A pointer to the get supported channel mask callback function.
+     *
+     */
+    Return<void> getSupportedChannelMask(getSupportedChannelMask_cb _hidl_cb) override;
+
+    /**
+     * This method gets the Thread routing locator.
+     *
+     * @param[in] _hidl_cb  A pointer to the get Thread routing locator callback function.
+     *
+     */
+    Return<void> getRloc16(getRloc16_cb _hidl_cb) override;
+
+    /**
+     * This method gets 802.15.4 extended address.
+     *
+     * @param[in] _hidl_cb  A pointer to the get 802.15.4 extended address callback function.
+     *
+     */
+    Return<void> getExtendedAddress(getExtendedAddress_cb _hidl_cb) override;
+
+    /**
+     * This method gets the node's router id.
+     *
+     * @param[in] _hidl_cb  A pointer to the get node's router id callback function.
+     *
+     */
+    Return<void> getRouterId(getRouterId_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network's leader data.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network's leader data callback function.
+     *
+     */
+    Return<void> getLeaderData(getLeaderData_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network data.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network data callback function.
+     *
+     */
+    Return<void> getNetworkData(getNetworkData_cb _hidl_cb) override;
+
+    /**
+     * This method gets the stable network data.
+     *
+     * @param[in] _hidl_cb  A pointer to the get stable network data callback function.
+     *
+     */
+    Return<void> getStableNetworkData(getStableNetworkData_cb _hidl_cb) override;
+
+    /**
+     * This method gets the node's local leader weight.
+     *
+     * @param[in] _hidl_cb  A pointer to the get node's local leader weight callback function.
+     *
+     */
+    Return<void> getLocalLeaderWeight(getLocalLeaderWeight_cb _hidl_cb) override;
+
+    /**
+     * This method gets the channel monitor sample count.
+     *
+     * @param[in] _hidl_cb  A pointer to the get channel monitor sample count callback function.
+     *
+     */
+    Return<void> getChannelMonitorSampleCount(getChannelMonitorSampleCount_cb _hidl_cb) override;
+
+    /**
+     * This method gets the channel qualities.
+     *
+     * @param[in] _hidl_cb  A pointer to the get channel qualities callback function.
+     *
+     */
+    Return<void> getChannelMonitorAllChannelQualities(getChannelMonitorAllChannelQualities_cb _hidl_cb) override;
+
+    /**
+     * This method gets the child table.
+     *
+     * @param[in] _hidl_cb  A pointer to the get child table callback function.
+     *
+     */
+    Return<void> getChildTable(getChildTable_cb _hidl_cb) override;
+
+    /**
+     * This method gets the neighbor table.
+     *
+     * @param[in] _hidl_cb  A pointer to the get neighbor table callback function.
+     *
+     */
+    Return<void> getNeighborTable(getNeighborTable_cb _hidl_cb) override;
+
+    /**
+     * This method gets the network's parition id.
+     *
+     * @param[in] _hidl_cb  A pointer to the get network's parition id callback function.
+     *
+     */
+    Return<void> getPartitionId(getPartitionId_cb _hidl_cb) override;
+
+    /**
+     * This method gets the rssi of the latest packet.
+     *
+     * @param[in] _hidl_cb  A pointer to the get rssi of the latest packet callback function.
+     *
+     */
+    Return<void> getInstantRssi(getInstantRssi_cb _hidl_cb) override;
+
+    /**
+     * This method gets the radio transmit power.
+     *
+     * @param[in] _hidl_cb  A pointer to the get radio transmit power callback function.
+     *
+     */
+    Return<void> getRadioTxPower(getRadioTxPower_cb _hidl_cb) override;
+
+    /**
+     * This method gets the external route table.
+     *
+     * @param[in] _hidl_cb  A pointer to the get external route table callback function.
+     *
+     */
+    Return<void> getExternalRoutes(getExternalRoutes_cb _hidl_cb) override;
+
+    /**
+     * This method gets the active operational dataset
+     *
+     * @param[in] _hidl_cb  A pointer to the get active dataset tlvs callback function.
+     */
+    Return<void> getActiveDatasetTlvs(getActiveDatasetTlvs_cb _hidl_cb) override;
+
+    /**
+     * This method gets the radio region.
+     *
+     * @param[in] _hidl_cb  A pointer to the get region callback function.
+     *
+     */
+    Return<void> getRadioRegion(getRadioRegion_cb _hidl_cb) override;
+
+private:
+    void ScanResultHandler(otError aError, const std::vector<otActiveScanResult> &aResult);
+    void DeviceRoleHandler(otDeviceRole aDeviceRole);
+    void NcpResetHandler(void);
+
+    static void sClientDeathCallback(void *aContext)
+    {
+        HidlThread *hidlServer = static_cast<HidlThread *>(aContext);
+        hidlServer->deinitialize();
+    }
+
+    otbr::Ncp::ControllerOpenThread *mNcp;
+    sp<IThreadCallback>              mThreadCallback;
+    sp<ClientDeathRecipient>         mDeathRecipient;
+};
+
+} // namespace Hidl
+} // namespace otbr


### PR DESCRIPTION
This CL implements the HIDL server on the Android platform. The HIDL
server provides IThread and IThreadSettings HIDL interfaces for the
HIDL client.
The IThread interface is implemented by the HIDL server to provides
all control operations of the Thread network.
The IThreadSettings interface is mainly called by the HIDL server to
send sensitive settings to Thread System service. The Thread System
servie stores the sensitive settings to a secure area.