### PR TITLE
[agent] print thread version at start

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -60,9 +60,6 @@
 
 namespace otbr {
 
-static const uint16_t kThreadVersion11 = 2; ///< Thread Version 1.1
-static const uint16_t kThreadVersion12 = 3; ///< Thread Version 1.2
-
 static const char kBorderAgentServiceType[] = "_meshcop._udp"; ///< Border agent service type of mDNS
 
 /**
@@ -216,20 +213,6 @@ void BorderAgent::Process(const MainloopContext &aMainloop)
     }
 }
 
-static const char *ThreadVersionToString(uint16_t aThreadVersion)
-{
-    switch (aThreadVersion)
-    {
-    case kThreadVersion11:
-        return "1.1.1";
-    case kThreadVersion12:
-        return "1.2.0";
-    default:
-        otbrLog(OTBR_LOG_ERR, "unexpected thread version %hu", aThreadVersion);
-        abort();
-    }
-}
-
 void BorderAgent::PublishMeshCopService(void)
 {
     StateBitmap              state;
@@ -244,7 +227,7 @@ void BorderAgent::PublishMeshCopService(void)
 
     txtList.emplace_back("nn", networkName);
     txtList.emplace_back("xp", extPanId->m8, sizeof(extPanId->m8));
-    txtList.emplace_back("tv", ThreadVersionToString(otThreadGetVersion()));
+    txtList.emplace_back("tv", mNcp.GetThreadVersion());
 
     // "dd" represents for device discriminator which
     // should always be the IEEE 802.15.4 extended address.

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -267,10 +267,11 @@ static int realmain(int argc, char *argv[])
 
     otbrLogInit(kSyslogIdent, logLevel, verbose);
     otbrLog(OTBR_LOG_INFO, "Running %s", OTBR_PACKAGE_VERSION);
+    otbrLog(OTBR_LOG_INFO, "Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
     VerifyOrExit(optind < argc, ret = EXIT_FAILURE);
 
-    otbrLog(OTBR_LOG_INFO, "Thread interface %s", interfaceName);
-    otbrLog(OTBR_LOG_INFO, "Backbone interface %s", backboneInterfaceName);
+    otbrLog(OTBR_LOG_INFO, "Thread interface: %s", interfaceName);
+    otbrLog(OTBR_LOG_INFO, "Backbone interface: %s", backboneInterfaceName);
 
     {
         otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, argv[optind], backboneInterfaceName};

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -56,6 +56,9 @@
 namespace otbr {
 namespace Ncp {
 
+static const uint16_t kThreadVersion11 = 2; ///< Thread Version 1.1
+static const uint16_t kThreadVersion12 = 3; ///< Thread Version 1.2
+
 ControllerOpenThread::ControllerOpenThread(const char *aInterfaceName,
                                            const char *aRadioUrl,
                                            const char *aBackboneInterfaceName)
@@ -199,6 +202,25 @@ void ControllerOpenThread::RegisterResetHandler(std::function<void(void)> aHandl
 void ControllerOpenThread::AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback)
 {
     mThreadStateChangedCallbacks.emplace_back(std::move(aCallback));
+}
+
+const char *ControllerOpenThread::GetThreadVersion(void)
+{
+    const char *version;
+
+    switch (otThreadGetVersion())
+    {
+    case kThreadVersion11:
+        version = "1.1.1";
+        break;
+    case kThreadVersion12:
+        version = "1.2.0";
+        break;
+    default:
+        otbrLog(OTBR_LOG_EMERG, "unexpected thread version %hu", otThreadGetVersion());
+        exit(-1);
+    }
+    return version;
 }
 
 /*

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -125,7 +125,21 @@ public:
      */
     void RegisterResetHandler(std::function<void(void)> aHandler);
 
+    /**
+     * This method adds a event listener for Thread state changes.
+     *
+     * @param[in]  aCallback  The callback to receive Thread state changed events.
+     *
+     */
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback);
+
+    /**
+     * This method returns the Thread protocol version as a string.
+     *
+     * @returns  A pointer to the Thread version string.
+     *
+     */
+    static const char *GetThreadVersion(void);
 
     ~ControllerOpenThread(void) override;
 


### PR DESCRIPTION
example output:
```
☁  ot-br-posix [print-thread-version] ⚡  sudo otbr-agent -I wpan0 -B eno1 -d 7 -v 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
otbr-agent[765464]: Running 0.3.0-cf3a67383-dirty
otbr-agent[765464]: Thread version: 1.2.0
otbr-agent[765464]: Thread interface: wpan0
otbr-agent[765464]: Backbone interface: eno1
```