### PR TITLE
[certification] support TestHarness BBR discovery

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -113,6 +113,11 @@ otbr_install()
         sudo systemctl enable otbr-agent || true
         sudo systemctl is-enabled otbr-agent || die 'Failed to enable otbr-agent!'
         without WEB_GUI || sudo systemctl is-enabled otbr-web || die 'Failed to enable otbr-web!'
+
+        if [[ ${REFERENCE_DEVICE} == "1" ]]; then
+            sudo systemctl enable testharness-discovery || true
+            sudo systemctl is-enabled testharness-discovery || die 'Failed to enable otbr-agent!'
+        fi
     else
         echo >&2 ' *** WARNING: systemctl not found. otbr cannot start on boot.'
     fi

--- a/tools/testharness_discovery/CMakeLists.txt
+++ b/tools/testharness_discovery/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2021, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,26 +26,19 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(pskc
-    pskc.cpp
-)
-target_link_libraries(pskc PRIVATE
-    otbr-config
-    otbr-common
-    otbr-utils
-    mbedtls
+install(
+        PROGRAMS testharness-discovery
+        DESTINATION sbin
 )
 
-add_executable(steering-data
-    steering_data.cpp
-)
-target_link_libraries(steering-data PRIVATE
-    otbr-config
-    otbr-common
-    otbr-utils
-    mbedtls
-)
-
-if ($ENV{REFERENCE_DEVICE})
-    add_subdirectory(testharness_discovery)
+if(OTBR_SYSTEMD_UNIT_DIR)
+    configure_file(testharness-discovery.service.in testharness-discovery.service)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/testharness-discovery.service
+            DESTINATION ${OTBR_SYSTEMD_UNIT_DIR}
+            )
+else()
+    configure_file(testharness-discovery.init.in testharness-discovery.init)
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/testharness-discovery.init
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/init.d
+            RENAME testharness-discovery)
 endif()

--- a/tools/testharness_discovery/testharness-discovery
+++ b/tools/testharness_discovery/testharness-discovery
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+import ctypes
+import ctypes.util
+import json
+import os
+import socket
+import struct
+import logging
+
+PORT = 12345
+IFNAME = 'eth0'
+GROUP = 'ff02::114'
+
+libc = ctypes.CDLL(ctypes.util.find_library('c'))
+
+logging.basicConfig(level=logging.INFO)
+
+
+def if_nametoindex(name):
+    if not isinstance(name, str):
+        raise TypeError('name must be a string.')
+    ret = libc.if_nametoindex(name.encode('ascii'))
+    if not ret:
+        raise RuntimeError("Invalid Name")
+    return ret
+
+
+def get_ipaddr():
+    for line in os.popen(f'ip addr list dev {IFNAME} | grep inet | grep global'):
+        addr = line.strip().split()[1]
+        return addr.split('/')[0]
+
+
+def advertise_bbr(s: socket.socket, src):
+    bbr_info = {
+        'ven': 'OpenThread_BR',
+        'mod': 'OpenThread_BR',
+        'ver': '1.0',
+        'add': get_ipaddr(),
+        'por': 22,
+    }
+
+    logging.info("Advertise: %r", bbr_info)
+    s.sendto(json.dumps(bbr_info).encode('utf8'), src)
+
+
+def main():
+    # Look up multicast group address in name server and find out IP version
+    addrinfo = socket.getaddrinfo(GROUP, None)[0]
+    assert addrinfo[0] == socket.AF_INET6
+
+    # Create a socket
+    s = socket.socket(addrinfo[0], socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, (IFNAME + '\0').encode('ascii'))
+
+    # Bind it to the port
+    s.bind(('', PORT))
+
+    group_bin = socket.inet_pton(addrinfo[0], addrinfo[4][0])
+    # Join group
+    interface_index = if_nametoindex(IFNAME)
+    mreq = group_bin + struct.pack('@I', interface_index)
+    s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, mreq)
+
+    logging.info("Advertising BBR on interface %s group %s ...", IFNAME, GROUP)
+
+    # Loop, printing any data we receive
+    while True:
+        data, src = s.recvfrom(100)
+        if data == b'BBR':
+            logging.info('Received BBR query, advertising')
+            advertise_bbr(s, src)
+        else:
+            logging.warn('Received %r, but ignored', data)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/testharness_discovery/testharness-discovery.init.in
+++ b/tools/testharness_discovery/testharness-discovery.init.in
@@ -1,0 +1,96 @@
+#!/bin/sh
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+### BEGIN INIT INFO
+# Provides:          testharness-discovery
+# Required-Start:
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Test Harness Discovery Service.
+# Description: Test Harness Discovery Service.
+### END INIT INFO
+
+set -e
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DESC="TestHarness Discovery"
+NAME=testharness-discovery
+DAEMON=/home/pi/scripts/
+PIDFILE=/var/run/testharness-discovery.pid
+
+. /lib/lsb/init-functions
+. /lib/init/vars.sh
+
+start_testharness_discovery()
+{
+    if [ -e $PIDFILE ]; then
+        if $0 status > /dev/null ; then
+            log_success_msg "$DESC already started; not starting."
+            return
+        else
+            log_success_msg "Removing stale PID file $PIDFILE."
+            rm -f $PIDFILE
+        fi
+    fi
+
+    log_daemon_msg "Starting $DESC" "$NAME"
+    start-stop-daemon --start --quiet \
+        --pidfile $PIDFILE --make-pidfile \
+        -b --exec $DAEMON
+    log_end_msg $?
+}
+
+stop_testharness_discovery()
+{
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    start-stop-daemon --stop --retry 5 --quiet --oknodo \
+        --pidfile $PIDFILE --remove-pidfile
+    log_end_msg $?
+}
+
+case "$1" in
+    start)
+        start_testharness_discovery
+        ;;
+    restart|reload|force-reload)
+        stop_testharness_discovery
+        start_testharness_discovery
+        ;;
+    stop|force-stop)
+        stop_testharness_discovery
+        ;;
+    status)
+        status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+        ;;
+    *)
+        log_action_msg "Usage: /etc/init.d/$NAME {start|stop|status|restart|reload|force-reload}"
+        exit 2
+        ;;
+esac

--- a/tools/testharness_discovery/testharness-discovery.service.in
+++ b/tools/testharness_discovery/testharness-discovery.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=TestHarness Discovery Service
+ConditionPathExists=@CMAKE_INSTALL_FULL_SBINDIR@/testharness-discovery
+
+[Service]
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/testharness-discovery
+Restart=on-failure
+RestartSec=5
+RestartPreventExitStatus=SIGKILL
+
+[Install]
+WantedBy=multi-user.target
+Alias=testharness-discovery.service


### PR DESCRIPTION
This commit implements the TestHarness BBR Discovery protocol so that TestHarness can discover OTBRs connected to the same Backbone link, without UART connections. 

Verified that it works:
```
pi@raspberrypi:~/ot-br-posix $ service testharness-discovery status
● testharness-discovery.service - TestHarness Discovery Service
   Loaded: loaded (/lib/systemd/system/testharness-discovery.service; disabled; vendor preset: enabled)
   Active: inactive (dead)
pi@raspberrypi:~/ot-br-posix $ sudo service testharness-discovery start
pi@raspberrypi:~/ot-br-posix $ sudo service testharness-discovery status
● testharness-discovery.service - TestHarness Discovery Service
   Loaded: loaded (/lib/systemd/system/testharness-discovery.service; disabled; vendor preset: enabled)
   Active: active (running) since Tue 2021-05-18 03:30:39 BST; 5s ago
 Main PID: 5545 (python3)
    Tasks: 1 (limit: 2062)
   CGroup: /system.slice/testharness-discovery.service
           └─5545 python3 /usr/sbin/testharness-discovery

May 18 03:30:39 raspberrypi systemd[1]: Started TestHarness Discovery Service.
May 18 03:30:39 raspberrypi testharness-discovery[5545]: INFO:root:Advertising BBR on interface eth0 group ff02::114 ...

```
Service is automatically started after reboots.