### PR TITLE
[mdns] update the service port in mDNSResponder implementation

### DIFF
--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -241,6 +241,7 @@ private:
         char          mType[kMaxSizeOfServiceType];
         std::string   mRegType; ///< Service type with optional subtypes separated by commas
         DNSServiceRef mService;
+        uint16_t      mPort = 0;
     };
 
     struct Host
@@ -370,8 +371,12 @@ private:
     typedef std::vector<HostSubscription>    HostSubscriptionList;
 
     void        DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef = nullptr);
-    void        RecordService(const char *aName, const char *aType, const char *aRegType, DNSServiceRef aServiceRef);
-    static bool IsServiceOutdated(const Service &service, const std::string &aNewRegType);
+    void        RecordService(const char *  aName,
+                              const char *  aType,
+                              const char *  aRegType,
+                              uint16_t      aPort,
+                              DNSServiceRef aServiceRef);
+    static bool IsServiceOutdated(const Service &service, const std::string &aNewRegType, int aNewPort);
 
     otbrError DiscardHost(const char *aName, bool aSendGoodbye = true);
     void      RecordHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength, DNSRecordRef aRecordRef);


### PR DESCRIPTION
Previously in mDNSResponder implementation, otbr-agent won't update the service port when `PublishService` is called. 