### PR TITLE
[adproxy] re-register all services when the mDNS publisher becomes ready

### DIFF
--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -136,12 +136,6 @@ void AdvertisingProxy::AdvertisingHandler(otSrpServerServiceUpdateId aId,
                                           const otSrpServerHost *    aHost,
                                           uint32_t                   aTimeout)
 {
-    // TODO: There are corner cases that the `aHost` is freed by SRP server because
-    // of timeout, but this `aHost` is passed back to SRP server and matches a newly
-    // allocated otSrpServerHost object which has the same pointer value as this
-    // `aHost`. This results in mismatching of the outstanding SRP updates. Solutions
-    // are cleaning up the outstanding update entries before timing out or using
-    // incremental ID to match oustanding SRP updates.
     OTBR_UNUSED_VARIABLE(aTimeout);
 
     OutstandingUpdate *update;
@@ -262,9 +256,6 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     uint8_t                   hostAddressNum;
     bool                      hostDeleted;
     const otSrpServerService *service;
-
-    mOutstandingUpdates.resize(mOutstandingUpdates.size() + 1);
-    aUpdate = &mOutstandingUpdates.back();
 
     fullHostName = otSrpServerHostGetFullName(aHost);
 

--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -245,8 +245,8 @@ void AdvertisingProxy::PublishAllHostsAndServices(void)
 {
     const otSrpServerHost *host = nullptr;
 
-    otbrLogErr("Publish all services");
-    while ((host = otSrpServerGetNextHost(GetInstance(), host)) != nullptr)
+    otbrLogInfo("Publish all hosts and services");
+    while ((host = otSrpServerGetNextHost(GetInstance(), host)))
     {
         PublishHostAndItsServices(host, nullptr);
     }
@@ -279,7 +279,7 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
         aUpdate->mCallbackCount += !hostDeleted;
         aUpdate->mHostName = hostName;
         service            = nullptr;
-        while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
+        while ((service = otSrpServerHostGetNextService(aHost, service)))
         {
             aUpdate->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
         }
@@ -299,7 +299,7 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     }
 
     service = nullptr;
-    while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
+    while ((service = otSrpServerHostGetNextService(aHost, service)))
     {
         const char *fullServiceName = otSrpServerServiceGetFullName(service);
         std::string serviceName;

--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -248,7 +248,7 @@ exit:
     return;
 }
 
-otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *update)
+otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate)
 {
     otbrError                 error = OTBR_ERROR_NONE;
     const char *              fullHostName;
@@ -267,14 +267,14 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     hostAddress = otSrpServerHostGetAddresses(aHost, &hostAddressNum);
     hostDeleted = otSrpServerHostIsDeleted(aHost);
 
-    if (update)
+    if (aUpdate)
     {
-        update->mCallbackCount += !hostDeleted;
-        update->mHostName = hostName;
-        service           = nullptr;
+        aUpdate->mCallbackCount += !hostDeleted;
+        aUpdate->mHostName = hostName;
+        service            = nullptr;
         while ((service = otSrpServerHostGetNextService(aHost, service)))
         {
-            update->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
+            aUpdate->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
         }
     }
 
@@ -301,9 +301,9 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
 
         SuccessOrExit(error = SplitFullServiceInstanceName(fullServiceName, serviceName, serviceType, serviceDomain));
 
-        if (update)
+        if (aUpdate)
         {
-            update->mServiceNames.emplace_back(serviceName, serviceType);
+            aUpdate->mServiceNames.emplace_back(serviceName, serviceType);
         }
 
         if (!hostDeleted && !otSrpServerServiceIsDeleted(service))

--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -144,79 +144,14 @@ void AdvertisingProxy::AdvertisingHandler(otSrpServerServiceUpdateId aId,
     // incremental ID to match oustanding SRP updates.
     OTBR_UNUSED_VARIABLE(aTimeout);
 
-    otbrError                 error = OTBR_ERROR_NONE;
-    const char *              fullHostName;
-    std::string               hostName;
-    std::string               hostDomain;
-    const otIp6Address *      hostAddress;
-    uint8_t                   hostAddressNum;
-    bool                      hostDeleted;
-    const otSrpServerService *service;
-    OutstandingUpdate *       update;
+    OutstandingUpdate *update;
+    otbrError          error = OTBR_ERROR_NONE;
 
-    mOutstandingUpdates.resize(mOutstandingUpdates.size() + 1);
-    update = &mOutstandingUpdates.back();
-
-    fullHostName = otSrpServerHostGetFullName(aHost);
-
-    otbrLogInfo("Advertise SRP service updates: host=%s", fullHostName);
-
-    SuccessOrExit(error = SplitFullHostName(fullHostName, hostName, hostDomain));
-    hostAddress = otSrpServerHostGetAddresses(aHost, &hostAddressNum);
-    hostDeleted = otSrpServerHostIsDeleted(aHost);
-
+    mOutstandingUpdates.emplace_back();
+    update      = &mOutstandingUpdates.back();
     update->mId = aId;
-    update->mCallbackCount += !hostDeleted;
-    update->mHostName = hostName;
 
-    service = nullptr;
-    while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
-    {
-        update->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
-    }
-
-    if (!hostDeleted)
-    {
-        // TODO: select a preferred address or advertise all addresses from SRP client.
-        otbrLogInfo("Publish SRP host: %s", fullHostName);
-        SuccessOrExit(error =
-                          mPublisher.PublishHost(hostName.c_str(), hostAddress[0].mFields.m8, sizeof(hostAddress[0])));
-    }
-    else
-    {
-        otbrLogInfo("Unpublish SRP host: %s", fullHostName);
-        SuccessOrExit(error = mPublisher.UnpublishHost(hostName.c_str()));
-    }
-
-    service = nullptr;
-    while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
-    {
-        const char *fullServiceName = otSrpServerServiceGetFullName(service);
-        std::string serviceName;
-        std::string serviceType;
-        std::string serviceDomain;
-
-        SuccessOrExit(error = SplitFullServiceInstanceName(fullServiceName, serviceName, serviceType, serviceDomain));
-
-        update->mServiceNames.emplace_back(serviceName, serviceType);
-
-        if (!hostDeleted && !otSrpServerServiceIsDeleted(service))
-        {
-            Mdns::Publisher::TxtList txtList = MakeTxtList(service);
-
-            otbrLogInfo("Publish SRP service: %s", fullServiceName);
-            SuccessOrExit(error = mPublisher.PublishService(hostName.c_str(), otSrpServerServiceGetPort(service),
-                                                            serviceName.c_str(), serviceType.c_str(), txtList));
-        }
-        else
-        {
-            otbrLogInfo("Unpublish SRP service: %s", fullServiceName);
-            SuccessOrExit(error = mPublisher.UnpublishService(serviceName.c_str(), serviceType.c_str()));
-        }
-    }
-
-exit:
-    if (error != OTBR_ERROR_NONE || update->mCallbackCount == 0)
+    if ((error = PublishHostAndItsServices(aHost, update)) != OTBR_ERROR_NONE || update->mCallbackCount == 0)
     {
         if (error != OTBR_ERROR_NONE)
         {
@@ -304,6 +239,101 @@ exit:
     {
         otbrLogWarning("Failed to handle result of host %s", aName);
     }
+}
+
+void AdvertisingProxy::PublishAllHostsAndServices(void)
+{
+    const otSrpServerHost *host = nullptr;
+
+    otbrLogErr("Publish all services");
+    while ((host = otSrpServerGetNextHost(GetInstance(), host)) != nullptr)
+    {
+        PublishHostAndItsServices(host, nullptr);
+    }
+}
+
+otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate)
+{
+    otbrError                 error = OTBR_ERROR_NONE;
+    const char *              fullHostName;
+    std::string               hostName;
+    std::string               hostDomain;
+    const otIp6Address *      hostAddress;
+    uint8_t                   hostAddressNum;
+    bool                      hostDeleted;
+    const otSrpServerService *service;
+
+    mOutstandingUpdates.resize(mOutstandingUpdates.size() + 1);
+    aUpdate = &mOutstandingUpdates.back();
+
+    fullHostName = otSrpServerHostGetFullName(aHost);
+
+    otbrLogInfo("Advertise SRP service updates: host=%s", fullHostName);
+
+    SuccessOrExit(error = SplitFullHostName(fullHostName, hostName, hostDomain));
+    hostAddress = otSrpServerHostGetAddresses(aHost, &hostAddressNum);
+    hostDeleted = otSrpServerHostIsDeleted(aHost);
+
+    if (aUpdate)
+    {
+        aUpdate->mCallbackCount += !hostDeleted;
+        aUpdate->mHostName = hostName;
+        service            = nullptr;
+        while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
+        {
+            aUpdate->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
+        }
+    }
+
+    if (!hostDeleted)
+    {
+        // TODO: select a preferred address or advertise all addresses from SRP client.
+        otbrLogInfo("Publish SRP host: %s", fullHostName);
+        SuccessOrExit(error =
+                          mPublisher.PublishHost(hostName.c_str(), hostAddress[0].mFields.m8, sizeof(hostAddress[0])));
+    }
+    else
+    {
+        otbrLogInfo("Unpublish SRP host: %s", fullHostName);
+        SuccessOrExit(error = mPublisher.UnpublishHost(hostName.c_str()));
+    }
+
+    service = nullptr;
+    while ((service = otSrpServerHostGetNextService(aHost, service)) != nullptr)
+    {
+        const char *fullServiceName = otSrpServerServiceGetFullName(service);
+        std::string serviceName;
+        std::string serviceType;
+        std::string serviceDomain;
+
+        SuccessOrExit(error = SplitFullServiceInstanceName(fullServiceName, serviceName, serviceType, serviceDomain));
+
+        if (aUpdate)
+        {
+            aUpdate->mServiceNames.emplace_back(serviceName, serviceType);
+        }
+
+        if (!hostDeleted && !otSrpServerServiceIsDeleted(service))
+        {
+            Mdns::Publisher::TxtList txtList = MakeTxtList(service);
+
+            otbrLogInfo("Publish SRP service: %s", fullServiceName);
+            SuccessOrExit(error = mPublisher.PublishService(hostName.c_str(), otSrpServerServiceGetPort(service),
+                                                            serviceName.c_str(), serviceType.c_str(), txtList));
+        }
+        else
+        {
+            otbrLogInfo("Unpublish SRP service: %s", fullServiceName);
+            SuccessOrExit(error = mPublisher.UnpublishService(serviceName.c_str(), serviceType.c_str()));
+        }
+    }
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogInfo("Failed to advertise SRP service updates %p", aHost);
+    }
+    return error;
 }
 
 Mdns::Publisher::TxtList AdvertisingProxy::MakeTxtList(const otSrpServerService *aSrpService)

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -107,7 +107,7 @@ private:
     static void PublishHostHandler(const char *aName, otbrError aError, void *aContext);
     void        PublishHostHandler(const char *aName, otbrError aError);
 
-    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);
+    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, otSrpServerServiceUpdateId aId, bool aMakeUpdate);
 
     otInstance *GetInstance(void) { return mNcp.GetInstance(); }
 

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -77,6 +77,12 @@ public:
      */
     void Stop();
 
+    /**
+     * This method publishes all registered hosts and services.
+     *
+     */
+    void PublishAllHostsAndServices(void);
+
 private:
     struct OutstandingUpdate
     {
@@ -100,6 +106,8 @@ private:
     void        PublishServiceHandler(const char *aName, const char *aType, otbrError aError);
     static void PublishHostHandler(const char *aName, otbrError aError, void *aContext);
     void        PublishHostHandler(const char *aName, otbrError aError);
+
+    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);
 
     otInstance *GetInstance(void) { return mNcp.GetInstance(); }
 

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -107,7 +107,7 @@ private:
     static void PublishHostHandler(const char *aName, otbrError aError, void *aContext);
     void        PublishHostHandler(const char *aName, otbrError aError);
 
-    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, otSrpServerServiceUpdateId aId, bool aMakeUpdate);
+    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *update);
 
     otInstance *GetInstance(void) { return mNcp.GetInstance(); }
 

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -108,11 +108,16 @@ private:
     void        PublishHostHandler(const char *aName, otbrError aError);
 
     /**
-     * This method publishes a specified host and its services. It also makes a OutstandingUpdate object when needed.
+     * This method publishes a specified host and its services.
      *
-     * @param[in]  aHost      A pointer to the host.
-     * @param[in]  aUpdate    A pointer to the output OutstandingUpdate object. When it's not null, the method will fill
-     * its fields, otherwise it's ignored.
+     * It also makes a OutstandingUpdate object when needed.
+     *
+     * @param[in]  aHost         A pointer to the host.
+     * @param[in]  aUpdate       A pointer to the output OutstandingUpdate object. When it's not null, the method will
+     *                           fill its fields, otherwise it's ignored.
+     *
+     * @retval  OTBR_ERROR_NONE  Successfully published the host and its services.
+     * @retval  ...              Failed to publish the host and/or its services.
      *
      */
     otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -107,7 +107,15 @@ private:
     static void PublishHostHandler(const char *aName, otbrError aError, void *aContext);
     void        PublishHostHandler(const char *aName, otbrError aError);
 
-    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *update);
+    /**
+     * This method publishes a specified host and its services. It also makes a OutstandingUpdate object when needed.
+     *
+     * @param[in]  aHost      A pointer to the host.
+     * @param[in]  aUpdate    A pointer to the output OutstandingUpdate object. When it's not null, the method will fill
+     * its fields, otherwise it's ignored.
+     *
+     */
+    otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);
 
     otInstance *GetInstance(void) { return mNcp.GetInstance(); }
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -192,7 +192,9 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
         UpdateMeshCopService();
         break;
     case Mdns::Publisher::State::kRestarted:
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
         mAdvertisingProxy.PublishAllHostsAndServices();
+#endif
         break;
     default:
         otbrLogWarning("MDNS service not available!");

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -191,9 +191,6 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
     case Mdns::Publisher::State::kReady:
         UpdateMeshCopService();
         break;
-    case Mdns::Publisher::State::kRestarted:
-        mAdvertisingProxy.PublishAllHostsAndServices();
-        break;
     default:
         otbrLogWarning("MDNS service not available!");
         break;

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -191,6 +191,9 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
     case Mdns::Publisher::State::kReady:
         UpdateMeshCopService();
         break;
+    case Mdns::Publisher::State::kRestarted:
+        mAdvertisingProxy.PublishAllHostsAndServices();
+        break;
     default:
         otbrLogWarning("MDNS service not available!");
         break;

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -190,8 +190,6 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
     {
     case Mdns::Publisher::State::kReady:
         UpdateMeshCopService();
-        break;
-    case Mdns::Publisher::State::kRestarted:
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
         mAdvertisingProxy.PublishAllHostsAndServices();
 #endif

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -159,9 +159,8 @@ public:
      */
     enum class State
     {
-        kIdle,      ///< Unable to publishing service.
-        kReady,     ///< Ready for publishing service.
-        kRestarted, ///< Recently restarted
+        kIdle,  ///< Unable to publishing service.
+        kReady, ///< Ready for publishing service.
     };
 
     /**

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -159,8 +159,9 @@ public:
      */
     enum class State
     {
-        kIdle,  ///< Unable to publishing service.
-        kReady, ///< Ready for publishing service.
+        kIdle,  ///< Unable to publish service.
+        kReady, ///< Ready to publish service.
+        kRestarted, ///< Recently restarted.
     };
 
     /**

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -159,8 +159,8 @@ public:
      */
     enum class State
     {
-        kIdle,  ///< Unable to publish service.
-        kReady, ///< Ready to publish service.
+        kIdle,      ///< Unable to publish service.
+        kReady,     ///< Ready to publish service.
         kRestarted, ///< Recently restarted.
     };
 

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -159,8 +159,9 @@ public:
      */
     enum class State
     {
-        kIdle,  ///< Unable to publishing service.
-        kReady, ///< Ready for publishing service.
+        kIdle,      ///< Unable to publishing service.
+        kReady,     ///< Ready for publishing service.
+        kRestarted, ///< Recently restarted
     };
 
     /**

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -159,9 +159,8 @@ public:
      */
     enum class State
     {
-        kIdle,      ///< Unable to publish service.
-        kReady,     ///< Ready to publish service.
-        kRestarted, ///< Recently restarted.
+        kIdle,  ///< Unable to publish service.
+        kReady, ///< Ready to publish service.
     };
 
     /**


### PR DESCRIPTION
When mDNS daemon restarts, our mDNS library may need to re-advertise all hosts and services. Thus I extracted this functionality and made it a public method. 

Also, on `kReady`, SRP server will publish all registered hosts and services. This is helpful when the advertising proxy reconnects to the mDNS provider.