### PR TITLE
[mdns] resolve service name conflicts when using avahi

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -680,6 +680,7 @@ otbrError PublisherAvahi::PublishService(const char *       aHostName,
     // aligned with AvahiStringList
     AvahiStringList  buffer[(kMaxSizeOfTxtRecord - 1) / sizeof(AvahiStringList) + 1];
     AvahiStringList *head = nullptr;
+
     SuccessOrExit(error = TxtListToAvahiStringList(aTxtList, buffer, sizeof(buffer), head));
 
     VerifyOrExit(mState == State::kReady, errno = EAGAIN, error = OTBR_ERROR_ERRNO);
@@ -879,6 +880,7 @@ otbrError PublisherAvahi::TxtListToAvahiStringList(const TxtList &   aTxtList,
     size_t           used  = 0;
     AvahiStringList *last  = nullptr;
     AvahiStringList *curr  = aBuffer;
+
     aHead                  = nullptr;
     for (const auto &txtEntry : aTxtList)
     {

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -881,7 +881,7 @@ otbrError PublisherAvahi::TxtListToAvahiStringList(const TxtList &   aTxtList,
     AvahiStringList *last  = nullptr;
     AvahiStringList *curr  = aBuffer;
 
-    aHead                  = nullptr;
+    aHead = nullptr;
     for (const auto &txtEntry : aTxtList)
     {
         const char *   name        = txtEntry.mName.c_str();

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -373,6 +373,7 @@ void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupSt
         if (serviceIt != mServices.end())
         {
             char *alternativeName = avahi_alternative_service_name(serviceIt->mName.c_str());
+            assert(alternativeName != nullptr);
             otbrLogInfo("Re-publishing service %s using an alternative name: %s", serviceIt->mName.c_str(),
                         alternativeName);
             serviceIt->mName = alternativeName;

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -531,6 +531,11 @@ private:
     void             HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
     void             CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
 
+    static otbrError TxtListToAvahiStringList(const TxtList &   aTxtList,
+                                              AvahiStringList * aBuffer,
+                                              size_t            aBufferSize,
+                                              AvahiStringList *&aHead);
+
     std::string MakeFullName(const char *aName);
 
     void        OnServiceResolved(ServiceSubscription &aService);

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -374,6 +374,7 @@ private:
         std::string      mHostName;
         uint16_t         mPort  = 0;
         AvahiEntryGroup *mGroup = nullptr;
+        TxtList          mTxtList;
     };
 
     typedef std::vector<Service> Services;
@@ -514,6 +515,7 @@ private:
     otbrError       CreateHost(AvahiClient &aClient, const char *aHostName, Hosts::iterator &aOutHostIt);
 
     Services::iterator FindService(const char *aName, const char *aType);
+    Services::iterator FindService(AvahiEntryGroup *aGroup);
     otbrError          CreateService(AvahiClient &       aClient,
                                      const char *        aName,
                                      const char *        aType,
@@ -530,6 +532,7 @@ private:
     static void      HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
     void             HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
     void             CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError) const;
+    otbrError        RetryPublishService(const Services::iterator &aServiceIt);
 
     static otbrError TxtListToAvahiStringList(const TxtList &   aTxtList,
                                               AvahiStringList * aBuffer,


### PR DESCRIPTION
Previously we didn't implement the strategy for resolving service name conflicts while using avahi mdns. Therefore, when there is a service name conflict, the registration will fail silently. Especially, this issue affects the situation when their are two border routers on the same infra link, where there will only have one meshcop service successfully registered.

Have tested locally, will add the test case once https://github.com/openthread/openthread/pull/6865 is checked in.

This PR should fix issue: https://github.com/openthread/ot-br-posix/issues/826