### PR TITLE
[mdns] fix pointer to object on stack in TxtList

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -63,10 +63,10 @@ otbrError Publisher::EncodeTxtData(const TxtList &aTxtList, uint8_t *aTxtData, u
 
     for (const auto &txtEntry : aTxtList)
     {
-        const char *   name        = txtEntry.mName;
-        const size_t   nameLength  = txtEntry.mNameLength;
-        const uint8_t *value       = txtEntry.mValue;
-        const size_t   valueLength = txtEntry.mValueLength;
+        const char *   name        = txtEntry.mName.c_str();
+        const size_t   nameLength  = txtEntry.mName.length();
+        const uint8_t *value       = txtEntry.mValue.data();
+        const size_t   valueLength = txtEntry.mValue.size();
         const size_t   entryLength = nameLength + 1 + valueLength;
 
         VerifyOrExit(nameLength > 0 && nameLength <= kMaxTextEntrySize, error = OTBR_ERROR_INVALID_ARGS);

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -35,6 +35,7 @@
 #define OTBR_AGENT_MDNS_HPP_
 
 #include <functional>
+#include <string>
 #include <vector>
 
 #include <sys/select.h>
@@ -68,10 +69,8 @@ public:
      */
     struct TxtEntry
     {
-        const char *   mName;        ///< The name of the TXT entry.
-        size_t         mNameLength;  ///< The length of the name of the TXT entry.
-        const uint8_t *mValue;       ///< The value of the TXT entry.
-        size_t         mValueLength; ///< The length of the value of the TXT entry.
+        std::string          mName;  ///< The name of the TXT entry.
+        std::vector<uint8_t> mValue; ///< The value of the TXT entry.
 
         TxtEntry(const char *aName, const char *aValue)
             : TxtEntry(aName, reinterpret_cast<const uint8_t *>(aValue), strlen(aValue))
@@ -84,10 +83,8 @@ public:
         }
 
         TxtEntry(const char *aName, size_t aNameLength, const uint8_t *aValue, size_t aValueLength)
-            : mName(aName)
-            , mNameLength(aNameLength)
-            , mValue(aValue)
-            , mValueLength(aValueLength)
+            : mName(aName, aNameLength)
+            , mValue(aValue, aValue + aValueLength)
         {
         }
     };

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -623,10 +623,10 @@ otbrError PublisherAvahi::PublishService(const char *   aHostName,
 
     for (const auto &txtEntry : aTxtList)
     {
-        const char *   name        = txtEntry.mName;
-        size_t         nameLength  = txtEntry.mNameLength;
-        const uint8_t *value       = txtEntry.mValue;
-        size_t         valueLength = txtEntry.mValueLength;
+        const char *   name        = txtEntry.mName.c_str();
+        size_t         nameLength  = txtEntry.mName.length();
+        const uint8_t *value       = txtEntry.mValue.data();
+        size_t         valueLength = txtEntry.mValue.size();
         // +1 for the size of "=", avahi doesn't need '\0' at the end of the entry
         size_t needed = sizeof(AvahiStringList) - sizeof(AvahiStringList::text) + nameLength + valueLength + 1;
 


### PR DESCRIPTION
`TxtList` is a list of DNS TXT records to publish, represented as memory ranges for keys and values of the records.
While memory ranges for the values point directly to a `otSrpServerService` object's member whose lifetime is longer
than lifetime of the `TxtList`, memory ranges for the keys pointed to a member of `otDnsTxtEntryIterator` structure,
allocated on stack during the translation.

It resulted in publishing garbage TXT records.

Fix the issue by using `std::string` to store the keys instead of raw pointers/lengths.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>