### PR TITLE
[dns] Add DNS64 recursive query server

### DIFF
--- a/src/agent/discovery_proxy.hpp
+++ b/src/agent/discovery_proxy.hpp
@@ -97,6 +97,7 @@ private:
                                            const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo);
     void OnHostDiscovered(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aHostInfo);
     static uint32_t CapTtl(uint32_t aTtl);
+    void            QeueryRecursive(const std::string &aName);
 
     Ncp::ControllerOpenThread &mNcp;
     Mdns::Publisher &          mMdnsPublisher;

--- a/src/common/dns_utils.cpp
+++ b/src/common/dns_utils.cpp
@@ -37,6 +37,17 @@ static bool NameEndsWithDot(const std::string &aName)
     return !aName.empty() && aName.back() == '.';
 }
 
+bool NameIsLocalService(const std::string &aName)
+{
+    std::string fullName = aName;
+
+    if (!NameEndsWithDot(fullName))
+    {
+        fullName += '.';
+    }
+    return fullName.find("._udp.") != std::string::npos || fullName.find("._tcp.") != std::string::npos;
+}
+
 DnsNameInfo SplitFullDnsName(const std::string &aName)
 {
     size_t      transportPos;

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -75,6 +75,16 @@ struct DnsNameInfo
 };
 
 /**
+ * This method checks whether a name is a local service.
+ *
+ * @param[in] aName     The full DNS name to check.
+ *
+ * @returns  Whether a name is a local service
+ *
+ */
+bool NameIsLocalService(const std::string &aName);
+
+/**
  * This method splits a full DNS name into name components.
  *
  * @param[in] aName     The full DNS name to dissect.


### PR DESCRIPTION
The DNS64 server allows devices in the Thread network to visit IPv4
hostnames transparently via the 6-to-4 border router.

Depends-On: https://github.com/openthread/openthread/pull/6823