### PR TITLE
[dbus] add `AttachToNetwork` API

### DIFF
--- a/src/agent/thread_helper.cpp
+++ b/src/agent/thread_helper.cpp
@@ -405,7 +405,7 @@ void ThreadHelper::AttachTo(const std::vector<uint8_t> &aDatasetTlvs, ResultHand
     otDeviceRole         role = otThreadGetDeviceRole(mInstance);
 
     assert(aHandler != nullptr);
-    VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = OT_ERROR_BUSY);
 
     if (role == OT_DEVICE_ROLE_DISABLED || role == OT_DEVICE_ROLE_DETACHED)
     {
@@ -458,6 +458,17 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult, void *aContext)
 void ThreadHelper::MgmtSetResponseHandler(otError aResult)
 {
     assert(mAttachHandler != nullptr);
+
+    switch (aResult)
+    {
+    case OT_ERROR_NONE:
+    case OT_ERROR_REJECTED:
+        break;
+    default:
+        aResult = OT_ERROR_FAILED;
+        break;
+    }
+
     mAttachHandler(aResult);
     mAttachHandler = nullptr;
 }

--- a/src/agent/thread_helper.hpp
+++ b/src/agent/thread_helper.hpp
@@ -145,6 +145,15 @@ public:
     void Attach(ResultHandler aHandler);
 
     /**
+     * This method migrates the current network to the network specified by the dataset TLVs.
+     *
+     * @param[in] aDatasetTlvs  The dataset TLVs.
+     * @param[in] aHandler      The result handler.
+     *
+     */
+    void AttachTo(const std::vector<uint8_t> &aDatasetTlvs, ResultHandler aHandler);
+
+    /**
      * This method resets the OpenThread stack.
      *
      * @returns The error value of underlying OpenThread api calls.
@@ -208,11 +217,14 @@ public:
     static void LogOpenThreadResult(const char *aAction, otError aError);
 
 private:
-    static void sActiveScanHandler(otActiveScanResult *aResult, void *aThreadHelper);
+    static void ActiveScanHandler(otActiveScanResult *aResult, void *aThreadHelper);
     void        ActiveScanHandler(otActiveScanResult *aResult);
 
-    static void sJoinerCallback(otError aError, void *aThreadHelper);
+    static void JoinerCallback(otError aError, void *aThreadHelper);
     void        JoinerCallback(otError aResult);
+
+    static void MgmtSetResponseHandler(otError aResult, void *aContext);
+    void        MgmtSetResponseHandler(otError aResult);
 
     void    RandomFill(void *aBuf, size_t size);
     uint8_t RandomChannelFromChannelMask(uint32_t aChannelMask);

--- a/src/dbus/client/client_error.cpp
+++ b/src/dbus/client/client_error.cpp
@@ -71,6 +71,7 @@ static const std::pair<ClientError, const char *> sErrorNames[] = {
     {ClientError::OT_ERROR_NOT_TMF, OTBR_OPENTHREAD_ERROR_PREFIX ".NotTmf"},
     {ClientError::OT_ERROR_NOT_LOWPAN_DATA_FRAME, OTBR_OPENTHREAD_ERROR_PREFIX ".NonLowpanDatatFrame"},
     {ClientError::OT_ERROR_LINK_MARGIN_LOW, OTBR_OPENTHREAD_ERROR_PREFIX ".LinkMarginLow"},
+    {ClientError::OT_ERROR_REJECTED, OTBR_OPENTHREAD_ERROR_PREFIX ".Rejected"},
 };
 
 ClientError ConvertFromDBusErrorName(const std::string &aErrorName)

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -713,5 +713,11 @@ void ThreadApiDBus::sHandleDBusPendingCall(DBusPendingCall *aPending, void *aThr
     (api->*Handler)(aPending);
 }
 
+ClientError ThreadApiDBus::AttachTo(const std::vector<uint8_t> &aDataset)
+{
+    auto args = std::tie(aDataset);
+    return CallDBusMethodSync(OTBR_DBUS_ATTACH_TO_NETWORK_METHOD, args);
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -146,17 +146,19 @@ public:
     ClientError Attach(const OtResultHandler &aHandler);
 
     /**
-     * This method attaches the device to the specified Thread network.
+     * This method attaches the device to the specified Thread network. If already attached to a network, sends a
+     * request to migrate the existing network.
      *
      * @param  aDataset  The Operational Dataset that contains parameter values of the Thread network to attach to. It
      * must have a valid Delay Timer and Pending Timestamp.
      *
-     * @retval ERROR_NONE                  successfully requested the Thread network migration.
-     * @retval ERROR_DBUS                  dbus encode/decode error.
-     * @retval OT_ERROR_REJECTED           the request was rejected by the leader.
-     * @retval OT_ERROR_FAILED             an invalid response was received.
-     * @retval OT_ERROR_ABORT              the CoAP transaction was reset by peer.
-     * @retval OT_ERROR_RESPONSE_TIMEOUT   no response or acknowledgment received during timeout period.
+     * @retval ERROR_NONE              successfully requested the Thread network migration.
+     * @retval ERROR_DBUS              dbus encode/decode error.
+     * @retval OT_ERROR_REJECTED       the request was rejected by the leader.
+     * @retval OT_ERROR_FAILED         failed to send the request.
+     * @retval OT_ERROR_INVALID_STATE  the device is attaching.
+     * @retval OT_ERROR_INVALID_ARGS   arguments are invalid.
+     * @retval OT_ERROR_BUSY           there is an ongoing request.
      *
      */
     ClientError AttachTo(const std::vector<uint8_t> &aDataset);

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -146,6 +146,22 @@ public:
     ClientError Attach(const OtResultHandler &aHandler);
 
     /**
+     * This method attaches the device to the specified Thread network.
+     *
+     * @param  aDataset  The Operational Dataset that contains parameter values of the Thread network to attach to. It
+     * must have a valid Delay Timer and Pending Timestamp.
+     *
+     * @retval ERROR_NONE                  successfully requested the Thread network migration.
+     * @retval ERROR_DBUS                  dbus encode/decode error.
+     * @retval OT_ERROR_REJECTED           the request was rejected by the leader.
+     * @retval OT_ERROR_FAILED             an invalid response was received.
+     * @retval OT_ERROR_ABORT              the CoAP transaction was reset by peer.
+     * @retval OT_ERROR_RESPONSE_TIMEOUT   no response or acknowledgment received during timeout period.
+     *
+     */
+    ClientError AttachTo(const std::vector<uint8_t> &aDataset);
+
+    /**
      * This method performs a factory reset.
      *
      * @param[in]   aHandler        The reset result handler.

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -46,6 +46,7 @@
 
 #define OTBR_DBUS_SCAN_METHOD "Scan"
 #define OTBR_DBUS_ATTACH_METHOD "Attach"
+#define OTBR_DBUS_ATTACH_TO_NETWORK_METHOD "AttachTo"
 #define OTBR_DBUS_DETACH_METHOD "Detach"
 #define OTBR_DBUS_FACTORY_RESET_METHOD "FactoryReset"
 #define OTBR_DBUS_RESET_METHOD "Reset"

--- a/src/dbus/common/error.hpp
+++ b/src/dbus/common/error.hpp
@@ -217,6 +217,11 @@ enum class ClientError
     OT_ERROR_LINK_MARGIN_LOW = 34,
 
     /**
+     * Request rejected.
+     */
+    OT_ERROR_REJECTED = 37,
+
+    /**
      * Generic error (should not use).
      */
     OT_ERROR_GENERIC = 255,

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -86,6 +86,7 @@ private:
 
     void ScanHandler(DBusRequest &aRequest);
     void AttachHandler(DBusRequest &aRequest);
+    void AttachToHandler(DBusRequest &aRequest);
     void DetachHandler(DBusRequest &aRequest);
     void LeaveHandler(DBusRequest &aRequest);
     void FactoryResetHandler(DBusRequest &aRequest);

--- a/src/dbus/server/error_helper.cpp
+++ b/src/dbus/server/error_helper.cpp
@@ -67,6 +67,7 @@ static const std::pair<otError, const char *> sErrorNames[] = {
     {OT_ERROR_NOT_TMF, OPENTHREAD_ERROR_PREFIX ".NotTmf"},
     {OT_ERROR_NOT_LOWPAN_DATA_FRAME, OPENTHREAD_ERROR_PREFIX ".NonLowpanDatatFrame"},
     {OT_ERROR_LINK_MARGIN_LOW, OPENTHREAD_ERROR_PREFIX ".LinkMarginLow"},
+    {OT_ERROR_REJECTED, OPENTHREAD_ERROR_PREFIX ".Rejected"},
 };
 
 namespace otbr {

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -46,6 +46,14 @@
       <arg name="channel_mask" type="u"/>
     </method>
 
+    <!-- AttachTo: Attach the current device to the specified Thread network.
+      @dataset: The Operational Dataset that contains parameter values of the Thread network
+                to attach to. It must have a valid Delay Timer and Pending Timestamp.
+    -->
+    <method name="AttachTo">
+      <arg name="dataset" type="ay"/>
+    </method>
+
     <!-- Detach: Detach the current device from the Thread network. -->
     <method name="Detach">
     </method>

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -916,7 +916,8 @@ int UbusServer::UbusMgmtset(struct ubus_context *     aContext,
         otCommissionerStop(mController->GetInstance());
     }
     SuccessOrExit(
-        error = otDatasetSendMgmtActiveSet(mController->GetInstance(), &dataset, tlvs, static_cast<uint8_t>(length)));
+        error = otDatasetSendMgmtActiveSet(
+            mController->GetInstance(), &dataset, tlvs, static_cast<uint8_t>(length), [](otError, void *) {}, nullptr));
 exit:
     AppendResult(error, aContext, aRequest);
     return 0;

--- a/tests/dbus/CMakeLists.txt
+++ b/tests/dbus/CMakeLists.txt
@@ -53,4 +53,4 @@ add_test(
 set_tests_properties(dbus-client PROPERTIES
     ENVIRONMENT CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
 )
-set_tests_properties(dbus-client PROPERTIES TIMEOUT 120)
+set_tests_properties(dbus-client PROPERTIES TIMEOUT 420)

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -118,13 +118,49 @@ EOF
         string:ABCDEF string:mock string:mock \
         string:mock string:mock string:mock
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep -e child -e router
+
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.Detach
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep disabled
+
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
     sleep 1
+
     sudo "${CMAKE_BINARY_DIR}"/tests/dbus/otbr-test-dbus-client
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
+    sleep 1
+
+    sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
+        io.openthread.BorderRouter.Attach \
+        array:byte: \
+        uint16:0xffff \
+        string:OpenThread \
+        uint64:0xffffffffffffffff \
+        array:byte: \
+        uint32:0xffffffff
+
+    local dataset="0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x33,0x08,0x00,0x00,0x00,"
+    dataset+="0x00,0x00,0x01,0x00,0x00,0x34,0x04,0x00,0x04,0x80,0x88,0x00,0x03,0x00,0x00,0x0d,"
+    dataset+="0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0xae,0x9b,0xd4,0x19,0x59,0x55,"
+    dataset+="0x56,0x43,0x07,0x08,0xfd,0xc2,0x04,0x93,0xa7,0x64,0x6c,0x28,0x05,0x10,0x3c,0x2e,"
+    dataset+="0x53,0xb6,0xd6,0x42,0xc5,0x9e,0x25,0x79,0xe4,0x3a,0x5a,0x0d,0xb2,0xfb,0x03,0x0f,"
+    dataset+="0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x32,0x36,0x35,0x38,0x01,"
+    dataset+="0x02,0x26,0x58,0x04,0x10,0x84,0xd7,0x14,0x51,0x72,0xb9,0xdc,0x74,0x22,0x45,0xe7,"
+    dataset+="0x89,0x97,0x87,0xd3,0xb2,0x0c,0x04,0x02,0xa0,0xff,0xf8"
+    sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
+        io.openthread.BorderRouter.AttachTo \
+        "array:byte:${dataset}"
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset pending | grep "Active Timestamp: 2"
+
+    sleep 310
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset active | grep "Active Timestamp: 2"
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl networkkey | grep 3c2e53b6d642c59e2579e43a5a0db2fb
 }
 
 main "$@"


### PR DESCRIPTION
This adds the `AttachToNetwork` API, which attaches the device to the specified network. It sets the active dataset directly if there is no active dataset, or sends `MGMT_SET` if there is an active dataset.

Depends on <https://github.com/openthread/openthread/pull/6877>, please ignore the submodule update when reviewing.