### PR TITLE
[tests] wait longer for services to be ready

### DIFF
--- a/tests/scripts/check-scripts
+++ b/tests/scripts/check-scripts
@@ -72,7 +72,7 @@ main()
     SERVICES_PID=$!
     sudo service tayga start
     echo 'Waiting for services to be ready...'
-    sleep 10
+    sleep 30
     check_otbr_agent
     netstat -an | grep 80
     pidof tayga


### PR DESCRIPTION
Addresses some of the failures in `check-scripts`.

Fixes #786.