### PR TITLE
[dbus] add missing header inclusion

### DIFF
--- a/src/dbus/client/CMakeLists.txt
+++ b/src/dbus/client/CMakeLists.txt
@@ -28,7 +28,9 @@
 
 add_library(otbr-dbus-client
     client_error.cpp
+    client_error.hpp
     thread_api_dbus.cpp
+    thread_api_dbus.hpp
 )
 
 target_link_libraries(otbr-dbus-client PUBLIC

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -38,6 +38,7 @@
 
 #include <dbus/dbus.h>
 
+#include "common/code_utils.hpp"
 #include "common/types.hpp"
 #include "dbus/common/constants.hpp"
 #include "dbus/common/error.hpp"


### PR DESCRIPTION
This file uses `OTBR_UNUSED_VARIABLE` which is in `common/code_utils.hpp`.