### PR TITLE
[mdns] rename `Publisher` to `MDns`

### DIFF
--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -56,11 +56,11 @@ public:
     /**
      * This constructor initializes the Advertising Proxy object.
      *
-     * @param[in]  aNcp        A reference to the NCP controller.
-     * @param[in]  aPublisher  A reference to the mDNS publisher.
+     * @param[in]  aNcp     A reference to the NCP controller.
+     * @param[in]  aMDns    A reference to the mDNS publisher.
      *
      */
-    explicit AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    explicit AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::MDns &aMDns);
 
     /**
      * This method starts the Advertising Proxy.
@@ -91,7 +91,7 @@ private:
     static void AdvertisingHandler(const otSrpServerHost *aHost, uint32_t aTimeout, void *aContext);
     void        AdvertisingHandler(const otSrpServerHost *aHost, uint32_t aTimeout);
 
-    static Mdns::Publisher::TxtList MakeTxtList(const otSrpServerService *aSrpService);
+    static Mdns::MDns::TxtList MakeTxtList(const otSrpServerService *aSrpService);
 
     static void PublishServiceHandler(const char *aName, const char *aType, otbrError aError, void *aContext);
     void        PublishServiceHandler(const char *aName, const char *aType, otbrError aError);
@@ -103,8 +103,8 @@ private:
     // A reference to the NCP controller, has no ownership.
     Ncp::ControllerOpenThread &mNcp;
 
-    // A reference to the mDNS publisher, has no ownership.
-    Mdns::Publisher &mPublisher;
+    // A reference to the mDNS service, has no ownership.
+    Mdns::MDns &mMDns;
 
     // A vector that tracks outstanding updates.
     std::vector<OutstandingUpdate> mOutstandingUpdates;

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -117,11 +117,11 @@ private:
      */
     void Stop(void);
 
-    static void HandleMdnsState(void *aContext, Mdns::Publisher::State aState)
+    static void HandleMdnsState(void *aContext, Mdns::MDns::State aState)
     {
         static_cast<BorderAgent *>(aContext)->HandleMdnsState(aState);
     }
-    void HandleMdnsState(Mdns::Publisher::State aState);
+    void HandleMdnsState(Mdns::MDns::State aState);
     void PublishService(void);
     void StartPublishService(void);
     void StopPublishService(void);
@@ -141,7 +141,7 @@ private:
     static void HandleExtAddr(void *aContext, int aEvent, va_list aArguments);
 
     Ncp::Controller *mNcp;
-    Mdns::Publisher *mPublisher;
+    Mdns::MDns *     mMDns;
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     AdvertisingProxy mAdvertisingProxy;

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -39,7 +39,7 @@ namespace otbr {
 
 namespace Mdns {
 
-bool Publisher::IsServiceTypeEqual(const char *aFirstType, const char *aSecondType)
+bool MDns::IsServiceTypeEqual(const char *aFirstType, const char *aSecondType)
 {
     size_t firstLength  = strlen(aFirstType);
     size_t secondLength = strlen(aSecondType);
@@ -56,7 +56,7 @@ bool Publisher::IsServiceTypeEqual(const char *aFirstType, const char *aSecondTy
     return firstLength == secondLength && memcmp(aFirstType, aSecondType, firstLength) == 0;
 }
 
-otbrError Publisher::EncodeTxtData(const TxtList &aTxtList, uint8_t *aTxtData, uint16_t &aTxtLength)
+otbrError MDns::EncodeTxtData(const TxtList &aTxtList, uint8_t *aTxtData, uint16_t &aTxtLength)
 {
     otbrError error = OTBR_ERROR_NONE;
     uint8_t * cur   = aTxtData;

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -57,7 +57,7 @@ namespace Mdns {
  * This interface defines the functionality of MDNS service.
  *
  */
-class Publisher
+class MDns
 {
 public:
     /**
@@ -271,7 +271,7 @@ public:
                              int &    aMaxFd,
                              timeval &aTimeout) = 0;
 
-    virtual ~Publisher(void) {}
+    virtual ~MDns(void) {}
 
     /**
      * This function creates a MDNS publisher.
@@ -284,15 +284,15 @@ public:
      * @returns A pointer to the newly created MDNS publisher.
      *
      */
-    static Publisher *Create(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
+    static MDns *Create(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
     /**
      * This function destroys the MDNS publisher.
      *
-     * @param[in]   aPublisher          A pointer to the publisher.
+     * @param[in]   aMDns   A pointer to the publisher.
      *
      */
-    static void Destroy(Publisher *aPublisher);
+    static void Destroy(MDns *aMDns);
 
     /**
      * This function decides if two service types (names) are equal.

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -307,7 +307,7 @@ void Poller::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const 
     }
 }
 
-PublisherAvahi::PublisherAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
+MDnsAvahi::MDnsAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
     : mClient(nullptr)
     , mProtocol(aProtocol == AF_INET6 ? AVAHI_PROTO_INET6
                                       : aProtocol == AF_INET ? AVAHI_PROTO_INET : AVAHI_PROTO_UNSPEC)
@@ -318,11 +318,11 @@ PublisherAvahi::PublisherAvahi(int aProtocol, const char *aDomain, StateHandler 
 {
 }
 
-PublisherAvahi::~PublisherAvahi(void)
+MDnsAvahi::~MDnsAvahi(void)
 {
 }
 
-otbrError PublisherAvahi::Start(void)
+otbrError MDnsAvahi::Start(void)
 {
     otbrError error      = OTBR_ERROR_NONE;
     int       avahiError = 0;
@@ -338,12 +338,12 @@ otbrError PublisherAvahi::Start(void)
     return error;
 }
 
-bool PublisherAvahi::IsStarted(void) const
+bool MDnsAvahi::IsStarted(void) const
 {
     return mClient != nullptr;
 }
 
-void PublisherAvahi::Stop(void)
+void MDnsAvahi::Stop(void)
 {
     FreeAllGroups();
 
@@ -356,17 +356,17 @@ void PublisherAvahi::Stop(void)
     }
 }
 
-void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext)
+void MDnsAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext)
 {
-    static_cast<PublisherAvahi *>(aContext)->HandleClientState(aClient, aState);
+    static_cast<MDnsAvahi *>(aContext)->HandleClientState(aClient, aState);
 }
 
-void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext)
+void MDnsAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext)
 {
-    static_cast<PublisherAvahi *>(aContext)->HandleGroupState(aGroup, aState);
+    static_cast<MDnsAvahi *>(aContext)->HandleGroupState(aGroup, aState);
 }
 
-void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState)
+void MDnsAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState)
 {
     otbrLog(OTBR_LOG_INFO, "Avahi group change to state %d.", aState);
 
@@ -402,7 +402,7 @@ void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupSt
     }
 }
 
-void PublisherAvahi::CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const
+void MDnsAvahi::CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const
 {
     if (mHostHandler != nullptr)
     {
@@ -427,7 +427,7 @@ void PublisherAvahi::CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrErro
     }
 }
 
-PublisherAvahi::Hosts::iterator PublisherAvahi::FindHost(const char *aHostName)
+MDnsAvahi::Hosts::iterator MDnsAvahi::FindHost(const char *aHostName)
 {
     assert(aHostName != nullptr);
 
@@ -435,7 +435,7 @@ PublisherAvahi::Hosts::iterator PublisherAvahi::FindHost(const char *aHostName)
                         [aHostName](const Host &aHost) { return aHost.mHostName == aHostName; });
 }
 
-otbrError PublisherAvahi::CreateHost(AvahiClient &aClient, const char *aHostName, Hosts::iterator &aOutHostIt)
+otbrError MDnsAvahi::CreateHost(AvahiClient &aClient, const char *aHostName, Hosts::iterator &aOutHostIt)
 {
     assert(aHostName != nullptr);
 
@@ -452,7 +452,7 @@ exit:
     return error;
 }
 
-PublisherAvahi::Services::iterator PublisherAvahi::FindService(const char *aName, const char *aType)
+MDnsAvahi::Services::iterator MDnsAvahi::FindService(const char *aName, const char *aType)
 {
     assert(aName != nullptr);
     assert(aType != nullptr);
@@ -462,10 +462,10 @@ PublisherAvahi::Services::iterator PublisherAvahi::FindService(const char *aName
     });
 }
 
-otbrError PublisherAvahi::CreateService(AvahiClient &       aClient,
-                                        const char *        aName,
-                                        const char *        aType,
-                                        Services::iterator &aOutServiceIt)
+otbrError MDnsAvahi::CreateService(AvahiClient &       aClient,
+                                   const char *        aName,
+                                   const char *        aType,
+                                   Services::iterator &aOutServiceIt)
 {
     assert(aName != nullptr);
     assert(aType != nullptr);
@@ -484,7 +484,7 @@ exit:
     return error;
 }
 
-otbrError PublisherAvahi::CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup)
+otbrError MDnsAvahi::CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup)
 {
     otbrError error = OTBR_ERROR_NONE;
 
@@ -503,7 +503,7 @@ exit:
     return error;
 }
 
-otbrError PublisherAvahi::ResetGroup(AvahiEntryGroup *aGroup)
+otbrError MDnsAvahi::ResetGroup(AvahiEntryGroup *aGroup)
 {
     assert(aGroup != nullptr);
 
@@ -519,7 +519,7 @@ otbrError PublisherAvahi::ResetGroup(AvahiEntryGroup *aGroup)
     return error;
 }
 
-otbrError PublisherAvahi::FreeGroup(AvahiEntryGroup *aGroup)
+otbrError MDnsAvahi::FreeGroup(AvahiEntryGroup *aGroup)
 {
     assert(aGroup != nullptr);
 
@@ -535,7 +535,7 @@ otbrError PublisherAvahi::FreeGroup(AvahiEntryGroup *aGroup)
     return error;
 }
 
-void PublisherAvahi::FreeAllGroups(void)
+void MDnsAvahi::FreeAllGroups(void)
 {
     for (Service &service : mServices)
     {
@@ -552,7 +552,7 @@ void PublisherAvahi::FreeAllGroups(void)
     mHosts.clear();
 }
 
-void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState)
+void MDnsAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState)
 {
     otbrLog(OTBR_LOG_INFO, "Avahi client state changed to %d.", aState);
     switch (aState)
@@ -598,25 +598,25 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
     }
 }
 
-void PublisherAvahi::UpdateFdSet(fd_set & aReadFdSet,
-                                 fd_set & aWriteFdSet,
-                                 fd_set & aErrorFdSet,
-                                 int &    aMaxFd,
-                                 timeval &aTimeout)
+void MDnsAvahi::UpdateFdSet(fd_set & aReadFdSet,
+                            fd_set & aWriteFdSet,
+                            fd_set & aErrorFdSet,
+                            int &    aMaxFd,
+                            timeval &aTimeout)
 {
     mPoller.UpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd, aTimeout);
 }
 
-void PublisherAvahi::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void MDnsAvahi::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
 {
     mPoller.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
 }
 
-otbrError PublisherAvahi::PublishService(const char *   aHostName,
-                                         uint16_t       aPort,
-                                         const char *   aName,
-                                         const char *   aType,
-                                         const TxtList &aTxtList)
+otbrError MDnsAvahi::PublishService(const char *   aHostName,
+                                    uint16_t       aPort,
+                                    const char *   aName,
+                                    const char *   aType,
+                                    const TxtList &aTxtList)
 {
     otbrError          error        = OTBR_ERROR_NONE;
     int                avahiError   = 0;
@@ -721,7 +721,7 @@ exit:
     return error;
 }
 
-otbrError PublisherAvahi::UnpublishService(const char *aName, const char *aType)
+otbrError MDnsAvahi::UnpublishService(const char *aName, const char *aType)
 {
     otbrError          error = OTBR_ERROR_NONE;
     Services::iterator serviceIt;
@@ -740,7 +740,7 @@ exit:
     return error;
 }
 
-otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
+otbrError MDnsAvahi::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
 {
     otbrError       error      = OTBR_ERROR_NONE;
     int             avahiError = 0;
@@ -810,7 +810,7 @@ exit:
     return error;
 }
 
-otbrError PublisherAvahi::UnpublishHost(const char *aName)
+otbrError MDnsAvahi::UnpublishHost(const char *aName)
 {
     otbrError       error = OTBR_ERROR_NONE;
     Hosts::iterator hostIt;
@@ -828,7 +828,7 @@ exit:
     return error;
 }
 
-std::string PublisherAvahi::MakeFullName(const char *aName)
+std::string MDnsAvahi::MakeFullName(const char *aName)
 {
     assert(aName != nullptr);
 
@@ -840,14 +840,14 @@ std::string PublisherAvahi::MakeFullName(const char *aName)
     return fullHostName;
 }
 
-Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
+MDns *MDns::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
 {
-    return new PublisherAvahi(aFamily, aDomain, aHandler, aContext);
+    return new MDnsAvahi(aFamily, aDomain, aHandler, aContext);
 }
 
-void Publisher::Destroy(Publisher *aPublisher)
+void MDns::Destroy(MDns *aMDns)
 {
-    delete static_cast<PublisherAvahi *>(aPublisher);
+    delete static_cast<MDnsAvahi *>(aMDns);
 }
 
 } // namespace Mdns

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -187,11 +187,11 @@ private:
  * This class implements MDNS service with avahi.
  *
  */
-class PublisherAvahi : public Publisher
+class MDnsAvahi : public MDns
 {
 public:
     /**
-     * The constructor to initialize a Publisher.
+     * The constructor to initialize a MDns.
      *
      * @param[in]   aProtocol           The protocol used for publishing. IPv4, IPv6 or both.
      * @param[in]   aDomain             The domain of the host. nullptr to use default.
@@ -199,9 +199,9 @@ public:
      * @param[in]   aContext            A pointer to application-specific context.
      *
      */
-    PublisherAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
+    MDnsAvahi(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
-    ~PublisherAvahi(void) override;
+    ~MDnsAvahi(void) override;
 
     /**
      * This method publishes or updates a service.

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -204,7 +204,7 @@ static const char *DNSErrorToString(DNSServiceErrorType aError)
     }
 }
 
-PublisherMDnsSd::PublisherMDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
+MDnsSd::MDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext)
     : mHostsRef(nullptr)
     , mDomain(aDomain)
     , mState(State::kIdle)
@@ -214,24 +214,24 @@ PublisherMDnsSd::PublisherMDnsSd(int aProtocol, const char *aDomain, StateHandle
     OTBR_UNUSED_VARIABLE(aProtocol);
 }
 
-PublisherMDnsSd::~PublisherMDnsSd(void)
+MDnsSd::~MDnsSd(void)
 {
     Stop();
 }
 
-otbrError PublisherMDnsSd::Start(void)
+otbrError MDnsSd::Start(void)
 {
     mState = State::kReady;
     mStateHandler(mContext, State::kReady);
     return OTBR_ERROR_NONE;
 }
 
-bool PublisherMDnsSd::IsStarted(void) const
+bool MDnsSd::IsStarted(void) const
 {
     return mState == State::kReady;
 }
 
-void PublisherMDnsSd::Stop(void)
+void MDnsSd::Stop(void)
 {
     VerifyOrExit(mState == State::kReady);
 
@@ -251,11 +251,7 @@ exit:
     return;
 }
 
-void PublisherMDnsSd::UpdateFdSet(fd_set & aReadFdSet,
-                                  fd_set & aWriteFdSet,
-                                  fd_set & aErrorFdSet,
-                                  int &    aMaxFd,
-                                  timeval &aTimeout)
+void MDnsSd::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout)
 {
     OTBR_UNUSED_VARIABLE(aWriteFdSet);
     OTBR_UNUSED_VARIABLE(aErrorFdSet);
@@ -292,7 +288,7 @@ void PublisherMDnsSd::UpdateFdSet(fd_set & aReadFdSet,
     }
 }
 
-void PublisherMDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void MDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
 {
     std::vector<DNSServiceRef> readyServices;
 
@@ -330,24 +326,23 @@ void PublisherMDnsSd::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSe
     }
 }
 
-void PublisherMDnsSd::HandleServiceRegisterResult(DNSServiceRef         aService,
-                                                  const DNSServiceFlags aFlags,
-                                                  DNSServiceErrorType   aError,
-                                                  const char *          aName,
-                                                  const char *          aType,
-                                                  const char *          aDomain,
-                                                  void *                aContext)
+void MDnsSd::HandleServiceRegisterResult(DNSServiceRef         aService,
+                                         const DNSServiceFlags aFlags,
+                                         DNSServiceErrorType   aError,
+                                         const char *          aName,
+                                         const char *          aType,
+                                         const char *          aDomain,
+                                         void *                aContext)
 {
-    static_cast<PublisherMDnsSd *>(aContext)->HandleServiceRegisterResult(aService, aFlags, aError, aName, aType,
-                                                                          aDomain);
+    static_cast<MDnsSd *>(aContext)->HandleServiceRegisterResult(aService, aFlags, aError, aName, aType, aDomain);
 }
 
-void PublisherMDnsSd::HandleServiceRegisterResult(DNSServiceRef         aServiceRef,
-                                                  const DNSServiceFlags aFlags,
-                                                  DNSServiceErrorType   aError,
-                                                  const char *          aName,
-                                                  const char *          aType,
-                                                  const char *          aDomain)
+void MDnsSd::HandleServiceRegisterResult(DNSServiceRef         aServiceRef,
+                                         const DNSServiceFlags aFlags,
+                                         DNSServiceErrorType   aError,
+                                         const char *          aName,
+                                         const char *          aType,
+                                         const char *          aDomain)
 {
     OTBR_UNUSED_VARIABLE(aDomain);
 
@@ -399,7 +394,7 @@ exit:
     return;
 }
 
-void PublisherMDnsSd::DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
+void MDnsSd::DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
 {
     ServiceIterator service = FindPublishedService(aName, aType);
 
@@ -414,7 +409,7 @@ void PublisherMDnsSd::DiscardService(const char *aName, const char *aType, DNSSe
     }
 }
 
-void PublisherMDnsSd::RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
+void MDnsSd::RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
 {
     ServiceIterator service = FindPublishedService(aName, aType);
 
@@ -435,11 +430,11 @@ void PublisherMDnsSd::RecordService(const char *aName, const char *aType, DNSSer
     }
 }
 
-otbrError PublisherMDnsSd::PublishService(const char *   aHostName,
-                                          uint16_t       aPort,
-                                          const char *   aName,
-                                          const char *   aType,
-                                          const TxtList &aTxtList)
+otbrError MDnsSd::PublishService(const char *   aHostName,
+                                 uint16_t       aPort,
+                                 const char *   aName,
+                                 const char *   aType,
+                                 const TxtList &aTxtList)
 {
     otbrError       ret   = OTBR_ERROR_NONE;
     int             error = 0;
@@ -489,13 +484,13 @@ exit:
     return ret;
 }
 
-otbrError PublisherMDnsSd::UnpublishService(const char *aName, const char *aType)
+otbrError MDnsSd::UnpublishService(const char *aName, const char *aType)
 {
     DiscardService(aName, aType);
     return OTBR_ERROR_NONE;
 }
 
-otbrError PublisherMDnsSd::DiscardHost(const char *aName, bool aSendGoodbye)
+otbrError MDnsSd::DiscardHost(const char *aName, bool aSendGoodbye)
 {
     otbrError    ret   = OTBR_ERROR_NONE;
     int          error = 0;
@@ -530,10 +525,7 @@ exit:
     return ret;
 }
 
-void PublisherMDnsSd::RecordHost(const char *   aName,
-                                 const uint8_t *aAddress,
-                                 uint8_t        aAddressLength,
-                                 DNSRecordRef   aRecordRef)
+void MDnsSd::RecordHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength, DNSRecordRef aRecordRef)
 {
     HostIterator host = FindPublishedHost(aName);
 
@@ -558,7 +550,7 @@ void PublisherMDnsSd::RecordHost(const char *   aName,
     }
 }
 
-otbrError PublisherMDnsSd::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
+otbrError MDnsSd::PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength)
 {
     otbrError    ret   = OTBR_ERROR_NONE;
     int          error = 0;
@@ -615,25 +607,24 @@ exit:
     return ret;
 }
 
-otbrError PublisherMDnsSd::UnpublishHost(const char *aName)
+otbrError MDnsSd::UnpublishHost(const char *aName)
 {
     return DiscardHost(aName);
 }
 
-void PublisherMDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
-                                               DNSRecordRef        aHostRecord,
-                                               DNSServiceFlags     aFlags,
-                                               DNSServiceErrorType aErrorCode,
-                                               void *              aContext)
+void MDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                      DNSRecordRef        aHostRecord,
+                                      DNSServiceFlags     aFlags,
+                                      DNSServiceErrorType aErrorCode,
+                                      void *              aContext)
 {
-    static_cast<PublisherMDnsSd *>(aContext)->HandleRegisterHostResult(aHostsConnection, aHostRecord, aFlags,
-                                                                       aErrorCode);
+    static_cast<MDnsSd *>(aContext)->HandleRegisterHostResult(aHostsConnection, aHostRecord, aFlags, aErrorCode);
 }
 
-void PublisherMDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
-                                               DNSRecordRef        aHostRecord,
-                                               DNSServiceFlags     aFlags,
-                                               DNSServiceErrorType aErrorCode)
+void MDnsSd::HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
+                                      DNSRecordRef        aHostRecord,
+                                      DNSServiceFlags     aFlags,
+                                      DNSServiceErrorType aErrorCode)
 {
     OTBR_UNUSED_VARIABLE(aHostsConnection);
     OTBR_UNUSED_VARIABLE(aFlags);
@@ -667,7 +658,7 @@ exit:
     return;
 }
 
-otbrError PublisherMDnsSd::MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName)
+otbrError MDnsSd::MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName)
 {
     otbrError   error      = OTBR_ERROR_NONE;
     size_t      nameLength = strlen(aName);
@@ -685,39 +676,39 @@ exit:
     return error;
 }
 
-PublisherMDnsSd::ServiceIterator PublisherMDnsSd::FindPublishedService(const char *aName, const char *aType)
+MDnsSd::ServiceIterator MDnsSd::FindPublishedService(const char *aName, const char *aType)
 {
     return std::find_if(mServices.begin(), mServices.end(), [&aName, aType](const Service &service) {
         return strcmp(aName, service.mName) == 0 && IsServiceTypeEqual(aType, service.mType);
     });
 }
 
-PublisherMDnsSd::ServiceIterator PublisherMDnsSd::FindPublishedService(const DNSServiceRef &aServiceRef)
+MDnsSd::ServiceIterator MDnsSd::FindPublishedService(const DNSServiceRef &aServiceRef)
 {
     return std::find_if(mServices.begin(), mServices.end(),
                         [&aServiceRef](const Service &service) { return service.mService == aServiceRef; });
 }
 
-PublisherMDnsSd::HostIterator PublisherMDnsSd::FindPublishedHost(const DNSRecordRef &aRecordRef)
+MDnsSd::HostIterator MDnsSd::FindPublishedHost(const DNSRecordRef &aRecordRef)
 {
     return std::find_if(mHosts.begin(), mHosts.end(),
                         [&aRecordRef](const Host &host) { return host.mRecord == aRecordRef; });
 }
 
-PublisherMDnsSd::HostIterator PublisherMDnsSd::FindPublishedHost(const char *aHostName)
+MDnsSd::HostIterator MDnsSd::FindPublishedHost(const char *aHostName)
 {
     return std::find_if(mHosts.begin(), mHosts.end(),
                         [&aHostName](const Host &host) { return strcmp(host.mName, aHostName) == 0; });
 }
 
-Publisher *Publisher::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
+MDns *MDns::Create(int aFamily, const char *aDomain, StateHandler aHandler, void *aContext)
 {
-    return new PublisherMDnsSd(aFamily, aDomain, aHandler, aContext);
+    return new MDnsSd(aFamily, aDomain, aHandler, aContext);
 }
 
-void Publisher::Destroy(Publisher *aPublisher)
+void MDns::Destroy(MDns *aMDns)
 {
-    delete static_cast<PublisherMDnsSd *>(aPublisher);
+    delete static_cast<MDnsSd *>(aMDns);
 }
 
 } // namespace Mdns

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -50,11 +50,11 @@ namespace Mdns {
  * This class implements MDNS service with avahi.
  *
  */
-class PublisherMDnsSd : public Publisher
+class MDnsSd : public MDns
 {
 public:
     /**
-     * The constructor to initialize a Publisher.
+     * The constructor to initialize a MDns.
      *
      * @param[in]   aProtocol           The protocol used for publishing. IPv4, IPv6 or both.
      * @param[in]   aDomain             The domain of the host. nullptr to use default.
@@ -62,9 +62,9 @@ public:
      * @param[in]   aContext            A pointer to application-specific context.
      *
      */
-    PublisherMDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
+    MDnsSd(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
-    ~PublisherMDnsSd(void) override;
+    ~MDnsSd(void) override;
 
     /**
      * This method publishes or updates a service.

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -44,11 +44,11 @@ using namespace otbr;
 
 static struct Context
 {
-    Mdns::Publisher *mPublisher;
-    bool             mUpdate;
+    Mdns::MDns *mMDns;
+    bool        mUpdate;
 } sContext;
 
-int Mainloop(Mdns::Publisher &aPublisher)
+int Mainloop(Mdns::MDns &aMDns)
 {
     int rval = 0;
 
@@ -64,7 +64,7 @@ int Mainloop(Mdns::Publisher &aPublisher)
         FD_ZERO(&writeFdSet);
         FD_ZERO(&errorFdSet);
 
-        aPublisher.UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
+        aMDns.UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
         rval =
             select(maxFd + 1, &readFdSet, &writeFdSet, &errorFdSet, (timeout.tv_sec == INT_MAX ? nullptr : &timeout));
 
@@ -74,13 +74,13 @@ int Mainloop(Mdns::Publisher &aPublisher)
             break;
         }
 
-        aPublisher.Process(readFdSet, writeFdSet, errorFdSet);
+        aMDns.Process(readFdSet, writeFdSet, errorFdSet);
     }
 
     return rval;
 }
 
-void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State aState)
+void PublishSingleServiceWithCustomHost(void *aContext, Mdns::MDns::State aState)
 {
     uint8_t    xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t    extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
@@ -92,21 +92,21 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
     hostAddr[15] = 0x01;
 
     VerifyOrDie(aContext == &sContext, "unexpected context");
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
-        otbrError                error;
-        Mdns::Publisher::TxtList txtList{
+        otbrError           error;
+        Mdns::MDns::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishHost(hostName, hostAddr, sizeof(hostAddr));
+        error = sContext.mMDns->PublishHost(hostName, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the host");
 
-        error = sContext.mPublisher->PublishService(hostName, 12345, "SingleService", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(hostName, 12345, "SingleService", "_meshcop._udp.", txtList);
         SuccessOrDie(error, "cannot publish the service");
     }
 }
 
-void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::State aState)
+void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::MDns::State aState)
 {
     uint8_t    xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t    extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
@@ -119,103 +119,102 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
     hostAddr[15] = 0x01;
 
     VerifyOrDie(aContext == &sContext, "unexpected context");
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
-        otbrError                error;
-        Mdns::Publisher::TxtList txtList{
+        otbrError           error;
+        Mdns::MDns::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishHost(hostName1, hostAddr, sizeof(hostAddr));
+        error = sContext.mMDns->PublishHost(hostName1, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the first host");
 
-        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService11", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(hostName1, 12345, "MultipleService11", "_meshcop._udp.", txtList);
         SuccessOrDie(error, "cannot publish the first service");
 
-        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService12", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(hostName1, 12345, "MultipleService12", "_meshcop._udp.", txtList);
         SuccessOrDie(error, "cannot publish the second service");
 
-        error = sContext.mPublisher->PublishHost(hostName2, hostAddr, sizeof(hostAddr));
+        error = sContext.mMDns->PublishHost(hostName2, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the second host");
 
-        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService21", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(hostName2, 12345, "MultipleService21", "_meshcop._udp.", txtList);
         SuccessOrDie(error, "cannot publish the first service");
 
-        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService22", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(hostName2, 12345, "MultipleService22", "_meshcop._udp.", txtList);
         SuccessOrDie(error, "cannot publish the second service");
     }
 }
 
-void PublishSingleService(void *aContext, Mdns::Publisher::State aState)
+void PublishSingleService(void *aContext, Mdns::MDns::State aState)
 {
-    uint8_t                  xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t                  extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    Mdns::Publisher::TxtList txtList{
+    uint8_t             xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t             extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    Mdns::MDns::TxtList txtList{
         {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
     assert(aContext == &sContext);
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
-        otbrError error =
-            sContext.mPublisher->PublishService(nullptr, 12345, "SingleService", "_meshcop._udp.", txtList);
+        otbrError error = sContext.mMDns->PublishService(nullptr, 12345, "SingleService", "_meshcop._udp.", txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 }
 
-void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
+void PublishMultipleServices(void *aContext, Mdns::MDns::State aState)
 {
     uint8_t xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
 
     assert(aContext == &sContext);
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
-        otbrError                error;
-        Mdns::Publisher::TxtList txtList{
+        otbrError           error;
+        Mdns::MDns::TxtList txtList{
             {"nn", "cool1"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService1", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(nullptr, 12345, "MultipleService1", "_meshcop._udp.", txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
-        otbrError                error;
-        Mdns::Publisher::TxtList txtList{
+        otbrError           error;
+        Mdns::MDns::TxtList txtList{
             {"nn", "cool2"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService2", "_meshcop._udp.", txtList);
+        error = sContext.mMDns->PublishService(nullptr, 12345, "MultipleService2", "_meshcop._udp.", txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 }
 
-void PublishUpdateServices(void *aContext, Mdns::Publisher::State aState)
+void PublishUpdateServices(void *aContext, Mdns::MDns::State aState)
 {
     uint8_t xpanidOld[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t xpanidNew[kSizeExtPanId] = {0x48, 0x47, 0x46, 0x45, 0x44, 0x43, 0x42, 0x41};
     uint8_t extAddr[kSizeExtAddr]    = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
 
     assert(aContext == &sContext);
-    if (aState == Mdns::Publisher::State::kReady)
+    if (aState == Mdns::MDns::State::kReady)
     {
         otbrError error;
 
         if (!sContext.mUpdate)
         {
-            Mdns::Publisher::TxtList txtList{{"nn", "cool"},
-                                             {"xp", xpanidOld, sizeof(xpanidOld)},
-                                             {"tv", "1.1.1"},
-                                             {"dd", extAddr, sizeof(extAddr)}};
+            Mdns::MDns::TxtList txtList{{"nn", "cool"},
+                                        {"xp", xpanidOld, sizeof(xpanidOld)},
+                                        {"tv", "1.1.1"},
+                                        {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
+            error = sContext.mMDns->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
         }
         else
         {
-            Mdns::Publisher::TxtList txtList{{"nn", "coolcool"},
-                                             {"xp", xpanidNew, sizeof(xpanidNew)},
-                                             {"tv", "1.1.1"},
-                                             {"dd", extAddr, sizeof(extAddr)}};
+            Mdns::MDns::TxtList txtList{{"nn", "coolcool"},
+                                        {"xp", xpanidNew, sizeof(xpanidNew)},
+                                        {"tv", "1.1.1"},
+                                        {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
+            error = sContext.mMDns->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
         }
         assert(error == OTBR_ERROR_NONE);
     }
@@ -225,14 +224,14 @@ otbrError TestSingleServiceWithCustomHost(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleServiceWithCustomHost, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::MDns *pub =
+        Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleServiceWithCustomHost, &sContext);
+    sContext.mMDns = pub;
     SuccessOrExit(error = pub->Start());
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return error;
 }
 
@@ -240,14 +239,14 @@ otbrError TestMultipleServicesWithCustomHost(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServicesWithCustomHost, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::MDns *pub =
+        Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServicesWithCustomHost, &sContext);
+    sContext.mMDns = pub;
     SuccessOrExit(error = pub->Start());
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return error;
 }
 
@@ -255,13 +254,13 @@ otbrError TestSingleService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
-    sContext.mPublisher  = pub;
+    Mdns::MDns *pub = Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
+    sContext.mMDns  = pub;
     SuccessOrExit(ret = pub->Start());
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return ret;
 }
 
@@ -269,14 +268,13 @@ otbrError TestMultipleServices(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServices, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::MDns *pub = Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServices, &sContext);
+    sContext.mMDns  = pub;
     SuccessOrExit(ret = pub->Start());
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return ret;
 }
 
@@ -284,16 +282,16 @@ otbrError TestUpdateService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishUpdateServices, &sContext);
-    sContext.mPublisher  = pub;
-    sContext.mUpdate     = false;
+    Mdns::MDns *pub  = Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishUpdateServices, &sContext);
+    sContext.mMDns   = pub;
+    sContext.mUpdate = false;
     SuccessOrExit(ret = pub->Start());
     sContext.mUpdate = true;
-    PublishUpdateServices(&sContext, Mdns::Publisher::State::kReady);
+    PublishUpdateServices(&sContext, Mdns::MDns::State::kReady);
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return ret;
 }
 
@@ -313,19 +311,19 @@ otbrError TestStopService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
-    sContext.mPublisher  = pub;
+    Mdns::MDns *pub = Mdns::MDns::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
+    sContext.mMDns  = pub;
     SuccessOrExit(ret = pub->Start());
     signal(SIGUSR1, RecoverSignal);
     signal(SIGUSR2, RecoverSignal);
     Mainloop(*pub);
-    sContext.mPublisher->Stop();
+    sContext.mMDns->Stop();
     Mainloop(*pub);
-    SuccessOrExit(ret = sContext.mPublisher->Start());
+    SuccessOrExit(ret = sContext.mMDns->Start());
     Mainloop(*pub);
 
 exit:
-    Mdns::Publisher::Destroy(pub);
+    Mdns::MDns::Destroy(pub);
     return ret;
 }
 


### PR DESCRIPTION
This commit renames `otbr::Mdns::Publisher` to `otbr::Mdns::MDns` because the "Publisher" will also allow subscribing to services, which is beyond the scope of "Publisher".

Related to #706 

Alternative names to consider:
- `otbr::Mdns::Client` - Our mDNS implementations are effectively mDNS clients (to Avahi/mDNSResponder), so I think it's also a good choice.
- `otbr::Mdns::Responder` 