### PR TITLE
[netdiag] do not request TypeList TLV type when retrieving diagnostics

### DIFF
--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -70,7 +70,7 @@ namespace rest {
 static const char *kMulticastAddrAllRouters = "ff03::2";
 
 // Default TlvTypes for Diagnostic inforamtion
-static const uint8_t kAllTlvTypes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 18, 19};
+static const uint8_t kAllTlvTypes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 19};
 
 // Timeout (in Microseconds) for deleting outdated diagnostics
 static const uint32_t kDiagResetTimeout = 3000000;


### PR DESCRIPTION
Removes the `TypeList` TLV (18) from the list of TLV type being requested as this is an invalid TLV type to request, which breaks getting diagnostic information from thread routers running OpenThread < https://github.com/openthread/openthread/commit/582c2c136ad798db0b3d2f0e495b5d620d9bcd0b (including the latest OpenThread Reference)

FIxes #1035 