### PR TITLE
fix the problem that the web page may get wrong results prefixed with…

### DIFF
--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -167,7 +167,7 @@ char *OpenThreadClient::Execute(const char *aFormat, ...)
         rxLength += count;
 
         mBuffer[rxLength] = '\0';
-        done              = strstr(mBuffer, "Done\r\n");
+        done              = strstr(mBuffer, "Done\r\n> ");
 
         if (done != nullptr)
         {


### PR DESCRIPTION
fix the problem that the web page may get wrong results prefixed with "> "，the problem occurs when multiple commands are sent to otbr-agent continuously and quickly .