### PR TITLE
[dns] handle instance names with dots

### DIFF
--- a/src/agent/discovery_proxy.cpp
+++ b/src/agent/discovery_proxy.cpp
@@ -88,35 +88,20 @@ void DiscoveryProxy::OnDiscoveryProxySubscribe(void *aContext, const char *aFull
 void DiscoveryProxy::OnDiscoveryProxySubscribe(const char *aFullName)
 {
     std::string                    fullName(aFullName);
-    std::string                    instanceName, serviceName, hostName, domain;
     otbrError                      error = OTBR_ERROR_NONE;
     MdnsSubscriptionList::iterator it;
-    DnsNameType                    nameType = GetDnsNameType(fullName);
+    DnsNameInfo                    nameInfo = SplitFullDnsName(fullName);
 
     otbrLog(OTBR_LOG_INFO, "[discproxy] subscribe: %s", fullName.c_str());
 
-    switch (nameType)
-    {
-    case kDnsNameTypeService:
-        SuccessOrExit(error = SplitFullServiceName(fullName, serviceName, domain));
-        break;
-    case kDnsNameTypeInstance:
-        SuccessOrExit(error = SplitFullServiceInstanceName(fullName, instanceName, serviceName, domain));
-        break;
-    case kDnsNameTypeHost:
-        SuccessOrExit(error = SplitFullHostName(fullName, hostName, domain));
-        break;
-    default:
-        ExitNow(error = OTBR_ERROR_NOT_IMPLEMENTED);
-    }
-
     it = std::find_if(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
-        return aSubscription.Matches(instanceName, serviceName, hostName, domain);
+        return aSubscription.Matches(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName,
+                                     nameInfo.mDomain);
     });
 
     VerifyOrExit(it == mSubscriptions.end(), it->mSubscriptionCount++);
 
-    mSubscriptions.emplace_back(instanceName, serviceName, hostName, domain);
+    mSubscriptions.emplace_back(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName, nameInfo.mDomain);
 
     {
         MdnsSubscription &subscription = mSubscriptions.back();
@@ -124,15 +109,15 @@ void DiscoveryProxy::OnDiscoveryProxySubscribe(const char *aFullName)
         otbrLog(OTBR_LOG_DEBUG, "[discproxy] subscriptions: %sx%d", subscription.ToString().c_str(),
                 subscription.mSubscriptionCount);
 
-        if (GetServiceSubscriptionCount(instanceName, serviceName) == 1)
+        if (GetServiceSubscriptionCount(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName) == 1)
         {
             if (subscription.mHostName.empty())
             {
-                mMdnsPublisher.SubscribeService(serviceName, instanceName);
+                mMdnsPublisher.SubscribeService(nameInfo.mServiceName, nameInfo.mInstanceName);
             }
             else
             {
-                mMdnsPublisher.SubscribeHost(hostName);
+                mMdnsPublisher.SubscribeHost(nameInfo.mHostName);
             }
         }
     }
@@ -152,30 +137,15 @@ void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(void *aContext, const char *aFu
 void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(const char *aFullName)
 {
     std::string                    fullName(aFullName);
-    std::string                    instanceName, serviceName, hostName, domain;
     otbrError                      error = OTBR_ERROR_NONE;
     MdnsSubscriptionList::iterator it;
-    DnsNameType                    nameType = GetDnsNameType(fullName);
+    DnsNameInfo                    nameInfo = SplitFullDnsName(fullName);
 
     otbrLog(OTBR_LOG_INFO, "[discproxy] unsubscribe: %s", fullName.c_str());
 
-    switch (nameType)
-    {
-    case kDnsNameTypeService:
-        SuccessOrExit(error = SplitFullServiceName(fullName, serviceName, domain));
-        break;
-    case kDnsNameTypeInstance:
-        SuccessOrExit(error = SplitFullServiceInstanceName(fullName, instanceName, serviceName, domain));
-        break;
-    case kDnsNameTypeHost:
-        SuccessOrExit(error = SplitFullHostName(fullName, hostName, domain));
-        break;
-    default:
-        ExitNow(error = OTBR_ERROR_NOT_IMPLEMENTED);
-    }
-
     it = std::find_if(mSubscriptions.begin(), mSubscriptions.end(), [&](const MdnsSubscription &aSubscription) {
-        return aSubscription.Matches(instanceName, serviceName, hostName, domain);
+        return aSubscription.Matches(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName,
+                                     nameInfo.mDomain);
     });
 
     VerifyOrExit(it != mSubscriptions.end(), error = OTBR_ERROR_NOT_FOUND);
@@ -194,15 +164,15 @@ void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(const char *aFullName)
         otbrLog(OTBR_LOG_DEBUG, "[discproxy] service subscriptions: %sx%d", it->ToString().c_str(),
                 it->mSubscriptionCount);
 
-        if (GetServiceSubscriptionCount(instanceName, serviceName) == 0)
+        if (GetServiceSubscriptionCount(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName) == 0)
         {
             if (subscription.mHostName.empty())
             {
-                mMdnsPublisher.UnsubscribeService(serviceName, instanceName);
+                mMdnsPublisher.UnsubscribeService(nameInfo.mServiceName, nameInfo.mInstanceName);
             }
             else
             {
-                mMdnsPublisher.UnsubscribeHost(hostName);
+                mMdnsPublisher.UnsubscribeHost(nameInfo.mHostName);
             }
         }
     }
@@ -307,11 +277,14 @@ exit:
     return targetName;
 }
 
-int DiscoveryProxy::GetServiceSubscriptionCount(const std::string &aInstanceName, const std::string &aServiceName)
+int DiscoveryProxy::GetServiceSubscriptionCount(const std::string &aInstanceName,
+                                                const std::string &aServiceName,
+                                                const std::string &aHostName)
 {
     return std::accumulate(
         mSubscriptions.begin(), mSubscriptions.end(), 0, [&](int aAccum, const MdnsSubscription &aSubscription) {
-            return aAccum + (aSubscription.mInstanceName == aInstanceName && aSubscription.mServiceName == aServiceName
+            return aAccum + ((aSubscription.mInstanceName == aInstanceName &&
+                              aSubscription.mServiceName == aServiceName && aSubscription.mHostName == aHostName)
                                  ? aSubscription.mSubscriptionCount
                                  : 0);
         });

--- a/src/agent/discovery_proxy.hpp
+++ b/src/agent/discovery_proxy.hpp
@@ -124,7 +124,9 @@ private:
     void               OnDiscoveryProxySubscribe(const char *aSubscription);
     static void        OnDiscoveryProxyUnsubscribe(void *aContext, const char *aFullName);
     void               OnDiscoveryProxyUnsubscribe(const char *aSubscription);
-    int                GetServiceSubscriptionCount(const std::string &aInstanceName, const std::string &aSubscription);
+    int                GetServiceSubscriptionCount(const std::string &aInstanceName,
+                                                   const std::string &aServiceName,
+                                                   const std::string &aHostName);
     static std::string TranslateDomain(const std::string &aName, const std::string &aTargetDomain);
     static void        CheckServiceNameSanity(const std::string &aType);
     static void        CheckHostnameSanity(const std::string &aHostName);

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -37,26 +37,54 @@
 #include "common/types.hpp"
 
 /**
- * This enum represents a DNS name type.
+ * This structure represents DNS Name information.
+ *
+ * @sa SplitFullDnsName
  *
  */
-enum DnsNameType
+struct DnsNameInfo
 {
-    kDnsNameTypeUnknown,
-    kDnsNameTypeService,
-    kDnsNameTypeInstance,
-    kDnsNameTypeHost,
+    std::string mInstanceName; ///< Instance name, or empty if the DNS name is not a service instance.
+    std::string mServiceName;  ///< Service name, or empty if the DNS name is not a service or service instance.
+    std::string mHostName;     ///< Host name.
+    std::string mDomain;       ///< Domain name.
+
+    /**
+     * This method returns if the DNS name is a service instance.
+     *
+     * @returns Whether the DNS name is a service instance.
+     *
+     */
+    bool IsServiceInstance(void) const { return !mInstanceName.empty(); };
+
+    /**
+     * This method returns if the DNS name is a service.
+     *
+     * @returns Whether the DNS name is a service.
+     *
+     */
+    bool IsService(void) const { return !mServiceName.empty() && mInstanceName.empty(); }
+
+    /**
+     * This method returns if the DNS name is a host.
+     *
+     * @returns Whether the DNS name is a host.
+     *
+     */
+    bool IsHost(void) const { return mServiceName.empty(); }
 };
 
 /**
- * This function gets the DNS name type.
+ * This method splits a full DNS name into name components.
  *
- * @param[in] aFullName The DNS name.
+ * @param[in] aName     The full DNS name to dissect.
  *
- * @returns  The DNS name type.
+ * @returns  A `DnsNameInfo` structure containing DNS name information.
+ *
+ * @sa DnsNameInfo
  *
  */
-DnsNameType GetDnsNameType(const std::string &aFullName);
+DnsNameInfo SplitFullDnsName(const std::string &aName);
 
 /**
  * This function splits a full service name into components.

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -46,7 +46,7 @@ struct DnsNameInfo
 {
     std::string mInstanceName; ///< Instance name, or empty if the DNS name is not a service instance.
     std::string mServiceName;  ///< Service name, or empty if the DNS name is not a service or service instance.
-    std::string mHostName;     ///< Host name.
+    std::string mHostName;     ///< Host name, or empty if the DNS name is not a host name.
     std::string mDomain;       ///< Domain name.
 
     /**

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(otbr-test-unit
     $<$<BOOL:${OTBR_DBUS}>:test_dbus_message.cpp>
     $<$<STREQUAL:${OTBR_MDNS},"mDNSResponder">:test_mdns_mdnssd.cpp>
     main.cpp
+    test_dns_utils.cpp
     test_logging.cpp
     test_pskc.cpp
     test_task_runner.cpp

--- a/tests/unit/test_dns_utils.cpp
+++ b/tests/unit/test_dns_utils.cpp
@@ -1,0 +1,97 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "common/dns_utils.hpp"
+
+#include <assert.h>
+
+#include <CppUTest/TestHarness.h>
+
+TEST_GROUP(DnsUtils){};
+
+static void CheckSplitFullDnsName(const std::string &aFullName,
+                                  bool               aIsServiceInstance,
+                                  bool               aIsService,
+                                  bool               aIsHost,
+                                  const std::string &aInstanceName,
+                                  const std::string &aServiceName,
+                                  const std::string &aHostName,
+                                  const std::string &aDomain)
+{
+    DnsNameInfo info;
+
+    assert(aFullName.empty() || aFullName.back() != '.');
+
+    info = SplitFullDnsName(aFullName);
+
+    CHECK_EQUAL(aIsServiceInstance, info.IsServiceInstance());
+    CHECK_EQUAL(aIsService, info.IsService());
+    CHECK_EQUAL(aIsHost, info.IsHost());
+    CHECK_EQUAL(aInstanceName, info.mInstanceName);
+    CHECK_EQUAL(aServiceName, info.mServiceName);
+    CHECK_EQUAL(aHostName, info.mHostName);
+    CHECK_EQUAL(aDomain, info.mDomain);
+
+    info = SplitFullDnsName(aFullName + ".");
+
+    CHECK_EQUAL(aIsServiceInstance, info.IsServiceInstance());
+    CHECK_EQUAL(aIsService, info.IsService());
+    CHECK_EQUAL(aIsHost, info.IsHost());
+    CHECK_EQUAL(aInstanceName, info.mInstanceName);
+    CHECK_EQUAL(aServiceName, info.mServiceName);
+    CHECK_EQUAL(aHostName, info.mHostName);
+    CHECK_EQUAL(aDomain, info.mDomain);
+}
+
+TEST(DnsUtils, TestSplitFullDnsName)
+{
+    // Check service instance names
+    CheckSplitFullDnsName("ins1._ipps._tcp.default.service.arpa", true, false, false, "ins1", "_ipps._tcp", "",
+                          "default.service.arpa.");
+    CheckSplitFullDnsName("Instance Name._ipps._tcp.default.service.arpa", true, false, false, "Instance Name",
+                          "_ipps._tcp", "", "default.service.arpa.");
+    CheckSplitFullDnsName("Instance.Name.With.Dots._ipps._tcp.default.service.arpa", true, false, false,
+                          "Instance.Name.With.Dots", "_ipps._tcp", "", "default.service.arpa.");
+
+    // Check service names
+    CheckSplitFullDnsName("_ipps._tcp.default.service.arpa", false, true, false, "", "_ipps._tcp", "",
+                          "default.service.arpa.");
+    CheckSplitFullDnsName("_meshcop._udp.default.service.arpa", false, true, false, "", "_meshcop._udp", "",
+                          "default.service.arpa.");
+
+    // Check invalid service names
+    CheckSplitFullDnsName("_meshcop._abc.default.service.arpa", false, false, true, "", "", "_meshcop",
+                          "_abc.default.service.arpa.");
+    CheckSplitFullDnsName("_tcp.default.service.arpa", false, false, true, "", "", "_tcp", "default.service.arpa.");
+
+    // Check host names
+    CheckSplitFullDnsName("abc.example.com", false, false, true, "", "", "abc", "example.com.");
+    CheckSplitFullDnsName("example.com", false, false, true, "", "", "example", "com.");
+    CheckSplitFullDnsName("com", false, false, true, "", "", "com", ".");
+    CheckSplitFullDnsName("", false, false, true, "", "", "", ".");
+}


### PR DESCRIPTION
This commit adds a new method `SplitFullDnsName` which handles instance names with dots correctly. 

- [x] Add a unit test.