### PR TITLE
[crypto] Update otThreadGetNetworkKey and otThreadGetPskc usage

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -382,10 +382,12 @@ bool BorderAgent::IsThreadStarted(void) const
 
 bool BorderAgent::IsPskcInitialized(void) const
 {
-    bool          initialized = false;
-    const otPskc *pskc        = otThreadGetPskc(mNcp.GetInstance());
+    bool   initialized = false;
+    otPskc pskc;
 
-    for (uint8_t byte : pskc->m8)
+    otThreadGetPskc(mNcp.GetInstance(), &pskc);
+
+    for (uint8_t byte : pskc.m8)
     {
         if (byte != 0x00)
         {

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -597,11 +597,12 @@ exit:
 
 otError DBusThreadObject::GetNetworkKeyHandler(DBusMessageIter &aIter)
 {
-    auto                 threadHelper = mNcp->GetThreadHelper();
-    const otNetworkKey * networkKey   = otThreadGetNetworkKey(threadHelper->GetInstance());
-    std::vector<uint8_t> keyVal(networkKey->m8, networkKey->m8 + sizeof(networkKey->m8));
-    otError              error = OT_ERROR_NONE;
+    auto         threadHelper = mNcp->GetThreadHelper();
+    otNetworkKey networkKey;
+    otError      error = OT_ERROR_NONE;
 
+    otThreadGetNetworkKey(threadHelper->GetInstance(), &networkKey);
+    std::vector<uint8_t> keyVal(networkKey.m8, networkKey.m8 + sizeof(networkKey.m8));
     VerifyOrExit(DBusMessageEncodeToVariant(&aIter, keyVal) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
 exit:

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -1103,16 +1103,20 @@ int UbusServer::UbusGetInformation(struct ubus_context *     aContext,
     }
     else if (!strcmp(aAction, "networkkey"))
     {
-        char           outputKey[NETWORKKEY_LENGTH] = "";
-        const uint8_t *key = reinterpret_cast<const uint8_t *>(otThreadGetNetworkKey(mController->GetInstance()));
-        OutputBytes(key, OT_NETWORK_KEY_SIZE, outputKey);
+        char         outputKey[NETWORKKEY_LENGTH] = "";
+        otNetworkKey key;
+
+        otThreadGetNetworkKey(mController->GetInstance(), &key);
+        OutputBytes(key.m8, OT_NETWORK_KEY_SIZE, outputKey);
         blobmsg_add_string(&mBuf, "Networkkey", outputKey);
     }
     else if (!strcmp(aAction, "pskc"))
     {
-        char          outputPskc[NETWORKKEY_LENGTH] = "";
-        const otPskc *pskc                          = otThreadGetPskc(mController->GetInstance());
-        OutputBytes(pskc->m8, OT_NETWORK_KEY_SIZE, outputPskc);
+        char   outputPskc[NETWORKKEY_LENGTH] = "";
+        otPskc pskc;
+
+        otThreadGetPskc(mController->GetInstance(), &pskc);
+        OutputBytes(pskc.m8, OT_NETWORK_KEY_SIZE, outputPskc);
         blobmsg_add_string(&mBuf, "pskc", outputPskc);
     }
     else if (!strcmp(aAction, "extpanid"))

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -1116,7 +1116,7 @@ int UbusServer::UbusGetInformation(struct ubus_context *     aContext,
         otPskc pskc;
 
         otThreadGetPskc(mController->GetInstance(), &pskc);
-        OutputBytes(pskc.m8, OT_NETWORK_KEY_SIZE, outputPskc);
+        OutputBytes(pskc.m8, OT_PSKC_MAX_SIZE, outputPskc);
         blobmsg_add_string(&mBuf, "pskc", outputPskc);
     }
     else if (!strcmp(aAction, "extpanid"))


### PR DESCRIPTION
This PR aims to update the usage of `otThreadGetNetworkKey` and `otThreadGetPskc` based on the updates proposed in openthread/openthread#6862. This should be merged at the same time with openthread/openthread#6862.

Depends-On: openthread/openthread#6862