### PR TITLE
[github-actions] fix brew install issue on macOS

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -54,6 +54,7 @@ jobs:
         submodules: true
     - name: Bootstrap
       run: |
+        rm -f '/usr/local/bin/2to3'
         brew update
         brew reinstall boost cmake cpputest dbus jsoncpp ninja
     - name: Build


### PR DESCRIPTION
This PR aims to fix https://github.com/openthread/ot-br-posix/issues/1002.

When brew install ninja, python 3.9 is being installed as a dependency. However, the installation failed because there is a conflict on binary /usr/local/bin/2to3.