### PR TITLE
[dbus] fix failure to  get 'All' OpenThread properties

### DIFF
--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -183,10 +183,12 @@ otbrError DBusThreadObject::Init(void)
                                std::bind(&DBusThreadObject::GetStableNetworkDataHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_LOCAL_LEADER_WEIGHT,
                                std::bind(&DBusThreadObject::GetLocalLeaderWeightHandler, this, _1));
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_CHANNEL_MONITOR_SAMPLE_COUNT,
                                std::bind(&DBusThreadObject::GetChannelMonitorSampleCountHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_CHANNEL_MONITOR_ALL_CHANNEL_QUALITIES,
                                std::bind(&DBusThreadObject::GetChannelMonitorAllChannelQualities, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_CHILD_TABLE,
                                std::bind(&DBusThreadObject::GetChildTableHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NEIGHBOR_TABLE_PROEPRTY,


### PR DESCRIPTION
dbus client's call to 'GetAll' properties fails
with following error, if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE is not enabled.

Error log:-
[INFO]-DBUS----: Handling method org.freedesktop.DBus.Properties.GetAll
[ERR ]-UTILS---: Replied to org.freedesktop.DBus.Properties.GetAll with result io.openthread.Error.NotImplemented

This patch fixes above issue, by applying conditional
registration of following properties:
- OTBR_DBUS_PROPERTY_CHANNEL_MONITOR_SAMPLE_COUNT
- OTBR_DBUS_PROPERTY_CHANNEL_MONITOR_ALL_CHANNEL_QUALITIES

Signed-off-by: Anupam Roy <anupam.r@samsung.com>