### PR TITLE
[netdiag] fix network diagnostic get response callback

### DIFF
--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -78,8 +78,6 @@ UbusServer &UbusServer::GetInstance(void)
 void UbusServer::Initialize(Ncp::ControllerOpenThread *aController)
 {
     sUbusServerInstance = new UbusServer(aController);
-    otThreadSetReceiveDiagnosticGetCallback(aController->GetInstance(), &UbusServer::HandleDiagnosticGetResponse,
-                                            sUbusServerInstance);
 }
 
 enum
@@ -1184,7 +1182,8 @@ int UbusServer::UbusGetInformation(struct ubus_context *     aContext,
             tlvTypes[count++] = static_cast<uint8_t>(OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE);
 
             sBufNum = 0;
-            otThreadSendDiagnosticGet(mController->GetInstance(), &address, tlvTypes, count);
+            otThreadSendDiagnosticGet(mController->GetInstance(), &address, tlvTypes, count,
+                                      &UbusServer::HandleDiagnosticGetResponse, this);
             mSecond = time(nullptr);
         }
         goto exit;

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -125,7 +125,6 @@ Resource::Resource(ControllerOpenThread *aNcp)
 
 void Resource::Init(void)
 {
-    otThreadSetReceiveDiagnosticGetCallback(mInstance, &Resource::DiagnosticResponseHandler, this);
 }
 
 void Resource::Handle(Request &aRequest, Response &aResponse) const
@@ -523,13 +522,15 @@ void Resource::Diagnostic(const Request &aRequest, Response &aResponse) const
     struct otIp6Address rloc16address = *otThreadGetRloc(mInstance);
     struct otIp6Address multicastAddress;
 
-    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &rloc16address, kAllTlvTypes, sizeof(kAllTlvTypes)) ==
-                     OT_ERROR_NONE,
+    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &rloc16address, kAllTlvTypes, sizeof(kAllTlvTypes),
+                                           &Resource::DiagnosticResponseHandler,
+                                           const_cast<Resource *>(this)) == OT_ERROR_NONE,
                  error = OTBR_ERROR_REST);
     VerifyOrExit(otIp6AddressFromString(kMulticastAddrAllRouters, &multicastAddress) == OT_ERROR_NONE,
                  error = OTBR_ERROR_REST);
-    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &multicastAddress, kAllTlvTypes, sizeof(kAllTlvTypes)) ==
-                     OT_ERROR_NONE,
+    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &multicastAddress, kAllTlvTypes, sizeof(kAllTlvTypes),
+                                           &Resource::DiagnosticResponseHandler,
+                                           const_cast<Resource *>(this)) == OT_ERROR_NONE,
                  error = OTBR_ERROR_REST);
 
 exit:


### PR DESCRIPTION
This PR sets the `DIAG_GET` response callback every time the `otThreadSendDiagnosticGet` is called. This is because the callback may be changed to other modules (e,g. `OTBR_REST`, `OT_CLI`).

addresses issue: #689 

Related PR in openthread: https://github.com/openthread/openthread/pull/6192