### PR TITLE
[dbus] remove inclusion of code_utils.hpp in dbus api header

### DIFF
--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -38,7 +38,6 @@
 
 #include <dbus/dbus.h>
 
-#include "common/code_utils.hpp"
 #include "common/types.hpp"
 #include "dbus/common/constants.hpp"
 #include "dbus/common/error.hpp"

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -684,7 +684,7 @@ private:
     static void sScanPendingCallHandler(DBusPendingCall *aPending, void *aThreadApiDBus);
     void        ScanPendingCallHandler(DBusPendingCall *aPending);
 
-    static void EmptyFree(void *aData) { OTBR_UNUSED_VARIABLE(aData); }
+    static void EmptyFree(void *) {}
 
     std::string mInterfaceName;
 


### PR DESCRIPTION
`common/code_utils.hpp` includes macros like `VerifiOrDie` which are not protected by C++ namespace, so it will easily get conflicted with other definitions.

We should not include `common/code_utils.hpp` in public headers.

Blocking: https://github.com/project-chip/connectedhomeip/pull/5062