### PR TITLE
[tests] use `--no-check-certificates` when invoking `wget`

### DIFF
--- a/tests/scripts/check-android-build
+++ b/tests/scripts/check-android-build
@@ -42,7 +42,7 @@ set -x
 prepare_dbus()
 {
     DBUS_SOURCE=dbus-1.4.26
-    wget -nv "https://dbus.freedesktop.org/releases/dbus/${DBUS_SOURCE}.tar.gz"
+    wget --tries 4 --no-check-certificate --quiet "https://dbus.freedesktop.org/releases/dbus/${DBUS_SOURCE}.tar.gz"
     tar xvf "${DBUS_SOURCE}.tar.gz"
     (cd "${DBUS_SOURCE}" && ./configure --prefix= --exec-prefix=/usr \
         && sed -i '/HAVE_BACKTRACE/d' config.h \
@@ -162,7 +162,7 @@ prepare_libmdnssd()
 
     [[ ${OTBR_MDNS} == mDNSResponder ]] || return 0
 
-    wget -nv "https://opensource.apple.com/tarballs/mDNSResponder/${MDNSRESPONDER_SOURCE}.tar.gz"
+    wget --tries 4 --no-check-certificate --quiet "https://opensource.apple.com/tarballs/mDNSResponder/${MDNSRESPONDER_SOURCE}.tar.gz"
     tar xvf "${MDNSRESPONDER_SOURCE}.tar.gz"
     cat >"${MDNSRESPONDER_SOURCE}/Android.mk" <<EOF
 LOCAL_PATH:= \$(call my-dir)


### PR DESCRIPTION
To address the following issue:
```
get -nv https://dbus.freedesktop.org/releases/dbus/dbus-1.4.26.tar.gz
ERROR: cannot verify dbus.freedesktop.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
  Issued certificate has expired.
To connect to dbus.freedesktop.org insecurely, use `--no-check-certificate'.
Error: Process completed with exit code 5.
```