### PR TITLE
[mdns] unify mDNS interface to use std::string

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -93,7 +93,7 @@ uint32_t BorderAgent::StateBitmap::ToUint32(void) const
 BorderAgent::BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp)
     : mNcp(aNcp)
 #if OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO
-    , mPublisher(Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, HandleMdnsState, this))
+    , mPublisher(Mdns::Publisher::Create(HandleMdnsState, this))
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     , mAdvertisingProxy(aNcp, *mPublisher)
 #endif
@@ -278,9 +278,8 @@ void BorderAgent::PublishMeshCopService(void)
     txtList.emplace_back("dn", otThreadGetDomainName(instance));
 #endif
 
-    mPublisher->PublishService(/* aHostName */ nullptr, otBorderAgentGetUdpPort(instance),
-                               kBorderAgentServiceInstanceName, kBorderAgentServiceType, Mdns::Publisher::SubTypeList{},
-                               txtList);
+    mPublisher->PublishService(/* aHostName */ "", otBorderAgentGetUdpPort(instance), kBorderAgentServiceInstanceName,
+                               kBorderAgentServiceType, Mdns::Publisher::SubTypeList{}, txtList);
 }
 
 void BorderAgent::UnpublishMeshCopService(void)

--- a/src/common/task_runner.hpp
+++ b/src/common/task_runner.hpp
@@ -109,7 +109,7 @@ public:
     {
         std::promise<T> pro;
 
-        Post([&]() { pro.set_value(aTask()); });
+        Post([&pro, &aTask]() { pro.set_value(aTask()); });
 
         return pro.get_future().get();
     }

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -160,7 +160,10 @@ public:
      * @param[in]  aContext  A user context.
      *
      */
-    typedef void (*PublishServiceHandler)(const char *aName, const char *aType, otbrError aError, void *aContext);
+    typedef void (*PublishServiceHandler)(const std::string &aName,
+                                          const std::string &aType,
+                                          otbrError          aError,
+                                          void *             aContext);
 
     /**
      * This method reports the result of a host publication.
@@ -170,7 +173,7 @@ public:
      * @param[in]  aContext  A user context.
      *
      */
-    typedef void (*PublishHostHandler)(const char *aName, otbrError aError, void *aContext);
+    typedef void (*PublishHostHandler)(const std::string &aName, otbrError aError, void *aContext);
 
     /**
      * This method sets the handler for service publication.
@@ -225,10 +228,10 @@ public:
     /**
      * This method publishes or updates a service.
      *
-     * @param[in]   aHostName           The name of the host which this service resides on. If NULL is provided,
-     *                                  this service resides on local host and it is the implementation to provide
-     *                                  specific host name. Otherwise, the caller MUST publish the host with method
-     *                                  PublishHost.
+     * @param[in]   aHostName           The name of the host which this service resides on. If an empty string is
+     *                                  provided, this service resides on local host and it is the implementation
+     *                                  to provide specific host name. Otherwise, the caller MUST publish the host
+     *                                  with method PublishHost.
      * @param[in]   aPort               The port number of this service.
      * @param[in]   aName               The name of this service.
      * @param[in]   aType               The type of this service.
@@ -239,10 +242,10 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    virtual otbrError PublishService(const char *       aHostName,
+    virtual otbrError PublishService(const std::string &aHostName,
                                      uint16_t           aPort,
-                                     const char *       aName,
-                                     const char *       aType,
+                                     const std::string &aName,
+                                     const std::string &aType,
                                      const SubTypeList &aSubTypeList,
                                      const TxtList &    aTxtList) = 0;
 
@@ -256,24 +259,23 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the service.
      *
      */
-    virtual otbrError UnpublishService(const char *aName, const char *aType) = 0;
+    virtual otbrError UnpublishService(const std::string &aName, const std::string &aType) = 0;
 
     /**
      * This method publishes or updates a host.
      *
-     * Publishing a host is advertising an A/AAAA RR for the host name. This method should be called
-     * before a service with non-null host name is published.
+     * Publishing a host is advertising an AAAA RR for the host name. This method should be called
+     * before a service with non-empty host name is published.
      *
-     * @param[in]  aName           The name of the host.
-     * @param[in]  aAddress        The address of the host.
-     * @param[in]  aAddressLength  The length of @p aAddress.
+     * @param[in]  aName     The name of the host.
+     * @param[in]  aAddress  The address of the host.
      *
      * @retval  OTBR_ERROR_NONE          Successfully published or updated the host.
      * @retval  OTBR_ERROR_INVALID_ARGS  The arguments are not valid.
      * @retval  OTBR_ERROR_ERRNO         Failed to publish or update the host.
      *
      */
-    virtual otbrError PublishHost(const char *aName, const uint8_t *aAddress, uint8_t aAddressLength) = 0;
+    virtual otbrError PublishHost(const std::string &aName, const std::vector<uint8_t> &aAddress) = 0;
 
     /**
      * This method un-publishes a host.
@@ -284,7 +286,7 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the host.
      *
      */
-    virtual otbrError UnpublishHost(const char *aName) = 0;
+    virtual otbrError UnpublishHost(const std::string &aName) = 0;
 
     /**
      * This method subscribes a given service or service instance.
@@ -357,15 +359,13 @@ public:
     /**
      * This function creates a mDNS publisher.
      *
-     * @param[in]   aProtocol           Protocol to use for publishing. AF_INET6, AF_INET or AF_UNSPEC.
-     * @param[in]   aDomain             The domain to register in. Set nullptr to use default mDNS domain ("local.").
-     * @param[in]   aHandler            The function to be called when this service state changed.
-     * @param[in]   aContext            A pointer to application-specific context.
+     * @param[in] aHandler  The function to be called when this service state changed.
+     * @param[in] aContext  A pointer to application-specific context.
      *
      * @returns A pointer to the newly created mDNS publisher.
      *
      */
-    static Publisher *Create(int aProtocol, const char *aDomain, StateHandler aHandler, void *aContext);
+    static Publisher *Create(StateHandler aHandler, void *aContext);
 
     /**
      * This function destroys the mDNS publisher.
@@ -388,7 +388,7 @@ public:
      * returns  A boolean that indicates whether the two service types are equal.
      *
      */
-    static bool IsServiceTypeEqual(const char *aFirstType, const char *aSecondType);
+    static bool IsServiceTypeEqual(std::string aFirstType, std::string aSecondType);
 
     /**
      * This function writes the TXT entry list to a TXT data buffer.
@@ -398,14 +398,12 @@ public:
      *
      * @param[in]     aTxtList    A TXT entry list.
      * @param[out]    aTxtData    A TXT data buffer.
-     * @param[inout]  aTxtLength  As input, it is the length of the TXT data buffer;
-     *                            As output, it is the length of the TXT data written.
      *
      * @retval  OTBR_ERROR_NONE          Successfully write the TXT entry list.
-     * @retval  OTBR_ERROR_INVALID_ARGS  The input TXT data buffer cannot hold the TXT data.
+     * @retval  OTBR_ERROR_INVALID_ARGS  The @p aTxtList includes invalid TXT entry.
      *
      */
-    static otbrError EncodeTxtData(const TxtList &aTxtList, uint8_t *aTxtData, uint16_t &aTxtLength);
+    static otbrError EncodeTxtData(const TxtList &aTxtList, std::vector<uint8_t> &aTxtData);
 
 protected:
     enum : uint8_t

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -104,10 +104,13 @@ private:
     static Mdns::Publisher::TxtList     MakeTxtList(const otSrpServerService *aSrpService);
     static Mdns::Publisher::SubTypeList MakeSubTypeList(const otSrpServerService *aSrpService);
 
-    static void PublishServiceHandler(const char *aName, const char *aType, otbrError aError, void *aContext);
-    void        PublishServiceHandler(const char *aName, const char *aType, otbrError aError);
-    static void PublishHostHandler(const char *aName, otbrError aError, void *aContext);
-    void        PublishHostHandler(const char *aName, otbrError aError);
+    static void PublishServiceHandler(const std::string &aName,
+                                      const std::string &aType,
+                                      otbrError          aError,
+                                      void *             aContext);
+    void        PublishServiceHandler(const std::string &aName, const std::string &aType, otbrError aError);
+    static void PublishHostHandler(const std::string &aName, otbrError aError, void *aContext);
+    void        PublishHostHandler(const std::string &aName, otbrError aError);
 
     /**
      * This method publishes a specified host and its services.

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -36,6 +36,8 @@
 #include <netinet/in.h>
 #include <signal.h>
 
+#include <vector>
+
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/mainloop.hpp"
@@ -82,10 +84,10 @@ int RunMainloop(void)
 
 void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State aState)
 {
-    uint8_t    xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t    extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t    hostAddr[16]          = {0};
-    const char hostName[]            = "custom-host";
+    uint8_t              xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t              extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    std::vector<uint8_t> hostAddr(16, 0);
+    const char           hostName[] = "custom-host";
 
     hostAddr[0]  = 0x20;
     hostAddr[1]  = 0x02;
@@ -98,7 +100,7 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishHost(hostName, hostAddr, sizeof(hostAddr));
+        error = sContext.mPublisher->PublishHost(hostName, hostAddr);
         SuccessOrDie(error, "cannot publish the host");
 
         error = sContext.mPublisher->PublishService(hostName, 12345, "SingleService", "_meshcop._udp.",
@@ -109,11 +111,11 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
 
 void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::State aState)
 {
-    uint8_t    xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t    extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t    hostAddr[16]          = {0};
-    const char hostName1[]           = "custom-host-1";
-    const char hostName2[]           = "custom-host-2";
+    uint8_t              xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t              extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    std::vector<uint8_t> hostAddr(16, 0);
+    const char           hostName1[] = "custom-host-1";
+    const char           hostName2[] = "custom-host-2";
 
     hostAddr[0]  = 0x20;
     hostAddr[1]  = 0x02;
@@ -126,7 +128,7 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishHost(hostName1, hostAddr, sizeof(hostAddr));
+        error = sContext.mPublisher->PublishHost(hostName1, hostAddr);
         SuccessOrDie(error, "cannot publish the first host");
 
         error = sContext.mPublisher->PublishService(hostName1, 12345, "MultipleService11", "_meshcop._udp.",
@@ -137,7 +139,7 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
                                                     Mdns::Publisher::SubTypeList{}, txtList);
         SuccessOrDie(error, "cannot publish the second service");
 
-        error = sContext.mPublisher->PublishHost(hostName2, hostAddr, sizeof(hostAddr));
+        error = sContext.mPublisher->PublishHost(hostName2, hostAddr);
         SuccessOrDie(error, "cannot publish the second host");
 
         error = sContext.mPublisher->PublishService(hostName2, 12345, "MultipleService21", "_meshcop._udp.",
@@ -160,7 +162,7 @@ void PublishSingleService(void *aContext, Mdns::Publisher::State aState)
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
-        otbrError error = sContext.mPublisher->PublishService(nullptr, 12345, "SingleService", "_meshcop._udp.",
+        otbrError error = sContext.mPublisher->PublishService("", 12345, "SingleService", "_meshcop._udp.",
                                                               Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
@@ -178,7 +180,7 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool1"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService1", "_meshcop._udp.",
+        error = sContext.mPublisher->PublishService("", 12345, "MultipleService1", "_meshcop._udp.",
                                                     Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
@@ -189,7 +191,7 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool2"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"dd", extAddr, sizeof(extAddr)}};
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "MultipleService2", "_meshcop._udp.",
+        error = sContext.mPublisher->PublishService("", 12345, "MultipleService2", "_meshcop._udp.",
                                                     Mdns::Publisher::SubTypeList{}, txtList);
         assert(error == OTBR_ERROR_NONE);
     }
@@ -213,7 +215,7 @@ void PublishUpdateServices(void *aContext, Mdns::Publisher::State aState)
                                              {"tv", "1.1.1"},
                                              {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.",
+            error = sContext.mPublisher->PublishService("", 12345, "UpdateService", "_meshcop._udp.",
                                                         Mdns::Publisher::SubTypeList{}, txtList);
         }
         else
@@ -223,7 +225,7 @@ void PublishUpdateServices(void *aContext, Mdns::Publisher::State aState)
                                              {"tv", "1.1.1"},
                                              {"dd", extAddr, sizeof(extAddr)}};
 
-            error = sContext.mPublisher->PublishService(nullptr, 12345, "UpdateService", "_meshcop._udp.",
+            error = sContext.mPublisher->PublishService("", 12345, "UpdateService", "_meshcop._udp.",
                                                         Mdns::Publisher::SubTypeList{}, txtList);
         }
         assert(error == OTBR_ERROR_NONE);
@@ -243,8 +245,8 @@ void PublishServiceSubTypes(void *aContext, Mdns::Publisher::State aState)
             subTypeList.back() = "_SUBTYPE3";
         }
 
-        error = sContext.mPublisher->PublishService(nullptr, 12345, "ServiceWithSubTypes", "_meshcop._udp.",
-                                                    subTypeList, Mdns::Publisher::TxtList{});
+        error = sContext.mPublisher->PublishService("", 12345, "ServiceWithSubTypes", "_meshcop._udp.", subTypeList,
+                                                    Mdns::Publisher::TxtList{});
         assert(error == OTBR_ERROR_NONE);
     }
 }
@@ -253,9 +255,8 @@ otbrError TestSingleServiceWithCustomHost(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleServiceWithCustomHost, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishSingleServiceWithCustomHost, &sContext);
+    sContext.mPublisher  = pub;
     SuccessOrExit(error = pub->Start());
     RunMainloop();
 
@@ -268,9 +269,8 @@ otbrError TestMultipleServicesWithCustomHost(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServicesWithCustomHost, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishMultipleServicesWithCustomHost, &sContext);
+    sContext.mPublisher  = pub;
     SuccessOrExit(error = pub->Start());
     RunMainloop();
 
@@ -283,7 +283,7 @@ otbrError TestSingleService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishSingleService, &sContext);
     sContext.mPublisher  = pub;
     SuccessOrExit(ret = pub->Start());
     RunMainloop();
@@ -297,9 +297,8 @@ otbrError TestMultipleServices(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub =
-        Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishMultipleServices, &sContext);
-    sContext.mPublisher = pub;
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishMultipleServices, &sContext);
+    sContext.mPublisher  = pub;
     SuccessOrExit(ret = pub->Start());
     RunMainloop();
 
@@ -312,7 +311,7 @@ otbrError TestUpdateService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishUpdateServices, &sContext);
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishUpdateServices, &sContext);
     sContext.mPublisher  = pub;
     sContext.mUpdate     = false;
     SuccessOrExit(ret = pub->Start());
@@ -329,7 +328,7 @@ otbrError TestServiceSubTypes(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishServiceSubTypes, &sContext);
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishServiceSubTypes, &sContext);
     sContext.mPublisher  = pub;
     sContext.mUpdate     = false;
     SuccessOrExit(ret = pub->Start());
@@ -358,7 +357,7 @@ otbrError TestStopService(void)
 {
     otbrError ret = OTBR_ERROR_NONE;
 
-    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, /* aDomain */ nullptr, PublishSingleService, &sContext);
+    Mdns::Publisher *pub = Mdns::Publisher::Create(PublishSingleService, &sContext);
     sContext.mPublisher  = pub;
     SuccessOrExit(ret = pub->Start());
     signal(SIGUSR1, RecoverSignal);


### PR DESCRIPTION
We are inconsistenly using both const char * and std::string in the
code which is sure bad practice. We have been seen bugs caused by
raw char * strings and I think it should be safer to use std::string
for easier life-time management.
    
This commit unifies the mDNS and advertising proxy modules to always
use std::string against const char * and std::vector<uint8_t> against
const uint8_t * whenever appliable. This makes the code more maintainable
and avoids potential memory segments.

This commit also removes the unused `aProtocol` and `aDomain` parameters
of `Publisher::Create()`.

------
This PR depends on https://github.com/openthread/ot-br-posix/pull/1072 so please review only the second commit, thanks.