### PR TITLE
[github-action] downgrade rpi image to 2020-12-02-raspios-buster

### DIFF
--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -43,7 +43,7 @@ jobs:
   raspbian-check:
     runs-on: ubuntu-20.04
     env:
-      IMAGE_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip
+      IMAGE_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2020-12-04/2020-12-02-raspios-buster-armhf-lite.zip
       BUILD_TARGET: raspbian-gcc
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
testing