### PR TITLE
[mdns] avahi publish an address/host with both IPv4 and IPv6

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -760,8 +760,8 @@ otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress
     memcpy(&address.data.ipv6.address[0], aAddress, aAddressLength);
 
     otbrLogInfo("Create host %s", aName);
-    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, mProtocol,
-                                               AVAHI_PUBLISH_NO_REVERSE, fullHostName.c_str(), &address);
+    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, mProtocol, AVAHI_PUBLISH_NO_REVERSE,
+                                               fullHostName.c_str(), &address);
     SuccessOrExit(avahiError);
 
     otbrLogInfo("Commit host %s", aName);

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -760,7 +760,7 @@ otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress
     memcpy(&address.data.ipv6.address[0], aAddress, aAddressLength);
 
     otbrLogInfo("Create host %s", aName);
-    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC,
+    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, mProtocol,
                                                AVAHI_PUBLISH_NO_REVERSE, fullHostName.c_str(), &address);
     SuccessOrExit(avahiError);
 

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -760,7 +760,7 @@ otbrError PublisherAvahi::PublishHost(const char *aName, const uint8_t *aAddress
     memcpy(&address.data.ipv6.address[0], aAddress, aAddressLength);
 
     otbrLogInfo("Create host %s", aName);
-    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, AVAHI_PROTO_INET6,
+    avahiError = avahi_entry_group_add_address(hostIt->mGroup, AVAHI_IF_UNSPEC, AVAHI_PROTO_UNSPEC,
                                                AVAHI_PUBLISH_NO_REVERSE, fullHostName.c_str(), &address);
     SuccessOrExit(avahiError);
 


### PR DESCRIPTION
Current mDNS-avahi implementation publishes the SRP client IPv6 addresses
in only IPv6 space. This results in the host being not discoverable with IPv4 queries
on infra link. This commit fixes this issue by advertising the AAAA record in both
IPv4 and IPv6 spaces.