### PR TITLE
[trel] enable TREL by default

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -53,11 +53,11 @@ jobs:
       matrix:
         include:
           - name: "Border Router"
-            otbr_options: "-DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=OFF"
+            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=OFF"
             border_routing: 1
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
           - name: "Backbone Router"
-            otbr_options: "-DOT_DUA=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON"
+            otbr_options: "-DOT_TREL=OFF -DOT_DUA=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON"
             border_routing: 0
             cert_scripts: ./tests/scripts/thread-cert/backbone/*.py
     name: ${{ matrix.name }}

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -191,7 +191,8 @@ static int Mainloop(otbr::AgentInstance &aInstance, const char *aInterfaceName)
 
 static void PrintHelp(const char *aProgramName)
 {
-    fprintf(stderr, "Usage: %s [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] RADIO_URL\n", aProgramName);
+    fprintf(stderr, "Usage: %s [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] RADIO_URL [RADIO_URL]\n",
+            aProgramName);
     fprintf(stderr, "%s", otSysGetRadioUrlHelpString());
 }
 
@@ -213,13 +214,14 @@ static void OnAllocateFailed(void)
 
 static int realmain(int argc, char *argv[])
 {
-    otbrLogLevel logLevel = OTBR_LOG_INFO;
-    int          opt;
-    int          ret                   = EXIT_SUCCESS;
-    const char * interfaceName         = kDefaultInterfaceName;
-    const char * backboneInterfaceName = "";
-    bool         verbose               = false;
-    bool         printRadioVersion     = false;
+    otbrLogLevel              logLevel = OTBR_LOG_INFO;
+    int                       opt;
+    int                       ret                   = EXIT_SUCCESS;
+    const char *              interfaceName         = kDefaultInterfaceName;
+    const char *              backboneInterfaceName = "";
+    bool                      verbose               = false;
+    bool                      printRadioVersion     = false;
+    std::vector<const char *> radioUrls;
 
     std::set_new_handler(OnAllocateFailed);
 
@@ -268,13 +270,17 @@ static int realmain(int argc, char *argv[])
     otbrLogInit(kSyslogIdent, logLevel, verbose);
     otbrLogInfo("Running %s", OTBR_PACKAGE_VERSION);
     otbrLogInfo("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
-    VerifyOrExit(optind < argc, ret = EXIT_FAILURE);
-
     otbrLogInfo("Thread interface: %s", interfaceName);
     otbrLogInfo("Backbone interface: %s", backboneInterfaceName);
 
+    for (int i = optind; i < argc; i++)
     {
-        otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, argv[optind], backboneInterfaceName};
+        otbrLogInfo("Radio URL: %s", argv[i]);
+        radioUrls.push_back(argv[i]);
+    }
+
+    {
+        otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, radioUrls, backboneInterfaceName};
         otbr::AgentInstance             instance(ncpOpenThread);
 
         otbr::InstanceParams::Get().SetThreadIfName(interfaceName);

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -60,17 +60,22 @@ namespace Ncp {
 static const uint16_t kThreadVersion11 = 2; ///< Thread Version 1.1
 static const uint16_t kThreadVersion12 = 3; ///< Thread Version 1.2
 
-ControllerOpenThread::ControllerOpenThread(const char *aInterfaceName,
-                                           const char *aRadioUrl,
-                                           const char *aBackboneInterfaceName)
+ControllerOpenThread::ControllerOpenThread(const char *                     aInterfaceName,
+                                           const std::vector<const char *> &aRadioUrls,
+                                           const char *                     aBackboneInterfaceName)
     : mInstance(nullptr)
 {
+    VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
+
     memset(&mConfig, 0, sizeof(mConfig));
 
     mConfig.mInterfaceName         = aInterfaceName;
     mConfig.mBackboneInterfaceName = aBackboneInterfaceName;
-    mConfig.mRadioUrl              = aRadioUrl;
-    mConfig.mSpeedUpFactor         = 1;
+    for (const char *url : aRadioUrls)
+    {
+        mConfig.mRadioUrls[mConfig.mRadioUrlNum++] = url;
+    }
+    mConfig.mSpeedUpFactor = 1;
 }
 
 ControllerOpenThread::~ControllerOpenThread(void)

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -63,11 +63,13 @@ public:
      * This constructor initializes this object.
      *
      * @param[in]   aInterfaceName          A string of the NCP interface name.
-     * @param[in]   aRadioUrl               The URL describes the radio chip.
+     * @param[in]   aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
      * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
      *
      */
-    ControllerOpenThread(const char *aInterfaceName, const char *aRadioUrl, const char *aBackboneInterfaceName);
+    ControllerOpenThread(const char *                     aInterfaceName,
+                         const std::vector<const char *> &aRadioUrls,
+                         const char *                     aBackboneInterfaceName);
 
     /**
      * This method initalize the NCP controller.

--- a/src/agent/otbr-agent.default.in
+++ b/src/agent/otbr-agent.default.in
@@ -1,4 +1,4 @@
 # Default settings for otbr-agent. This file is sourced by systemd
 
 # Options to pass to otbr-agent
-OTBR_AGENT_OPTS="-I wpan0 -B @OTBR_INFRA_IF_NAME@ spinel+hdlc+uart:///dev/ttyACM0"
+OTBR_AGENT_OPTS="-I wpan0 -B @OTBR_INFRA_IF_NAME@ spinel+hdlc+uart:///dev/ttyACM0 trel://@OTBR_INFRA_IF_NAME@"

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -36,6 +36,7 @@ set(OT_DAEMON ON CACHE BOOL "enable daemon mode" FORCE)
 set(OT_JOINER ON CACHE BOOL "enable joiner" FORCE)
 set(OT_LEGACY ON CACHE STRING "enable legacy network support" FORCE)
 set(OT_SLAAC ON CACHE BOOL "enable SLAAC" FORCE)
+set(OT_TREL ON CACHE BOOL "enable TREL")
 
 if (NOT OT_LOG_LEVEL)
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
This commit enables TREL by default.

**TREL is enabled by default using the Backbone interface**

- [x] Make sure OTBR setup works with TREL enabled