### PR TITLE
[mdns] fix unused variable of aServiceRef

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -435,12 +435,13 @@ exit:
 
 void PublisherMDnsSd::DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
 {
+    OT_UNUSED_VARIABLE(aServiceRef);
+
     ServiceIterator service = FindPublishedService(aName, aType);
 
     if (service != mServices.end())
     {
         assert(aServiceRef == nullptr || aServiceRef == service->mService);
-        OTBR_UNUSED_VARIABLE(aServiceRef);
 
         otbrLogInfo("Remove service ref %p", service->mService);
 

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -435,7 +435,7 @@ exit:
 
 void PublisherMDnsSd::DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef)
 {
-    OT_UNUSED_VARIABLE(aServiceRef);
+    OTBR_UNUSED_VARIABLE(aServiceRef);
 
     ServiceIterator service = FindPublishedService(aName, aType);
 


### PR DESCRIPTION
Without this change clang may complain `aServiceRef` is unused in some situations.