### PR TITLE
[advertising-proxy] harden duplicate SRP update handling

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -207,6 +207,9 @@ void BorderAgent::Update(MainloopContext &aMainloop)
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mBackboneAgent.Update(aMainloop);
 #endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mAdvertisingProxy.Update(aMainloop);
+#endif
 
     if (mPublisher != nullptr)
     {
@@ -219,6 +222,10 @@ void BorderAgent::Process(const MainloopContext &aMainloop)
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mBackboneAgent.Process(aMainloop);
 #endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mAdvertisingProxy.Process(aMainloop);
+#endif
+
     if (mPublisher != nullptr)
     {
         mPublisher->Process(aMainloop);


### PR DESCRIPTION
Currently, handlers called after completing an asynchronous
update of a DNS host or service simply decrement the number
of outstanding operations. It may lead to incorrect
handling of several SRP updates related to a single host,
sent within a short period of time, such as the ones below:

```
UPDATE1:
  EXISTING_HOST
    SERVICE1
UPDATE2:
  EXISTING_HOST
    SERVICE1
```

It may happen that both UPDATE1.EXISTING_HOST and
UPDATE2.EXISTING_HOST decrement the number of outstanding
operations for UPDATE1 and UPDATE1 is considered completed
even before UPDATE1.EXISTING_HOST.SERVICE1 is published.

Moreover, since the handlers can be called synchronously
in certain scenarios, it may occur that an update object
is released before PublishHostAndItsServices() exits which
may lead to accessing an invalid memory location. Make sure
that the handlers are called in the main loop.

Due the the mentioned problems, an SRP client may not
receive a response for UPDATE2 and keep re-sending the same
update.

Fixes #1011

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>