### PR TITLE
[dnssd] fix printing string after its destruction

### DIFF
--- a/src/agent/discovery_proxy.cpp
+++ b/src/agent/discovery_proxy.cpp
@@ -157,12 +157,12 @@ void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(const char *aFullName)
         subscription.mSubscriptionCount--;
         assert(subscription.mSubscriptionCount >= 0);
 
+        otbrLogDebug("service subscriptions: %sx%d", it->ToString().c_str(), it->mSubscriptionCount);
+
         if (subscription.mSubscriptionCount == 0)
         {
             mSubscriptions.erase(it);
         }
-
-        otbrLogDebug("service subscriptions: %sx%d", it->ToString().c_str(), it->mSubscriptionCount);
 
         if (GetServiceSubscriptionCount(nameInfo.mInstanceName, nameInfo.mServiceName, nameInfo.mHostName) == 0)
         {


### PR DESCRIPTION
Subscriptions were stored in a vector. The previous code printed a subscription after the subscription had been erased from the vector.

Before: 
```
otbr-agent[2470450]: [DEBG]-DPROXY--: service subscriptions: _meshcop._udp.�6>(CVx0
```
After: 
```
otbr-agent[2477680]: [DEBG]-DPROXY--: service subscriptions: _meshcop._udp.default.service.arpa.x0
```