### PR TITLE
Propagate the "preferred" flag via D-Bus

### DIFF
--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -375,6 +375,7 @@ void DBusThreadObject::AddOnMeshPrefixHandler(DBusRequest &aRequest)
               &config.mPrefix.mPrefix.mFields.m8[0]);
     config.mPrefix.mLength = onMeshPrefix.mPrefix.mLength;
     config.mPreference     = onMeshPrefix.mPreference;
+    config.mPreferred      = onMeshPrefix.mPreferred;
     config.mSlaac          = onMeshPrefix.mSlaac;
     config.mDhcp           = onMeshPrefix.mDhcp;
     config.mConfigure      = onMeshPrefix.mConfigure;


### PR DESCRIPTION
When calling `AddOnMeshPrefix` passing the following parameters via D-Bus
```
/usr/bin/gdbus call --system --dest=io.openthread.BorderRouter.$_DEV \
                --object-path /io/openthread/BorderRouter/$_DEV --method io.openthread.BorderRouter.AddOnMeshPrefix \
                "(([0x12, 0x34, 0, 0, 0, 0],64),1,(true,false,true,true,true,false,true))"
```
`ot-ctl prefix` returns `1234:0:0:0::/64 dcrs high fff` while I was expecting `pdcrs` given that the `preferred` flag is set.

Applying the suggested change before compiling fixes the issue, as in the `preferred` flag is now taken into account, and visible (as `pdcrs`) through `ot-ctl prefix`