### PR TITLE
[dnssd] set TTL as 10 for entries discovered by avahi

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1074,7 +1074,7 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
     // TODO priority
     // TODO weight
     // TODO use a more proper TTL
-    mInstanceInfo.mTtl = 10;
+    mInstanceInfo.mTtl = kDefaultTtl;
     for (auto p = aTxt; p; p = avahi_string_list_get_next(p))
     {
         totalTxtSize += avahi_string_list_get_size(p) + 1;
@@ -1166,7 +1166,7 @@ void PublisherAvahi::HostSubscription::HandleResolveResult(AvahiRecordBrowser * 
     mHostInfo.mHostName = std::string(aName) + ".";
     mHostInfo.mAddresses.push_back(std::move(address));
     // TODO: Use a more proper TTL
-    mHostInfo.mTtl = 10;
+    mHostInfo.mTtl = kDefaultTtl;
     mPublisherAvahi->OnHostResolved(*this);
 
 exit:

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1073,7 +1073,8 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
 
     // TODO priority
     // TODO weight
-    // TODO ttl
+    // TODO use a more proper TTL
+    mInstanceInfo.mTtl = 10;
     for (auto p = aTxt; p; p = avahi_string_list_get_next(p))
     {
         totalTxtSize += avahi_string_list_get_size(p) + 1;
@@ -1164,7 +1165,8 @@ void PublisherAvahi::HostSubscription::HandleResolveResult(AvahiRecordBrowser * 
 
     mHostInfo.mHostName = std::string(aName) + ".";
     mHostInfo.mAddresses.push_back(std::move(address));
-    // TODO: ttl
+    // TODO: Use a more proper TTL
+    mHostInfo.mTtl = 10;
     mPublisherAvahi->OnHostResolved(*this);
 
 exit:

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -361,6 +361,7 @@ private:
         kMaxSizeOfHost        = AVAHI_LABEL_MAX,
         kMaxSizeOfDomain      = AVAHI_LABEL_MAX,
         kMaxSizeOfServiceType = AVAHI_LABEL_MAX,
+        kDefaultTtl           = 10,
     };
 
     struct Service


### PR DESCRIPTION
Currently I don't see an easy way to get TTL information via avahi API. This PR is a workaround to set TTL as 10 all the time to avoid zero TTLs.