### PR TITLE
[WIP] add HIDL mdns interface support

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -30,7 +30,7 @@ soong_config_module_type {
     name: "otbr_config_cc_defaults",
     module_type: "cc_defaults",
     config_namespace: "otbr",
-    bool_variables: ["enable_unsecure_join", "enable_legacy", "enable_android_bp", "disable_android_bp"],
+    bool_variables: ["enable_unsecure_join", "enable_legacy", "enable_mdns_mdnssd", "enable_android_bp", "disable_android_bp"],
     value_variables: ["vendor_config_include_dir", "vendor_config_init_rc"],
     properties: ["cflags", "enabled", "include_dirs", "init_rc"],
 }
@@ -43,6 +43,12 @@ otbr_config_cc_defaults {
         },
         enable_legacy: {
             cflags: ["-DOTBR_ENABLE_LEGACY=1"]
+        },
+        enable_mdns_mdnssd: {
+            cflags: [
+                "-DOTBR_ENABLE_MDNS_MDNSSD=1",
+                "-DOTBR_ENABLE_MDNS_MDNSSD_HIDL=1"
+            ],
         },
         vendor_config_include_dir: {
             include_dirs: ["%s"]
@@ -90,6 +96,8 @@ cc_binary {
         "src/agent/thread_helper.cpp",
         "src/common/logging.cpp",
         "src/common/types.cpp",
+        "src/hidl/1.0/hidl_mdns.cpp",
+        "src/mdns/mdns_mdnssd.cpp",
         "src/utils/event_emitter.cpp",
         "src/utils/hex.cpp",
         "src/utils/strcpy_utils.cpp",

--- a/src/hidl/1.0/hidl_mdns.cpp
+++ b/src/hidl/1.0/hidl_mdns.cpp
@@ -1,0 +1,410 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements HIDL MDNS interface.
+ */
+
+#include "hidl/1.0/hidl_mdns.hpp"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <hidl/HidlTransportSupport.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+#if !OTBR_ENABLE_HIDL_SERVER
+#error "OTBR_ENABLE_HIDL_SERVER is required for OTBR_ENABLE_MDNS_MDNSSD_HIDL."
+#endif
+
+namespace otbr {
+namespace Hidl {
+using android::hardware::setupTransportPolling;
+
+HidlMdns::HidlMdns(void)
+    : mMdnsCallback(nullptr)
+    , mServiceRegisterCallback(nullptr)
+    , mServiceRegisterContext(nullptr)
+    , mServiceRegisterRecordCallback(nullptr)
+    , mServiceRegisterRecordContext(nullptr)
+    , mStateUpdateCallback(nullptr)
+    , mStateUpdateCallbackContext(nullptr)
+{
+    VerifyOrDie((setupTransportPolling()) >= 0, "Setup HIDL transport for use with (e)poll failed");
+}
+
+void HidlMdns::Init(void)
+{
+    otbrLog(OTBR_LOG_INFO, "Register HIDL MDNS service");
+    VerifyOrDie(registerAsService() == android::NO_ERROR, "Register HIDL MDNS service failed");
+
+    mDeathRecipient = new ClientDeathRecipient(sClientDeathCallback, this);
+    VerifyOrDie(mDeathRecipient != nullptr, "Create client death reciptient failed");
+}
+
+Return<void> HidlMdns::initialize(const sp<IThreadMdnsCallback> &aCallback)
+{
+    VerifyOrExit(aCallback != NULL);
+
+    mMdnsCallback = aCallback;
+
+    mDeathRecipient->SetClientHasDied(false);
+    mMdnsCallback->linkToDeath(mDeathRecipient, 3);
+
+    if (mStateUpdateCallback != nullptr)
+    {
+        mStateUpdateCallback(kDNSServiceStateIsReady, mStateUpdateCallbackContext);
+    }
+
+    otbrLog(OTBR_LOG_INFO, "HIDL MDNS interface initialized");
+
+exit:
+    return Void();
+}
+
+Return<void> HidlMdns::deinitialize(void)
+{
+    if ((!mDeathRecipient->GetClientHasDied()) && (mMdnsCallback != nullptr))
+    {
+        mMdnsCallback->unlinkToDeath(mDeathRecipient);
+        mDeathRecipient->SetClientHasDied(true);
+    }
+
+    mMdnsCallback = nullptr;
+
+    if (mStateUpdateCallback != nullptr)
+    {
+        mStateUpdateCallback(kDNSServiceStateIdle, mStateUpdateCallbackContext);
+    }
+
+    otbrLog(OTBR_LOG_INFO, "HIDL MDNS interface deinitialized");
+
+    return Void();
+}
+
+void HidlMdns::ServiceInit(MdnsStateUpdatedCallback aCallback, void *aContext)
+{
+    mStateUpdateCallback        = aCallback;
+    mStateUpdateCallbackContext = aContext;
+}
+
+bool HidlMdns::IsReady(void)
+{
+    return (mMdnsCallback != nullptr);
+}
+
+DNSServiceErrorType HidlMdns::ServiceCreateConnection(DNSServiceRef *aServiceRef)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(mMdnsCallback != nullptr, error = kDNSServiceErr_BadState);
+
+    mMdnsCallback->onServiceCreateConnection([&](int aError, uint32_t aServiceRefId) {
+        if ((error = aError) == kDNSServiceErr_NoError)
+        {
+            *aServiceRef = aServiceRefId;
+        }
+    });
+
+exit:
+    return error;
+}
+
+Return<void> HidlMdns::setServiceRegisterReply(uint32_t           aServiceRef,
+                                               uint32_t           aFlags,
+                                               int32_t            aError,
+                                               const hidl_string &aName,
+                                               const hidl_string &aType,
+                                               const hidl_string &aDomain)
+{
+    if (mServiceRegisterCallback != nullptr)
+    {
+        mServiceRegisterCallback(aServiceRef, aFlags, aError, aName.c_str(), aType.c_str(), aDomain.c_str(),
+                                 mServiceRegisterContext);
+        mServiceRegisterCallback = nullptr;
+    }
+
+    return Void();
+}
+
+DNSServiceErrorType HidlMdns::ServiceRegister(DNSServiceRef *         aServiceRef,
+                                              DNSServiceFlags         aFlags,
+                                              uint32_t                aInterfaceIndex,
+                                              const char *            aServiceName,
+                                              const char *            aServiceType,
+                                              const char *            aDomain,
+                                              const char *            aHost,
+                                              uint16_t                aPort,
+                                              uint16_t                aTxtLength,
+                                              const void *            aTxtRecord,
+                                              DNSServiceRegisterReply aCallback,
+                                              void *                  aContext)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(mMdnsCallback != nullptr, error = kDNSServiceErr_BadState);
+
+    mServiceRegisterCallback = aCallback;
+    mServiceRegisterContext  = aContext;
+
+    mMdnsCallback->onServiceRegister(aFlags, aInterfaceIndex, ToHidlString(aServiceName), ToHidlString(aServiceType),
+                                     ToHidlString(aDomain), ToHidlString(aHost), aPort,
+                                     hidl_vec<uint8_t>(reinterpret_cast<const uint8_t *>(aTxtRecord),
+                                                       reinterpret_cast<const uint8_t *>(aTxtRecord) + aTxtLength),
+                                     [&](int32_t aError, uint32_t aServiceRefId) {
+                                         if ((error = aError) == kDNSServiceErr_NoError)
+                                         {
+                                             *aServiceRef = aServiceRefId;
+                                         }
+                                     });
+
+exit:
+    return error;
+}
+
+Return<void> HidlMdns::setServiceRegisterRecordReply(uint32_t aServiceRef,
+                                                     uint32_t aRecordRef,
+                                                     uint32_t aFlags,
+                                                     int32_t  aError)
+{
+    if (mServiceRegisterRecordCallback != nullptr)
+    {
+        mServiceRegisterRecordCallback(aServiceRef, aRecordRef, aFlags, aError, mServiceRegisterRecordContext);
+        mServiceRegisterRecordCallback = nullptr;
+    }
+
+    return Void();
+}
+
+DNSServiceErrorType HidlMdns::ServiceRegisterRecord(DNSServiceRef                 aServiceRef,
+                                                    DNSRecordRef *                aRecordRef,
+                                                    DNSServiceFlags               aFlags,
+                                                    uint32_t                      aInterfaceIndex,
+                                                    const char *                  aFullName,
+                                                    uint16_t                      aResourceRecordType,
+                                                    uint16_t                      aResourceRecordClass,
+                                                    uint16_t                      aResourceDataLength,
+                                                    const void *                  aResourceData,
+                                                    uint32_t                      aTimeToLive,
+                                                    DNSServiceRegisterRecordReply aCallback,
+                                                    void *                        aContext)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(mMdnsCallback != nullptr, error = kDNSServiceErr_BadState);
+
+    mServiceRegisterRecordCallback = aCallback;
+    mServiceRegisterRecordContext  = aContext;
+
+    mMdnsCallback->onServiceRegisterRecord(
+        aServiceRef, aFlags, aInterfaceIndex, aFullName, aResourceRecordType, aResourceRecordClass,
+        hidl_vec<uint8_t>(reinterpret_cast<const uint8_t *>(aResourceData),
+                          reinterpret_cast<const uint8_t *>(aResourceData) + aResourceDataLength),
+        aTimeToLive, [&](int32_t aError, uint32_t aRecordRefId) {
+            if ((error = aError) == kDNSServiceErr_NoError)
+            {
+                *aRecordRef = aRecordRefId;
+            }
+        });
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType HidlMdns::ServiceUpdateRecord(DNSServiceRef   aServiceRef,
+                                                  DNSRecordRef    aRecordRef,
+                                                  DNSServiceFlags aFlags,
+                                                  uint16_t        aResourceDataLength,
+                                                  const void *    aResourceData,
+                                                  uint32_t        aTimeToLive)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(mMdnsCallback != nullptr, error = kDNSServiceErr_BadState);
+    error = mMdnsCallback->onServiceUpdateRecord(
+        aServiceRef, aRecordRef, aFlags,
+        hidl_vec<uint8_t>(reinterpret_cast<const uint8_t *>(aResourceData),
+                          reinterpret_cast<const uint8_t *>(aResourceData) + aResourceDataLength),
+        aTimeToLive);
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType HidlMdns::ServiceRemoveRecord(DNSServiceRef   aServiceRef,
+                                                  DNSRecordRef    aRecordRef,
+                                                  DNSServiceFlags aFlags)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(mMdnsCallback != nullptr, error = kDNSServiceErr_BadState);
+    error = mMdnsCallback->onServiceRemoveRecord(aServiceRef, aRecordRef, aFlags);
+
+exit:
+    return error;
+}
+
+void HidlMdns::ServiceRefDeallocate(DNSServiceRef aServiceRef)
+{
+    VerifyOrExit(mMdnsCallback != nullptr);
+    mMdnsCallback->onServiceRefDeallocate(aServiceRef);
+
+exit:
+    return;
+}
+
+} // namespace Hidl
+
+} // namespace otbr
+
+#include "hidl/1.0/hidl_agent.hpp"
+
+extern std::unique_ptr<otbr::Hidl::HidlAgent> gHidlAgent;
+
+DNSServiceErrorType HidlMdnsInit(MdnsStateUpdatedCallback aCallback, void *aContext)
+{
+    DNSServiceErrorType error = kDNSServiceErr_NoError;
+
+    VerifyOrExit(gHidlAgent != nullptr, error = kDNSServiceErr_BadState);
+    gHidlAgent->GetMdns().ServiceInit(aCallback, aContext);
+
+exit:
+    return error;
+}
+
+bool HidlMdnsIsReady(void)
+{
+    bool isReady;
+
+    VerifyOrExit(gHidlAgent != nullptr, isReady = false);
+    isReady = gHidlAgent->GetMdns().IsReady();
+
+exit:
+    return isReady;
+}
+
+DNSServiceErrorType DNSServiceCreateConnection(DNSServiceRef *aServiceRef)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(HidlMdnsIsReady(), error = kDNSServiceErr_BadState);
+    error = gHidlAgent->GetMdns().ServiceCreateConnection(aServiceRef);
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType DNSServiceRegister(DNSServiceRef *         aServiceRef,
+                                       DNSServiceFlags         aFlags,
+                                       uint32_t                aInterfaceIndex,
+                                       const char *            aName,
+                                       const char *            aType,
+                                       const char *            aDomain,
+                                       const char *            aHost,
+                                       uint16_t                aPort,
+                                       uint16_t                aTxtLength,
+                                       const void *            aTxtRecord,
+                                       DNSServiceRegisterReply aCallback,
+                                       void *                  aContext)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(HidlMdnsIsReady(), error = kDNSServiceErr_BadState);
+    error = gHidlAgent->GetMdns().ServiceRegister(aServiceRef, aFlags, aInterfaceIndex, aName, aType, aDomain, aHost,
+                                                  aPort, aTxtLength, aTxtRecord, aCallback, aContext);
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType DNSServiceRegisterRecord(DNSServiceRef                 aServiceRef,
+                                             DNSRecordRef *                aRecordRef,
+                                             DNSServiceFlags               aFlags,
+                                             uint32_t                      aInterfaceIndex,
+                                             const char *                  aFullName,
+                                             uint16_t                      aRRType,
+                                             uint16_t                      aRRclass,
+                                             uint16_t                      aResourceDataLength,
+                                             const void *                  aResourceData,
+                                             uint32_t                      aTimeToLive,
+                                             DNSServiceRegisterRecordReply aCallback,
+                                             void *                        aContext)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(HidlMdnsIsReady(), error = kDNSServiceErr_BadState);
+    error = gHidlAgent->GetMdns().ServiceRegisterRecord(aServiceRef, aRecordRef, aFlags, aInterfaceIndex, aFullName,
+                                                        aRRType, aRRclass, aResourceDataLength, aResourceData,
+                                                        aTimeToLive, aCallback, aContext);
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType DNSServiceUpdateRecord(DNSServiceRef   aServiceRef,
+                                           DNSRecordRef    aRecordRef,
+                                           DNSServiceFlags aFlags,
+                                           uint16_t        aResourceDataLength,
+                                           const void *    aResourceData,
+                                           uint32_t        aTimeToLive)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(HidlMdnsIsReady(), error = kDNSServiceErr_BadState);
+    error = gHidlAgent->GetMdns().ServiceUpdateRecord(aServiceRef, aRecordRef, aFlags, aResourceDataLength,
+                                                      aResourceData, aTimeToLive);
+
+exit:
+    return error;
+}
+
+DNSServiceErrorType DNSServiceRemoveRecord(DNSServiceRef aServiceRef, DNSRecordRef aRecordRef, DNSServiceFlags aFlags)
+{
+    DNSServiceErrorType error;
+
+    VerifyOrExit(HidlMdnsIsReady(), error = kDNSServiceErr_BadState);
+    error = gHidlAgent->GetMdns().ServiceRemoveRecord(aServiceRef, aRecordRef, aFlags);
+
+exit:
+    return error;
+}
+
+void DNSServiceRefDeallocate(DNSServiceRef aServiceRef)
+{
+    VerifyOrExit(HidlMdnsIsReady());
+    gHidlAgent->GetMdns().ServiceRefDeallocate(aServiceRef);
+
+exit:
+    return;
+}
+#endif // OTBR_ENABLE_MDNS_MDNSSD_HIDL

--- a/src/hidl/1.0/hidl_mdns.hpp
+++ b/src/hidl/1.0/hidl_mdns.hpp
@@ -1,0 +1,320 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for MDNS HIDL interface.
+ */
+
+#pragma once
+
+#include <openthread-br/config.h>
+
+#include <vector>
+
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+#include <android/hardware/thread/1.0/IThreadMdns.h>
+#include <android/hardware/thread/1.0/IThreadMdnsCallback.h>
+#endif
+
+#include "common/types.hpp"
+#include "hidl/1.0/hidl_death_recipient.hpp"
+#include "hidl/1.0/hidl_mdns_api.hpp"
+#include "mdns/mdns.hpp"
+
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+namespace otbr {
+namespace Hidl {
+using ::android::sp;
+using ::android::hardware::hidl_string;
+using ::android::hardware::hidl_vec;
+using ::android::hardware::Return;
+using ::android::hardware::Void;
+using ::android::hardware::thread::V1_0::IThreadMdns;
+using ::android::hardware::thread::V1_0::IThreadMdnsCallback;
+
+/**
+ * This class implements HIDL MDNS interface.
+ *
+ */
+class HidlMdns : public IThreadMdns
+{
+public:
+    /**
+     * The constructor to initialize a HIDL MDNS interface.
+     *
+     */
+    HidlMdns(void);
+
+    ~HidlMdns(void){};
+
+    /**
+     * This method performs initialization for the HIDL MDNS service.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method is called by the HIDL client to initalizes the HIDL MDNS callback object.
+     *
+     */
+    Return<void> initialize(const sp<IThreadMdnsCallback> &aCallback) override;
+
+    /**
+     * This method is called by the HIDL client to deinitalizes the HIDL MDNS callback object.
+     *
+     */
+    Return<void> deinitialize(void) override;
+
+    /**
+     * This methid is called by the HIDL client when the service specified by ServiceRegister() is registered
+     * successfully or failed.
+     *
+     * @param[in] aServiceRef   The DNS service reference identifier initialized by onServiceRegister().
+     * @param[in] aFlags        When a name is successfully registered, the callback will be invoked with the
+     *                          kDNSServiceFlagsAdd flag set.
+     * @param[in] aError        The error code. It will be set to kDNSServiceErr_NoError on success, otherwise will
+     *                          indicate the failure that occurred.
+     * @param[in] aServiceName  The service name registered (if the application did not specify a name in
+     *                          DNSServiceRegister(), this indicates what name was automatically chosen).
+     * @param[in] aServiceType  The type of service registered, as it was passed to the callout.
+     * @param[in] aDomain       The domain on which the service was registered (if the application did not specify a
+     *                          domain in ServiceRegister(), this indicates the default domain on which the service
+     *                          was registered).
+     *
+     */
+    Return<void> setServiceRegisterReply(uint32_t           aServiceRefId,
+                                         uint32_t           aFlags,
+                                         int32_t            aError,
+                                         const hidl_string &aServiceName,
+                                         const hidl_string &aServiceType,
+                                         const hidl_string &aDomain) override;
+
+    /**
+     * This method is called by the HIDL client when the resource record specified by ServiceRegisterRecord() is
+     * registered successfully or failed.
+     *
+     * @param[in] aServiceRef   The connected DNS service reference identifier initialized by
+     *                          onServiceCreateConnection().
+     * @param[in] aRecordRef    The DNS record reference identifier initialized by on ServiceRegisterRecord().
+     * @param[in] aFlags        Currently unused, reserved for future use.
+     * @param[in] aError        The error code. It will be set to kDNSServiceErr_NoError on success, otherwise will
+     *                          indicate the failure that occurred.
+     *
+     */
+    Return<void> setServiceRegisterRecordReply(uint32_t aServiceRefId,
+                                               uint32_t aRecordRef,
+                                               uint32_t aFlags,
+                                               int32_t  aError) override;
+
+    /**
+     * This method registers a handles to monitor the DNS service state.
+     *
+     * @param[in] aCallback        The function to be called when the DNS service state is updated.
+     * @param[in] aContext         An application context pointer which is passed to the callback function.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+     *                                 delivered to the callback).
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    void ServiceInit(MdnsStateUpdatedCallback aCallback, void *aContext);
+
+    /**
+     * This method indicates whether the DNS service is ready to use.
+     *
+     * @retval TRUE   The DNS service is ready.
+     * @retval FALSE  The DNS service is not ready.
+     *
+     */
+    bool IsReady(void);
+
+    /**
+     * This method creates a connection to the daemon allowing efficient registration of multiple individual records.
+     *
+     * @[param[out]] aServiceRef  A pointer to an uninitialized DNSServiceRef.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully created a connection.
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    DNSServiceErrorType ServiceCreateConnection(DNSServiceRef *aServiceRef);
+
+    /**
+     * This method registers a DNS service.
+     *
+     * @param[out] aServiceRef     A pointer to an uninitialized DNSServiceRef. If the call succeeds then it
+     *                             initializes the DNSServiceRef.
+     * @param[in] aFlags           Indicates the renaming behavior on name conflict.
+     * @param[in] aInterfaceIndex  The interface index. If non-zero, specifies the interface on which to register the
+     *                             service. If zero, registers on all avaliable interfaces.
+     * @param[in] aServiceName     A pointer to the service name to be registered or NULL to use the computer name as
+     *                             the service name.
+     * @param[in] aServiceType     A pointer to the service type followed by the protocol, separated by a dot.
+     *                             (e.g. "_ftp._tcp").
+     * @param[in] aDomain          A pointer to the domain on which to advertise the service or NULL to use the default
+     *                             domain(s).
+     * @param[in] aHost            A pointer to the SRV target host name or NULL to use the machines's default host
+     *                             name.
+     * @param[in] aPort            The port, in network byte order, on which the service accepts connections.
+     * @param[in] aTxtLength       The length of the @p aTxtRecord, in bytes. Must be zero if the @p aTxtRecord is NULL.
+     * @param[in] aTxtRecord       A pointer TXT record rdata.
+     * @param[in] aCallback        The function to be called when the registration completes or asynchronously fails.
+     * @param[in] aContext         An application context pointer which is passed to the callback function.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+     *                                 delivered to the callback).
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    DNSServiceErrorType ServiceRegister(DNSServiceRef *         aServiceRef,
+                                        DNSServiceFlags         aFlags,
+                                        uint32_t                aInterfaceIndex,
+                                        const char *            aServiceName,
+                                        const char *            aServiceType,
+                                        const char *            aDomain,
+                                        const char *            aHost,
+                                        uint16_t                aPort,
+                                        uint16_t                aTxtLength,
+                                        const void *            aTxtRecord,
+                                        DNSServiceRegisterReply aCallback,
+                                        void *                  aContext);
+
+    /**
+     * This methods registers an individual resource record on a connected DNSServiceRef.
+     *
+     * Note that name conflicts occurring for records registered via this call must be handled
+     * by the client in the callback.
+     *
+     * @param[in]  aServiceRef           A DNSServiceRef initialized by ServiceCreateConnection().
+     * @param[out] aRecordRef            A pointer to an uninitialized DNSRecordRef. Upon succesfull completion of this
+     *                                   call, this ref may be passed to ServiceUpdateRecord() or ServiceRemoveRecord().
+     * @param[in]  aFlags                Possible values are kDNSServiceFlagsShared or kDNSServiceFlagsUnique.
+     * @param[in]  aInterfaceIndex       If non-zero, specifies the interface on which to register the record
+     *                                   Passing 0 causes the record to be registered on all interfaces.
+     * @param[in]  aFullName             A poniter to the full domain name of the resource record.
+     * @param[in]  aResourceRecordType   The type of the resource record.
+     * @param[in]  aResourceRecordClass  The class of the resource record.
+     * @param[in]  aResourceDataLength   The length of the @p aResourceData, in bytes.
+     * @param[in]  aResourceData         A pointer to the raw rdata, as it is to appear in the DNS record.
+     * @param[in]  aTimeToLive           The time to live of the resource record, in seconds.
+     * @param[in]  aCallback             The function to be called when a result is found, or if the call
+     *                                   asynchronously fails (e.g. because of a name conflict.)
+     * @param[in]  aContext              An application context pointer which is passed to the callback function.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+     *                                 delivered to the callback).
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    DNSServiceErrorType ServiceRegisterRecord(DNSServiceRef                 aServiceRef,
+                                              DNSRecordRef *                aRecordRef,
+                                              DNSServiceFlags               aFlags,
+                                              uint32_t                      aInterfaceIndex,
+                                              const char *                  aFullName,
+                                              uint16_t                      aResourceRecordType,
+                                              uint16_t                      aResourceRecordClass,
+                                              uint16_t                      aResourceDataLength,
+                                              const void *                  aResourceData,
+                                              uint32_t                      aTimeToLive,
+                                              DNSServiceRegisterRecordReply aCallback,
+                                              void *                        aContext);
+    /**
+     * This methods updates a registered resource record. The record must either be:
+     *   - The primary txt record of a service registered via ServiceRegister()
+     *   - An individual record registered by ServiceRegisterRecord()
+     *
+     * @param[in] aServiceRef          A DNSServiceRef that was initialized by ServiceRegister() or
+     *                                 ServiceCreateConnection().
+     * @param[in] aRecordRef           A DNSRecordRef initialized by ServiceRegisterRecord(), or NULL to update the
+     *                                 service's primary txt record.
+     * @param[in] aFlags               Currently ignored, reserved for future use.
+     * @param[in] aResourceDataLength  The length of the @p aResourceData, in bytes.
+     * @param[in] aResourceData        A pointer to resource data to be contained in the updated resource record.
+     * @param[in] aTimeToLive          The time to live of the updated resource record, in seconds.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully updated the resource record.
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    DNSServiceErrorType ServiceUpdateRecord(DNSServiceRef   aServiceRef,
+                                            DNSRecordRef    aRecordRef,
+                                            DNSServiceFlags aFlags,
+                                            uint16_t        aResourceDataLength,
+                                            const void *    aResourceData,
+                                            uint32_t        aTimeToLive);
+
+    /**
+     * This methods removes a record previously added to a service record set via ServiceAddRecord(), or deregister
+     * an record registered individually via ServiceRegisterRecord().
+     *
+     * @param[in] aServiceRef  A DNSServiceRef initialized by ServiceRegister() or by ServiceCreateConnection() (if the
+     *                         record  being removed was registered via ServiceRegisterRecord()).
+     * @param[in] aRecordRef   A DNSRecordRef initialized by a successful call to ServiceRegisterRecord().
+     * @param[in] aFlags       Currently ignored, reserved for future use.
+     *
+     * @retval kDNSServiceErr_NoError  Successfully removed the resource record.
+     * @retval ...                     Other DNS error codes.
+     *
+     */
+    DNSServiceErrorType ServiceRemoveRecord(DNSServiceRef aServiceRef, DNSRecordRef aRecordRef, DNSServiceFlags aFlags);
+
+    /**
+     * This method terminates a connection with the daemon and free memory associated with the DNSServiceRef.
+     * Any services or records registered with this DNSServiceRef will be deregistered.
+     *
+     * @param[in] aServiceRef  A DNSServiceRef initialized by any of the DNS Service calls.
+     *
+     */
+    void ServiceRefDeallocate(DNSServiceRef aServiceRef);
+
+private:
+    hidl_string ToHidlString(const char *aString)
+    {
+        return ((aString == nullptr) || (strlen(aString) == 0)) ? hidl_string() : hidl_string(aString);
+    }
+
+    static void sClientDeathCallback(void *aContext)
+    {
+        HidlMdns *hidlMdns = static_cast<HidlMdns *>(aContext);
+        hidlMdns->deinitialize();
+    }
+
+    sp<IThreadMdnsCallback>       mMdnsCallback;
+    DNSServiceRegisterReply       mServiceRegisterCallback;
+    void *                        mServiceRegisterContext;
+    DNSServiceRegisterRecordReply mServiceRegisterRecordCallback;
+    void *                        mServiceRegisterRecordContext;
+    MdnsStateUpdatedCallback      mStateUpdateCallback;
+    void *                        mStateUpdateCallbackContext;
+    sp<ClientDeathRecipient>      mDeathRecipient;
+};
+
+} // namespace Hidl
+} // namespace otbr
+#endif // OTBR_ENABLE_MDNS_MDNSSD_HIDL

--- a/src/hidl/1.0/hidl_mdns_api.hpp
+++ b/src/hidl/1.0/hidl_mdns_api.hpp
@@ -1,0 +1,358 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for MDNS service.
+ */
+
+#ifndef OTBR_AGENT_HIDL_MDNS_HPP_
+#define OTBR_AGENT_HIDL_MDNS_HPP_
+#include <android/hardware/thread/1.0/IThreadMdns.h>
+
+/**
+ * This enumeration defines the DNS error codes.
+ *
+ */
+enum
+{
+    kDNSServiceErr_NoError                   = 0,
+    kDNSServiceErr_Unknown                   = -65537, /* 0xFFFE FFFF */
+    kDNSServiceErr_NoSuchName                = -65538,
+    kDNSServiceErr_NoMemory                  = -65539,
+    kDNSServiceErr_BadParam                  = -65540,
+    kDNSServiceErr_BadReference              = -65541,
+    kDNSServiceErr_BadState                  = -65542,
+    kDNSServiceErr_BadFlags                  = -65543,
+    kDNSServiceErr_Unsupported               = -65544,
+    kDNSServiceErr_NotInitialized            = -65545,
+    kDNSServiceErr_AlreadyRegistered         = -65547,
+    kDNSServiceErr_NameConflict              = -65548,
+    kDNSServiceErr_Invalid                   = -65549,
+    kDNSServiceErr_Firewall                  = -65550,
+    kDNSServiceErr_Incompatible              = -65551,
+    kDNSServiceErr_BadInterfaceIndex         = -65552,
+    kDNSServiceErr_Refused                   = -65553,
+    kDNSServiceErr_NoSuchRecord              = -65554,
+    kDNSServiceErr_NoAuth                    = -65555,
+    kDNSServiceErr_NoSuchKey                 = -65556,
+    kDNSServiceErr_NATTraversal              = -65557,
+    kDNSServiceErr_DoubleNAT                 = -65558,
+    kDNSServiceErr_BadTime                   = -65559,
+    kDNSServiceErr_BadSig                    = -65560,
+    kDNSServiceErr_BadKey                    = -65561,
+    kDNSServiceErr_Transient                 = -65562,
+    kDNSServiceErr_ServiceNotRunning         = -65563,
+    kDNSServiceErr_NATPortMappingUnsupported = -65564,
+    kDNSServiceErr_NATPortMappingDisabled    = -65565,
+    kDNSServiceErr_NoRouter                  = -65566,
+    kDNSServiceErr_PollingMode               = -65567,
+    kDNSServiceErr_Timeout                   = -65568
+};
+
+/**
+ * This type represents the DNS service error codes.
+ *
+ */
+typedef int32_t DNSServiceErrorType;
+
+/**
+ * This type represents an identifier for the DNS service.
+ *
+ * The value is an opaque unsigned integer maintained by the HDIL client.
+ *
+ */
+typedef uint32_t DNSServiceRef;
+
+/**
+ * This type represents an identifier for the DNS record.
+ *
+ * The value is an opaque unsigned identifier maintained by the HDIL client.
+ *
+ */
+typedef uint32_t DNSRecordRef;
+
+/**
+ * This type represents the DNS service flags.
+ *
+ */
+typedef uint32_t DNSServiceFlags;
+
+/**
+ * This enumeration defines the DNS related constants.
+ *
+ */
+enum
+{
+    kDNSServiceMaxServiceName    = 64,   ///< The max length of the service name.
+    kDNSServiceMaxDomainName     = 1009, ///< The max length of the domain name.
+    kDNSServiceInterfaceIndexAny = 0,    ///< This interface index indicates that if the service name is in an mDNS
+                                         ///< local multicast domain then multicast on all applicable interfaces,
+                                         ///< otherwise send via unicast to the appropriate DNS server.
+    kDNSServiceFlagsAdd    = 0x02,       ///< This flag indicates that the domain has been successfully registered.
+    kDNSServiceFlagsUnique = 0x20,       ///< This flag indicates that the record's name is to be unique on the
+                                         ///< network (e.g. SRV records).
+    kDNSServiceClass_IN  = 1,            ///< The DNS service class Internet.
+    kDNSServiceType_AAAA = 28,           ///< The DNS service type AAAA.
+};
+
+/**
+ * This enumeration defines the invalid DNSServiceRef and DNSRecordRef values.
+ *
+ */
+enum
+{
+    kDNSInvalidServiceRef = 0xffffffff, ///< Invalid DNSServiceRef value.
+    kDNSInvalidRecordRef  = 0xffffffff, ///< Invalid DNSRecordRef value.
+};
+
+/**
+ * This enumeration defines the DNS service state.
+ *
+ */
+typedef enum
+{
+    kDNSServiceStateIdle    = 0, ///< The DNS service is unavailable.
+    kDNSServiceStateIsReady = 1, ///< The DNS service is available.
+} DnsServiceState;
+
+/**
+ * This function pointer is called when the DNS service state is updated.
+ *
+ * @param[in] aState    The DNS service state.
+ * @param[in] aContext  The context pointer that was passed to the callout.
+ *
+ */
+typedef void (*MdnsStateUpdatedCallback)(DnsServiceState aState, void *aContext);
+
+/**
+ * This method registers a handles to monitor the DNS service state.
+ *
+ * @param[in] aCallback        The function to be called when the DNS service state is updated.
+ * @param[in] aContext         An application context pointer which is passed to the callback function.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+ *                                 delivered to the callback).
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType HidlMdnsInit(MdnsStateUpdatedCallback aCallback, void *aContext);
+
+/**
+ * This method indicates whether the DNS service is ready to use.
+ *
+ * @retval TRUE   The DNS service is ready.
+ * @retval FALSE  The DNS service is not ready.
+ *
+ */
+bool HidlMdnsIsReady(void);
+
+/**
+ * This method create a connection to the daemon allowing efficient registration of multiple individual records.
+ *
+ * @[param[out]] aServiceRef  A pointer to an uninitialized DNSServiceRef.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully created a connection.
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType DNSServiceCreateConnection(DNSServiceRef *aServiceRef);
+
+/**
+ * This function pointer is called when the service specified by DNSServiceRegister() is registered successfully or
+ * failed.
+ *
+ * @param[in] aServiceRef   The DNSServiceRef initialized by DNSServiceRegister().
+ * @param[in] aFlags        When a name is successfully registered, the callback will be invoked with the
+ *                          kDNSServiceFlagsAdd flag set.
+ * @param[in] aError        The error code. It will be set to kDNSServiceErr_NoError on success, otherwise will
+ *                          indicate the failure that occurred.
+ * @param[in] aServiceName  The service name registered (if the application did not specify a name in
+ *                          DNSServiceRegister(), this indicates what name was automatically chosen).
+ * @param[in] aServiceType  The type of service registered, as it was passed to the callout.
+ * @param[in] aDomain       The domain on which the service was registered (if the application did not specify a domain
+ *                          in DNSServiceRegister(), this indicates the default domain on which the service was
+ *                          registered).
+ * @param[in] aContext      The context pointer that was passed to the callout.
+ *
+ */
+typedef void (*DNSServiceRegisterReply)(DNSServiceRef       aServiceRef,
+                                        DNSServiceFlags     aFlags,
+                                        DNSServiceErrorType aError,
+                                        const char *        aServiceName,
+                                        const char *        aServiceType,
+                                        const char *        aDomain,
+                                        void *              aContext);
+
+/**
+ * This method registers a DNS service.
+ *
+ * @param[out] aServiceRef     A pointer to an uninitialized DNSServiceRef. If the call succeeds then it
+ *                             initializes the DNSServiceRef.
+ * @param[in] aFlags           Indicates the renaming behavior on name conflict.
+ * @param[in] aInterfaceIndex  The interface index. If non-zero, specifies the interface on which to register the
+ *                             service. If zero, registers on all avaliable interfaces.
+ * @param[in] aServiceName     A pointer to the service name to be registered or NULL to use the computer name as
+ *                             the service name.
+ * @param[in] aServiceType     A pointer to the service type followed by the protocol, separated by a dot.
+ *                             (e.g. "_ftp._tcp").
+ * @param[in] aDomain          A pointer to the domain on which to advertise the service or NULL to use the default
+ *                             domain(s).
+ * @param[in] aHost            A pointer to the SRV target host name or NULL to use the machines's default host
+ *                             name.
+ * @param[in] aPort            The port, in network byte order, on which the service accepts connections.
+ * @param[in] aTxtLength       The length of the @p aTxtRecord, in bytes. Must be zero if the @p aTxtRecord is NULL.
+ * @param[in] aTxtRecord       A pointer TXT record rdata.
+ * @param[in] aCallback        The function to be called when the registration completes or asynchronously fails.
+ * @param[in] aContext         An application context pointer which is passed to the callback function.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+ *                                 delivered to the callback).
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType DNSServiceRegister(DNSServiceRef *         aServiceRef,
+                                       DNSServiceFlags         aFlags,
+                                       uint32_t                aInterfaceIndex,
+                                       const char *            aServiceName,
+                                       const char *            aServiceType,
+                                       const char *            aDomain,
+                                       const char *            aHost,
+                                       uint16_t                aPort,
+                                       uint16_t                aTxtLength,
+                                       const void *            aTxtRecord,
+                                       DNSServiceRegisterReply aCallback,
+                                       void *                  aContext);
+/**
+ * This function pointer is called when the resource record specified by DNSServiceRegisterRecord() is registered
+ * successfully or failed.
+ *
+ * @param[in] aServiceRef   The connected DNSServiceRef initialized by DNSServiceCreateConnection().
+ * @param[in] aRecordRef    The DNSRecordRef initialized by DNSServiceRegisterRecord().
+ * @param[in] aFlags        Currently unused, reserved for future use.
+ * @param[in] aError        The error code. It will be set to kDNSServiceErr_NoError on success, otherwise will
+ *                          indicate the failure that occurred.
+ * @param[in] aContext      The context pointer that was passed to the callout.
+ *
+ */
+typedef void (*DNSServiceRegisterRecordReply)(DNSServiceRef       aServiceRef,
+                                              DNSRecordRef        aRecordRef,
+                                              DNSServiceFlags     aFlags,
+                                              DNSServiceErrorType aError,
+                                              void *              aContext);
+
+/**
+ * This methods registers an individual resource record on a connected DNSServiceRef.
+ *
+ * Note that name conflicts occurring for records registered via this call must be handled
+ * by the client in the callback.
+ *
+ * @param[in]  aServiceRef           A DNSServiceRef initialized by DNSServiceCreateConnection().
+ * @param[out] aRecordRef            A pointer to an uninitialized DNSRecordRef. Upon succesfull completion of this
+ *                                   call, this ref may be passed to DNSServiceUpdateRecord() or
+ *                                   DNSServiceRemoveRecord().
+ * @param[in]  aFlags                Possible values are kDNSServiceFlagsShared or kDNSServiceFlagsUnique.
+ * @param[in]  aInterfaceIndex       If non-zero, specifies the interface on which to register the record
+ *                                   Passing 0 causes the record to be registered on all interfaces.
+ * @param[in]  aFullName             A poniter to the full domain name of the resource record.
+ * @param[in]  aResourceRecordType   The type of the resource record.
+ * @param[in]  aResourceRecordClass  The class of the resource record.
+ * @param[in]  aResourceDataLength   The length of the @p aResourceData, in bytes.
+ * @param[in]  aResourceData         A pointer to the raw rdata, as it is to appear in the DNS record.
+ * @param[in]  aTimeToLive           The time to live of the resource record, in seconds.
+ * @param[in]  aCallback             The function to be called when a result is found, or if the call
+ *                                   asynchronously fails (e.g. because of a name conflict.)
+ * @param[in]  aContext              An application context pointer which is passed to the callback function.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully registerd the service (any subsequent, asynchronous, errors are
+ *                                 delivered to the callback).
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType DNSServiceRegisterRecord(DNSServiceRef                 aServiceRef,
+                                             DNSRecordRef *                aRecordRef,
+                                             DNSServiceFlags               aFlags,
+                                             uint32_t                      aInterfaceIndex,
+                                             const char *                  aFullName,
+                                             uint16_t                      aResourceRecordType,
+                                             uint16_t                      aResourceRecordClass,
+                                             uint16_t                      aResourceDataLength,
+                                             const void *                  aResourceData,
+                                             uint32_t                      aTimeToLive,
+                                             DNSServiceRegisterRecordReply aCallback,
+                                             void *                        aContext);
+
+/**
+ * This methods updates a registered resource record. The record must either be:
+ *   - The primary txt record of a service registered via DNSServiceRegister()
+ *   - An individual record registered by DNSServiceRegisterRecord()
+ *
+ * @param[in] aServiceRef          A DNSServiceRef that was initialized by DNSServiceRegister() or
+ *                                 DNSServiceCreateConnection().
+ * @param[in] aRecordRef           A DNSRecordRef initialized by DNSServiceRegisterRecord(), or NULL to update the
+ *                                 service's primary txt record.
+ * @param[in] aFlags               Currently ignored, reserved for future use.
+ * @param[in] aResourceDataLength  The length of the @p aResourceData, in bytes.
+ * @param[in] aResourceData        A pointer to resource data to be contained in the updated resource record.
+ * @param[in] aTimeToLive          The time to live of the updated resource record, in seconds.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully updated the resource record.
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType DNSServiceUpdateRecord(DNSServiceRef   aServiceRef,
+                                           DNSRecordRef    aRecordRef,
+                                           DNSServiceFlags aFlags,
+                                           uint16_t        aResourceDataLength,
+                                           const void *    aResourceData,
+                                           uint32_t        aTimeToLive);
+
+/**
+ * This methods removes a record previously added to a service record set via DNSServiceAddRecord(), or deregister
+ * an record registered individually via DNSServiceRegisterRecord().
+ *
+ * @param[in] aServiceRef  A DNSServiceRef initialized by DNSServiceRegister() or by DNSServiceCreateConnection() (if
+ *                         the record being removed was registered via DNSServiceRegisterRecord()).
+ * @param[in] aRecordRef   A DNSRecordRef initialized by a successful call to DNSServiceRegisterRecord().
+ * @param[in] aFlags       Currently ignored, reserved for future use.
+ *
+ * @retval kDNSServiceErr_NoError  Successfully removed the resource record.
+ * @retval ...                     Other DNS error codes.
+ *
+ */
+DNSServiceErrorType DNSServiceRemoveRecord(DNSServiceRef aServiceRef, DNSRecordRef aRecordRef, DNSServiceFlags aFlags);
+
+/**
+ * This method terminates a connection with the daemon and free memory associated with the DNSServiceRef.
+ * Any services or records registered with this DNSServiceRef will be deregistered.
+ *
+ * @param[in] aServiceRef  A DNSServiceRef initialized by any of the DNS Service calls.
+ *
+ */
+void DNSServiceRefDeallocate(DNSServiceRef aServiceRef);
+#endif // OTBR_AGENT_HIDL_MDNS_HPP_

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -36,7 +36,14 @@
 
 #include <vector>
 
+#if OTBR_ENABLE_MDNS_MDNSSD
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+#include "hidl/1.0/hidl_mdns_api.hpp"
+#else
 #include <dns_sd.h>
+#define kDNSInvalidServiceRef nullptr
+#define kDNSInvalidRecordRef nullptr
+#endif
 
 #include "common/types.hpp"
 #include "mdns/mdns.hpp"
@@ -46,7 +53,7 @@ namespace otbr {
 namespace Mdns {
 
 /**
- * This class implements MDNS service with avahi.
+ * This class implements MDNS service with mDnsSd.
  *
  */
 class PublisherMDnsSd : public Publisher
@@ -179,7 +186,7 @@ public:
                      timeval &aTimeout) override;
 
 private:
-    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = nullptr);
+    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = kDNSInvalidServiceRef);
     void RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
 
     static void HandleServiceRegisterResult(DNSServiceRef         aService,
@@ -206,6 +213,11 @@ private:
                                          DNSServiceErrorType aErrorCode);
 
     otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
+
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+    static void HandleMdnsStateUpdated(DnsServiceState aState, void *aContext);
+    void        HandleMdnsStateUpdated(DnsServiceState aState);
+#endif
 
     enum
     {
@@ -240,6 +252,10 @@ private:
     State         mState;
     StateHandler  mStateHandler;
     void *        mContext;
+
+#if OTBR_ENABLE_MDNS_MDNSSD_HIDL
+    bool mIsStarted;
+#endif
 };
 
 /**
@@ -250,4 +266,5 @@ private:
 
 } // namespace otbr
 
+#endif // OTBR_ENABLE_MDNS_MDNSSD
 #endif // OTBR_AGENT_MDNS_MDNSSD_HPP_


### PR DESCRIPTION
In an ideal Android 8.0 and higher world, framework processes do not
load vendor shared libraries, all vendor processes load only vendor
shared libraries, and communications between framework processes and
vendor processes are governed by HIDL and hardware binder.

The mDnsResponder library provided by Android is located in the system
image, the otbr-agent is located in the vendor image. The otbr-agent
is unable to call the mDnsResponder library directly. This CL adds a
HIDL mdns interface between otbr-agent and Thread System service. The
otbr-agent uses IThreadMdns interface to remotely call the mDns APIs.

To reuse the source code of `mdns_mdnssd.cpp`, the HIDL mdns interfaces
are wrapped into mDnsResponder APIs.