### PR TITLE
[android] fix android build check for mDNSResponder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       env:
         OTBR_MDNS: ${{ matrix.mdns }}
       run: >
-        docker run --rm -v $PWD:/build/ot-br-posix -v $PWD/third_party/openthread/repo:/build/external/openthread openthread/android-trusty bash -c
+        docker run --rm --env OTBR_MDNS=$OTBR_MDNS -v $PWD:/build/ot-br-posix -v $PWD/third_party/openthread/repo:/build/external/openthread openthread/android-trusty bash -c
         "BUILD_TARGET=android-check ot-br-posix/tests/scripts/bootstrap.sh && \
          ot-br-posix/tests/scripts/check-android-build"
 

--- a/Android.mk
+++ b/Android.mk
@@ -140,6 +140,9 @@ LOCAL_LDLIBS := \
     -lutil
 
 ifeq ($(OTBR_MDNS),mDNSResponder)
+LOCAL_CFLAGS += \
+    -DOTBR_ENABLE_MDNS_MDNSSD=1 \
+
 LOCAL_SRC_FILES += \
     src/mdns/mdns_mdnssd.cpp \
 

--- a/tests/scripts/check-android-build
+++ b/tests/scripts/check-android-build
@@ -180,6 +180,8 @@ LOCAL_MODULE_TAGS := eng
 DBUS_HEADERS := \$(wildcard \$(LOCAL_PATH)/mDNSShared/*.h)
 LOCAL_COPY_HEADERS := \$(DBUS_HEADERS:\$(LOCAL_PATH)/%=%)
 
+LOCAL_EXPORT_C_INCLUDE_DIRS := \$(LOCAL_PATH)/mDNSShared
+
 LOCAL_CFLAGS := -O2 -g -W -Wall -D_GNU_SOURCE -DHAVE_IPV6 -DNOT_HAVE_SA_LEN -DUSES_NETLINK -DTARGET_OS_LINUX -fno-strict-aliasing -DHAVE_LINUX -DMDNS_DEBUGMSGS=0
 
 include \$(BUILD_SHARED_LIBRARY)
@@ -220,6 +222,8 @@ main()
 
     test -f out/target/product/generic/system/bin/otbr-agent
     test -f out/target/product/generic/system/etc/dbus-1/system.d/otbr-agent.conf
+
+    [[ ${OTBR_MDNS} != mDNSResponder ]] || test out/target/product/generic/system/lib/libmdnssd.so
 }
 
 main "$@"


### PR DESCRIPTION
Currently in the github action for checking android build, the env
`OTBR_MDNS` doesn't take effect because the script is actually run in
a docker image. Thus when building it, `libmdnsd` and `PublisherMDnsSd`
are not compiled. This PR adds `OTBR_MDNS` env variable to the docker
and FLAGS, INCLUDES for using mDNSResponder in ot-br-posix.