### PR TITLE
[bbr] update Backbone Router configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,9 +105,6 @@ if (OTBR_BACKBONE_ROUTER)
     target_compile_definitions(otbr-config INTERFACE
             OTBR_ENABLE_BACKBONE_ROUTER=1
     )
-    set(OT_THREAD_VERSION 1.2 CACHE STRING "Backbone Router requires Thread 1.2 or higher" FORCE)
-    set(OT_BACKBONE_ROUTER ON CACHE BOOL "Enable Backbone Router feature in OpenThread" FORCE)
-    set(OT_SERVICE ON CACHE BOOL "Backbone Router requires Thread network service" FORCE)
 endif()
 
 if (OTBR_DUA_ROUTING)

--- a/src/backbone_router/backbone_agent.cpp
+++ b/src/backbone_router/backbone_agent.cpp
@@ -62,7 +62,7 @@ void BackboneAgent::Init(void)
     mNdProxyManager.Init();
 #endif
 
-    HandleBackboneRouterState();
+    otBackboneRouterSetEnabled(mNcp.GetInstance(), /* aEnabled */ true);
 }
 
 void BackboneAgent::HandleBackboneRouterState(void *aContext, int aEvent, va_list aArguments)

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -60,6 +60,16 @@ if (OTBR_SRP_ADVERTISING_PROXY)
     set(OT_EXTERNAL_HEAP ON CACHE BOOL "enable external heap" FORCE)
 endif()
 
+if (OTBR_BACKBONE_ROUTER)
+    set(OT_THREAD_VERSION 1.2 CACHE STRING "Backbone Router requires Thread 1.2 or higher" FORCE)
+    set(OT_BACKBONE_ROUTER ON CACHE BOOL "Enable Backbone Router feature in OpenThread" FORCE)
+    set(OT_SERVICE ON CACHE BOOL "Backbone Router requires Thread network service" FORCE)
+endif()
+
+if (OT_THREAD_VERSION STREQUAL "1.2")
+    set(OT_MLR ON CACHE BOOL "Enable Thread 1.2 MLR by default")
+endif()
+
 list(APPEND OT_PLATFORM_DEFINES "-DOPENTHREAD_CONFIG_POSIX_SETTINGS_PATH=\"/var/lib/thread\"")
 
 add_subdirectory(repo EXCLUDE_FROM_ALL)
@@ -68,4 +78,5 @@ target_compile_definitions(ot-config INTERFACE
     "-DOPENTHREAD_CONFIG_LOG_CLI=1"
     "-DOPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS=3"
     "-DOPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE=1"
+    "-DOPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE=$<BOOL:${OTBR_DUA_ROUTING}>"
 )


### PR DESCRIPTION
This commit introduces several `Backbone Router` configuration changes:
- Enable `Backbone Router` service by default. (Users can still turn off `Backbone Router` using `ot-ctl bbr disable`.)
- Disalbe `DUA TMF PROXY` when `DUA ROUTING` is disabled.
- Set `OT_MLR=ON` for `BACKBONE_ROUTER` setup option