### PR TITLE
[meshcop] add vn and mn fields in meshcop service's TXT record

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(OTBR_INFRA_IF_NAME "wlan0" CACHE STRING "The infrastructure interface name")
 set(OTBR_VENDOR_NAME "OpenThread" CACHE STRING "The vendor name")
 set(OTBR_PRODUCT_NAME "BorderRouter" CACHE STRING "The product name")
 set(OTBR_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The package name")
+set(OTBR_MESHCOP_SERVICE_INSTANCE_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The OTBR MeshCoP service instance name")
 set(OTBR_MDNS "avahi" CACHE STRING "mDNS service provider")
 
 set_property(CACHE OTBR_MDNS PROPERTY STRINGS "avahi" "mDNSResponder")
@@ -89,6 +90,7 @@ target_compile_definitions(otbr-config INTERFACE
     "OTBR_PRODUCT_NAME=\"${OTBR_PRODUCT_NAME}\""
     "OTBR_PACKAGE_NAME=\"${OTBR_NAME}\""
     "OTBR_PACKAGE_VERSION=\"${OTBR_VERSION}\""
+    "OTBR_MESHCOP_SERVICE_INSTANCE_NAME=\"${OTBR_MESHCOP_SERVICE_INSTANCE_NAME}\""
 )
 
 if(BUILD_SHARED_LIBS)

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -63,6 +63,8 @@
 
 namespace otbr {
 
+static const char kVendorName[]             = OTBR_VENDOR_NAME;
+static const char kProductName[]            = OTBR_PRODUCT_NAME;
 static const char kBorderAgentServiceType[] = "_meshcop._udp"; ///< Border agent service type of mDNS
 static const char kBorderAgentServiceInstanceName[] =
     OTBR_MESHCOP_SERVICE_INSTANCE_NAME; ///< Border agent service name of mDNS
@@ -214,6 +216,8 @@ void BorderAgent::PublishMeshCopService(void)
 
     otbrLogInfo("Publish meshcop service %s.%s.local.", kBorderAgentServiceInstanceName, kBorderAgentServiceType);
 
+    txtList.emplace_back("vn", kVendorName);
+    txtList.emplace_back("mn", kProductName);
     txtList.emplace_back("nn", networkName);
     txtList.emplace_back("xp", extPanId->m8, sizeof(extPanId->m8));
     txtList.emplace_back("tv", mNcp.GetThreadVersion());


### PR DESCRIPTION
vn: vendor name
mn: model name

These fields are defined as optional in the spec. 