### PR TITLE
[border agent] [WIP] publish meshcop service when thread is disabled (part 2/3): disable unpublishing meshcop service

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -121,6 +121,8 @@ otbrError BorderAgent::Start(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
+    otBorderAgentStart(mNcp.GetInstance());
+
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     mAdvertisingProxy.Start();

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -121,8 +121,6 @@ otbrError BorderAgent::Start(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    otBorderAgentStart(mNcp.GetInstance());
-
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     mAdvertisingProxy.Start();

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -311,6 +311,9 @@ void otPlatReset(otInstance *aInstance)
 {
     gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE && OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    otBorderAgentStop(instance);
+#endif
     otInstanceFinalize(aInstance);
     otSysDeinit();
 


### PR DESCRIPTION
This PR is part 2 of the fix of https://github.com/openthread/ot-br-posix/issues/736.

In this PR, we remove the logic of unpublishing meshcop service, and start OpenThread's border agent as soon as possible.

Part 1: https://github.com/openthread/openthread/pull/6847
Part 2: https://github.com/openthread/ot-br-posix/pull/942
Part 3: https://github.com/openthread/openthread/pull/6850