### PR TITLE
[dbus] use pseudo reset in DBus APIs

### DIFF
--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -209,6 +209,20 @@ void ControllerOpenThread::AddThreadStateChangedCallback(ThreadStateChangedCallb
     mThreadStateChangedCallbacks.emplace_back(std::move(aCallback));
 }
 
+void ControllerOpenThread::SoftReset(void)
+{
+    gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
+
+    otInstanceFinalize(mInstance);
+    otSysDeinit();
+    Init();
+    for (auto &handler : mResetHandlers)
+    {
+        handler();
+    }
+    unsetenv("OTBR_NO_AUTO_ATTACH");
+}
+
 const char *ControllerOpenThread::GetThreadVersion(void)
 {
     const char *version;

--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -209,7 +209,7 @@ void ControllerOpenThread::AddThreadStateChangedCallback(ThreadStateChangedCallb
     mThreadStateChangedCallbacks.emplace_back(std::move(aCallback));
 }
 
-void ControllerOpenThread::SoftReset(void)
+void ControllerOpenThread::Reset(void)
 {
     gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
 

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -137,10 +137,10 @@ public:
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback);
 
     /**
-     * This method does a soft reset of the OpenThread instance.
+     * This method resets the OpenThread instance.
      *
      */
-    void SoftReset(void);
+    void Reset(void);
 
     /**
      * This method returns the Thread protocol version as a string.

--- a/src/agent/ncp_openthread.hpp
+++ b/src/agent/ncp_openthread.hpp
@@ -137,6 +137,12 @@ public:
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback);
 
     /**
+     * This method does a soft reset of the OpenThread instance.
+     *
+     */
+    void SoftReset(void);
+
+    /**
      * This method returns the Thread protocol version as a string.
      *
      * @returns  A pointer to the Thread version string.

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -300,7 +300,7 @@ void DBusThreadObject::FactoryResetHandler(DBusRequest &aRequest)
 
     SuccessOrExit(error = mNcp->GetThreadHelper()->Detach());
     SuccessOrExit(otInstanceErasePersistentInfo(mNcp->GetThreadHelper()->GetInstance()));
-    mNcp->SoftReset();
+    mNcp->Reset();
 
 exit:
     aRequest.ReplyOtResult(error);
@@ -308,7 +308,7 @@ exit:
 
 void DBusThreadObject::ResetHandler(DBusRequest &aRequest)
 {
-    mNcp->SoftReset();
+    mNcp->Reset();
     aRequest.ReplyOtResult(OT_ERROR_NONE);
 }
 

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -296,14 +296,20 @@ void DBusThreadObject::DetachHandler(DBusRequest &aRequest)
 
 void DBusThreadObject::FactoryResetHandler(DBusRequest &aRequest)
 {
-    aRequest.ReplyOtResult(OT_ERROR_NONE);
-    otInstanceFactoryReset(mNcp->GetThreadHelper()->GetInstance());
+    otError error = OT_ERROR_NONE;
+
+    SuccessOrExit(error = mNcp->GetThreadHelper()->Detach());
+    SuccessOrExit(otInstanceErasePersistentInfo(mNcp->GetThreadHelper()->GetInstance()));
+    mNcp->SoftReset();
+
+exit:
+    aRequest.ReplyOtResult(error);
 }
 
 void DBusThreadObject::ResetHandler(DBusRequest &aRequest)
 {
+    mNcp->SoftReset();
     aRequest.ReplyOtResult(OT_ERROR_NONE);
-    otInstanceReset(mNcp->GetThreadHelper()->GetInstance());
 }
 
 void DBusThreadObject::JoinerStartHandler(DBusRequest &aRequest)

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -175,7 +175,6 @@ int main()
                             TEST_ASSERT(api->GetRadioTxPower(txPower) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetActiveDatasetTlvs(activeDataset) == OTBR_ERROR_NONE);
                             api->FactoryReset(nullptr);
-                            sleep(1);
                             TEST_ASSERT(api->GetNetworkName(name) == OTBR_ERROR_NONE);
                             TEST_ASSERT(rloc16 != 0xffff);
                             TEST_ASSERT(extAddress != 0);
@@ -220,7 +219,6 @@ int main()
                             TEST_ASSERT(api->RemoveOnMeshPrefix(onMeshPrefix.mPrefix) == OTBR_ERROR_NONE);
 
                             api->FactoryReset(nullptr);
-                            sleep(1);
                             TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", nullptr) ==
                                         ClientError::OT_ERROR_NOT_FOUND);
                             TEST_ASSERT(api->JoinerStart("ABCDEF", "", "", "", "", "", [](ClientError aJoinError) {


### PR DESCRIPTION
Full reset is intended to be used only for testing purposes. This changes the behaviors of DBus APIs back.