### PR TITLE
[github-actions] fix border router CI failures

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -97,7 +97,7 @@ jobs:
           --build-arg OT_BACKBONE_CI=1 \
           --build-arg NAT64=0 \
           --build-arg MDNS="${{ matrix.otbr_mdns }}" \
-          --build-arg OTBR_OPTIONS="${otbr_options}"
+          --build-arg OTBR_OPTIONS="${otbr_options} -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF=1'"
     - name: Bootstrap OpenThread Test
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update


### PR DESCRIPTION
This commit fixes border router CI failures caused by https://github.com/openthread/openthread/pull/6838 changes.