### PR TITLE
[cmake] include CoAPS PSK support for OTBR

### DIFF
--- a/third_party/openthread/mbedtls-config.h
+++ b/third_party/openthread/mbedtls-config.h
@@ -71,7 +71,10 @@
 #define MBEDTLS_SSL_SRV_C
 #define MBEDTLS_SSL_TLS_C
 
-// Enable ECDSA support
+// Enable CoAPS PSK support
+#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
+
+// Enable CoAPS ECDSA support
 #define MBEDTLS_BASE64_C
 #define MBEDTLS_ECDH_C
 #define MBEDTLS_ECDSA_C


### PR DESCRIPTION
Turn on mbedtls PSK support for CoAP testing on reference OTBR (similar to ECDSA)