### PR TITLE
[types] remove dependency of OpenThread header

### DIFF
--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -92,6 +92,44 @@ exit:
     return error;
 }
 
+static otError OtbrErrorToOtError(otbrError aError)
+{
+    otError error;
+
+    switch (aError)
+    {
+    case OTBR_ERROR_NONE:
+        error = OT_ERROR_NONE;
+        break;
+
+    case OTBR_ERROR_NOT_FOUND:
+        error = OT_ERROR_NOT_FOUND;
+        break;
+
+    case OTBR_ERROR_PARSE:
+        error = OT_ERROR_PARSE;
+        break;
+
+    case OTBR_ERROR_NOT_IMPLEMENTED:
+        error = OT_ERROR_NOT_IMPLEMENTED;
+        break;
+
+    case OTBR_ERROR_INVALID_ARGS:
+        error = OT_ERROR_INVALID_ARGS;
+        break;
+
+    case OTBR_ERROR_DUPLICATED:
+        error = OT_ERROR_DUPLICATED;
+        break;
+
+    default:
+        error = OT_ERROR_FAILED;
+        break;
+    }
+
+    return error;
+}
+
 AdvertisingProxy::AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
     : mNcp(aNcp)
     , mPublisher(aPublisher)

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -34,44 +34,6 @@
 #include "common/logging.hpp"
 #include "common/types.hpp"
 
-otError OtbrErrorToOtError(otbrError aError)
-{
-    otError error;
-
-    switch (aError)
-    {
-    case OTBR_ERROR_NONE:
-        error = OT_ERROR_NONE;
-        break;
-
-    case OTBR_ERROR_NOT_FOUND:
-        error = OT_ERROR_NOT_FOUND;
-        break;
-
-    case OTBR_ERROR_PARSE:
-        error = OT_ERROR_PARSE;
-        break;
-
-    case OTBR_ERROR_NOT_IMPLEMENTED:
-        error = OT_ERROR_NOT_IMPLEMENTED;
-        break;
-
-    case OTBR_ERROR_INVALID_ARGS:
-        error = OT_ERROR_INVALID_ARGS;
-        break;
-
-    case OTBR_ERROR_DUPLICATED:
-        error = OT_ERROR_DUPLICATED;
-        break;
-
-    default:
-        error = OT_ERROR_FAILED;
-        break;
-    }
-
-    return error;
-}
-
 namespace otbr {
 
 Ip6Address::Ip6Address(const uint8_t (&aAddress)[16])

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -41,8 +41,6 @@
 #include <string>
 #include <vector>
 
-#include <openthread/error.h>
-
 #include "common/toolchain.hpp"
 
 #ifndef IN6ADDR_ANY
@@ -83,16 +81,6 @@ enum otbrError
     OTBR_ERROR_INVALID_ARGS    = -10, ///< Invalid arguments error.
     OTBR_ERROR_DUPLICATED      = -11, ///< Duplicated operation, resource or name.
 };
-
-/**
- * This function converts `otbrError` to `otError`.
- *
- * @param[in]  aError  An OTBR error.
- *
- * @returns  The corresponding OT error.
- *
- */
-otError OtbrErrorToOtError(otbrError aError);
 
 namespace otbr {
 


### PR DESCRIPTION
This removes the dependency of openthread/error.h from common/types.hpp.