### PR TITLE
[dns-sd] support service subtypes in advertising proxy

### DIFF
--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -283,7 +283,7 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
         aUpdate->mHostName = hostName;
         service            = nullptr;
         while ((service = otSrpServerHostFindNextService(aHost, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
-                                                         nullptr, nullptr)))
+                                                         /* aServiceName */ nullptr, /* aInstanceName */ nullptr)))
         {
             aUpdate->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
         }
@@ -304,7 +304,7 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
 
     service = nullptr;
     while ((service = otSrpServerHostFindNextService(aHost, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
-                                                     nullptr, nullptr)))
+                                                     /* aServiceName */ nullptr, /* aInstanceName */ nullptr)))
     {
         const char *fullServiceName = otSrpServerServiceGetFullName(service);
         std::string serviceName;
@@ -367,12 +367,12 @@ Mdns::Publisher::SubTypeList AdvertisingProxy::MakeSubTypeList(const otSrpServer
 {
     const otSrpServerHost *      host         = otSrpServerServiceGetHost(aSrpService);
     const char *                 instanceName = otSrpServerServiceGetInstanceName(aSrpService);
-    const otSrpServerService *   subService   = aSrpService;
+    const otSrpServerService *   subService   = nullptr;
     Mdns::Publisher::SubTypeList subTypeList;
 
     while ((subService = otSrpServerHostFindNextService(
-                host, subService, (OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE | OT_SRP_SERVER_SERVICE_FLAG_ACTIVE), nullptr,
-                instanceName)) != nullptr)
+                host, subService, (OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE | OT_SRP_SERVER_SERVICE_FLAG_ACTIVE),
+                /* aServiceName */ nullptr, instanceName)) != nullptr)
     {
         char subLabel[OT_DNS_MAX_LABEL_SIZE];
 

--- a/src/agent/advertising_proxy.cpp
+++ b/src/agent/advertising_proxy.cpp
@@ -282,7 +282,8 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
         aUpdate->mCallbackCount += !hostDeleted;
         aUpdate->mHostName = hostName;
         service            = nullptr;
-        while ((service = otSrpServerHostGetNextService(aHost, service)))
+        while ((service = otSrpServerHostFindNextService(aHost, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
+                                                         nullptr, nullptr)))
         {
             aUpdate->mCallbackCount += !hostDeleted && !otSrpServerServiceIsDeleted(service);
         }
@@ -302,7 +303,8 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     }
 
     service = nullptr;
-    while ((service = otSrpServerHostGetNextService(aHost, service)))
+    while ((service = otSrpServerHostFindNextService(aHost, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
+                                                     nullptr, nullptr)))
     {
         const char *fullServiceName = otSrpServerServiceGetFullName(service);
         std::string serviceName;
@@ -318,11 +320,13 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
 
         if (!hostDeleted && !otSrpServerServiceIsDeleted(service))
         {
-            Mdns::Publisher::TxtList txtList = MakeTxtList(service);
+            Mdns::Publisher::TxtList     txtList     = MakeTxtList(service);
+            Mdns::Publisher::SubTypeList subTypeList = MakeSubTypeList(service);
 
             otbrLogInfo("Publish SRP service: %s", fullServiceName);
             SuccessOrExit(error = mPublisher.PublishService(hostName.c_str(), otSrpServerServiceGetPort(service),
-                                                            serviceName.c_str(), serviceType.c_str(), txtList));
+                                                            serviceName.c_str(), serviceType.c_str(), subTypeList,
+                                                            txtList));
         }
         else
         {
@@ -357,6 +361,32 @@ Mdns::Publisher::TxtList AdvertisingProxy::MakeTxtList(const otSrpServerService 
     }
 
     return txtList;
+}
+
+Mdns::Publisher::SubTypeList AdvertisingProxy::MakeSubTypeList(const otSrpServerService *aSrpService)
+{
+    const otSrpServerHost *      host         = otSrpServerServiceGetHost(aSrpService);
+    const char *                 instanceName = otSrpServerServiceGetInstanceName(aSrpService);
+    const otSrpServerService *   subService   = aSrpService;
+    Mdns::Publisher::SubTypeList subTypeList;
+
+    while ((subService = otSrpServerHostFindNextService(
+                host, subService, (OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE | OT_SRP_SERVER_SERVICE_FLAG_ACTIVE), nullptr,
+                instanceName)) != nullptr)
+    {
+        char subLabel[OT_DNS_MAX_LABEL_SIZE];
+
+        if (otSrpServerServiceGetServiceSubTypeLabel(subService, subLabel, sizeof(subLabel)) == OT_ERROR_NONE)
+        {
+            subTypeList.emplace_back(subLabel);
+        }
+        else
+        {
+            otbrLogWarning("Failed to retrieve subtype of SRP service: %s", otSrpServerServiceGetFullName(aSrpService));
+        }
+    }
+
+    return subTypeList;
 }
 
 } // namespace otbr

--- a/src/agent/advertising_proxy.hpp
+++ b/src/agent/advertising_proxy.hpp
@@ -100,7 +100,8 @@ private:
                                    void *                     aContext);
     void        AdvertisingHandler(otSrpServerServiceUpdateId aId, const otSrpServerHost *aHost, uint32_t aTimeout);
 
-    static Mdns::Publisher::TxtList MakeTxtList(const otSrpServerService *aSrpService);
+    static Mdns::Publisher::TxtList     MakeTxtList(const otSrpServerService *aSrpService);
+    static Mdns::Publisher::SubTypeList MakeSubTypeList(const otSrpServerService *aSrpService);
 
     static void PublishServiceHandler(const char *aName, const char *aType, otbrError aError, void *aContext);
     void        PublishServiceHandler(const char *aName, const char *aType, otbrError aError);

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -300,7 +300,7 @@ void BorderAgent::PublishMeshCopService(void)
 #endif
 
     mPublisher->PublishService(/* aHostName */ nullptr, otBorderAgentGetUdpPort(instance), networkName,
-                               kBorderAgentServiceType, txtList);
+                               kBorderAgentServiceType, Mdns::Publisher::SubTypeList{}, txtList);
 }
 
 void BorderAgent::UnpublishMeshCopService(void)

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -89,7 +89,8 @@ public:
         }
     };
 
-    typedef std::vector<TxtEntry> TxtList;
+    typedef std::vector<TxtEntry>    TxtList;
+    typedef std::vector<std::string> SubTypeList;
 
     /**
      * This structure represents information of a discovered service instance.
@@ -250,20 +251,22 @@ public:
      *                                  this service resides on local host and it is the implementation to provide
      *                                  specific host name. Otherwise, the caller MUST publish the host with method
      *                                  PublishHost.
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
+     * @param[in]   aSubTypeList        A list of service subtypes.
      * @param[in]   aTxtList            A list of TXT name/value pairs.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    virtual otbrError PublishService(const char *   aHostName,
-                                     uint16_t       aPort,
-                                     const char *   aName,
-                                     const char *   aType,
-                                     const TxtList &aTxtList) = 0;
+    virtual otbrError PublishService(const char *       aHostName,
+                                     uint16_t           aPort,
+                                     const char *       aName,
+                                     const char *       aType,
+                                     const SubTypeList &aSubTypeList,
+                                     const TxtList &    aTxtList) = 0;
 
     /**
      * This method un-publishes a service.

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -207,20 +207,22 @@ public:
      *                                  this service resides on local host and it is the implementation to provide
      *                                  specific host name. Otherwise, the caller MUST publish the host with method
      *                                  PublishHost.
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
+     * @param[in]   aSubTypeList        A list of service subtypes.
      * @param[in]   aTxtList            A list of TXT name/value pairs.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(const char *   aHostName,
-                             uint16_t       aPort,
-                             const char *   aName,
-                             const char *   aType,
-                             const TxtList &aTxtList) override;
+    otbrError PublishService(const char *       aHostName,
+                             uint16_t           aPort,
+                             const char *       aName,
+                             const char *       aType,
+                             const SubTypeList &aSubTypeList,
+                             const TxtList &    aTxtList) override;
 
     /**
      * This method un-publishes a service.
@@ -368,6 +370,7 @@ private:
     {
         std::string      mName;
         std::string      mType;
+        SubTypeList      mSubTypeList;
         std::string      mHostName;
         uint16_t         mPort  = 0;
         AvahiEntryGroup *mGroup = nullptr;
@@ -515,6 +518,10 @@ private:
                                      const char *        aName,
                                      const char *        aType,
                                      Services::iterator &aOutServiceIt);
+    static bool        IsServiceOutdated(const Service &    aService,
+                                         const char *       aNewHostName,
+                                         uint16_t           aNewPort,
+                                         const SubTypeList &aNewSubTypeList);
 
     otbrError        CreateGroup(AvahiClient &aClient, AvahiEntryGroup *&aOutGroup);
     static otbrError ResetGroup(AvahiEntryGroup *aGroup);

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -77,20 +77,22 @@ public:
      *                                  this service resides on local host and it is the implementation to provide
      *                                  specific host name. Otherwise, the caller MUST publish the host with method
      *                                  PublishHost.
+     * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
-     * @param[in]   aPort               The port number of this service.
+     * @param[in]   aSubTypeList        A list of service subtypes.
      * @param[in]   aTxtList            A list of TXT name/value pairs.
      *
      * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(const char *   aHostName,
-                             uint16_t       aPort,
-                             const char *   aName,
-                             const char *   aType,
-                             const TxtList &aTxtList) override;
+    otbrError PublishService(const char *       aHostName,
+                             uint16_t           aPort,
+                             const char *       aName,
+                             const char *       aType,
+                             const SubTypeList &aSubTypeList,
+                             const TxtList &    aTxtList) override;
 
     /**
      * This method un-publishes a service.
@@ -237,6 +239,7 @@ private:
     {
         char          mName[kMaxSizeOfServiceName];
         char          mType[kMaxSizeOfServiceType];
+        std::string   mRegType; ///< Service type with optional subtypes separated by commas
         DNSServiceRef mService;
     };
 
@@ -366,8 +369,9 @@ private:
     typedef std::vector<ServiceSubscription> ServiceSubscriptionList;
     typedef std::vector<HostSubscription>    HostSubscriptionList;
 
-    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = nullptr);
-    void RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
+    void        DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = nullptr);
+    void        RecordService(const char *aName, const char *aType, const char *aRegType, DNSServiceRef aServiceRef);
+    static bool IsServiceOutdated(const Service &service, const std::string &aNewRegType);
 
     otbrError DiscardHost(const char *aName, bool aSendGoodbye = true);
     void      RecordHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength, DNSRecordRef aRecordRef);
@@ -395,7 +399,8 @@ private:
                                          DNSServiceFlags     aFlags,
                                          DNSServiceErrorType aErrorCode);
 
-    otbrError MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
+    otbrError          MakeFullName(char *aFullName, size_t aFullNameLength, const char *aName);
+    static std::string MakeRegType(const char *aType, const SubTypeList &aSubTypeList);
 
     ServiceIterator FindPublishedService(const char *aName, const char *aType);
     ServiceIterator FindPublishedService(const DNSServiceRef &aServiceRef);

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -99,7 +99,8 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
         error = sContext.mPublisher->PublishHost(hostName, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the host");
 
-        error = sContext.mPublisher->PublishService(hostName, 12345, "SingleService", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(hostName, 12345, "SingleService", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the service");
     }
 }
@@ -126,19 +127,23 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
         error = sContext.mPublisher->PublishHost(hostName1, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the first host");
 
-        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService11", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService11", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the first service");
 
-        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService12", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService12", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the second service");
 
         error = sContext.mPublisher->PublishHost(hostName2, hostAddr, sizeof(hostAddr));
         SuccessOrDie(error, "cannot publish the second host");
 
-        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService21", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService21", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the first service");
 
-        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService22", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService22", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the second service");
     }
 }
@@ -153,8 +158,8 @@ void PublishSingleService(void *aContext, Mdns::Publisher::State aState)
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
-        otbrError error =
-            sContext.mPublisher->PublishService(nullptr, 12345, "SingleService", "_meshcop._udp.", txtList);
+        otbrError error = sContext.mPublisher->PublishService(nullptr, 12345, "SingleService", "_meshcop._udp.",
+                                                              Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 }
@@ -171,7 +176,8 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool1"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService1", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService1", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 
@@ -181,7 +187,8 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool2"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService2", "_meshcop._udp.", txtList);
+        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService2", "_meshcop._udp.",
+                                                    Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
 }
@@ -204,7 +211,8 @@ void PublishUpdateServices(void *aContext, Mdns::Publisher::State aState)
                                              {"tv", "1.1.1"},
                                              {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
+            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.",
+                                                        Mdns::Publisher::SubTypeList{}, txtList);
         }
         else
         {
@@ -213,8 +221,28 @@ void PublishUpdateServices(void *aContext, Mdns::Publisher::State aState)
                                              {"tv", "1.1.1"},
                                              {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.", txtList);
+            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.",
+                                                        Mdns::Publisher::SubTypeList{}, txtList);
         }
+        assert(error == OTBR_ERROR_NONE);
+    }
+}
+
+void PublishServiceSubTypes(void *aContext, Mdns::Publisher::State aState)
+{
+    assert(aContext == &sContext);
+    if (aState == Mdns::Publisher::State::kReady)
+    {
+        otbrError                    error;
+        Mdns::Publisher::SubTypeList subTypeList{"_subtype1", "_SUBTYPE2"};
+
+        if (sContext.mUpdate)
+        {
+            subTypeList.back() = "_SUBTYPE3";
+        }
+
+        error = sContext.mPublisher->PublishService(nullptr, 12345, "ServiceWithSubTypes", "_meshcop._udp.",
+                                                    subTypeList, Mdns::Publisher::TxtList{});
         assert(error == OTBR_ERROR_NONE);
     }
 }
@@ -295,6 +323,23 @@ exit:
     return ret;
 }
 
+otbrError TestServiceSubTypes(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+
+    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishServiceSubTypes, &sContext);
+    sContext.mPublisher  = pub;
+    sContext.mUpdate     = false;
+    SuccessOrExit(ret = pub->Start());
+    sContext.mUpdate = true;
+    PublishServiceSubTypes(&sContext, Mdns::Publisher::State::kReady);
+    Mainloop(*pub);
+
+exit:
+    Mdns::Publisher::Destroy(pub);
+    return ret;
+}
+
 void RecoverSignal(int aSignal)
 {
     if (aSignal == SIGUSR1)
@@ -351,6 +396,10 @@ int main(int argc, char *argv[])
 
     case 'u':
         ret = TestUpdateService();
+        break;
+
+    case 't':
+        ret = TestServiceSubTypes();
         break;
 
     case 'k':

--- a/tests/mdns/test-service-subtypes
+++ b/tests/mdns/test-service-subtypes
@@ -1,5 +1,6 @@
+#!/bin/bash
 #
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2021, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,58 +27,26 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(otbr-test-mdns
-    main.cpp
-)
+#
+# This script tests publishing multiple services.
+#
 
-target_link_libraries(otbr-test-mdns PRIVATE
-    otbr-config
-    otbr-mdns
-)
+# shellcheck source=tests/mdns/test_init
+. "$(dirname "$0")/test_init"
 
-add_test(
-    NAME mdns-single
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single
-)
+main()
+{
+    start_publisher t
 
-add_test(
-    NAME mdns-multiple
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple
-)
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
+        dns_sd_check_type 'ServiceWithSubTypes' '_meshcop._udp,_subtype1'
+        dns_sd_check_type 'ServiceWithSubTypes' '_meshcop._udp,_subtype2' && exit 1
+        dns_sd_check_type 'ServiceWithSubTypes' '_meshcop._udp,_subtype3'
+    else
+        avahi_check 'ServiceWithSubTypes;_meshcop._udp;' '_subtype1._sub._meshcop._udp'
+        avahi_check 'ServiceWithSubTypes;_meshcop._udp;' '_subtype2._sub._meshcop._udp' && exit 1
+        avahi_check 'ServiceWithSubTypes;_meshcop._udp;' '_subtype3._sub._meshcop._udp'
+    fi
+}
 
-add_test(
-    NAME mdns-update
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-update
-)
-
-add_test(
-    NAME mdns-stop
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-stop
-)
-
-add_test(
-    NAME mdns-single-custom-host
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single-custom-host
-)
-
-add_test(
-    NAME mdns-multiple-custom-hosts
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple-custom-hosts
-)
-
-add_test(
-    NAME mdns-service-subtypes
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-service-subtypes
-)
-
-set_tests_properties(
-    mdns-single
-    mdns-multiple
-    mdns-update
-    mdns-stop
-    mdns-single-custom-host
-    mdns-multiple-custom-hosts
-    mdns-service-subtypes
-    PROPERTIES
-        ENVIRONMENT "OTBR_MDNS=${OTBR_MDNS};OTBR_TEST_MDNS=$<TARGET_FILE:otbr-test-mdns>"
-)
+main "$@"

--- a/tests/mdns/test_init
+++ b/tests/mdns/test_init
@@ -98,6 +98,30 @@ dns_sd_check()
 }
 
 #######################################
+# Check if a service is registered with
+# a given type.
+#
+# Arguments:
+#   $1  Name
+#   $2  Type
+#
+# Returns:
+#   0           Registered
+#   otherwise   Not registered
+#######################################
+dns_sd_check_type()
+{
+    # dns-sd will not exit
+    dns-sd -B "$2" local >"${DNS_SD_RESULT}" 2>&1 &
+    DNS_SD_PID=$!
+    sleep 1
+    kill "${DNS_SD_PID}"
+
+    cat "${DNS_SD_RESULT}"
+    grep "$1" "${DNS_SD_RESULT}"
+}
+
+#######################################
 # Check if a host is regisered
 #
 # Arguments:
@@ -121,10 +145,12 @@ dns_sd_check_host()
 }
 
 #######################################
-# Check if a service is regisered
+# Check if a service is registered
 #
 # Arguments:
 #   $1  Expected avahi query result string
+#   $2  Service type. If omitted, all
+#       services will be examined.
 #
 # Returns:
 #   0           Registered
@@ -132,5 +158,8 @@ dns_sd_check_host()
 #######################################
 avahi_check()
 {
-    avahi-browse -aprt | tee | grep "$1"
+    local service_type
+    (($# == 2)) && service_type="$2" || service_type="-a"
+
+    avahi-browse -prt "$service_type" | tee | grep "$1"
 }


### PR DESCRIPTION
After recent changes in the SRP client & server, SRP services
can now have a base DNS type (such as _meshcop._udp) or
a subtype such as _subtype1._sub._meshcop._udp.

* Make advertising-proxy group the services by the base type
  and pass a list of the subtype labels to the DNS publisher.
* Update both the mDNSResponder and Avahi implementations
  so that it is possible publish a services with additional
  subtypes and to update the subtypes.
* Add unit tests.