### PR TITLE
[backbone-router] add OTBR_DUA_ROUTING option (OFF by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(otbr-config INTERFACE)
 
 option(OTBR_SRP_ADVERTISING_PROXY   "Enable Advertising Proxy" OFF)
 option(OTBR_BACKBONE_ROUTER         "Enable Backbone Router" OFF)
+option(OTBR_DUA_ROUTING             "Enable Backbone Router DUA Routing" OFF)
 option(OTBR_DBUS                    "Enable DBus support" OFF)
 option(OTBR_OPENWRT                 "Enable OpenWrt support" OFF)
 option(OTBR_UNSECURE_JOIN           "Enable unsecure joining" OFF)
@@ -104,10 +105,15 @@ if (OTBR_BACKBONE_ROUTER)
     target_compile_definitions(otbr-config INTERFACE
             OTBR_ENABLE_BACKBONE_ROUTER=1
     )
-    set(OT_BACKBONE_ROUTER_DUA_NDPROXYING ON CACHE BOOL "Enable Backbone Router DUA ND Proxying in OpenThread" FORCE)
     set(OT_THREAD_VERSION 1.2 CACHE STRING "Backbone Router requires Thread 1.2 or higher" FORCE)
     set(OT_BACKBONE_ROUTER ON CACHE BOOL "Enable Backbone Router feature in OpenThread" FORCE)
     set(OT_SERVICE ON CACHE BOOL "Backbone Router requires Thread network service" FORCE)
+endif()
+
+if (OTBR_DUA_ROUTING)
+    target_compile_definitions(otbr-config INTERFACE
+            OTBR_ENABLE_DUA_ROUTING=1
+    )
 endif()
 
 if(OTBR_DBUS)

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -127,7 +127,9 @@ otbrError ControllerOpenThread::Init(void)
 #if OTBR_ENABLE_BACKBONE_ROUTER
     otBackboneRouterSetDomainPrefixCallback(mInstance, &ControllerOpenThread::HandleBackboneRouterDomainPrefixEvent,
                                             this);
+#if OTBR_ENABLE_DUA_ROUTING
     otBackboneRouterSetNdProxyCallback(mInstance, &ControllerOpenThread::HandleBackboneRouterNdProxyEvent, this);
+#endif
 #endif
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
@@ -330,6 +332,7 @@ void ControllerOpenThread::HandleBackboneRouterDomainPrefixEvent(otBackboneRoute
     EventEmitter::Emit(kEventBackboneRouterDomainPrefixEvent, aEvent, aDomainPrefix);
 }
 
+#if OTBR_ENABLE_DUA_ROUTING
 void ControllerOpenThread::HandleBackboneRouterNdProxyEvent(void *                       aContext,
                                                             otBackboneRouterNdProxyEvent aEvent,
                                                             const otIp6Address *         aAddress)
@@ -342,6 +345,7 @@ void ControllerOpenThread::HandleBackboneRouterNdProxyEvent(otBackboneRouterNdPr
 {
     EventEmitter::Emit(kEventBackboneRouterNdProxyEvent, aEvent, aAddress);
 }
+#endif
 #endif
 
 Controller *Controller::Create(const char *aInterfaceName, const char *aRadioUrl, const char *aBackboneInterfaceName)

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -148,16 +148,12 @@ private:
     void        HandleBackboneRouterDomainPrefixEvent(otBackboneRouterDomainPrefixEvent aEvent,
                                                       const otIp6Prefix *               aDomainPrefix);
 
+#if OTBR_ENABLE_DUA_ROUTING
     static void HandleBackboneRouterNdProxyEvent(void *                       aContext,
                                                  otBackboneRouterNdProxyEvent aEvent,
                                                  const otIp6Address *         aAddress);
     void        HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aAddress);
-
-    static void HandleBackboneRouterMulticastListenerEvent(void *                                 aContext,
-                                                           otBackboneRouterMulticastListenerEvent aEvent,
-                                                           const otIp6Address *                   aAddress);
-    void        HandleBackboneRouterMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
-                                                           const otIp6Address *                   aAddress);
+#endif
 
     otInstance *mInstance;
 

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -108,15 +108,20 @@ private:
     static void HandleBackboneRouterDomainPrefixEvent(void *aContext, int aEvent, va_list aArguments);
     void        HandleBackboneRouterDomainPrefixEvent(otBackboneRouterDomainPrefixEvent aEvent,
                                                       const otIp6Prefix *               aDomainPrefix);
+#if OTBR_ENABLE_DUA_ROUTING
     static void HandleBackboneRouterNdProxyEvent(void *aContext, int aEvent, va_list aArguments);
     void        HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aAddress);
+#endif
 
     static const char *StateToString(otBackboneRouterState aState);
 
     otbr::Ncp::ControllerOpenThread &mNcp;
     otBackboneRouterState            mBackboneRouterState;
-    NdProxyManager                   mNdProxyManager;
     Ip6Prefix                        mDomainPrefix;
+
+#if OTBR_ENABLE_DUA_ROUTING
+    NdProxyManager mNdProxyManager;
+#endif
 };
 
 /**

--- a/src/backbone_router/nd_proxy.cpp
+++ b/src/backbone_router/nd_proxy.cpp
@@ -33,6 +33,8 @@
 
 #include "backbone_router/nd_proxy.hpp"
 
+#if OTBR_ENABLE_DUA_ROUTING
+
 #include <openthread/backbone_router_ftd.h>
 
 #include <assert.h>
@@ -573,3 +575,5 @@ exit:
 
 } // namespace BackboneRouter
 } // namespace otbr
+
+#endif // OTBR_ENABLE_DUA_ROUTING

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -34,6 +34,8 @@
 #ifndef ND_PROXY_HPP_
 #define ND_PROXY_HPP_
 
+#if OTBR_ENABLE_DUA_ROUTING
+
 #ifdef __APPLE__
 #define __APPLE_USE_RFC_3542
 #endif
@@ -186,4 +188,5 @@ private:
 } // namespace BackboneRouter
 } // namespace otbr
 
+#endif // OTBR_ENABLE_DUA_ROUTING
 #endif // ND_PROXY_HPP_

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -51,6 +51,7 @@ set(OT_PLATFORM "posix" CACHE STRING "use posix platform" FORCE)
 set(OT_PLATFORM_NETIF ON CACHE BOOL "enable platform netif" FORCE)
 set(OT_PLATFORM_UDP ON CACHE BOOL "enable platform UDP" FORCE)
 set(OT_UDP_FORWARD OFF CACHE BOOL "diable udp forward" FORCE)
+set(OT_BACKBONE_ROUTER_DUA_NDPROXYING ${OTBR_DUA_ROUTING} CACHE BOOL "Configure DUA ND Proxy feature in OpenThread" FORCE)
 
 if (OTBR_SRP_ADVERTISING_PROXY)
     set(OT_SRP_SERVER ON CACHE BOOL "enable SRP server" FORCE)


### PR DESCRIPTION
This commit adds the `OTBR_DUA_ROUTING` option, which configures whether the DUA routing related features (e.g. DUA ND Proxying) are enabled for the Backbone Router.

The `OTBR_DUA_ROUTING` option is `OFF` by default. The option also configures OT option `OT_BACKBONE_ROUTER_DUA_NDPROXYING` correspondingly.

Required by #712 and #586