### PR TITLE
[mdns-avahi] browse or resolve using unspecified protocol

### DIFF
--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -409,7 +409,11 @@ private:
 
         void Release(void);
         void Browse(void);
-        void Resolve(uint32_t aInterfaceIndex, const char *aInstanceName, const char *aType, const char *aDomain);
+        void Resolve(uint32_t      aInterfaceIndex,
+                     AvahiProtocol aProtocol,
+                     const char *  aInstanceName,
+                     const char *  aType,
+                     const char *  aDomain);
         void GetAddrInfo(uint32_t aInterfaceIndex);
 
         static void HandleBrowseResult(AvahiServiceBrowser *  aServiceBrowser,


### PR DESCRIPTION
This commit fixes the bug that mDNS using Avahi only browses or resolves services using IPv6 sockets. 

Note that `avahi-daemon` may be configured to not use IPv6 socket:

```
       use-ipv6=  Takes a boolean value ("yes" or "no"). If set to "no" avahi-daemon will not use
       IPv6 sockets. Default is "yes".
```
