### PR TITLE
[mdns] rename "MDNS" to "mDNS"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 
 include(GNUInstallDirs)
 
-set(OTBR_MDNS "avahi" CACHE STRING "MDNS service provider")
+set(OTBR_MDNS "avahi" CACHE STRING "mDNS service provider")
 set_property(CACHE OTBR_MDNS PROPERTY STRINGS "avahi" "mDNSResponder")
 
 pkg_check_modules(SYSTEMD systemd)

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -197,7 +197,7 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
 #endif
         break;
     default:
-        otbrLogWarning("MDNS service not available!");
+        otbrLogWarning("mDNS service not available!");
         break;
     }
 }

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -72,7 +72,7 @@ enum otbrError
 
     OTBR_ERROR_ERRNO           = -1,  ///< Error defined by errno.
     OTBR_ERROR_DBUS            = -2,  ///< DBus error.
-    OTBR_ERROR_MDNS            = -3,  ///< MDNS error.
+    OTBR_ERROR_MDNS            = -3,  ///< mDNS error.
     OTBR_ERROR_OPENTHREAD      = -4,  ///< OpenThread error.
     OTBR_ERROR_REST            = -5,  ///< Rest Server error.
     OTBR_ERROR_SMCROUTE        = -6,  ///< SMCRoute error.

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -51,13 +51,13 @@ namespace Mdns {
  * @addtogroup border-router-mdns
  *
  * @brief
- *   This module includes definition for MDNS service.
+ *   This module includes definition for mDNS service.
  *
  * @{
  */
 
 /**
- * This interface defines the functionality of MDNS service.
+ * This interface defines the functionality of mDNS service.
  *
  */
 class Publisher : public MainloopProcessor
@@ -155,7 +155,7 @@ public:
         std::function<void(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo)>;
 
     /**
-     * MDNS state values.
+     * mDNS state values.
      *
      */
     enum class State
@@ -165,7 +165,7 @@ public:
     };
 
     /**
-     * This function pointer is called when MDNS service state changed.
+     * This function pointer is called when mDNS service state changed.
      *
      * @param[in]   aContext        A pointer to application-specific context.
      * @param[in]   aState          The new state.
@@ -221,16 +221,16 @@ public:
     }
 
     /**
-     * This method starts the MDNS service.
+     * This method starts the mDNS service.
      *
-     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
-     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     * @retval OTBR_ERROR_NONE  Successfully started mDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start mDNS service.
      *
      */
     virtual otbrError Start(void) = 0;
 
     /**
-     * This method stops the MDNS service.
+     * This method stops the mDNS service.
      *
      */
     virtual void Stop(void) = 0;
@@ -377,20 +377,20 @@ public:
     virtual ~Publisher(void) = default;
 
     /**
-     * This function creates a MDNS publisher.
+     * This function creates a mDNS publisher.
      *
      * @param[in]   aProtocol           Protocol to use for publishing. AF_INET6, AF_INET or AF_UNSPEC.
      * @param[in]   aDomain             The domain to register in. Set nullptr to use default mDNS domain ("local.").
      * @param[in]   aHandler            The function to be called when this service state changed.
      * @param[in]   aContext            A pointer to application-specific context.
      *
-     * @returns A pointer to the newly created MDNS publisher.
+     * @returns A pointer to the newly created mDNS publisher.
      *
      */
     static Publisher *Create(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
 
     /**
-     * This function destroys the MDNS publisher.
+     * This function destroys the mDNS publisher.
      *
      * @param[in]   aPublisher          A pointer to the publisher.
      *

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file implements MDNS service based on avahi.
+ *   This file implements mDNS service based on avahi.
  */
 
 #define OTBR_LOG_TAG "MDNS"

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definition for MDNS service based on avahi.
+ *   This file includes definition for mDNS service based on avahi.
  */
 
 #ifndef OTBR_AGENT_MDNS_AVAHI_HPP_
@@ -50,7 +50,7 @@
  * @addtogroup border-router-mdns
  *
  * @brief
- *   This module includes definition for avahi-based MDNS service.
+ *   This module includes definition for avahi-based mDNS service.
  *
  * @{
  */
@@ -181,7 +181,7 @@ private:
 };
 
 /**
- * This class implements MDNS service with avahi.
+ * This class implements mDNS service with avahi.
  *
  */
 class PublisherAvahi : public Publisher
@@ -316,10 +316,10 @@ public:
     void UnsubscribeHost(const std::string &aHostName) override;
 
     /**
-     * This method starts the MDNS service.
+     * This method starts the mDNS service.
      *
-     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
-     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     * @retval OTBR_ERROR_NONE  Successfully started mDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start mDNS service.
      *
      */
     otbrError Start(void) override;
@@ -334,7 +334,7 @@ public:
     bool IsStarted(void) const override;
 
     /**
-     * This method stops the MDNS service.
+     * This method stops the mDNS service.
      *
      */
     void Stop(void) override;

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definition for MDNS service.
+ *   This file includes definition for mDNS service.
  */
 
 #ifndef OTBR_AGENT_MDNS_MDNSSD_HPP_
@@ -51,7 +51,7 @@ namespace otbr {
 namespace Mdns {
 
 /**
- * This class implements MDNS service with mDNSResponder.
+ * This class implements mDNS service with mDNSResponder.
  *
  */
 class PublisherMDnsSd : public Publisher
@@ -186,10 +186,10 @@ public:
     void UnsubscribeHost(const std::string &aHostName) override;
 
     /**
-     * This method starts the MDNS service.
+     * This method starts the mDNS service.
      *
-     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
-     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     * @retval OTBR_ERROR_NONE  Successfully started mDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start mDNS service.
      *
      */
     otbrError Start(void) override;
@@ -204,7 +204,7 @@ public:
     bool IsStarted(void) const override;
 
     /**
-     * This method stops the MDNS service.
+     * This method stops the mDNS service.
      *
      */
     void Stop(void) override;


### PR DESCRIPTION
Per [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762), the name should be "mDNS".