### PR TITLE
[common] add Task Runner

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -27,8 +27,18 @@
 #
 
 add_library(otbr-common
+    byteswap.hpp
+    code_utils.hpp
     logging.cpp
+    logging.hpp
+    mainloop.h
+    task_runner.cpp
+    task_runner.hpp
+    time.hpp
+    tlv.hpp
+    toolchain.hpp
     types.cpp
+    types.hpp
 )
 
 target_link_libraries(otbr-common

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -33,6 +33,8 @@
 #ifndef OTBR_COMMON_CODE_UTILS_HPP_
 #define OTBR_COMMON_CODE_UTILS_HPP_
 
+#include "common/logging.hpp"
+
 /**
  *  This aligns the pointer to @p aAlignType.
  *

--- a/src/common/task_runner.cpp
+++ b/src/common/task_runner.cpp
@@ -1,0 +1,148 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file implements the Task Runner that executes tasks on the mainloop.
+ */
+
+#include "common/task_runner.hpp"
+
+#include <algorithm>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "common/code_utils.hpp"
+
+namespace otbr {
+
+TaskRunner::TaskRunner(void)
+{
+    int flags;
+
+    // We do not handle failures when creating a pipe, simply die.
+    VerifyOrDie(pipe(mEventFd) != -1, strerror(errno));
+
+    flags = fcntl(mEventFd[kRead], F_GETFL, 0);
+    VerifyOrDie(fcntl(mEventFd[kRead], F_SETFL, flags | O_NONBLOCK) != -1, strerror(errno));
+    flags = fcntl(mEventFd[kWrite], F_GETFL, 0);
+    VerifyOrDie(fcntl(mEventFd[kWrite], F_SETFL, flags | O_NONBLOCK) != -1, strerror(errno));
+}
+
+TaskRunner::~TaskRunner(void)
+{
+    if (mEventFd[kRead] != -1)
+    {
+        close(mEventFd[kRead]);
+        mEventFd[kRead] = -1;
+    }
+    if (mEventFd[kWrite] != -1)
+    {
+        close(mEventFd[kWrite]);
+        mEventFd[kWrite] = -1;
+    }
+}
+
+void TaskRunner::Post(const Task<void> &aTask)
+{
+    PushTask(aTask);
+}
+
+void TaskRunner::UpdateFdSet(otSysMainloopContext &aMainloop)
+{
+    FD_SET(mEventFd[kRead], &aMainloop.mReadFdSet);
+    aMainloop.mMaxFd = std::max(mEventFd[kRead], aMainloop.mMaxFd);
+}
+
+void TaskRunner::Process(const otSysMainloopContext &aMainloop)
+{
+    if (FD_ISSET(mEventFd[kRead], &aMainloop.mReadFdSet))
+    {
+        uint8_t n;
+
+        // Read any data in the pipe.
+        while (read(mEventFd[kRead], &n, sizeof(n)) == sizeof(n))
+        {
+        }
+
+        PopTasks();
+    }
+}
+
+void TaskRunner::PushTask(const Task<void> &aTask)
+{
+    ssize_t                     rval;
+    const uint8_t               kOne = 1;
+    std::lock_guard<std::mutex> _(mTaskQueueMutex);
+
+    mTaskQueue.emplace(aTask);
+    do
+    {
+        rval = write(mEventFd[kWrite], &kOne, sizeof(kOne));
+    } while (rval == -1 && errno == EINTR);
+
+    VerifyOrExit(rval == -1);
+
+    // Critical error happens, simply die.
+    VerifyOrDie(errno == EAGAIN || errno == EWOULDBLOCK, strerror(errno));
+
+    // We are blocked because there are already data (written by other concurrent callers in
+    // different threads) in the pipe, and the mEventFd[kRead] should be readable now.
+    otbrLog(OTBR_LOG_WARNING, "failed to write fd %d: %s", mEventFd[kWrite], strerror(errno));
+
+exit:
+    return;
+}
+
+void TaskRunner::PopTasks(void)
+{
+    while (true)
+    {
+        Task<void> task;
+
+        // The braces here are necessary for auto-releasing of the mutex.
+        {
+            std::lock_guard<std::mutex> _(mTaskQueueMutex);
+
+            if (!mTaskQueue.empty())
+            {
+                task = std::move(mTaskQueue.front());
+                mTaskQueue.pop();
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        task();
+    }
+}
+
+} // namespace otbr

--- a/src/common/task_runner.hpp
+++ b/src/common/task_runner.hpp
@@ -1,0 +1,147 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file defines the Task Runner that executes tasks on the mainloop.
+ */
+
+#ifndef OTBR_COMMON_TASK_RUNNER_HPP_
+#define OTBR_COMMON_TASK_RUNNER_HPP_
+
+#include <openthread-br/config.h>
+
+#include <functional>
+#include <future>
+#include <mutex>
+#include <queue>
+
+#include "common/mainloop.h"
+
+namespace otbr {
+
+/**
+ * This class implements the Task Runner that executes
+ * tasks on the mainloop.
+ *
+ */
+class TaskRunner
+{
+public:
+    /**
+     * This type represents the generic executable task.
+     *
+     */
+    template <class T> using Task = std::function<T(void)>;
+
+    /**
+     * This constructor initializes the Task Runner instance.
+     *
+     */
+    TaskRunner(void);
+
+    /**
+     * This destructor destroys the Task Runner instance.
+     *
+     */
+    ~TaskRunner(void);
+
+    /**
+     * This method posts a task to the task runner.
+     *
+     * Tasks are executed sequentially and follow the First-Come-First-Serve rule.
+     * It is safe to call this method in different threads concurrently.
+     *
+     * @param[in]  aTask  The task to be executed.
+     *
+     */
+    void Post(const Task<void> &aTask);
+
+    /**
+     * This method posts a task and waits for the completion of the task.
+     *
+     * Tasks are executed sequentially and follow the First-Come-First-Serve rule.
+     * This method must be called in a thread other than the mainloop thread. Otherwise,
+     * the caller will be blocked forever.
+     *
+     * @returns  The result returned by the task @p aTask.
+     *
+     */
+    template <class T> T PostAndWait(const Task<T> &aTask)
+    {
+        std::promise<T> pro;
+
+        Post([&]() { pro.set_value(aTask()); });
+
+        return pro.get_future().get();
+    }
+
+    /**
+     * This method updates the file descriptor and sets timeout for the mainloop.
+     *
+     * This method should only be called on the mainloop thread.
+     *
+     * @param[inout]  aMainloop  A reference to OpenThread mainloop context.
+     *
+     */
+    void UpdateFdSet(otSysMainloopContext &aMainloop);
+
+    /**
+     * This method processes events.
+     *
+     * This method should only be called on the mainloop thread.
+     *
+     * @param[in]  aMainloop  A reference to OpenThread mainloop context.
+     *
+     */
+    void Process(const otSysMainloopContext &aMainloop);
+
+private:
+    enum
+    {
+        kRead  = 0,
+        kWrite = 1,
+    };
+
+    void PushTask(const Task<void> &aTask);
+    void PopTasks(void);
+
+    // The event fds which are used to wakeup the mainloop
+    // when there are pending tasks in the task queue.
+    int mEventFd[2];
+
+    std::queue<Task<void>> mTaskQueue;
+
+    // The mutex which protects the `mTaskQueue` from being
+    // simultaneously accessed by multiple threads.
+    std::mutex mTaskQueueMutex;
+};
+
+} // namespace otbr
+
+#endif // OTBR_COMMON_TASK_RUNNER_HPP_

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(otbr-test-unit
     test_event_emitter.cpp
     test_logging.cpp
     test_pskc.cpp
+    test_task_runner.cpp
 )
 target_include_directories(otbr-test-unit PRIVATE
     ${CPPUTEST_INCLUDE_DIRS}
@@ -45,6 +46,7 @@ target_link_libraries(otbr-test-unit
     mbedtls
     otbr-common
     otbr-utils
+    pthread
 )
 add_test(
     NAME unit

--- a/tests/unit/test_task_runner.cpp
+++ b/tests/unit/test_task_runner.cpp
@@ -1,0 +1,151 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "common/task_runner.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+#include <CppUTest/TestHarness.h>
+
+TEST_GROUP(TaskRunner){};
+
+TEST(TaskRunner, TestSingleThread)
+{
+    int                  rval;
+    int                  counter = 0;
+    otSysMainloopContext mainloop;
+    otbr::TaskRunner     taskRunner;
+
+    mainloop.mMaxFd   = -1;
+    mainloop.mTimeout = {10, 0};
+
+    FD_ZERO(&mainloop.mReadFdSet);
+    FD_ZERO(&mainloop.mWriteFdSet);
+    FD_ZERO(&mainloop.mErrorFdSet);
+
+    // Increase the `counter` to 3.
+    taskRunner.Post([&]() {
+        ++counter;
+        taskRunner.Post([&]() {
+            ++counter;
+            taskRunner.Post([&]() { ++counter; });
+        });
+    });
+
+    taskRunner.UpdateFdSet(mainloop);
+    rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
+                  &mainloop.mTimeout);
+    CHECK_EQUAL(1, rval);
+
+    taskRunner.Process(mainloop);
+    CHECK_EQUAL(3, counter);
+}
+
+TEST(TaskRunner, TestMultipleThreads)
+{
+    std::atomic<int>         counter{0};
+    otbr::TaskRunner         taskRunner;
+    std::vector<std::thread> threads;
+
+    // Increase the `counter` to 10 in separate threads.
+    for (size_t i = 0; i < 10; ++i)
+    {
+        threads.emplace_back([&]() { taskRunner.Post([&]() { ++counter; }); });
+    }
+
+    while (counter.load() < 10)
+    {
+        int                  rval;
+        otSysMainloopContext mainloop;
+
+        mainloop.mMaxFd   = -1;
+        mainloop.mTimeout = {10, 0};
+
+        FD_ZERO(&mainloop.mReadFdSet);
+        FD_ZERO(&mainloop.mWriteFdSet);
+        FD_ZERO(&mainloop.mErrorFdSet);
+
+        taskRunner.UpdateFdSet(mainloop);
+        rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
+                      &mainloop.mTimeout);
+        CHECK_EQUAL(1, rval);
+
+        taskRunner.Process(mainloop);
+    }
+
+    for (auto &th : threads)
+    {
+        th.join();
+    }
+
+    CHECK_EQUAL(10, counter.load());
+}
+
+TEST(TaskRunner, TestPostAndWait)
+{
+    std::atomic<int>         total{0};
+    std::atomic<int>         counter{0};
+    otbr::TaskRunner         taskRunner;
+    std::vector<std::thread> threads;
+
+    // Increase the `counter` to 10 in separate threads and accumulate the total value.
+    for (size_t i = 0; i < 10; ++i)
+    {
+        threads.emplace_back([&]() { total += taskRunner.PostAndWait<int>([&]() { return ++counter; }); });
+    }
+
+    while (counter.load() < 10)
+    {
+        int                  rval;
+        otSysMainloopContext mainloop;
+
+        mainloop.mMaxFd   = -1;
+        mainloop.mTimeout = {10, 0};
+
+        FD_ZERO(&mainloop.mReadFdSet);
+        FD_ZERO(&mainloop.mWriteFdSet);
+        FD_ZERO(&mainloop.mErrorFdSet);
+
+        taskRunner.UpdateFdSet(mainloop);
+        rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
+                      &mainloop.mTimeout);
+        CHECK_EQUAL(1, rval);
+
+        taskRunner.Process(mainloop);
+    }
+
+    for (auto &th : threads)
+    {
+        th.join();
+    }
+
+    CHECK_EQUAL(55, total);
+    CHECK_EQUAL(10, counter.load());
+}


### PR DESCRIPTION
This PR adds a `TaskRunner` module that executes tasks on the mainloop.
The `TaskRunner` is useful to dispatch a callback back to the mainloop.
(e.g. handle mDNS callbacks which may be invoked from another thread).

We are not using [eventfd](https://man7.org/linux/man-pages/man2/eventfd.2.html) because it is linux-specific.