### PR TITLE
[tests] pin cmake to version 3.10.3

### DIFF
--- a/tests/scripts/check-raspbian
+++ b/tests/scripts/check-raspbian
@@ -56,8 +56,16 @@ chown -R pi:pi /home/pi/repo
 cd /home/pi/repo
 echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 apt-get update
-apt-get install -y --no-install-recommends git
+apt-get install -y --no-install-recommends git python3-pip
 su -m -c 'script/bootstrap' pi
+
+# Pin CMake version to 3.10.3 for issue https://github.com/openthread/ot-br-posix/issues/728.
+# For more background, see https://gitlab.kitware.com/cmake/cmake/-/issues/20568.
+apt-get purge -y cmake
+pip3 install scikit-build
+pip3 install cmake==3.10.3
+cmake --version
+
 su -m -c 'NETWORK_MANAGER=0 script/setup' pi
 EOF
 


### PR DESCRIPTION
This commit fixes #728 by replacing default cmake distribution with cmake-3.10.3.

For the root cause of the failure, see https://gitlab.kitware.com/cmake/cmake/-/issues/20568.. 