### PR TITLE
[logging] fix OpenThread dynamic logging

### DIFF
--- a/src/agent/ncp_openthread.cpp
+++ b/src/agent/ncp_openthread.cpp
@@ -280,7 +280,7 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
 
     va_list ap;
     va_start(ap, aFormat);
-    otbrLogv(otbrLogLevel, aFormat, ap);
+    otbrLogvNoFilter(otbrLogLevel, aFormat, ap);
     va_end(ap);
 }
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -111,14 +111,19 @@ void otbrLog(otbrLogLevel aLevel, const char *aLogTag, const char *aFormat, ...)
 }
 
 /** log to the syslog or log file */
-void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list ap)
+void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list aArgList)
 {
     assert(aFormat);
 
     if (aLevel <= sLevel)
     {
-        vsyslog(static_cast<int>(aLevel), aFormat, ap);
+        otbrLogvNoFilter(aLevel, aFormat, aArgList);
     }
+}
+
+void otbrLogvNoFilter(otbrLogLevel aLevel, const char *aFormat, va_list aArgList)
+{
+    vsyslog(static_cast<int>(aLevel), aFormat, aArgList);
 }
 
 /** Hex dump data to the log */

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -96,11 +96,22 @@ void otbrLog(otbrLogLevel aLevel, const char *aLogTag, const char *aFormat, ...)
 /**
  * This function log at level @p aLevel.
  *
- * @param[in]   aLevel  Log level of the logger.
- * @param[in]   aFormat Format string as in printf.
+ * @param[in]   aLevel   Log level of the logger.
+ * @param[in]   aFormat  Format string as in printf.
+ * @param[in]   aArgList The variable-length arguments list.
  *
  */
-void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list);
+void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list aArgList);
+
+/**
+ * This function writes logs without filtering with the log level.
+ *
+ * @param[in]   aLevel  Log level of the logger.
+ * @param[in]   aFormat Format string as in printf.
+ * @param[in]   aArgList The variable-length arguments list.
+ *
+ */
+void otbrLogvNoFilter(otbrLogLevel aLevel, const char *aFormat, va_list aArgList);
 
 /**
  * This function dump memory as hex string at level @p aLevel.


### PR DESCRIPTION
OTBR is providing custom `otPlatLog` function which overwrites the default posix logging function. The problem is that the OTBR `otPlatLog` function will filter out logs based on current OTBR log level, this will result in the situation that we cannot print more OT logs with command `ot-ctl log level <level-value>` (when dynamic logging is enabled).