### PR TITLE
[dnssd] implement DNS-SD Discovery Proxy

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -111,11 +111,14 @@ LOCAL_SRC_FILES := \
     src/agent/agent_instance.cpp \
     src/agent/instance_params.cpp \
     src/agent/border_agent.cpp \
+    src/agent/discovery_proxy.cpp \
     src/agent/main.cpp \
     src/agent/ncp_openthread.cpp \
     src/agent/thread_helper.cpp \
+    src/common/dns_utils.cpp \
     src/common/logging.cpp \
     src/common/task_runner.cpp \
+    src/common/types.cpp \
     src/dbus/common/dbus_message_dump.cpp \
     src/dbus/common/dbus_message_helper.cpp \
     src/dbus/common/dbus_message_helper_openthread.cpp \

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -64,6 +64,11 @@ if (OTBR_SRP_ADVERTISING_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_SRP_ADVERTISING_PROXY=1)
 endif()
 
+option(OTBR_DNSSD_DISCOVERY_PROXY   "Enable DNS-SD Discovery Proxy support" OFF)
+if (OTBR_DNSSD_DISCOVERY_PROXY)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_DNSSD_DISCOVERY_PROXY=1)
+endif()
+
 option(OTBR_UNSECURE_JOIN "Enable unsecure joining" OFF)
 if(OTBR_UNSECURE_JOIN)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_UNSECURE_JOIN=1)

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -33,6 +33,8 @@ add_executable(otbr-agent
     agent_instance.hpp
     border_agent.cpp
     border_agent.hpp
+    discovery_proxy.cpp
+    discovery_proxy.hpp
     main.cpp
     uris.hpp
     ncp_openthread.cpp

--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -44,53 +44,10 @@
 #include <assert.h>
 
 #include "common/code_utils.hpp"
+#include "common/dns_utils.hpp"
 #include "common/logging.hpp"
 
 namespace otbr {
-
-// TODO: better to have SRP server provide separated service name labels.
-static otbrError SplitFullServiceName(const std::string &aFullName,
-                                      std::string &      aInstanceName,
-                                      std::string &      aType,
-                                      std::string &      aDomain)
-{
-    otbrError error = OTBR_ERROR_INVALID_ARGS;
-    size_t    dotPos[3];
-
-    dotPos[0] = aFullName.find_first_of('.');
-    VerifyOrExit(dotPos[0] != std::string::npos);
-
-    dotPos[1] = aFullName.find_first_of('.', dotPos[0] + 1);
-    VerifyOrExit(dotPos[1] != std::string::npos);
-
-    dotPos[2] = aFullName.find_first_of('.', dotPos[1] + 1);
-    VerifyOrExit(dotPos[2] != std::string::npos);
-
-    error         = OTBR_ERROR_NONE;
-    aInstanceName = aFullName.substr(0, dotPos[0]);
-    aType         = aFullName.substr(dotPos[0] + 1, dotPos[2] - dotPos[0] - 1);
-    aDomain       = aFullName.substr(dotPos[2] + 1, aFullName.size() - dotPos[2] - 1);
-
-exit:
-    return error;
-}
-
-// TODO: better to have the SRP server to provide separated host name.
-static otbrError SplitFullHostName(const std::string &aFullName, std::string &aHostName, std::string &aDomain)
-{
-    otbrError error = OTBR_ERROR_INVALID_ARGS;
-    size_t    dotPos;
-
-    dotPos = aFullName.find_first_of('.');
-    VerifyOrExit(dotPos != std::string::npos);
-
-    error     = OTBR_ERROR_NONE;
-    aHostName = aFullName.substr(0, dotPos);
-    aDomain   = aFullName.substr(dotPos + 1, aFullName.size() - dotPos - 1);
-
-exit:
-    return error;
-}
 
 static otError OtbrErrorToOtError(otbrError aError)
 {
@@ -232,7 +189,7 @@ void AdvertisingProxy::AdvertisingHandler(const otSrpServerHost *aHost, uint32_t
         std::string serviceType;
         std::string serviceDomain;
 
-        SuccessOrExit(error = SplitFullServiceName(fullServiceName, serviceName, serviceType, serviceDomain));
+        SuccessOrExit(error = SplitFullServiceInstanceName(fullServiceName, serviceName, serviceType, serviceDomain));
 
         update->mServiceNames.emplace_back(serviceName, serviceType);
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -104,6 +104,9 @@ BorderAgent::BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp)
 #else
     , mPublisher(nullptr)
 #endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    , mDiscoveryProxy(aNcp, *mPublisher)
+#endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     , mBackboneAgent(aNcp)
 #endif
@@ -142,6 +145,11 @@ otbrError BorderAgent::Start(void)
     mAdvertisingProxy.Start();
 #endif
     UpdateMeshCopService();
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mDiscoveryProxy.Start();
+#endif
+
 #endif // OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
 
 exit:
@@ -158,6 +166,11 @@ void BorderAgent::Stop(void)
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     mAdvertisingProxy.Stop();
 #endif
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mDiscoveryProxy.Stop();
+#endif
+
 #endif
 }
 

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include "agent/advertising_proxy.hpp"
+#include "agent/discovery_proxy.hpp"
 #include "agent/instance_params.hpp"
 #include "agent/ncp_openthread.hpp"
 #include "common/mainloop.hpp"
@@ -160,6 +161,9 @@ private:
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     AdvertisingProxy mAdvertisingProxy;
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    Dnssd::DiscoveryProxy mDiscoveryProxy;
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     BackboneRouter::BackboneAgent mBackboneAgent;

--- a/src/agent/discovery_proxy.cpp
+++ b/src/agent/discovery_proxy.cpp
@@ -1,0 +1,390 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file implements the DNS-SD Discovery Proxy.
+ */
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+
+#include "agent/discovery_proxy.hpp"
+
+#include <algorithm>
+#include <string>
+
+#include <assert.h>
+
+#include <openthread/dnssd_server.h>
+
+#include "common/code_utils.hpp"
+#include "common/dns_utils.hpp"
+#include "common/logging.hpp"
+
+namespace otbr {
+namespace Dnssd {
+
+DiscoveryProxy::DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
+    : mNcp(aNcp)
+    , mMdnsPublisher(aPublisher)
+{
+}
+
+void DiscoveryProxy::Start(void)
+{
+    otDnssdQuerySetCallbacks(mNcp.GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
+                             &DiscoveryProxy::OnDiscoveryProxyUnsubscribe, this);
+
+    mMdnsPublisher.SetSubscriptionCallbacks(
+        [this](const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo) {
+            OnServiceDiscovered(aType, aInstanceInfo);
+        },
+
+        [this](const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aHostInfo) {
+            OnHostDiscovered(aHostName, aHostInfo);
+        });
+
+    otbrLog(OTBR_LOG_INFO, "[discproxy] started");
+}
+
+void DiscoveryProxy::Stop(void)
+{
+    otDnssdQuerySetCallbacks(mNcp.GetInstance(), nullptr, nullptr, nullptr);
+    mMdnsPublisher.SetSubscriptionCallbacks(nullptr, nullptr);
+
+    otbrLog(OTBR_LOG_INFO, "[discproxy] stopped");
+}
+
+void DiscoveryProxy::OnDiscoveryProxySubscribe(void *aContext, const char *aFullName)
+{
+    reinterpret_cast<DiscoveryProxy *>(aContext)->OnDiscoveryProxySubscribe(aFullName);
+}
+
+void DiscoveryProxy::OnDiscoveryProxySubscribe(const char *aFullName)
+{
+    std::string                    fullName(aFullName);
+    std::string                    instanceName, serviceName, hostName, domain;
+    otbrError                      error = OTBR_ERROR_NONE;
+    MdnsSubscriptionList::iterator it;
+    DnsNameType                    nameType = GetDnsNameType(fullName);
+
+    otbrLog(OTBR_LOG_INFO, "[discproxy] subscribe: %s", fullName.c_str());
+
+    switch (nameType)
+    {
+    case kDnsNameTypeService:
+        SuccessOrExit(error = SplitFullServiceName(fullName, serviceName, domain));
+        break;
+    case kDnsNameTypeInstance:
+        SuccessOrExit(error = SplitFullServiceInstanceName(fullName, instanceName, serviceName, domain));
+        break;
+    case kDnsNameTypeHost:
+        SuccessOrExit(error = SplitFullHostName(fullName, hostName, domain));
+        break;
+    default:
+        ExitNow(error = OTBR_ERROR_NOT_IMPLEMENTED);
+    }
+
+    it = std::find_if(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
+        return aSubscription.Matches(instanceName, serviceName, hostName, domain);
+    });
+
+    VerifyOrExit(it == mSubscriptions.end(), it->mSubscriptionCount++);
+
+    mSubscriptions.emplace_back(instanceName, serviceName, hostName, domain);
+
+    {
+        MdnsSubscription &subscription = mSubscriptions.back();
+
+        otbrLog(OTBR_LOG_DEBUG, "[discproxy] subscriptions: %sx%d", subscription.ToString().c_str(),
+                subscription.mSubscriptionCount);
+
+        if (GetServiceSubscriptionCount(instanceName, serviceName) == 1)
+        {
+            if (subscription.mHostName.empty())
+            {
+                mMdnsPublisher.SubscribeService(serviceName, instanceName);
+            }
+            else
+            {
+                mMdnsPublisher.SubscribeHost(hostName);
+            }
+        }
+    }
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLog(OTBR_LOG_WARNING, "[discproxy] failed to subscribe %s: %s", fullName.c_str(), otbrErrorString(error));
+    }
+}
+
+void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(void *aContext, const char *aFullName)
+{
+    reinterpret_cast<DiscoveryProxy *>(aContext)->OnDiscoveryProxyUnsubscribe(aFullName);
+}
+
+void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(const char *aFullName)
+{
+    std::string                    fullName(aFullName);
+    std::string                    instanceName, serviceName, hostName, domain;
+    otbrError                      error = OTBR_ERROR_NONE;
+    MdnsSubscriptionList::iterator it;
+    DnsNameType                    nameType = GetDnsNameType(fullName);
+
+    otbrLog(OTBR_LOG_INFO, "[discproxy] unsubscribe: %s", fullName.c_str());
+
+    switch (nameType)
+    {
+    case kDnsNameTypeService:
+        SuccessOrExit(error = SplitFullServiceName(fullName, serviceName, domain));
+        break;
+    case kDnsNameTypeInstance:
+        SuccessOrExit(error = SplitFullServiceInstanceName(fullName, instanceName, serviceName, domain));
+        break;
+    case kDnsNameTypeHost:
+        SuccessOrExit(error = SplitFullHostName(fullName, hostName, domain));
+        break;
+    default:
+        ExitNow(error = OTBR_ERROR_NOT_IMPLEMENTED);
+    }
+
+    it = std::find_if(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
+        return aSubscription.Matches(instanceName, serviceName, hostName, domain);
+    });
+
+    VerifyOrExit(it != mSubscriptions.end(), error = OTBR_ERROR_NOT_FOUND);
+
+    {
+        MdnsSubscription &subscription = *it;
+
+        subscription.mSubscriptionCount--;
+        assert(subscription.mSubscriptionCount >= 0);
+
+        if (subscription.mSubscriptionCount == 0)
+        {
+            mSubscriptions.erase(it);
+        }
+
+        otbrLog(OTBR_LOG_DEBUG, "[discproxy] service subscriptions: %sx%d", it->ToString().c_str(),
+                it->mSubscriptionCount);
+
+        if (GetServiceSubscriptionCount(instanceName, serviceName) == 0)
+        {
+            if (subscription.mHostName.empty())
+            {
+                mMdnsPublisher.UnsubscribeService(serviceName, instanceName);
+            }
+            else
+            {
+                mMdnsPublisher.UnsubscribeHost(hostName);
+            }
+        }
+    }
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLog(OTBR_LOG_WARNING, "[discproxy] failed to unsubscribe %s: %s", fullName.c_str(), otbrErrorString(error));
+    }
+}
+
+void DiscoveryProxy::OnServiceDiscovered(const std::string &                            aType,
+                                         const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo)
+{
+    otDnssdServiceInstanceInfo instanceInfo;
+
+    otbrLog(OTBR_LOG_INFO,
+            "[discproxy] service discovered: %s, instance %s hostname %s addresses %zu port %d priority %d "
+            "weight %d",
+            aType.c_str(), aInstanceInfo.mName.c_str(), aInstanceInfo.mHostName.c_str(),
+            aInstanceInfo.mAddresses.size(), aInstanceInfo.mPort, aInstanceInfo.mPriority, aInstanceInfo.mWeight);
+
+    CheckServiceNameSanity(aType);
+    CheckHostnameSanity(aInstanceInfo.mHostName);
+
+    instanceInfo.mAddressNum = aInstanceInfo.mAddresses.size();
+
+    if (!aInstanceInfo.mAddresses.empty())
+    {
+        instanceInfo.mAddresses = reinterpret_cast<const otIp6Address *>(&aInstanceInfo.mAddresses[0]);
+    }
+    else
+    {
+        instanceInfo.mAddresses = nullptr;
+    }
+
+    instanceInfo.mPort      = aInstanceInfo.mPort;
+    instanceInfo.mPriority  = aInstanceInfo.mPriority;
+    instanceInfo.mWeight    = aInstanceInfo.mWeight;
+    instanceInfo.mTxtLength = static_cast<uint16_t>(aInstanceInfo.mTxtData.size());
+    instanceInfo.mTxtData   = aInstanceInfo.mTxtData.data();
+    instanceInfo.mTtl       = CapTtl(aInstanceInfo.mTtl);
+
+    std::for_each(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
+        if (aSubscription.MatchesServiceInstance(aType, aInstanceInfo.mName))
+        {
+            std::string serviceFullName  = aType + "." + aSubscription.mDomain;
+            std::string hostName         = TranslateDomain(aInstanceInfo.mHostName, aSubscription.mDomain);
+            std::string instanceFullName = aInstanceInfo.mName + "." + serviceFullName;
+
+            instanceInfo.mFullName = instanceFullName.c_str();
+            instanceInfo.mHostName = hostName.c_str();
+
+            otDnssdQueryHandleDiscoveredServiceInstance(mNcp.GetInstance(), serviceFullName.c_str(), &instanceInfo);
+        }
+    });
+}
+
+void DiscoveryProxy::OnHostDiscovered(const std::string &                        aHostName,
+                                      const Mdns::Publisher::DiscoveredHostInfo &aHostInfo)
+{
+    otDnssdHostInfo hostInfo;
+
+    otbrLog(OTBR_LOG_INFO, "[discproxy] host discovered: %s hostname %s addresses %zu", aHostName.c_str(),
+            aHostInfo.mHostName.c_str(), aHostInfo.mAddresses.size());
+
+    CheckHostnameSanity(aHostInfo.mHostName);
+
+    hostInfo.mAddressNum = aHostInfo.mAddresses.size();
+    if (!aHostInfo.mAddresses.empty())
+    {
+        hostInfo.mAddresses = reinterpret_cast<const otIp6Address *>(&aHostInfo.mAddresses[0]);
+    }
+    else
+    {
+        hostInfo.mAddresses = nullptr;
+    }
+
+    hostInfo.mTtl = CapTtl(aHostInfo.mTtl);
+
+    std::for_each(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
+        if (aSubscription.MatchesHost(aHostName))
+        {
+            std::string hostFullName = TranslateDomain(aHostInfo.mHostName, aSubscription.mDomain);
+
+            otDnssdQueryHandleDiscoveredHost(mNcp.GetInstance(), hostFullName.c_str(), &hostInfo);
+        }
+    });
+}
+
+std::string DiscoveryProxy::TranslateDomain(const std::string &aName, const std::string &aTargetDomain)
+{
+    std::string targetName;
+    std::string hostName, domain;
+
+    VerifyOrExit(OTBR_ERROR_NONE == SplitFullHostName(aName, hostName, domain), targetName = aName);
+    VerifyOrExit(domain == "local.", targetName = aName);
+
+    targetName = hostName + "." + aTargetDomain;
+
+exit:
+    otbrLog(OTBR_LOG_DEBUG, "[discproxy] translate domain: %s => %s", aName.c_str(), targetName.c_str());
+    return targetName;
+}
+
+int DiscoveryProxy::GetServiceSubscriptionCount(const std::string &aInstanceName, const std::string &aServiceName)
+{
+    return std::accumulate(
+        mSubscriptions.begin(), mSubscriptions.end(), 0, [&](int aAccum, const MdnsSubscription &aSubscription) {
+            return aAccum + (aSubscription.mInstanceName == aInstanceName && aSubscription.mServiceName == aServiceName
+                                 ? aSubscription.mSubscriptionCount
+                                 : 0);
+        });
+}
+
+void DiscoveryProxy::CheckServiceNameSanity(const std::string &aType)
+{
+    size_t dotpos;
+
+    OTBR_UNUSED_VARIABLE(aType);
+    OTBR_UNUSED_VARIABLE(dotpos);
+
+    assert(aType.length() > 0);
+    assert(aType[aType.length() - 1] != '.');
+    dotpos = aType.find_first_of('.');
+    assert(dotpos != std::string::npos);
+    assert(dotpos == aType.find_last_of('.'));
+}
+
+void DiscoveryProxy::CheckHostnameSanity(const std::string &aHostName)
+{
+    OTBR_UNUSED_VARIABLE(aHostName);
+
+    assert(aHostName.length() > 0);
+    assert(aHostName[aHostName.length() - 1] == '.');
+}
+
+uint32_t DiscoveryProxy::CapTtl(uint32_t aTtl)
+{
+    return std::min(aTtl, static_cast<uint32_t>(kServiceTtlCapLimit));
+}
+
+std::string DiscoveryProxy::MdnsSubscription::ToString(void) const
+{
+    std::string str;
+
+    if (!mHostName.empty())
+    {
+        str = mHostName + "." + mDomain;
+    }
+    else if (!mInstanceName.empty())
+    {
+        str = mInstanceName + "." + mServiceName + "." + mDomain;
+    }
+    else
+    {
+        str = mServiceName + "." + mDomain;
+    }
+
+    return str;
+}
+
+bool DiscoveryProxy::MdnsSubscription::Matches(const std::string &aInstanceName,
+                                               const std::string &aServiceName,
+                                               const std::string &aHostName,
+                                               const std::string &aDomain) const
+{
+    return mInstanceName == aInstanceName && mServiceName == aServiceName && mHostName == aHostName &&
+           mDomain == aDomain;
+}
+
+bool DiscoveryProxy::MdnsSubscription::MatchesServiceInstance(const std::string &aType,
+                                                              const std::string &aInstanceName) const
+{
+    return mServiceName == aType && (mInstanceName.empty() || mInstanceName == aInstanceName);
+}
+
+bool DiscoveryProxy::MdnsSubscription::MatchesHost(const std::string &aHostName) const
+{
+    return mHostName == aHostName;
+}
+
+} // namespace Dnssd
+} // namespace otbr
+
+#endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY

--- a/src/agent/discovery_proxy.hpp
+++ b/src/agent/discovery_proxy.hpp
@@ -1,0 +1,146 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for DNS-SD Discovery Proxy.
+ */
+
+#ifndef OTBR_AGENT_DISCOVERY_PROXY_HPP_
+#define OTBR_AGENT_DISCOVERY_PROXY_HPP_
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+
+#include <set>
+#include <utility>
+
+#include <stdint.h>
+
+#include <openthread/dnssd_server.h>
+#include <openthread/instance.h>
+
+#include "agent/ncp_openthread.hpp"
+#include "mdns/mdns.hpp"
+
+namespace otbr {
+namespace Dnssd {
+
+/**
+ * This class implements the DNS-SD Discovery Proxy.
+ *
+ */
+class DiscoveryProxy
+{
+public:
+    /**
+     * This constructor initializes the Discovery Proxy instance.
+     *
+     * @param[in] aNcp        A reference to the OpenThread Controller instance.
+     * @param[in] aPublisher  A reference to the mDNS Publisher.
+     *
+     */
+    explicit DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+
+    /**
+     * This method starts the Discovery Proxy.
+     *
+     */
+    void Start(void);
+
+    /**
+     * This method stops the Discovery Proxy.
+     *
+     */
+    void Stop(void);
+
+private:
+    enum : uint32_t
+    {
+        kServiceTtlCapLimit = 10, // TTL cap limit for Discovery Proxy (in seconds).
+    };
+
+    struct MdnsSubscription
+    {
+        explicit MdnsSubscription()
+            : mSubscriptionCount(0)
+        {
+        }
+
+        MdnsSubscription(std::string aInstanceName,
+                         std::string aServiceName,
+                         std::string aHostName,
+                         std::string aDomain)
+            : mInstanceName(std::move(aInstanceName))
+            , mServiceName(std::move(aServiceName))
+            , mHostName(std::move(aHostName))
+            , mDomain(std::move(aDomain))
+            , mSubscriptionCount(1)
+        {
+        }
+
+        std::string ToString(void) const;
+
+        std::string mInstanceName;
+        std::string mServiceName;
+        std::string mHostName;
+        std::string mDomain;
+        int         mSubscriptionCount;
+        bool        Matches(const std::string &aInstanceName,
+                            const std::string &aServiceName,
+                            const std::string &aHostName,
+                            const std::string &aDomain) const;
+        bool        MatchesServiceInstance(const std::string &aType, const std::string &aInstanceName) const;
+        bool        MatchesHost(const std::string &aHostName) const;
+    };
+
+    typedef std::vector<MdnsSubscription> MdnsSubscriptionList;
+
+    static void        OnDiscoveryProxySubscribe(void *aContext, const char *aFullName);
+    void               OnDiscoveryProxySubscribe(const char *aSubscription);
+    static void        OnDiscoveryProxyUnsubscribe(void *aContext, const char *aFullName);
+    void               OnDiscoveryProxyUnsubscribe(const char *aSubscription);
+    int                GetServiceSubscriptionCount(const std::string &aInstanceName, const std::string &aSubscription);
+    static std::string TranslateDomain(const std::string &aName, const std::string &aTargetDomain);
+    static void        CheckServiceNameSanity(const std::string &aType);
+    static void        CheckHostnameSanity(const std::string &aHostName);
+    void               OnServiceDiscovered(const std::string &                            aSubscription,
+                                           const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo);
+    void OnHostDiscovered(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aHostInfo);
+    static uint32_t CapTtl(uint32_t aTtl);
+
+    Ncp::ControllerOpenThread &mNcp;
+    Mdns::Publisher &          mMdnsPublisher;
+    MdnsSubscriptionList       mSubscriptions;
+};
+
+} // namespace Dnssd
+} // namespace otbr
+
+#endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+
+#endif // OTBR_AGENT_DISCOVERY_PROXY_HPP_

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,6 +29,7 @@
 add_library(otbr-common
     byteswap.hpp
     code_utils.hpp
+    dns_utils.cpp
     logging.cpp
     logging.hpp
     mainloop.hpp

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -33,6 +33,8 @@
 #ifndef OTBR_COMMON_CODE_UTILS_HPP_
 #define OTBR_COMMON_CODE_UTILS_HPP_
 
+#include <stdlib.h>
+
 #include "common/logging.hpp"
 
 /**

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -1,0 +1,115 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "common/dns_utils.hpp"
+#include "common/code_utils.hpp"
+
+DnsNameType GetDnsNameType(const std::string &aFullName)
+{
+    size_t      transportPos = aFullName.rfind("._udp.");
+    size_t      dotPos;
+    DnsNameType nameType = kDnsNameTypeUnknown;
+
+    if (transportPos == std::string::npos)
+    {
+        transportPos = aFullName.rfind("._tcp.");
+    }
+
+    VerifyOrExit(transportPos != std::string::npos, nameType = kDnsNameTypeHost);
+    VerifyOrExit(transportPos > 0);
+
+    dotPos = aFullName.find_last_of('.', transportPos - 1);
+    VerifyOrExit(dotPos != std::string::npos, nameType = kDnsNameTypeService);
+    VerifyOrExit(dotPos > 0);
+
+    nameType = kDnsNameTypeInstance;
+
+exit:
+    return nameType;
+}
+
+otbrError SplitFullServiceInstanceName(const std::string &aFullName,
+                                       std::string &      aInstanceName,
+                                       std::string &      aType,
+                                       std::string &      aDomain)
+{
+    otbrError error = OTBR_ERROR_INVALID_ARGS;
+    size_t    dotPos[3];
+
+    dotPos[0] = aFullName.find_first_of('.');
+    VerifyOrExit(dotPos[0] != std::string::npos);
+
+    dotPos[1] = aFullName.find_first_of('.', dotPos[0] + 1);
+    VerifyOrExit(dotPos[1] != std::string::npos);
+
+    dotPos[2] = aFullName.find_first_of('.', dotPos[1] + 1);
+    VerifyOrExit(dotPos[2] != std::string::npos);
+
+    error         = OTBR_ERROR_NONE;
+    aInstanceName = aFullName.substr(0, dotPos[0]);
+    aType         = aFullName.substr(dotPos[0] + 1, dotPos[2] - dotPos[0] - 1);
+    aDomain       = aFullName.substr(dotPos[2] + 1, aFullName.size() - dotPos[2] - 1);
+
+exit:
+    return error;
+}
+
+otbrError SplitFullServiceName(const std::string &aFullName, std::string &aType, std::string &aDomain)
+{
+    otbrError error = OTBR_ERROR_INVALID_ARGS;
+    size_t    dotPos[2];
+
+    dotPos[0] = aFullName.find_first_of('.');
+    VerifyOrExit(dotPos[0] != std::string::npos);
+
+    dotPos[1] = aFullName.find_first_of('.', dotPos[0] + 1);
+    VerifyOrExit(dotPos[1] != std::string::npos);
+
+    error   = OTBR_ERROR_NONE;
+    aType   = aFullName.substr(0, dotPos[1]);
+    aDomain = aFullName.substr(dotPos[1] + 1);
+
+exit:
+    return error;
+}
+
+otbrError SplitFullHostName(const std::string &aFullName, std::string &aHostName, std::string &aDomain)
+{
+    otbrError error = OTBR_ERROR_INVALID_ARGS;
+    size_t    dotPos;
+
+    dotPos = aFullName.find_first_of('.');
+    VerifyOrExit(dotPos != std::string::npos);
+
+    error     = OTBR_ERROR_NONE;
+    aHostName = aFullName.substr(0, dotPos);
+    aDomain   = aFullName.substr(dotPos + 1, aFullName.size() - dotPos - 1);
+
+exit:
+    return error;
+}

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -1,0 +1,104 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file includes DNS utilities.
+ *
+ */
+#ifndef OTBR_COMMON_DNS_UTILS_HPP_
+#define OTBR_COMMON_DNS_UTILS_HPP_
+
+#include "common/types.hpp"
+
+/**
+ * This enum represents a DNS name type.
+ *
+ */
+enum DnsNameType
+{
+    kDnsNameTypeUnknown,
+    kDnsNameTypeService,
+    kDnsNameTypeInstance,
+    kDnsNameTypeHost,
+};
+
+/**
+ * This function gets the DNS name type.
+ *
+ * @param[in] aFullName The DNS name.
+ *
+ * @returns  The DNS name type.
+ *
+ */
+DnsNameType GetDnsNameType(const std::string &aFullName);
+
+/**
+ * This function splits a full service name into components.
+ *
+ * @param[in]  aFullName  The full service name to split.
+ * @param[out] aType      A reference to a string to receive the service type.
+ * @param[out] aDomain    A reference to a string to receive the domain.
+ *
+ * @retval OTBR_ERROR_NONE          Successfully split the full service name.
+ * @retval OTBR_ERROR_INVALID_ARGS  If the full service name is not valid.
+ *
+ */
+otbrError SplitFullServiceName(const std::string &aFullName, std::string &aType, std::string &aDomain);
+
+/**
+ * This function splits a full service instance name into components.
+ *
+ * @param[in]  aFullName      The full service instance name to split.
+ * @param[out] aInstanceName  A reference to a string to receive the instance name.
+ * @param[out] aType          A reference to a string to receive the service type.
+ * @param[out] aDomain        A reference to a string to receive the domain.
+ *
+ * @retval OTBR_ERROR_NONE          Successfully split the full service instance name.
+ * @retval OTBR_ERROR_INVALID_ARGS  If the full service instance name is not valid.
+ *
+ */
+otbrError SplitFullServiceInstanceName(const std::string &aFullName,
+                                       std::string &      aInstanceName,
+                                       std::string &      aType,
+                                       std::string &      aDomain);
+
+/**
+ * This function splits a full host name into components.
+ *
+ * @param[in]  aFullName  The full host name to split.
+ * @param[out] aHostName  A reference to a string to receive the host name.
+ * @param[out] aDomain    A reference to a string to receive the domain.
+ *
+ * @retval OTBR_ERROR_NONE          Successfully split the full host name.
+ * @retval OTBR_ERROR_INVALID_ARGS  If the full host name is not valid.
+ *
+ */
+otbrError SplitFullHostName(const std::string &aFullName, std::string &aHostName, std::string &aDomain);
+
+#endif // OTBR_COMMON_DNS_UTILS_HPP_

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -69,9 +69,21 @@ void Ip6Address::CopyTo(struct sockaddr_in6 &aSockAddr) const
     aSockAddr.sin6_family = AF_INET6;
 }
 
+void Ip6Address::CopyFrom(const struct sockaddr_in6 &aSockAddr)
+{
+    CopyFrom(aSockAddr.sin6_addr);
+}
+
 void Ip6Address::CopyTo(struct in6_addr &aIn6Addr) const
 {
+    static_assert(sizeof(m8) == sizeof(aIn6Addr.s6_addr), "invalid IPv6 address size");
     memcpy(aIn6Addr.s6_addr, m8, sizeof(aIn6Addr.s6_addr));
+}
+
+void Ip6Address::CopyFrom(const struct in6_addr &aIn6Addr)
+{
+    static_assert(sizeof(m8) == sizeof(aIn6Addr.s6_addr), "invalid IPv6 address size");
+    memcpy(m8, aIn6Addr.s6_addr, sizeof(aIn6Addr.s6_addr));
 }
 
 otbrError Ip6Address::FromString(const char *aStr, Ip6Address &aAddr)

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -36,11 +36,13 @@
 
 #include "openthread-br/config.h"
 
+#include <netinet/in.h>
 #include <stdint.h>
 #include <string.h>
 #include <string>
 #include <vector>
 
+#include "common/byteswap.hpp"
 #include "common/toolchain.hpp"
 
 #ifndef IN6ADDR_ANY
@@ -182,12 +184,38 @@ public:
     std::string ToString(void) const;
 
     /**
+     * This method indicates whether or not the Ip6 address is the Unspecified Address.
+     *
+     * @retval TRUE   If the Ip6 address is the Unspecified Address.
+     * @retval FALSE  If the Ip6 address is not the Unspecified Address.
+     *
+     */
+    bool IsUnspecified(void) const { return m64[0] == 0 && m64[1] == 0; }
+
+    /**
      * This method returns if the Ip6 address is a multicast address.
      *
      * @returns  Whether the Ip6 address is a multicast address.
      *
      */
     bool IsMulticast(void) const { return m8[0] == 0xff; }
+
+    /**
+     * This method returns if the Ip6 address is a link-local address.
+     *
+     * @returns  Whether the Ip6 address is a link-local address.
+     *
+     */
+    bool IsLinkLocal(void) const { return (m16[0] & bswap_16(0xffc0)) == bswap_16(0xfe80); }
+
+    /**
+     * This method returns whether or not the Ip6 address is the Loopback Address.
+     *
+     * @retval TRUE   If the Ip6 address is the Loopback Address.
+     * @retval FALSE  If the Ip6 address is not the Loopback Address.
+     *
+     */
+    bool IsLoopback(void) const { return (m32[0] == 0 && m32[1] == 0 && m32[2] == 0 && m32[3] == htobe32(1)); }
 
     /**
      * This function returns the wellknown Link Local All Nodes Multicast Address (ff02::1).
@@ -230,18 +258,34 @@ public:
     /**
      * This method copies the Ip6 address to a `sockaddr_in6` structure.
      *
-     * @param[out] aSockAddr  The `sockaddr_in6` structure to copy the Ip6 adress to.
+     * @param[out] aSockAddr  The `sockaddr_in6` structure to copy the Ip6 address to.
      *
      */
     void CopyTo(struct sockaddr_in6 &aSockAddr) const;
 
     /**
+     * This method copies the Ip6 address from a `sockaddr_in6` structure.
+     *
+     * @param[in] aSockAddr  The `sockaddr_in6` structure to copy the Ip6 address from.
+     *
+     */
+    void CopyFrom(const struct sockaddr_in6 &aSockAddr);
+
+    /**
      * This method copies the Ip6 address to a `in6_addr` structure.
      *
-     * @param[out] aIn6Addr  The `in6_addr` structure to copy the Ip6 adress to.
+     * @param[out] aIn6Addr  The `in6_addr` structure to copy the Ip6 address to.
      *
      */
     void CopyTo(struct in6_addr &aIn6Addr) const;
+
+    /**
+     * This method copies the Ip6 address from a `in6_addr` structure.
+     *
+     * @param[in] aIn6Addr  The `in6_addr` structure to copy the Ip6 address from.
+     *
+     */
+    void CopyFrom(const struct in6_addr &aIn6Addr);
 
     union
     {

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -34,6 +34,7 @@
 #ifndef OTBR_AGENT_MDNS_HPP_
 #define OTBR_AGENT_MDNS_HPP_
 
+#include <functional>
 #include <vector>
 
 #include <sys/select.h>
@@ -92,6 +93,68 @@ public:
     };
 
     typedef std::vector<TxtEntry> TxtList;
+
+    /**
+     * This structure represents information of a discovered service instance.
+     *
+     */
+    struct DiscoveredInstanceInfo
+    {
+        /**
+         * Constructor to initialize a `DiscoveredInstanceInfo` instance.
+         *
+         */
+        DiscoveredInstanceInfo(void)
+            : mPort(0)
+            , mPriority(0)
+            , mWeight(0)
+            , mTtl(0)
+        {
+        }
+
+        std::string             mName;      ///< Instance name.
+        std::string             mHostName;  ///< Full host name.
+        std::vector<Ip6Address> mAddresses; ///< IPv6 addresses.
+        uint16_t                mPort;      ///< Port.
+        uint16_t                mPriority;  ///< Service priority.
+        uint16_t                mWeight;    ///< Service weight.
+        std::vector<uint8_t>    mTxtData;   ///< TXT RDATA bytes.
+        uint32_t                mTtl;       ///< Service TTL.
+    };
+
+    /**
+     * This structure represents information of a discovered host.
+     *
+     */
+    struct DiscoveredHostInfo
+    {
+        /**
+         * Constructor to initialize a `DiscoveredHostInfo` instance.
+         *
+         */
+        DiscoveredHostInfo(void)
+            : mTtl(0)
+        {
+        }
+
+        std::string             mHostName;  ///< Full host name.
+        std::vector<Ip6Address> mAddresses; ///< IP6 addresses.
+        uint32_t                mTtl;       ///< Host TTL.
+    };
+
+    /**
+     * This function is called to notify a discovered service instance.
+     *
+     */
+    using DiscoveredServiceInstanceCallback =
+        std::function<void(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo)>;
+
+    /**
+     * This function is called to notify a discovered host.
+     *
+     */
+    using DiscoveredHostCallback =
+        std::function<void(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo)>;
 
     /**
      * MDNS state values.
@@ -245,6 +308,72 @@ public:
      */
     virtual otbrError UnpublishHost(const char *aName) = 0;
 
+    /**
+     * This method subscribes a given service or service instance.
+     *
+     * If @p aInstanceName is not empty, this method subscribes the service instance. Otherwise, this method subscribes
+     * the service. mDNS implementations should use the `DiscoveredServiceInstanceCallback` function to notify
+     * discovered service instances.
+     *
+     * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same service or service
+     * instance.
+     *
+     * @param[in]  aType          The service type.
+     * @param[in]  aInstanceName  The service instance to subscribe, or empty to subscribe the service.
+     *
+     */
+    virtual void SubscribeService(const std::string &aType, const std::string &aInstanceName) = 0;
+
+    /**
+     * This method unsubscribes a given service or service instance.
+     *
+     * If @p aInstanceName is not empty, this method unsubscribes the service instance. Otherwise, this method
+     * unsubscribes the service.
+     *
+     * @note Discovery Proxy implementation guarantees no redundant unsubscription for a service or service instance.
+     *
+     * @param[in]  aType          The service type.
+     * @param[in]  aInstanceName  The service instance to unsubscribe, or empty to unsubscribe the service.
+     *
+     */
+    virtual void UnsubscribeService(const std::string &aType, const std::string &aInstanceName) = 0;
+
+    /**
+     * This method subscribes a given host.
+     *
+     * mDNS implementations should use the `DiscoveredHostCallback` function to notify discovered hosts.
+     *
+     * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same host.
+     *
+     * @param[in]  aHostName    The host name (without domain).
+     *
+     */
+    virtual void SubscribeHost(const std::string &aHostName) = 0;
+
+    /**
+     * This method unsubscribes a given host.
+     *
+     * @note Discovery Proxy implementation guarantees no redundant unsubscription for a host.
+     *
+     * @param[in]  aHostName    The host name (without domain).
+     *
+     */
+    virtual void UnsubscribeHost(const std::string &aHostName) = 0;
+
+    /**
+     * This method sets the callbacks for subscriptions.
+     *
+     * @param[in] aInstanceCallback     The callback function to receive discovered service instances.
+     * @param[in] aHostCallback         The callback function to receive discovered hosts.
+     *
+     */
+    void SetSubscriptionCallbacks(DiscoveredServiceInstanceCallback aInstanceCallback,
+                                  DiscoveredHostCallback            aHostCallback)
+    {
+        mDiscoveredServiceInstanceCallback = std::move(aInstanceCallback);
+        mDiscoveredHostCallback            = std::move(aHostCallback);
+    }
+
     virtual ~Publisher(void) = default;
 
     /**
@@ -311,6 +440,9 @@ protected:
 
     PublishHostHandler mHostHandler        = nullptr;
     void *             mHostHandlerContext = nullptr;
+
+    DiscoveredServiceInstanceCallback mDiscoveredServiceInstanceCallback = nullptr;
+    DiscoveredHostCallback            mDiscoveredHostCallback            = nullptr;
 };
 
 /**

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -820,6 +820,36 @@ std::string PublisherAvahi::MakeFullName(const char *aName)
     return fullHostName;
 }
 
+void PublisherAvahi::SubscribeService(const std::string &aType, const std::string &aInstanceName)
+{
+    OTBR_UNUSED_VARIABLE(aType);
+    OTBR_UNUSED_VARIABLE(aInstanceName);
+
+    VerifyOrDie(false, "SubscribeService is not implemented with avahi");
+}
+
+void PublisherAvahi::UnsubscribeService(const std::string &aType, const std::string &aInstanceName)
+{
+    OTBR_UNUSED_VARIABLE(aType);
+    OTBR_UNUSED_VARIABLE(aInstanceName);
+
+    VerifyOrDie(false, "UnsubscribeService is not implemented with avahi");
+}
+
+void PublisherAvahi::SubscribeHost(const std::string &aHostName)
+{
+    OTBR_UNUSED_VARIABLE(aHostName);
+
+    VerifyOrDie(false, "SubscribeHost is not implemented with avahi");
+}
+
+void PublisherAvahi::UnsubscribeHost(const std::string &aHostName)
+{
+    OTBR_UNUSED_VARIABLE(aHostName);
+
+    VerifyOrDie(false, "UnsubscribeHost is not implemented with avahi");
+}
+
 Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
 {
     return new PublisherAvahi(aFamily, aDomain, aHandler, aContext);

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -263,6 +263,56 @@ public:
     otbrError UnpublishHost(const char *aName) override;
 
     /**
+     * This method subscribes a given service or service instance. If @p aInstanceName is not empty, this method
+     * subscribes the service instance. Otherwise, this method subscribes the service.
+     *
+     * mDNS implementations should use the `DiscoveredServiceInstanceCallback` function to notify discovered service
+     * instances.
+     *
+     * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same service or service
+     * instance.
+     *
+     * @param[in]  aType          The service type.
+     * @param[in]  aInstanceName  The service instance to subscribe, or empty to subscribe the service.
+     *
+     */
+    void SubscribeService(const std::string &aType, const std::string &aInstanceName) override;
+
+    /**
+     * This method unsubscribes a given service or service instance. If @p aInstanceName is not empty, this method
+     * unsubscribes the service instance. Otherwise, this method unsubscribes the service.
+     *
+     * @note Discovery Proxy implementation guarantees no redundant unsubscription for a service or service instance.
+     *
+     * @param[in]  aType          The service type.
+     * @param[in]  aInstanceName  The service instance to unsubscribe, or empty to unsubscribe the service.
+     *
+     */
+    void UnsubscribeService(const std::string &aType, const std::string &aInstanceName) override;
+
+    /**
+     * This method subscribes a given host.
+     *
+     * mDNS implementations should use the `DiscoveredHostCallback` function to notify discovered hosts.
+     *
+     * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same host.
+     *
+     * @param[in]  aHostName    The host name (without domain).
+     *
+     */
+    void SubscribeHost(const std::string &aHostName) override;
+
+    /**
+     * This method unsubscribes a given host.
+     *
+     * @note Discovery Proxy implementation guarantees no redundant unsubscription for a host.
+     *
+     * @param[in]  aHostName    The host name (without domain).
+     *
+     */
+    void UnsubscribeHost(const std::string &aHostName) override;
+
+    /**
      * This method starts the MDNS service.
      *
      * @retval OTBR_ERROR_NONE  Successfully started MDNS service;

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -71,6 +71,10 @@ if (OT_THREAD_VERSION STREQUAL "1.2")
     set(OT_MLR ON CACHE BOOL "Enable Thread 1.2 MLR by default")
 endif()
 
+if (OTBR_DNSSD_DISCOVERY_PROXY)
+    set(OT_DNSSD_SERVER ON CACHE BOOL "enable DNS-SD server support" FORCE)
+endif()
+
 list(APPEND OT_PLATFORM_DEFINES "-DOPENTHREAD_CONFIG_POSIX_SETTINGS_PATH=\"/var/lib/thread\"")
 
 add_subdirectory(repo EXCLUDE_FROM_ALL)


### PR DESCRIPTION
This commit implements DNS-SD Discovery Proxy ([RFC 8766](https://tools.ietf.org/html/rfc8766)) over mDNSResponder.