### PR TITLE
[dns-sd] enlarge kMaxSizeOfTxtRecord for avahi

### DIFF
--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -355,7 +355,7 @@ public:
 private:
     enum
     {
-        kMaxSizeOfTxtRecord   = 256,
+        kMaxSizeOfTxtRecord   = 1024,
         kMaxSizeOfServiceName = AVAHI_LABEL_MAX,
         kMaxSizeOfHost        = AVAHI_LABEL_MAX,
         kMaxSizeOfDomain      = AVAHI_LABEL_MAX,


### PR DESCRIPTION
I met following error while running the `tests/scripts/thread-cert/border_router/test_dnssd_server.py` test using avahi as the mDNS daemon.

```
 708 May 23 09:46:20 fb1254174230 otbr-agent[111]: [INFO]-MDNS----: Avahi client ready.
 709 May 23 09:46:20 fb1254174230 otbr-agent[111]: [INFO]-AGENT---: Publish meshcop service OpenThread._meshcop._udp.local.
 710 May 23 09:46:20 fb1254174230 otbr-agent[111]: [ERR ]-MDNS----: Failed to publish service: Message too long!
``` 

Apparently it happened because the avahi TXT record buffer was not big enough. Therefore I increased the buffer size and the error disappeared.