### PR TITLE
[dbus] fix accidental line removal

### DIFF
--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -354,6 +354,7 @@ void ThreadApiDBus::JoinerStartPendingCallHandler(DBusPendingCall *aPending)
         ret = CheckErrorMessage(message.get());
     }
 
+    mJoinerHandler = nullptr;
     handler(ret);
 }
 


### PR DESCRIPTION
The removed line 356 in PR#688 is an accidental remove.