### PR TITLE
[web] extend web client timeout

### DIFF
--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -283,7 +283,7 @@ bool OpenThreadClient::FactoryReset(void)
     Execute("factoryreset");
     signal(SIGPIPE, handler);
     Disconnect();
-    sleep(1);
+    sleep(4);
     VerifyOrExit(rval = Connect());
 
     result = Execute("version");


### PR DESCRIPTION
RCP with USB transport needs more time for reinitialization after hard resetting due to reattaching the USB device to host OS.

Depends on:

- [x] https://github.com/openthread/openthread/pull/6963