### PR TITLE
[utils] unify mainloop interface

### DIFF
--- a/src/agent/agent_instance.cpp
+++ b/src/agent/agent_instance.cpp
@@ -59,17 +59,16 @@ exit:
     return error;
 }
 
-void AgentInstance::UpdateFdSet(otSysMainloopContext &aMainloop)
+void AgentInstance::Update(MainloopContext &aMainloop)
 {
-    mNcp->UpdateFdSet(aMainloop);
-    mBorderAgent.UpdateFdSet(aMainloop.mReadFdSet, aMainloop.mWriteFdSet, aMainloop.mErrorFdSet, aMainloop.mMaxFd,
-                             aMainloop.mTimeout);
+    mNcp->Update(aMainloop);
+    mBorderAgent.Update(aMainloop);
 }
 
-void AgentInstance::Process(const otSysMainloopContext &aMainloop)
+void AgentInstance::Process(const MainloopContext &aMainloop)
 {
     mNcp->Process(aMainloop);
-    mBorderAgent.Process(aMainloop.mReadFdSet, aMainloop.mWriteFdSet, aMainloop.mErrorFdSet);
+    mBorderAgent.Process(aMainloop);
 }
 
 AgentInstance::~AgentInstance(void)

--- a/src/agent/agent_instance.hpp
+++ b/src/agent/agent_instance.hpp
@@ -44,6 +44,7 @@
 #include "agent/border_agent.hpp"
 #include "agent/instance_params.hpp"
 #include "agent/ncp.hpp"
+#include "common/mainloop.hpp"
 
 namespace otbr {
 
@@ -51,7 +52,7 @@ namespace otbr {
  * This class implements an instance to host services used by border router.
  *
  */
-class AgentInstance
+class AgentInstance : public MainloopProcessor
 {
 public:
     /**
@@ -62,7 +63,7 @@ public:
      */
     AgentInstance(Ncp::Controller *aNcp);
 
-    ~AgentInstance(void);
+    ~AgentInstance(void) override;
 
     /**
      * This method initialize the agent.
@@ -74,20 +75,20 @@ public:
     otbrError Init(void);
 
     /**
-     * This method updates the file descriptor sets and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aMainloop   A reference to OpenThread mainloop context.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(otSysMainloopContext &aMainloop);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs processing.
+     * This method processes mainloop events.
      *
-     * @param[in]       aMainloop   A reference to OpenThread mainloop context.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const otSysMainloopContext &aMainloop);
+    void Process(const MainloopContext &aMainloop) override;
 
     /**
      * This method return mNcp pointer.

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -188,30 +188,26 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
     }
 }
 
-void BorderAgent::UpdateFdSet(fd_set & aReadFdSet,
-                              fd_set & aWriteFdSet,
-                              fd_set & aErrorFdSet,
-                              int &    aMaxFd,
-                              timeval &aTimeout)
+void BorderAgent::Update(MainloopContext &aMainloop)
 {
 #if OTBR_ENABLE_BACKBONE_ROUTER
-    mBackboneAgent.UpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd, aTimeout);
+    mBackboneAgent.Update(aMainloop);
 #endif
 
     if (mPublisher != nullptr)
     {
-        mPublisher->UpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd, aTimeout);
+        mPublisher->Update(aMainloop);
     }
 }
 
-void BorderAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void BorderAgent::Process(const MainloopContext &aMainloop)
 {
 #if OTBR_ENABLE_BACKBONE_ROUTER
-    mBackboneAgent.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
+    mBackboneAgent.Process(aMainloop);
 #endif
     if (mPublisher != nullptr)
     {
-        mPublisher->Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
+        mPublisher->Process(aMainloop);
     }
 }
 

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -39,6 +39,7 @@
 #include "agent/advertising_proxy.hpp"
 #include "agent/instance_params.hpp"
 #include "agent/ncp.hpp"
+#include "common/mainloop.hpp"
 #include "mdns/mdns.hpp"
 
 #if OTBR_ENABLE_BACKBONE_ROUTER
@@ -60,7 +61,7 @@ namespace otbr {
  * This class implements Thread border agent functionality.
  *
  */
-class BorderAgent
+class BorderAgent : public MainloopProcessor
 {
 public:
     /**
@@ -71,7 +72,7 @@ public:
      */
     BorderAgent(Ncp::Controller *aNcp);
 
-    ~BorderAgent(void);
+    ~BorderAgent(void) override;
 
     /**
      * This method initialize border agent service.
@@ -80,26 +81,20 @@ public:
     void Init(void);
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]  aReadFdSet   A reference to read file descriptors.
-     * @param[inout]  aWriteFdSet  A reference to write file descriptors.
-     * @param[inout]  aErrorFdSet  A reference to error file descriptors.
-     * @param[inout]  aMaxFd       A reference to the max file descriptor.
-     * @param[inout]  aTimeout     A reference to timeout.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs border agent processing.
+     * This method processes mainloop events.
      *
-     * @param[in]   aReadFdSet   A reference to read file descriptors.
-     * @param[in]   aWriteFdSet  A reference to write file descriptors.
-     * @param[in]   aErrorFdSet  A reference to error file descriptors.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     /**

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -50,6 +50,7 @@
 #include "agent/ncp_openthread.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 #if OTBR_ENABLE_REST_SERVER
 #include "rest/rest_web_server.hpp"
@@ -130,8 +131,8 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
 
     while (!sShouldTerminate)
     {
-        otSysMainloopContext mainloop;
-        int                  rval;
+        otbr::MainloopContext mainloop;
+        int                   rval;
 
         mainloop.mMaxFd   = -1;
         mainloop.mTimeout = kPollTimeout;
@@ -140,15 +141,14 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
         FD_ZERO(&mainloop.mWriteFdSet);
         FD_ZERO(&mainloop.mErrorFdSet);
 
-        aInstance.UpdateFdSet(mainloop);
+        aInstance.Update(mainloop);
 
 #if OTBR_ENABLE_DBUS_SERVER
-        dbusAgent->UpdateFdSet(mainloop.mReadFdSet, mainloop.mWriteFdSet, mainloop.mErrorFdSet, mainloop.mMaxFd,
-                               mainloop.mTimeout);
+        dbusAgent->Update(mainloop);
 #endif
 
 #if OTBR_ENABLE_REST_SERVER
-        restServer->UpdateFdSet(mainloop);
+        restServer->Update(mainloop);
 #endif
 
 #if OTBR_ENABLE_OPENWRT
@@ -173,7 +173,7 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
             aInstance.Process(mainloop);
 
 #if OTBR_ENABLE_DBUS_SERVER
-            dbusAgent->Process(mainloop.mReadFdSet, mainloop.mWriteFdSet, mainloop.mErrorFdSet);
+            dbusAgent->Process(mainloop);
 #endif
         }
         else if (errno != EINTR)

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -39,7 +39,7 @@
 #include <netinet/in.h>
 #include <stddef.h>
 
-#include "common/mainloop.h"
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 #include "utils/event_emitter.hpp"
 
@@ -80,7 +80,7 @@ using PowerMap = std::map<std::string, std::vector<int8_t>>;
  * This interface defines NCP Controller functionality.
  *
  */
-class Controller : public EventEmitter
+class Controller : public EventEmitter, public MainloopProcessor
 {
 public:
     /**
@@ -91,22 +91,6 @@ public:
      *
      */
     virtual otbrError Init(void) = 0;
-
-    /**
-     * This method updates the fd_set to poll.
-     *
-     * @param[inout]    aMainloop   A reference to OpenThread mainloop context.
-     *
-     */
-    virtual void UpdateFdSet(otSysMainloopContext &aMainloop) = 0;
-
-    /**
-     * This method performs the Thread processing.
-     *
-     * @param[in]       aMainloop   A reference to OpenThread mainloop context.
-     *
-     */
-    virtual void Process(const otSysMainloopContext &aMainloop) = 0;
 
     /**
      * This method request the event.
@@ -139,7 +123,7 @@ public:
      */
     static void Destroy(Controller *aController) { delete aController; }
 
-    virtual ~Controller(void) {}
+    virtual ~Controller(void) = default;
 };
 
 } // namespace Ncp

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -201,7 +201,7 @@ static struct timeval ToTimeVal(const microseconds &aTime)
     return val;
 };
 
-void ControllerOpenThread::UpdateFdSet(otSysMainloopContext &aMainloop)
+void ControllerOpenThread::Update(MainloopContext &aMainloop)
 {
     microseconds timeout = microseconds(aMainloop.mTimeout.tv_usec) + seconds(aMainloop.mTimeout.tv_sec);
     auto         now     = steady_clock::now();
@@ -227,7 +227,7 @@ void ControllerOpenThread::UpdateFdSet(otSysMainloopContext &aMainloop)
     otSysMainloopUpdate(mInstance, &aMainloop);
 }
 
-void ControllerOpenThread::Process(const otSysMainloopContext &aMainloop)
+void ControllerOpenThread::Process(const MainloopContext &aMainloop)
 {
     auto now = steady_clock::now();
 

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -90,20 +90,20 @@ public:
     otbr::agent::ThreadHelper *GetThreadHelper(void) { return mThreadHelper.get(); }
 
     /**
-     * This method updates the fd_set to poll.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aMainloop   A reference to OpenThread mainloop context.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(otSysMainloopContext &aMainloop) override;
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs the Thread processing.
+     * This method processes mainloop events.
      *
-     * @param[in]       aMainloop   A reference to OpenThread mainloop context.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const otSysMainloopContext &aMainloop) override;
+    void Process(const MainloopContext &aMainloop) override;
 
     /**
      * This method request the event.

--- a/src/backbone_router/backbone_agent.cpp
+++ b/src/backbone_router/backbone_agent.cpp
@@ -140,31 +140,21 @@ const char *BackboneAgent::StateToString(otBackboneRouterState aState)
 
     return ret;
 }
-void BackboneAgent::UpdateFdSet(fd_set & aReadFdSet,
-                                fd_set & aWriteFdSet,
-                                fd_set & aErrorFdSet,
-                                int &    aMaxFd,
-                                timeval &aTimeout) const
+void BackboneAgent::Update(MainloopContext &aMainloop)
 {
-    OTBR_UNUSED_VARIABLE(aReadFdSet);
-    OTBR_UNUSED_VARIABLE(aWriteFdSet);
-    OTBR_UNUSED_VARIABLE(aErrorFdSet);
-    OTBR_UNUSED_VARIABLE(aMaxFd);
-    OTBR_UNUSED_VARIABLE(aTimeout);
+    OTBR_UNUSED_VARIABLE(aMainloop);
 
 #if OTBR_ENABLE_DUA_ROUTING
-    mNdProxyManager.UpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd, aTimeout);
+    mNdProxyManager.Update(aMainloop);
 #endif
 }
 
-void BackboneAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void BackboneAgent::Process(const MainloopContext &aMainloop)
 {
-    OTBR_UNUSED_VARIABLE(aReadFdSet);
-    OTBR_UNUSED_VARIABLE(aWriteFdSet);
-    OTBR_UNUSED_VARIABLE(aErrorFdSet);
+    OTBR_UNUSED_VARIABLE(aMainloop);
 
 #if OTBR_ENABLE_DUA_ROUTING
-    mNdProxyManager.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
+    mNdProxyManager.Process(aMainloop);
 #endif
 }
 

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -39,6 +39,7 @@
 #include "agent/instance_params.hpp"
 #include "agent/ncp_openthread.hpp"
 #include "backbone_router/nd_proxy.hpp"
+#include "common/mainloop.hpp"
 
 namespace otbr {
 namespace BackboneRouter {
@@ -56,7 +57,7 @@ namespace BackboneRouter {
  * This class implements Thread Backbone agent functionality.
  *
  */
-class BackboneAgent
+class BackboneAgent : public MainloopProcessor
 {
 public:
     /**
@@ -74,30 +75,20 @@ public:
     void Init(void);
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling read.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the current max fd in @p aReadFdSet and @p aWriteFdSet.
-     * @param[inout]    aTimeout        A reference to the timeout.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(fd_set & aReadFdSet,
-                     fd_set & aWriteFdSet,
-                     fd_set & aErrorFdSet,
-                     int &    aMaxFd,
-                     timeval &aTimeout) const;
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs border agent processing.
+     * This method processes mainloop events.
      *
-     * @param[in]   aReadFdSet   A reference to read file descriptors.
-     * @param[in]   aWriteFdSet  A reference to write file descriptors.
-     * @param[in]   aErrorFdSet  A reference to error file descriptors.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     void        OnBecomePrimary(void);

--- a/src/backbone_router/nd_proxy.cpp
+++ b/src/backbone_router/nd_proxy.cpp
@@ -116,42 +116,31 @@ void NdProxyManager::Init(void)
     VerifyOrDie(mBackboneIfIndex > 0, "if_nametoindex failed");
 }
 
-void NdProxyManager::UpdateFdSet(fd_set & aReadFdSet,
-                                 fd_set & aWriteFdSet,
-                                 fd_set & aErrorFdSet,
-                                 int &    aMaxFd,
-                                 timeval &aTimeout) const
+void NdProxyManager::Update(MainloopContext &aMainloop)
 {
-    OTBR_UNUSED_VARIABLE(aWriteFdSet);
-    OTBR_UNUSED_VARIABLE(aErrorFdSet);
-    OTBR_UNUSED_VARIABLE(aTimeout);
-
     if (mIcmp6RawSock >= 0)
     {
-        FD_SET(mIcmp6RawSock, &aReadFdSet);
-        aMaxFd = std::max(aMaxFd, mIcmp6RawSock);
+        FD_SET(mIcmp6RawSock, &aMainloop.mReadFdSet);
+        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mIcmp6RawSock);
     }
 
     if (mUnicastNsQueueSock >= 0)
     {
-        FD_SET(mUnicastNsQueueSock, &aReadFdSet);
-        aMaxFd = std::max(aMaxFd, mUnicastNsQueueSock);
+        FD_SET(mUnicastNsQueueSock, &aMainloop.mReadFdSet);
+        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mUnicastNsQueueSock);
     }
 }
 
-void NdProxyManager::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void NdProxyManager::Process(const MainloopContext &aMainloop)
 {
-    OTBR_UNUSED_VARIABLE(aWriteFdSet);
-    OTBR_UNUSED_VARIABLE(aErrorFdSet);
-
     VerifyOrExit(IsEnabled());
 
-    if (FD_ISSET(mIcmp6RawSock, &aReadFdSet))
+    if (FD_ISSET(mIcmp6RawSock, &aMainloop.mReadFdSet))
     {
         ProcessMulticastNeighborSolicition();
     }
 
-    if (FD_ISSET(mUnicastNsQueueSock, &aReadFdSet))
+    if (FD_ISSET(mUnicastNsQueueSock, &aMainloop.mReadFdSet))
     {
         ProcessUnicastNeighborSolicition();
     }

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -50,6 +50,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "agent/ncp_openthread.hpp"
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
@@ -68,7 +69,7 @@ namespace BackboneRouter {
  * This class implements ND Proxy manager.
  *
  */
-class NdProxyManager
+class NdProxyManager : public MainloopProcessor
 {
 public:
     /**
@@ -105,30 +106,20 @@ public:
     void Disable(void);
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling read.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the current max fd in @p aReadFdSet and @p aWriteFdSet.
-     * @param[inout]    aTimeout        A reference to the timeout.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(fd_set & aReadFdSet,
-                     fd_set & aWriteFdSet,
-                     fd_set & aErrorFdSet,
-                     int &    aMaxFd,
-                     timeval &aTimeout) const;
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs border agent processing.
+     * This method processes mainloop events.
      *
-     * @param[in]   aReadFdSet   A reference to read file descriptors.
-     * @param[in]   aWriteFdSet  A reference to write file descriptors.
-     * @param[in]   aErrorFdSet  A reference to error file descriptors.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const MainloopContext &aMainloop) override;
 
     /**
      * This method handles a Backbone Router ND Proxy event.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(otbr-common
     code_utils.hpp
     logging.cpp
     logging.hpp
-    mainloop.h
+    mainloop.hpp
     task_runner.cpp
     task_runner.hpp
     time.hpp

--- a/src/common/mainloop.hpp
+++ b/src/common/mainloop.hpp
@@ -34,32 +34,46 @@
 #ifndef OTBR_COMMON_OTBR_MAINLOOP_HPP_
 #define OTBR_COMMON_OTBR_MAINLOOP_HPP_
 
-#include "openthread-br/config.h"
+#include <openthread-br/config.h>
 
 #include <openthread/openthread-system.h>
 
-#else
-#include <sys/select.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace otbr {
 
 /**
- * This structure represents a context for a select() based mainloop.
+ * This type defines the mainloop context that contains context data
+ * for running a mainloop.
  *
  */
-typedef struct otSysMainloopContext
-{
-    fd_set         mReadFdSet;  ///< The read file descriptors.
-    fd_set         mWriteFdSet; ///< The write file descriptors.
-    fd_set         mErrorFdSet; ///< The error file descriptors.
-    int            mMaxFd;      ///< The max file descriptor.
-    struct timeval mTimeout;    ///< The timeout.
-} otSysMainloopContext;
+using MainloopContext = otSysMainloopContext;
 
-#ifdef __cplusplus
-} // end of extern "C"
-#endif
+/**
+ * This abstract class defines the interface of a mainloop processor
+ * which add fds to the mainloop context and handle fd events.
+ *
+ */
+class MainloopProcessor
+{
+public:
+    virtual ~MainloopProcessor(void) = default;
+
+    /**
+     * This method updates the mainloop context.
+     *
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
+     *
+     */
+    virtual void Update(MainloopContext &aMainloop) = 0;
+
+    /**
+     * This method processes mainloop events.
+     *
+     * @param[in]  aMainloop  A reference to the mainloop context.
+     *
+     */
+    virtual void Process(const MainloopContext &aMainloop) = 0;
+};
+
+} // namespace otbr
 
 #endif // OTBR_COMMON_OTBR_MAINLOOP_HPP_

--- a/src/common/task_runner.cpp
+++ b/src/common/task_runner.cpp
@@ -74,13 +74,13 @@ void TaskRunner::Post(const Task<void> &aTask)
     PushTask(aTask);
 }
 
-void TaskRunner::UpdateFdSet(otSysMainloopContext &aMainloop)
+void TaskRunner::Update(MainloopContext &aMainloop)
 {
     FD_SET(mEventFd[kRead], &aMainloop.mReadFdSet);
     aMainloop.mMaxFd = std::max(mEventFd[kRead], aMainloop.mMaxFd);
 }
 
-void TaskRunner::Process(const otSysMainloopContext &aMainloop)
+void TaskRunner::Process(const MainloopContext &aMainloop)
 {
     if (FD_ISSET(mEventFd[kRead], &aMainloop.mReadFdSet))
     {

--- a/src/common/task_runner.hpp
+++ b/src/common/task_runner.hpp
@@ -41,7 +41,7 @@
 #include <mutex>
 #include <queue>
 
-#include "common/mainloop.h"
+#include "common/mainloop.hpp"
 
 namespace otbr {
 
@@ -50,7 +50,7 @@ namespace otbr {
  * tasks on the mainloop.
  *
  */
-class TaskRunner
+class TaskRunner : public MainloopProcessor
 {
 public:
     /**
@@ -69,7 +69,7 @@ public:
      * This destructor destroys the Task Runner instance.
      *
      */
-    ~TaskRunner(void);
+    ~TaskRunner(void) override;
 
     /**
      * This method posts a task to the task runner.
@@ -102,24 +102,20 @@ public:
     }
 
     /**
-     * This method updates the file descriptor and sets timeout for the mainloop.
+     * This method updates the mainloop context.
      *
-     * This method should only be called on the mainloop thread.
-     *
-     * @param[inout]  aMainloop  A reference to OpenThread mainloop context.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(otSysMainloopContext &aMainloop);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method processes events.
+     * This method processes mainloop events.
      *
-     * This method should only be called on the mainloop thread.
-     *
-     * @param[in]  aMainloop  A reference to OpenThread mainloop context.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const otSysMainloopContext &aMainloop);
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     enum

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -84,18 +84,14 @@ void DBusAgent::RemoveDBusWatch(struct DBusWatch *aWatch, void *aContext)
     static_cast<DBusAgent *>(aContext)->mWatches.erase(aWatch);
 }
 
-void DBusAgent::UpdateFdSet(fd_set &        aReadFdSet,
-                            fd_set &        aWriteFdSet,
-                            fd_set &        aErrorFdSet,
-                            int &           aMaxFd,
-                            struct timeval &aTimeOut)
+void DBusAgent::Update(MainloopContext &aMainloop)
 {
     unsigned int flags;
     int          fd;
 
     if (dbus_connection_get_dispatch_status(mConnection.get()) == DBUS_DISPATCH_DATA_REMAINS)
     {
-        aTimeOut = {0, 0};
+        aMainloop.mTimeout = {0, 0};
     }
 
     for (const auto &watch : mWatches)
@@ -115,24 +111,21 @@ void DBusAgent::UpdateFdSet(fd_set &        aReadFdSet,
 
         if (flags & DBUS_WATCH_READABLE)
         {
-            FD_SET(fd, &aReadFdSet);
+            FD_SET(fd, &aMainloop.mReadFdSet);
         }
 
         if ((flags & DBUS_WATCH_WRITABLE))
         {
-            FD_SET(fd, &aWriteFdSet);
+            FD_SET(fd, &aMainloop.mWriteFdSet);
         }
 
-        FD_SET(fd, &aErrorFdSet);
+        FD_SET(fd, &aMainloop.mErrorFdSet);
 
-        if (fd > aMaxFd)
-        {
-            aMaxFd = fd;
-        }
+        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, fd);
     }
 }
 
-void DBusAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+void DBusAgent::Process(const MainloopContext &aMainloop)
 {
     unsigned int flags;
     int          fd;
@@ -152,17 +145,17 @@ void DBusAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, con
             continue;
         }
 
-        if ((flags & DBUS_WATCH_READABLE) && !FD_ISSET(fd, &aReadFdSet))
+        if ((flags & DBUS_WATCH_READABLE) && !FD_ISSET(fd, &aMainloop.mReadFdSet))
         {
             flags &= static_cast<unsigned int>(~DBUS_WATCH_READABLE);
         }
 
-        if ((flags & DBUS_WATCH_WRITABLE) && !FD_ISSET(fd, &aWriteFdSet))
+        if ((flags & DBUS_WATCH_WRITABLE) && !FD_ISSET(fd, &aMainloop.mWriteFdSet))
         {
             flags &= static_cast<unsigned int>(~DBUS_WATCH_WRITABLE);
         }
 
-        if (FD_ISSET(fd, &aErrorFdSet))
+        if (FD_ISSET(fd, &aMainloop.mErrorFdSet))
         {
             flags |= DBUS_WATCH_ERROR;
         }

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <sys/select.h>
 
+#include "common/mainloop.hpp"
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
 #include "dbus/server/dbus_object.hpp"
@@ -49,7 +50,7 @@
 namespace otbr {
 namespace DBus {
 
-class DBusAgent
+class DBusAgent : public MainloopProcessor
 {
 public:
     /**
@@ -70,30 +71,20 @@ public:
     otbrError Init(void);
 
     /**
-     * This method performs the dbus select update.
+     * This method updates the mainloop context.
      *
-     * @param[out]      aReadFdSet   The read file descriptors.
-     * @param[out]      aWriteFdSet  The write file descriptors.
-     * @param[out]      aErorFdSet   The error file descriptors.
-     * @param[inout]    aMaxFd       The max file descriptor.
-     * @param[inout]    aTimeOut     The select timeout.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(fd_set &        aReadFdSet,
-                     fd_set &        aWriteFdSet,
-                     fd_set &        aErrorFdSet,
-                     int &           aMaxFd,
-                     struct timeval &aTimeOut);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method processes the dbus I/O.
+     * This method processes mainloop events.
      *
-     * @param[in]       aReadFdSet   The read file descriptors.
-     * @param[in]       aWriteFdSet  The write file descriptors.
-     * @param[in]       aErorFdSet   The error file descriptors.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     static dbus_bool_t AddDBusWatch(struct DBusWatch *aWatch, void *aContext);

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -38,6 +38,7 @@
 
 #include <sys/select.h>
 
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
@@ -57,7 +58,7 @@ namespace Mdns {
  * This interface defines the functionality of MDNS service.
  *
  */
-class Publisher
+class Publisher : public MainloopProcessor
 {
 public:
     /**
@@ -244,34 +245,7 @@ public:
      */
     virtual otbrError UnpublishHost(const char *aName) = 0;
 
-    /**
-     * This method performs the MDNS processing.
-     *
-     * @param[in]   aReadFdSet          A reference to fd_set ready for reading.
-     * @param[in]   aWriteFdSet         A reference to fd_set ready for writing.
-     * @param[in]   aErrorFdSet         A reference to fd_set with error occurred.
-     *
-     */
-    virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) = 0;
-
-    /**
-     * This method updates the fd_set and timeout for mainloop.
-     *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling read.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the current max fd in @p aReadFdSet and @p aWriteFdSet.
-     * @param[inout]    aTimeout        A reference to the timeout. Update this value if the MDNS service has
-     *                                  pending process in less than its current value.
-     *
-     */
-    virtual void UpdateFdSet(fd_set & aReadFdSet,
-                             fd_set & aWriteFdSet,
-                             fd_set & aErrorFdSet,
-                             int &    aMaxFd,
-                             timeval &aTimeout) = 0;
-
-    virtual ~Publisher(void) {}
+    virtual ~Publisher(void) = default;
 
     /**
      * This function creates a MDNS publisher.

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -42,6 +42,7 @@
 #include <avahi-common/watch.h>
 
 #include "mdns.hpp"
+#include "common/mainloop.hpp"
 
 /**
  * @addtogroup border-router-mdns
@@ -116,7 +117,7 @@ namespace Mdns {
  * This class implements the AvahiPoll.
  *
  */
-class Poller
+class Poller : public MainloopProcessor
 {
 public:
     /**
@@ -126,26 +127,20 @@ public:
     Poller(void);
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling write.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the max file descriptor.
-     * @param[inout]    aTimeout        A reference to the timeout.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs avahi poll processing.
+     * This method processes mainloop events.
      *
-     * @param[in]   aReadFdSet   A reference to read file descriptors.
-     * @param[in]   aWriteFdSet  A reference to write file descriptors.
-     * @param[in]   aErrorFdSet  A reference to error file descriptors.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+    void Process(const MainloopContext &aMainloop) override;
 
     /**
      * This method returns the AvahiPoll.
@@ -291,30 +286,20 @@ public:
     void Stop(void) override;
 
     /**
-     * This method performs avahi poll processing.
+     * This method updates the mainloop context.
      *
-     * @param[in]   aReadFdSet          A reference to read file descriptors.
-     * @param[in]   aWriteFdSet         A reference to write file descriptors.
-     * @param[in]   aErrorFdSet         A reference to error file descriptors.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) override;
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method processes mainloop events.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling write.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the max file descriptor.
-     * @param[inout]    aTimeout        A reference to the timeout.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void UpdateFdSet(fd_set & aReadFdSet,
-                     fd_set & aWriteFdSet,
-                     fd_set & aErrorFdSet,
-                     int &    aMaxFd,
-                     timeval &aTimeout) override;
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     enum

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -154,30 +154,20 @@ public:
     void Stop(void) override;
 
     /**
-     * This method performs avahi poll processing.
+     * This method updates the mainloop context.
      *
-     * @param[in]   aReadFdSet          A reference to read file descriptors.
-     * @param[in]   aWriteFdSet         A reference to write file descriptors.
-     * @param[in]   aErrorFdSet         A reference to error file descriptors.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) override;
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method updates the fd_set and timeout for mainloop.
+     * This method processes mainloop events.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aWriteFdSet     A reference to fd_set for polling write.
-     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
-     * @param[inout]    aMaxFd          A reference to the max file descriptor.
-     * @param[inout]    aTimeout        A reference to the timeout.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void UpdateFdSet(fd_set & aReadFdSet,
-                     fd_set & aWriteFdSet,
-                     fd_set & aErrorFdSet,
-                     int &    aMaxFd,
-                     timeval &aTimeout) override;
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     enum

--- a/src/rest/connection.cpp
+++ b/src/rest/connection.cpp
@@ -126,7 +126,7 @@ void Connection::UpdateTimeout(timeval &aTimeout) const
     }
 }
 
-void Connection::UpdateFdSet(otSysMainloopContext &aMainloop) const
+void Connection::Update(MainloopContext &aMainloop)
 {
     UpdateTimeout(aMainloop.mTimeout);
     UpdateReadFdSet(aMainloop.mReadFdSet, aMainloop.mMaxFd);
@@ -144,7 +144,7 @@ void Connection::Disconnect(void)
     }
 }
 
-void Connection::Process(fd_set &aReadFdSet, fd_set &aWriteFdSet)
+void Connection::Process(const MainloopContext &aMainloop)
 {
     otbrError error = OTBR_ERROR_NONE;
 
@@ -153,14 +153,14 @@ void Connection::Process(fd_set &aReadFdSet, fd_set &aWriteFdSet)
     // Initial state, directly read for the first time.
     case ConnectionState::kInit:
     case ConnectionState::kReadWait:
-        ProcessWaitRead(aReadFdSet);
+        ProcessWaitRead(aMainloop.mReadFdSet);
         break;
     case ConnectionState::kCallbackWait:
         //  Wait for Callback process.
         ProcessWaitCallback();
         break;
     case ConnectionState::kWriteWait:
-        ProcessWaitWrite(aWriteFdSet);
+        ProcessWaitWrite(aMainloop.mWriteFdSet);
         break;
     default:
         assert(false);
@@ -172,7 +172,7 @@ void Connection::Process(fd_set &aReadFdSet, fd_set &aWriteFdSet)
     }
 }
 
-void Connection::ProcessWaitRead(fd_set &aReadFdSet)
+void Connection::ProcessWaitRead(const fd_set &aReadFdSet)
 {
     otbrError error    = OTBR_ERROR_NONE;
     int32_t   received = 0, err;
@@ -275,7 +275,7 @@ void Connection::ProcessWaitCallback(void)
     }
 }
 
-void Connection::ProcessWaitWrite(fd_set &aWriteFdSet)
+void Connection::ProcessWaitWrite(const fd_set &aWriteFdSet)
 {
     auto duration = duration_cast<microseconds>(steady_clock::now() - mTimeStamp).count();
 

--- a/src/rest/connection.hpp
+++ b/src/rest/connection.hpp
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "common/mainloop.hpp"
 #include "rest/parser.hpp"
 #include "rest/resource.hpp"
 
@@ -49,7 +50,7 @@ namespace rest {
  * This class implements a Connection class of each socket connection.
  *
  */
-class Connection
+class Connection : public MainloopProcessor
 {
 public:
     /**
@@ -71,21 +72,20 @@ public:
     void Init(void);
 
     /**
-     * This method performs processing.
+     * This method updates the mainloop context.
      *
-     * @param[in]       aReadFdSet    The read file descriptors.
-     * @param[in]       aWriteFdSet   The write file descriptors.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void Process(fd_set &aReadFdSet, fd_set &aWriteFdSet);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method updates the file descriptor sets and timeout for mainloop.
+     * This method processes mainloop events.
      *
-     * @param[inout]    aMainloop   A reference to OpenThread mainloop context.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    void UpdateFdSet(otSysMainloopContext &aMainloop) const;
+    void Process(const MainloopContext &aMainloop) override;
 
     /**
      * This method indicates whether this connection no longer need to be processed.
@@ -100,9 +100,9 @@ private:
     void UpdateReadFdSet(fd_set &aReadFdSet, int &aMaxFd) const;
     void UpdateWriteFdSet(fd_set &aWriteFdSet, int &aMaxFd) const;
     void UpdateTimeout(timeval &aTimeout) const;
-    void ProcessWaitRead(fd_set &aReadFdSet);
+    void ProcessWaitRead(const fd_set &aReadFdSet);
     void ProcessWaitCallback(void);
-    void ProcessWaitWrite(fd_set &aWriteFdSet);
+    void ProcessWaitWrite(const fd_set &aWriteFdSet);
     void Write(void);
     void Handle(void);
     void Disconnect(void);

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -34,6 +34,7 @@
 #ifndef OTBR_REST_REST_WEB_SERVER_HPP_
 #define OTBR_REST_REST_WEB_SERVER_HPP_
 
+#include "common/mainloop.hpp"
 #include "rest/connection.hpp"
 
 using otbr::Ncp::ControllerOpenThread;
@@ -46,7 +47,7 @@ namespace rest {
  * This class implements a REST server.
  *
  */
-class RestWebServer
+class RestWebServer : public MainloopProcessor
 {
 public:
     /**
@@ -66,24 +67,24 @@ public:
     void Init(void);
 
     /**
-     * This method updates the file descriptor sets and timeout for mainloop.
+     * This method updates the mainloop context.
      *
-     * @param[inout]    aMainloop   A reference to OpenThread mainloop context.
+     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
      *
      */
-    void UpdateFdSet(otSysMainloopContext &aMainloop);
+    void Update(MainloopContext &aMainloop) override;
 
     /**
-     * This method performs processing.
+     * This method processes mainloop events.
      *
-     * @param[in]       aMainloop   A reference to OpenThread mainloop context.
+     * @param[in]  aMainloop  A reference to the mainloop context.
      *
      */
-    otbrError Process(otSysMainloopContext &aMainloop);
+    void Process(const MainloopContext &aMainloop) override;
 
 private:
     RestWebServer(ControllerOpenThread *aNcp);
-    otbrError UpdateConnections(fd_set &aReadFdSet);
+    void      UpdateConnections(const fd_set &aReadFdSet);
     void      CreateNewConnection(int32_t &aFd);
     otbrError Accept(int32_t aListenFd);
     void      InitializeListenFd(void);

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -54,19 +54,17 @@ int Mainloop(Mdns::Publisher &aPublisher)
 
     while (true)
     {
-        fd_set         readFdSet;
-        fd_set         writeFdSet;
-        fd_set         errorFdSet;
-        int            maxFd   = -1;
-        struct timeval timeout = {INT_MAX, INT_MAX};
+        MainloopContext mainloop;
 
-        FD_ZERO(&readFdSet);
-        FD_ZERO(&writeFdSet);
-        FD_ZERO(&errorFdSet);
+        mainloop.mMaxFd   = -1;
+        mainloop.mTimeout = {INT_MAX, INT_MAX};
+        FD_ZERO(&mainloop.mReadFdSet);
+        FD_ZERO(&mainloop.mWriteFdSet);
+        FD_ZERO(&mainloop.mErrorFdSet);
 
-        aPublisher.UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
-        rval =
-            select(maxFd + 1, &readFdSet, &writeFdSet, &errorFdSet, (timeout.tv_sec == INT_MAX ? nullptr : &timeout));
+        aPublisher.Update(mainloop);
+        rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
+                      (mainloop.mTimeout.tv_sec == INT_MAX ? nullptr : &mainloop.mTimeout));
 
         if (rval < 0)
         {
@@ -74,7 +72,7 @@ int Mainloop(Mdns::Publisher &aPublisher)
             break;
         }
 
-        aPublisher.Process(readFdSet, writeFdSet, errorFdSet);
+        aPublisher.Process(mainloop);
     }
 
     return rval;

--- a/tests/unit/test_task_runner.cpp
+++ b/tests/unit/test_task_runner.cpp
@@ -38,10 +38,10 @@ TEST_GROUP(TaskRunner){};
 
 TEST(TaskRunner, TestSingleThread)
 {
-    int                  rval;
-    int                  counter = 0;
-    otSysMainloopContext mainloop;
-    otbr::TaskRunner     taskRunner;
+    int                   rval;
+    int                   counter = 0;
+    otbr::MainloopContext mainloop;
+    otbr::TaskRunner      taskRunner;
 
     mainloop.mMaxFd   = -1;
     mainloop.mTimeout = {10, 0};
@@ -59,7 +59,7 @@ TEST(TaskRunner, TestSingleThread)
         });
     });
 
-    taskRunner.UpdateFdSet(mainloop);
+    taskRunner.Update(mainloop);
     rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
                   &mainloop.mTimeout);
     CHECK_EQUAL(1, rval);
@@ -82,8 +82,8 @@ TEST(TaskRunner, TestMultipleThreads)
 
     while (counter.load() < 10)
     {
-        int                  rval;
-        otSysMainloopContext mainloop;
+        int                   rval;
+        otbr::MainloopContext mainloop;
 
         mainloop.mMaxFd   = -1;
         mainloop.mTimeout = {10, 0};
@@ -92,7 +92,7 @@ TEST(TaskRunner, TestMultipleThreads)
         FD_ZERO(&mainloop.mWriteFdSet);
         FD_ZERO(&mainloop.mErrorFdSet);
 
-        taskRunner.UpdateFdSet(mainloop);
+        taskRunner.Update(mainloop);
         rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
                       &mainloop.mTimeout);
         CHECK_EQUAL(1, rval);
@@ -123,8 +123,8 @@ TEST(TaskRunner, TestPostAndWait)
 
     while (counter.load() < 10)
     {
-        int                  rval;
-        otSysMainloopContext mainloop;
+        int                   rval;
+        otbr::MainloopContext mainloop;
 
         mainloop.mMaxFd   = -1;
         mainloop.mTimeout = {10, 0};
@@ -133,7 +133,7 @@ TEST(TaskRunner, TestPostAndWait)
         FD_ZERO(&mainloop.mWriteFdSet);
         FD_ZERO(&mainloop.mErrorFdSet);
 
-        taskRunner.UpdateFdSet(mainloop);
+        taskRunner.Update(mainloop);
         rval = select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet,
                       &mainloop.mTimeout);
         CHECK_EQUAL(1, rval);


### PR DESCRIPTION
This PR unifies that mainloop interface to always use the `MainloopContext` structure rather than fd sets. We also define a `MainloopProcessor` interface to ensure that each module defines exactly the same mainloop processing methods.