### PR TITLE
[agent] set dry-run option in Thread config if printRadioVersion is true

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -285,7 +285,8 @@ static int realmain(int argc, char *argv[])
     }
 
     {
-        otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, radioUrls, backboneInterfaceName};
+        otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, radioUrls, backboneInterfaceName,
+                                                      /* DryRun */ printRadioVersion};
 
         otbr::InstanceParams::Get().SetThreadIfName(interfaceName);
         otbr::InstanceParams::Get().SetBackboneIfName(backboneInterfaceName);

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -286,7 +286,7 @@ static int realmain(int argc, char *argv[])
 
     {
         otbr::Ncp::ControllerOpenThread ncpOpenThread{interfaceName, radioUrls, backboneInterfaceName,
-                                                      /* DryRun */ printRadioVersion};
+                                                      /* aDryRun */ printRadioVersion};
 
         otbr::InstanceParams::Get().SetThreadIfName(interfaceName);
         otbr::InstanceParams::Get().SetBackboneIfName(backboneInterfaceName);

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -62,7 +62,8 @@ static const uint16_t kThreadVersion12 = 3; ///< Thread Version 1.2
 
 ControllerOpenThread::ControllerOpenThread(const char *                     aInterfaceName,
                                            const std::vector<const char *> &aRadioUrls,
-                                           const char *                     aBackboneInterfaceName)
+                                           const char *                     aBackboneInterfaceName,
+                                           bool                             aDryRun)
     : mInstance(nullptr)
 {
     VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
@@ -71,6 +72,8 @@ ControllerOpenThread::ControllerOpenThread(const char *                     aInt
 
     mConfig.mInterfaceName         = aInterfaceName;
     mConfig.mBackboneInterfaceName = aBackboneInterfaceName;
+    mConfig.mDryRun                = aDryRun;
+
     for (const char *url : aRadioUrls)
     {
         mConfig.mRadioUrls[mConfig.mRadioUrlNum++] = url;

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -62,14 +62,16 @@ public:
     /**
      * This constructor initializes this object.
      *
-     * @param[in] aInterfaceName          A string of the NCP interface name.
-     * @param[in] aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
-     * @param[in] aBackboneInterfaceName  The Backbone network interface name.
+     * @param[in]   aInterfaceName          A string of the NCP interface name.
+     * @param[in]   aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
+     * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
+     * @param[in]   aDryRun                 TRUE to indicate dry-run mode. FALSE otherwise.
      *
      */
     ControllerOpenThread(const char *                     aInterfaceName,
                          const std::vector<const char *> &aRadioUrls,
-                         const char *                     aBackboneInterfaceName);
+                         const char *                     aBackboneInterfaceName,
+                         bool                             aDryRun);
 
     /**
      * This method initalize the NCP controller.


### PR DESCRIPTION
`otbr-agent` will exit directly if `--radio-version` is passed in
parameters. This PR sets the DryRun option in PosixConfig when
`radio-version` is set. In this way, the posix instance will only
initialize very few things to avoid permission issues.
