### PR TITLE
[setup] fix libjsoncpp1 not found on Ubuntu 21.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,11 @@ jobs:
             build_args: ""
             platforms: "linux/amd64,linux/arm64"
             push: yes
+          - image_tag: "hirsute"
+            base_image: "ubuntu:hirsute"
+            build_args: ""
+            platforms: "linux/amd64,linux/arm64"
+            push: yes
           - image_tag: "reference-device"
             base_image: "ubuntu:bionic"
             build_args: >-

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -71,7 +71,7 @@ ENV OTBR_DOCKER_DEPS git ca-certificates
 # Required and installed during build (script/bootstrap), could be removed
 ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-certificates \
   libreadline-dev libncurses-dev libcpputest-dev libdbus-1-dev libavahi-common-dev \
-  libavahi-client-dev libboost-dev libboost-filesystem-dev libboost-system-dev libjsoncpp-dev \
+  libavahi-client-dev libboost-dev libboost-filesystem-dev libboost-system-dev \
   libnetfilter-queue-dev
 
 # Required for OpenThread Backbone CI

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -83,7 +83,7 @@ install_packages_apt()
     without DHCPV6_PD || sudo apt-get install --no-install-recommends -y dhcpcd5
 
     # libjsoncpp
-    sudo apt-get install --no-install-recommends -y libjsoncpp1 libjsoncpp-dev
+    sudo apt-get install --no-install-recommends -y libjsoncpp-dev
 
     # reference device
     without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/8235

Installing `libjsoncpp-dev` on Ubuntu since it will automatically install the correct `libjsoncpp<Version>` package.

**Ubuntu 21.04:**
```
# apt install libjsoncpp-dev
The following NEW packages will be installed:
  libjsoncpp-dev libjsoncpp24
```

**Ubuntu 18.04:**
```
# apt install libjsoncpp-dev
The following NEW packages will be installed:
  libjsoncpp-dev libjsoncpp1
```
