### PR TITLE
[dns-sd] implement missing Avahi bindings

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -34,6 +34,7 @@
 #include "mdns/mdns_avahi.hpp"
 
 #include <algorithm>
+
 #include <avahi-common/alternative.h>
 #include <avahi-common/error.h>
 #include <avahi-common/malloc.h>
@@ -487,7 +488,7 @@ otbrError PublisherAvahi::CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aO
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    VerifyOrExit(aOutGroup == nullptr, error = OTBR_ERROR_INVALID_ARGS);
+    assert(aOutGroup == nullptr);
 
     aOutGroup = avahi_entry_group_new(&aClient, HandleGroupState, this);
     VerifyOrExit(aOutGroup != nullptr, error = OTBR_ERROR_MDNS);
@@ -708,8 +709,7 @@ exit:
     }
     else if (error != OTBR_ERROR_NONE)
     {
-        otbrLog(OTBR_LOG_ERR, "Failed to publish service: %s!",
-                error == OTBR_ERROR_ERRNO ? strerror(errno) : otbrErrorString(error));
+        otbrLog(OTBR_LOG_ERR, "Failed to publish service: %s!", otbrErrorString(error));
     }
 
     if (error != OTBR_ERROR_NONE && serviceIt != mServices.end())
@@ -763,13 +763,11 @@ otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress
     }
     else if (memcmp(hostIt->mAddress.data.ipv6.address, aAddress, aAddressLength))
     {
-        // Check if the update is necessary
-        VerifyOrExit(memcmp(hostIt->mAddress.data.ipv6.address, aAddress, aAddressLength));
         SuccessOrExit(error = ResetGroup(hostIt->mGroup));
     }
     else
     {
-        if (avahiError == 0 && mHostHandler != nullptr)
+        if (mHostHandler != nullptr)
         {
             // The handler should be called even if the request can be processed synchronously
             mHostHandler(aName, OTBR_ERROR_NONE, mHostHandlerContext);
@@ -800,8 +798,7 @@ exit:
     }
     else if (error != OTBR_ERROR_NONE)
     {
-        otbrLog(OTBR_LOG_ERR, "Failed to publish host: %s!",
-                error == OTBR_ERROR_ERRNO ? strerror(errno) : otbrErrorString(error));
+        otbrLog(OTBR_LOG_ERR, "Failed to publish host: %s!", otbrErrorString(error));
     }
 
     if (error != OTBR_ERROR_NONE && hostIt != mHosts.end())

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -358,13 +358,13 @@ private:
                                      const char *        aType,
                                      Services::iterator &aOutServiceIt);
 
-    otbrError   CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
-    otbrError   ResetGroup(AvahiEntryGroup *aGroup);
-    otbrError   FreeGroup(AvahiEntryGroup *aGroup);
-    void        FreeAllGroups(void);
-    static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
-    void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
-    void        CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
+    otbrError        CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
+    static otbrError ResetGroup(AvahiEntryGroup *aGroup);
+    static otbrError FreeGroup(AvahiEntryGroup *aGroup);
+    void             FreeAllGroups(void);
+    static void      HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
+    void             HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
+    void             CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
 
     std::string MakeFullName(const char *aName);
 

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -360,7 +360,7 @@ private:
 
     otbrError   CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
     otbrError   ResetGroup(AvahiEntryGroup *aGroup);
-    void        FreeGroup(AvahiEntryGroup *aGroup);
+    otbrError   FreeGroup(AvahiEntryGroup *aGroup);
     void        FreeAllGroups();
     static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
     void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -328,29 +328,54 @@ private:
 
     struct Service
     {
-        char     mName[kMaxSizeOfServiceName];
-        char     mType[kMaxSizeOfServiceType];
-        uint16_t mPort;
+        std::string      mName;
+        std::string      mType;
+        std::string      mHostName;
+        uint16_t         mPort  = 0;
+        AvahiEntryGroup *mGroup = nullptr;
     };
 
     typedef std::vector<Service> Services;
 
+    struct Host
+    {
+        std::string      mHostName;
+        AvahiAddress     mAddress = {};
+        AvahiEntryGroup *mGroup   = nullptr;
+    };
+
+    typedef std::vector<Host> Hosts;
+
     static void HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext);
     void        HandleClientState(AvahiClient *aClient, AvahiClientState aState);
 
-    void        CreateGroup(AvahiClient *aClient);
+    Hosts::iterator FindHost(const char *aHostName);
+    otbrError       CreateHost(AvahiClient &aClient, const char *aHostName, Hosts::iterator &aOutHostIt);
+
+    Services::iterator FindService(const char *aName, const char *aType);
+    otbrError          CreateService(AvahiClient &       aClient,
+                                     const char *        aName,
+                                     const char *        aType,
+                                     Services::iterator &aOutServiceIt);
+
+    otbrError   CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
+    otbrError   ResetGroup(AvahiEntryGroup *aGroup);
+    void        FreeGroup(AvahiEntryGroup *aGroup);
+    void        FreeAllGroups();
     static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
     void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
 
-    Services         mServices;
-    AvahiClient *    mClient;
-    AvahiEntryGroup *mGroup;
-    Poller           mPoller;
-    int              mProtocol;
-    const char *     mDomain;
-    State            mState;
-    StateHandler     mStateHandler;
-    void *           mContext;
+    otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
+
+    AvahiClient *mClient;
+    Hosts        mHosts;
+    Services     mServices;
+    Poller       mPoller;
+    int          mProtocol;
+    const char * mDomain;
+    State        mState;
+    StateHandler mStateHandler;
+    void *       mContext;
 };
 
 } // namespace Mdns

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -364,6 +364,7 @@ private:
     void        FreeAllGroups();
     static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
     void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
+    void        CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
 
     otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
 

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -361,12 +361,12 @@ private:
     otbrError   CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
     otbrError   ResetGroup(AvahiEntryGroup *aGroup);
     otbrError   FreeGroup(AvahiEntryGroup *aGroup);
-    void        FreeAllGroups();
+    void        FreeAllGroups(void);
     static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
     void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
     void        CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
 
-    otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
+    std::string MakeFullName(const char *aName);
 
     AvahiClient *mClient;
     Hosts        mHosts;

--- a/tests/mdns/test-multiple-custom-hosts
+++ b/tests/mdns/test-multiple-custom-hosts
@@ -36,9 +36,9 @@
 
 main()
 {
-    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
-        start_publisher mc
+    start_publisher mc
 
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
         dns_sd_check MultipleService11 _meshcop._udp 'custom-host-1.local.'
         dns_sd_check MultipleService12 _meshcop._udp 'custom-host-1.local.'
         dns_sd_check_host 'custom-host-1.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
@@ -47,8 +47,10 @@ main()
         dns_sd_check MultipleService22 _meshcop._udp 'custom-host-2.local.'
         dns_sd_check_host 'custom-host-2.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
     else
-        #TODO:
-        echo "not implemented yet"
+        avahi_check 'MultipleService11;_meshcop._udp;local;custom-host-1.local;2002::1;12345;.*"xp=ABCDEFGH.\+"nn=cool"'
+        avahi_check 'MultipleService12;_meshcop._udp;local;custom-host-1.local;2002::1;12345;.*"xp=ABCDEFGH.\+"nn=cool"'
+        avahi_check 'MultipleService21;_meshcop._udp;local;custom-host-2.local;2002::1;12345;.*"xp=ABCDEFGH.\+"nn=cool"'
+        avahi_check 'MultipleService22;_meshcop._udp;local;custom-host-2.local;2002::1;12345;.*"xp=ABCDEFGH.\+"nn=cool"'
     fi
 }
 

--- a/tests/mdns/test-single-custom-host
+++ b/tests/mdns/test-single-custom-host
@@ -36,14 +36,13 @@
 
 main()
 {
-    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
-        start_publisher sc
+    start_publisher sc
 
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
         dns_sd_check SingleService _meshcop._udp 'custom-host.local.'
         dns_sd_check_host 'custom-host.local.' '2002:0000:0000:0000:0000:0000:0000:0001'
     else
-        #TODO:
-        echo "not implemented yet"
+        avahi_check 'SingleService;_meshcop._udp;local;custom-host.local;2002::1;12345;.*"xp=ABCDEFGH.\+"nn=cool"'
     fi
 }
 


### PR DESCRIPTION
Currently, only mDNSResponder can be used to test the OpenThread SRP server. Provide the functionality necessary to test registration of new services using Avahi daemon.
    
Avahi forbids modifying entry groups which have already been committed. As a result, in order to support methods for publishing and removing a single host/service, each host and each service is processed as a separate Avahi entry group.