### PR TITLE
[docs] unify spaces in documentations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(OTBR_VENDOR_NAME "OpenThread" CACHE STRING "The vendor name")
 set(OTBR_PRODUCT_NAME "BorderRouter" CACHE STRING "The product name")
 set(OTBR_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The package name")
 set(OTBR_MESHCOP_SERVICE_INSTANCE_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The OTBR MeshCoP service instance name")
-set(OTBR_MDNS "avahi" CACHE STRING "mDNS service provider")
+set(OTBR_MDNS "avahi" CACHE STRING "mDNS publisher provider")
 
 set_property(CACHE OTBR_MDNS PROPERTY STRINGS "avahi" "mDNSResponder")
 

--- a/src/agent/agent_instance.hpp
+++ b/src/agent/agent_instance.hpp
@@ -57,7 +57,7 @@ public:
     /**
      * The constructor to initialize the Thread border router agent instance.
      *
-     * @param[in]   aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     AgentInstance(Ncp::ControllerOpenThread &aNcp);
@@ -65,8 +65,8 @@ public:
     /**
      * This method initialize the agent.
      *
-     * @retval  OTBR_ERROR_NONE     Agent initialized successfully.
-     * @retval  OTBR_ERROR_ERRNO    Failed due to error indicated in errno.
+     * @retval OTBR_ERROR_NONE   Agent initialized successfully.
+     * @retval OTBR_ERROR_ERRNO  Failed due to error indicated in errno.
      *
      */
     otbrError Init(void);
@@ -74,7 +74,7 @@ public:
     /**
      * This method returns the NCP controller.
      *
-     * @retval  the pointer of the NCP controller.
+     * @returns The pointer of the NCP controller.
      *
      */
     otbr::Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }

--- a/src/agent/instance_params.hpp
+++ b/src/agent/instance_params.hpp
@@ -46,7 +46,7 @@ public:
     /**
      * This method gets the single `InstanceParams` instance.
      *
-     * @returns  The single `InstanceParams` instance.
+     * @returns The single `InstanceParams` instance.
      *
      */
     static InstanceParams &Get(void);

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -45,7 +45,7 @@ public:
     /**
      * The constructor of vendor server.
      *
-     * @param[in]  aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     VendorServer(otbr::Ncp::ControllerOpenThread &aNcp);

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -111,9 +111,9 @@ public:
     /**
      * This method handles a Backbone Router ND Proxy event.
      *
-     * @param[in] aEvent    The Backbone Router ND Proxy event type.
-     * @param[in] aDua      The Domain Unicast Address of the ND Proxy, or `nullptr` if @p `aEvent` is
-     *                      `OT_BACKBONE_ROUTER_NDPROXY_CLEARED`.
+     * @param[in] aEvent  The Backbone Router ND Proxy event type.
+     * @param[in] aDua    The Domain Unicast Address of the ND Proxy, or `nullptr` if @p `aEvent` is
+     *                    `OT_BACKBONE_ROUTER_NDPROXY_CLEARED`.
      *
      */
     void HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aDua);
@@ -121,7 +121,7 @@ public:
     /**
      * This method returns if the ND Proxy manager is enabled.
      *
-     * @returns  If the ND Proxy manager is enabled;
+     * @returns If the ND Proxy manager is enabled;
      *
      */
     bool IsEnabled(void) const { return mIcmp6RawSock >= 0; }

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -199,7 +199,7 @@ void BorderAgent::HandleMdnsState(Mdns::Publisher::State aState)
 #endif
         break;
     default:
-        otbrLogWarning("mDNS service not available!");
+        otbrLogWarning("mDNS publisher not available!");
         break;
     }
 }

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -82,7 +82,7 @@ public:
     /**
      * The constructor to initialize the Thread border agent.
      *
-     * @param[in]  aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp);

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -44,10 +44,10 @@
 /**
  *  This aligns the pointer to @p aAlignType.
  *
- *  @param[in]  aMem        A pointer to arbitrary memory.
- *  @param[in]  aAlignType  The type to align with and convert the pointer to this type.
+ *  @param[in] aMem        A pointer to arbitrary memory.
+ *  @param[in] aAlignType  The type to align with and convert the pointer to this type.
  *
- *  @returns A @aAlignType pointer to aligned memory.
+ *  @returns A pointer to aligned memory.
  *
  */
 #define OTBR_ALIGNED(aMem, aAlignType) \
@@ -65,7 +65,7 @@
  *  commonly be successful, and branches to the local label 'exit' if
  *  the status is unsuccessful.
  *
- *  @param[in]  aStatus     A scalar status to be evaluated against zero (0).
+ *  @param[in] aStatus  A scalar status to be evaluated against zero (0).
  *
  */
 #define SuccessOrExit(aStatus) \
@@ -81,8 +81,8 @@
  * This macro verifies a given error status to be successful (compared against value zero (0)), otherwise, it emits a
  * given error messages and exits the program.
  *
- * @param[in]  aStatus     A scalar error status to be evaluated against zero (0).
- * @param[in]  aMessage    A message (text string) to print on failure.
+ * @param[in] aStatus   A scalar error status to be evaluated against zero (0).
+ * @param[in] aMessage  A message (text string) to print on failure.
  *
  */
 #define SuccessOrDie(aStatus, aMessage)                                          \
@@ -100,9 +100,9 @@
  *  commonly be true, and both executes @a ... and branches to the
  *  local label 'exit' if the condition is false.
  *
- *  @param[in]  aCondition  A Boolean expression to be evaluated.
- *  @param[in]  ...         An expression or block to execute when the
- *                          assertion fails.
+ *  @param[in] aCondition  A Boolean expression to be evaluated.
+ *  @param[in] ...         An expression or block to execute when the
+ *                         assertion fails.
  *
  */
 #define VerifyOrExit(aCondition, ...) \
@@ -119,8 +119,8 @@
  * This macro checks for the specified condition, which is expected to commonly be true,
  * and both prints the message and terminates the program if the condition is false.
  *
- * @param[in]   aCondition  The condition to verify
- * @param[in]   aMessage    A message (text string) to print on failure.
+ * @param[in] aCondition  The condition to verify
+ * @param[in] aMessage    A message (text string) to print on failure.
  *
  */
 #define VerifyOrDie(aCondition, aMessage)                                        \
@@ -141,8 +141,8 @@
  *        failure for the overall exit status of the enclosing
  *        function body.
  *
- *  @param[in]  ...         An optional expression or block to execute
- *                          when the assertion fails.
+ *  @param[in] ...  An optional expression or block to execute
+ *                  when the assertion fails.
  *
  */
 #define ExitNow(...) \

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -77,9 +77,9 @@ struct DnsNameInfo
 /**
  * This method splits a full DNS name into name components.
  *
- * @param[in] aName     The full DNS name to dissect.
+ * @param[in] aName  The full DNS name to dissect.
  *
- * @returns  A `DnsNameInfo` structure containing DNS name information.
+ * @returns A `DnsNameInfo` structure containing DNS name information.
  *
  * @sa DnsNameInfo
  *

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -50,25 +50,25 @@
  */
 typedef enum
 {
-    OTBR_LOG_EMERG,   /* system is unusable */
-    OTBR_LOG_ALERT,   /* action must be taken immediately */
-    OTBR_LOG_CRIT,    /* critical conditions */
-    OTBR_LOG_ERR,     /* error conditions */
-    OTBR_LOG_WARNING, /* warning conditions */
-    OTBR_LOG_NOTICE,  /* normal but significant condition */
-    OTBR_LOG_INFO,    /* informational */
-    OTBR_LOG_DEBUG,   /* debug-level messages */
+    OTBR_LOG_EMERG,   ///< System is unusable
+    OTBR_LOG_ALERT,   ///< Action must be taken immediately
+    OTBR_LOG_CRIT,    ///< Critical conditions
+    OTBR_LOG_ERR,     ///< Error conditions
+    OTBR_LOG_WARNING, ///< Warning conditions
+    OTBR_LOG_NOTICE,  ///< Normal but significant condition
+    OTBR_LOG_INFO,    ///< Informational
+    OTBR_LOG_DEBUG,   ///< Debug level messages
 } otbrLogLevel;
 
 /**
- * Get current log level
+ * Get current log level.
  */
 otbrLogLevel otbrLogGetLevel(void);
 
 /**
- * Control log to syslog
+ * Control log to syslog.
  *
- * @param[in] enable true to log to/via syslog
+ * @param[in] enable  True to log to/via syslog.
  *
  */
 void otbrLogEnableSyslog(bool aEnabled);
@@ -76,9 +76,9 @@ void otbrLogEnableSyslog(bool aEnabled);
 /**
  * This function initialize the logging service.
  *
- * @param[in]   aIdent          Identity of the logger.
- * @param[in]   aLevel          Log level of the logger.
- * @param[in]   aPrintStderr    Whether to log to stderr.
+ * @param[in] aIdent        Identity of the logger.
+ * @param[in] aLevel        Log level of the logger.
+ * @param[in] aPrintStderr  Whether to log to stderr.
  *
  */
 void otbrLogInit(const char *aIdent, otbrLogLevel aLevel, bool aPrintStderr);
@@ -86,9 +86,9 @@ void otbrLogInit(const char *aIdent, otbrLogLevel aLevel, bool aPrintStderr);
 /**
  * This function log at level @p aLevel.
  *
- * @param[in]   aLevel         Log level of the logger.
- * @param[in]   aLogTag        Log tag.
- * @param[in]   aFormat        Format string as in printf.
+ * @param[in] aLevel   Log level of the logger.
+ * @param[in] aLogTag  Log tag.
+ * @param[in] aFormat  Format string as in printf.
  *
  */
 void otbrLog(otbrLogLevel aLevel, const char *aLogTag, const char *aFormat, ...);
@@ -96,9 +96,9 @@ void otbrLog(otbrLogLevel aLevel, const char *aLogTag, const char *aFormat, ...)
 /**
  * This function log at level @p aLevel.
  *
- * @param[in]   aLevel   Log level of the logger.
- * @param[in]   aFormat  Format string as in printf.
- * @param[in]   aArgList The variable-length arguments list.
+ * @param[in] aLevel    Log level of the logger.
+ * @param[in] aFormat   Format string as in printf.
+ * @param[in] aArgList  The variable-length arguments list.
  *
  */
 void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list aArgList);
@@ -106,9 +106,9 @@ void otbrLogv(otbrLogLevel aLevel, const char *aFormat, va_list aArgList);
 /**
  * This function writes logs without filtering with the log level.
  *
- * @param[in]   aLevel  Log level of the logger.
- * @param[in]   aFormat Format string as in printf.
- * @param[in]   aArgList The variable-length arguments list.
+ * @param[in] aLevel    Log level of the logger.
+ * @param[in] aFormat   Format string as in printf.
+ * @param[in] aArgList  The variable-length arguments list.
  *
  */
 void otbrLogvNoFilter(otbrLogLevel aLevel, const char *aFormat, va_list aArgList);
@@ -116,10 +116,10 @@ void otbrLogvNoFilter(otbrLogLevel aLevel, const char *aFormat, va_list aArgList
 /**
  * This function dump memory as hex string at level @p aLevel.
  *
- * @param[in]   aLevel  Log level of the logger.
- * @param[in]   aPrefix String before dumping memory.
- * @param[in]   aMemory The pointer to the memory to be dumped.
- * @param[in]   aSize   The size of memory in bytes to be dumped.
+ * @param[in] aLevel   Log level of the logger.
+ * @param[in] aPrefix  String before dumping memory.
+ * @param[in] aMemory  The pointer to the memory to be dumped.
+ * @param[in] aSize    The size of memory in bytes to be dumped.
  *
  */
 void otbrDump(otbrLogLevel aLevel, const char *aPrefix, const void *aMemory, size_t aSize);
@@ -127,7 +127,7 @@ void otbrDump(otbrLogLevel aLevel, const char *aPrefix, const void *aMemory, siz
 /**
  * This function converts error code to string.
  *
- * @param[in]   aError      The error code.
+ * @param[in] aError  The error code.
  *
  * @returns The string information of error.
  *
@@ -146,9 +146,9 @@ void otbrLogDeinit(void);
  * If @p aError is OTBR_ERROR_NONE, the log level will be OTBR_LOG_INFO,
  * otherwise OTBR_LOG_WARNING.
  *
- * @param[in]   aError    The action result.
- * @param[in]   aFormat   Format string as in printf.
- * @param[in]   ...       Arguments for the format specification.
+ * @param[in] aError   The action result.
+ * @param[in] aFormat  Format string as in printf.
+ * @param[in] ...      Arguments for the format specification.
  *
  */
 #define otbrLogResult(aError, aFormat, ...)                                                               \

--- a/src/common/mainloop.hpp
+++ b/src/common/mainloop.hpp
@@ -61,7 +61,7 @@ public:
     /**
      * This method updates the mainloop context.
      *
-     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
+     * @param[inout] aMainloop  A reference to the mainloop to be updated.
      *
      */
     virtual void Update(MainloopContext &aMainloop) = 0;
@@ -69,7 +69,7 @@ public:
     /**
      * This method processes mainloop events.
      *
-     * @param[in]  aMainloop  A reference to the mainloop context.
+     * @param[in] aMainloop  A reference to the mainloop context.
      *
      */
     virtual void Process(const MainloopContext &aMainloop) = 0;

--- a/src/common/mainloop_manager.hpp
+++ b/src/common/mainloop_manager.hpp
@@ -61,8 +61,6 @@ public:
     /**
      * This method returns the singleton instance of the mainloop manager.
      *
-     * @retval  A reference to the mainloop manager.
-     *
      */
     static MainloopManager &GetInstance(void)
     {
@@ -73,7 +71,7 @@ public:
     /**
      * This method adds a mainloop processors to the mainloop managger.
      *
-     * @param[in] aMainloopProcessor   A pointer to the mainloop processor.
+     * @param[in] aMainloopProcessor  A pointer to the mainloop processor.
      *
      */
     void AddMainloopProcessor(MainloopProcessor *aMainloopProcessor);
@@ -81,7 +79,7 @@ public:
     /**
      * This method removes a mainloop processors from the mainloop managger.
      *
-     * @param[in] aMainloopProcessor   A pointer to the mainloop processor.
+     * @param[in] aMainloopProcessor  A pointer to the mainloop processor.
      *
      */
     void RemoveMainloopProcessor(MainloopProcessor *aMainloopProcessor);
@@ -89,7 +87,7 @@ public:
     /**
      * This method updates the mainloop context of all mainloop processors.
      *
-     * @param[inout]  aMainloop  A reference to the mainloop to be updated.
+     * @param[inout] aMainloop  A reference to the mainloop to be updated.
      *
      */
     void Update(MainloopContext &aMainloop);
@@ -97,7 +95,7 @@ public:
     /**
      * This method processes mainloop events of all mainloop processors.
      *
-     * @param[in]  aMainloop  A reference to the mainloop context.
+     * @param[in] aMainloop  A reference to the mainloop context.
      *
      */
     void Process(const MainloopContext &aMainloop);

--- a/src/common/task_runner.hpp
+++ b/src/common/task_runner.hpp
@@ -79,7 +79,7 @@ public:
      * Tasks are executed sequentially and follow the First-Come-First-Serve rule.
      * It is safe to call this method in different threads concurrently.
      *
-     * @param[in]  aTask  The task to be executed.
+     * @param[in] aTask  The task to be executed.
      *
      */
     void Post(const Task<void> aTask);
@@ -89,8 +89,8 @@ public:
      *
      * The task will be executed on the mainloop after `aDelay` milliseconds from now.
      *
-     * @param[in]  aDelay  The delay before executing the task (in milliseconds).
-     * @param[in]  aTask   The task to be executed.
+     * @param[in] aDelay  The delay before executing the task (in milliseconds).
+     * @param[in] aTask   The task to be executed.
      *
      */
     void Post(Milliseconds aDelay, const Task<void> aTask);
@@ -102,7 +102,7 @@ public:
      * This method must be called in a thread other than the mainloop thread. Otherwise,
      * the caller will be blocked forever.
      *
-     * @returns  The result returned by the task @p aTask.
+     * @returns The result returned by the task @p aTask.
      *
      */
     template <class T> T PostAndWait(const Task<T> &aTask)

--- a/src/common/tlv.hpp
+++ b/src/common/tlv.hpp
@@ -131,7 +131,7 @@ public:
     /**
      * This method sets a uint64_t as the value.
      *
-     * @param[in]  aValue  The uint64_t value.
+     * @param[in] aValue  The uint64_t value.
      *
      */
     void SetValue(uint64_t aValue)
@@ -149,7 +149,7 @@ public:
     /**
      * This method sets a uint32_t as the value.
      *
-     * @param[in]  aValue   The uint32_t value.
+     * @param[in] aValue  The uint32_t value.
      *
      */
     void SetValue(uint32_t aValue)
@@ -167,7 +167,7 @@ public:
     /**
      * This method sets uint16_t as the value.
      *
-     * @param[in]    aValue         uint16_t value
+     * @param[in] aValue  The uint16_t value.
      *
      */
     void SetValue(uint16_t aValue)
@@ -183,7 +183,7 @@ public:
     /**
      * This method sets uint8_t as the value.
      *
-     * @param[in]    aValue         uint8_t value
+     * @param[in] aValue  The uint8_t value.
      *
      */
     void SetValue(uint8_t aValue)
@@ -195,7 +195,7 @@ public:
     /**
      * This method sets int8_t as the value.
      *
-     * @param[in]    aValue         int8_t value
+     * @param[in] aValue  The int8_t value.
      *
      */
     void SetValue(int8_t aValue)

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -117,7 +117,7 @@ public:
     /**
      * Constructor with an 16-bit Thread locator.
      *
-     * @param[in]   aLocator    16-bit Thread locator, RLOC or ALOC.
+     * @param[in] aLocator  The 16-bit Thread locator, RLOC or ALOC.
      *
      */
     Ip6Address(uint16_t aLocator)
@@ -132,7 +132,7 @@ public:
     /**
      * Constructor with an Ip6 address.
      *
-     * @param[in]   aAddress    The Ip6 address.
+     * @param[in] aAddress  The Ip6 address.
      *
      */
     Ip6Address(const uint8_t (&aAddress)[16]);
@@ -142,7 +142,7 @@ public:
      *
      * @param[in] aOther  The other Ip6 address to compare with.
      *
-     * @returns  Whether the Ip6 address is smaller than the other address.
+     * @returns Whether the Ip6 address is smaller than the other address.
      *
      */
     bool operator<(const Ip6Address &aOther) const { return memcmp(this, &aOther, sizeof(Ip6Address)) < 0; }
@@ -152,7 +152,7 @@ public:
      *
      * @param[in] aOther  The other Ip6 address to compare with.
      *
-     * @returns  Whether the Ip6 address is equal to the other address.
+     * @returns Whether the Ip6 address is equal to the other address.
      *
      */
     bool operator==(const Ip6Address &aOther) const { return m64[0] == aOther.m64[0] && m64[1] == aOther.m64[1]; }
@@ -193,7 +193,7 @@ public:
     /**
      * This method returns if the Ip6 address is a multicast address.
      *
-     * @returns  Whether the Ip6 address is a multicast address.
+     * @returns Whether the Ip6 address is a multicast address.
      *
      */
     bool IsMulticast(void) const { return m8[0] == 0xff; }
@@ -201,7 +201,7 @@ public:
     /**
      * This method returns if the Ip6 address is a link-local address.
      *
-     * @returns  Whether the Ip6 address is a link-local address.
+     * @returns Whether the Ip6 address is a link-local address.
      *
      */
     bool IsLinkLocal(void) const { return (m16[0] & bswap_16(0xffc0)) == bswap_16(0xfe80); }
@@ -244,8 +244,8 @@ public:
     /**
      * This function converts Ip6 addresses from text to `Ip6Address`.
      *
-     * @param[in]   aStr    The Ip6 address text.
-     * @param[out]  aAddr   A reference to `Ip6Address` to output the Ip6 address.
+     * @param[in]  aStr   The Ip6 address text.
+     * @param[out] aAddr  A reference to `Ip6Address` to output the Ip6 address.
      *
      * @retval OTBR_ERROR_NONE          If the Ip6 address was successfully converted.
      * @retval OTBR_ERROR_INVALID_ARGS  If @p `aStr` is not a valid string representing of Ip6 address.
@@ -335,7 +335,7 @@ public:
     /**
      * This method returns if the Ip6 prefix is valid.
      *
-     * @returns  If the Ip6 prefix is valid.
+     * @returns If the Ip6 prefix is valid.
      *
      */
     bool IsValid(void) const { return mLength > 0 && mLength <= 128; }

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -60,7 +60,7 @@ public:
      *
      * Will use the default interfacename
      *
-     * @param[in]   aConnection     The dbus connection.
+     * @param[in] aConnection  The dbus connection.
      *
      */
     ThreadApiDBus(DBusConnection *aConnection);
@@ -68,8 +68,8 @@ public:
     /**
      * The constructor of a d-bus object.
      *
-     * @param[in]   aConnection     The dbus connection.
-     * @param[in]   aInterfaceName  The network interface name.
+     * @param[in] aConnection     The dbus connection.
+     * @param[in] aInterfaceName  The network interface name.
      *
      */
     ThreadApiDBus(DBusConnection *aConnection, const std::string &aInterfaceName);
@@ -77,7 +77,7 @@ public:
     /**
      * This method adds a callback for device role change.
      *
-     * @param[in]   aHandler  The device role handler.
+     * @param[in] aHandler  The device role handler.
      *
      */
     void AddDeviceRoleHandler(const DeviceRoleHandler &aHandler);
@@ -85,12 +85,12 @@ public:
     /**
      * This method permits unsecure join on port.
      *
-     * @param[in]   aPort     The port number.
-     * @param[in]   aSeconds  The timeout to close the port, 0 for never close.
+     * @param[in] aPort     The port number.
+     * @param[in] aSeconds  The timeout to close the port, 0 for never close.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError PermitUnsecureJoin(uint16_t aPort, uint32_t aSeconds);
@@ -98,28 +98,28 @@ public:
     /**
      * This method performs a Thread network scan.
      *
-     * @param[in]   aHandler  The scan result handler.
+     * @param[in] aHandler  The scan result handler.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError Scan(const ScanHandler &aHandler);
 
     /**
      * This method attaches the device to the Thread network.
-     * @param[in]   aNetworkName    The network name.
-     * @param[in]   aPanId          The pan id, UINT16_MAX for random.
-     * @param[in]   aExtPanId       The extended pan id, UINT64_MAX for random.
-     * @param[in]   aNetworkKey     The network key, empty for random.
-     * @param[in]   aPSKc           The pre-shared commissioner key, empty for random.
-     * @param[in]   aChannelMask    A bitmask for valid channels, will random select one.
-     * @param[in]   aHandler        The attach result handler.
+     * @param[in] aNetworkName  The network name.
+     * @param[in] aPanId        The pan id, UINT16_MAX for random.
+     * @param[in] aExtPanId     The extended pan id, UINT64_MAX for random.
+     * @param[in] aNetworkKey   The network key, empty for random.
+     * @param[in] aPSKc         The pre-shared commissioner key, empty for random.
+     * @param[in] aChannelMask  A bitmask for valid channels, will random select one.
+     * @param[in] aHandler      The attach result handler.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError Attach(const std::string &         aNetworkName,
@@ -136,11 +136,11 @@ public:
      * The network parameters will be set with the active dataset under this
      * circumstance.
      *
-     * @param[in]   aHandler        The attach result handler.
+     * @param[in] aHandler  The attach result handler.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError Attach(const OtResultHandler &aHandler);
@@ -150,8 +150,8 @@ public:
      *
      * If the device has already attached to a network, send a request to migrate the existing network.
      *
-     * @param[in]  aDataset  The Operational Dataset that contains parameter values of the Thread network to attach
-     *                       to. It must have a valid Delay Timer and Pending Timestamp.
+     * @param[in] aDataset  The Operational Dataset that contains parameter values of the Thread network to attach
+     *                      to. It must have a valid Delay Timer and Pending Timestamp.
      *
      * @retval ERROR_NONE              Successfully requested the Thread network migration.
      * @retval ERROR_DBUS              D-Bus encode/decode error.
@@ -167,11 +167,11 @@ public:
     /**
      * This method performs a factory reset.
      *
-     * @param[in]   aHandler        The reset result handler.
+     * @param[in] aHandler  The reset result handler.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError FactoryReset(const OtResultHandler &aHandler);
@@ -179,9 +179,9 @@ public:
     /**
      * This method performs a soft reset.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError Reset(void);
@@ -191,17 +191,17 @@ public:
      *
      * @note The joiner start and the attach proccesses are exclusive
      *
-     * @param[in]   aPskd             The pre-shared key for device.
-     * @param[in]   aProvisioningUrl  The provision url.
-     * @param[in]   aVendorName       The vendor name.
-     * @param[in]   aVendorModel      The vendor model.
-     * @param[in]   aVendorSwVersion  The vendor software version.
-     * @param[in]   aVendorData       The vendor custom data.
-     * @param[in]   aHandler          The join result handler.
+     * @param[in] aPskd             The pre-shared key for device.
+     * @param[in] aProvisioningUrl  The provision url.
+     * @param[in] aVendorName       The vendor name.
+     * @param[in] aVendorModel      The vendor model.
+     * @param[in] aVendorSwVersion  The vendor software version.
+     * @param[in] aVendorData       The vendor custom data.
+     * @param[in] aHandler          The join result handler.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError JoinerStart(const std::string &    aPskd,
@@ -215,9 +215,9 @@ public:
     /**
      * This method stops the joiner process
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError JoinerStop(void);
@@ -225,11 +225,11 @@ public:
     /**
      * This method adds a on-mesh address prefix.
      *
-     * @param[in]   aPrefix     The address prefix.
+     * @param[in] aPrefix  The address prefix.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError AddOnMeshPrefix(const OnMeshPrefix &aPrefix);
@@ -237,11 +237,11 @@ public:
     /**
      * This method removes a on-mesh address prefix.
      *
-     * @param[in]   aPrefix     The address prefix.
+     * @param[in] aPrefix  The address prefix.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError RemoveOnMeshPrefix(const Ip6Prefix &aPrefix);
@@ -249,11 +249,11 @@ public:
     /**
      * This method adds an external route.
      *
-     * @param[in]   aExternalroute  The external route config
+     * @param[in] aExternalroute  The external route config
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError AddExternalRoute(const ExternalRoute &aExternalRoute);
@@ -261,11 +261,11 @@ public:
     /**
      * This method removes an external route.
      *
-     * @param[in]   aPrefix         The route prefix.
+     * @param[in] aPrefix  The route prefix.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError RemoveExternalRoute(const Ip6Prefix &aPrefix);
@@ -273,11 +273,11 @@ public:
     /**
      * This method sets the mesh-local prefix.
      *
-     * @param[in]   aPrefix     The address prefix.
+     * @param[in] aPrefix The address prefix.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError SetMeshLocalPrefix(const std::array<uint8_t, OTBR_IP6_PREFIX_SIZE> &aPrefix);
@@ -285,11 +285,11 @@ public:
     /**
      * This method sets the legacy prefix of ConnectIP.
      *
-     * @param[in]   aPrefix     The address prefix.
+     * @param[in] aPrefix  The address prefix.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError SetLegacyUlaPrefix(const std::array<uint8_t, OTBR_IP6_PREFIX_SIZE> &aPrefix);
@@ -297,11 +297,11 @@ public:
     /**
      * This method sets the active operational dataset.
      *
-     * @param[out]  aDataset    The active operational dataset
+     * @param[out] aDataset  The active operational dataset
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError SetActiveDatasetTlvs(const std::vector<uint8_t> &aDataset);
@@ -309,11 +309,11 @@ public:
     /**
      * This method sets the link operating mode.
      *
-     * @param[in]   aConfig   The operating mode config.
+     * @param[in] aConfig  The operating mode config.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError SetLinkMode(const LinkModeConfig &aConfig);
@@ -321,11 +321,11 @@ public:
     /**
      * This method sets the radio region.
      *
-     * @param[in]   aRadioRegion  The radio region.
+     * @param[in] aRadioRegion  The radio region.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError SetRadioRegion(const std::string &aRadioRegion);
@@ -333,11 +333,11 @@ public:
     /**
      * This method gets the link operating mode.
      *
-     * @param[out]  aConfig   The operating mode config.
+     * @param[out] aConfig  The operating mode config.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetLinkMode(LinkModeConfig &aConfig);
@@ -345,11 +345,11 @@ public:
     /**
      * This method gets the current device role.
      *
-     * @param[out]  aDeviceRole   The device role
+     * @param[out] aDeviceRole  The device role
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetDeviceRole(DeviceRole &aDeviceRole);
@@ -357,11 +357,11 @@ public:
     /**
      * This method gets the network name.
      *
-     * @param[out]  aName   The network name.
+     * @param[out] aName  The network name.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetNetworkName(std::string &aName);
@@ -369,11 +369,11 @@ public:
     /**
      * This method gets the network pan id.
      *
-     * @param[out]  aPanId  The pan id.
+     * @param[out] aPanId  The pan id.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetPanId(uint16_t &aPanId);
@@ -381,11 +381,11 @@ public:
     /**
      * This method gets the extended pan id.
      *
-     * @param[out]  aExtPanId   The extended pan id.
+     * @param[out] aExtPanId  The extended pan id.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetExtPanId(uint64_t &aExtPanId);
@@ -393,11 +393,11 @@ public:
     /**
      * This method gets the extended pan id.
      *
-     * @param[out]  aChannel   The extended pan id.
+     * @param[out] aChannel  The extended pan id.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetChannel(uint16_t &aChannel);
@@ -405,11 +405,11 @@ public:
     /**
      * This method gets the network network key.
      *
-     * @param[out]  aNetworkKey   The network network key.
+     * @param[out] aNetworkKey  The network network key.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetNetworkKey(std::vector<uint8_t> &aNetworkKey);
@@ -417,11 +417,11 @@ public:
     /**
      * This method gets the Clear Channel Assessment failure rate.
      *
-     * @param[out]  aFailureRate   The failure rate.
+     * @param[out] aFailureRate  The failure rate.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetCcaFailureRate(uint16_t &aFailureRate);
@@ -429,11 +429,11 @@ public:
     /**
      * This method gets the mac level statistics counters.
      *
-     * @param[out]  aCounters    The statistic counters.
+     * @param[out] aCounters  The statistic counters.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetLinkCounters(MacCounters &aCounters); // For telemetry
@@ -441,11 +441,11 @@ public:
     /**
      * This method gets the ip level statistics counters.
      *
-     * @param[out]  aCounters    The statistic counters.
+     * @param[out] aCounters  The statistic counters.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetIp6Counters(IpCounters &aCounters); // For telemetry
@@ -453,11 +453,11 @@ public:
     /**
      * This method gets the supported channel mask.
      *
-     * @param[out]  aChannelMask   The channel mask.
+     * @param[out] aChannelMask  The channel mask.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetSupportedChannelMask(uint32_t &aChannelMask);
@@ -465,11 +465,11 @@ public:
     /**
      * This method gets the Thread routing locator
      *
-     * @param[out]  aRloc16   The routing locator
+     * @param[out] aRloc16  The routing locator
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetRloc16(uint16_t &aRloc16);
@@ -477,11 +477,11 @@ public:
     /**
      * This method gets 802.15.4 extended address
      *
-     * @param[out]  aExtendedAddress    The extended address
+     * @param[out] aExtendedAddress  The extended address
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetExtendedAddress(uint64_t &aExtendedAddress);
@@ -489,12 +489,12 @@ public:
     /**
      * This method gets the node's router id.
      *
-     * @param[out]  aRouterId     The router id.
+     * @param[out] aRouterId  The router id.
      *
-     * @retval ERROR_NONE            Successfully performed the dbus function call.
-     * @retval ERROR_DBUS            dbus encode/decode error
-     * @retval OT_ERROR_INVALID_STATE     The node is not a router.
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE              Successfully performed the dbus function call.
+     * @retval ERROR_DBUS              dbus encode/decode error.
+     * @retval OT_ERROR_INVALID_STATE  The node is not a router.
+     * @retval ...                     OpenThread defined error value otherwise.
      *
      */
     ClientError GetRouterId(uint8_t &aRouterId);
@@ -502,11 +502,11 @@ public:
     /**
      * This method gets the network's leader data.
      *
-     * @param[out]  aLeaderData   The leader data.
+     * @param[out] aLeaderData  The leader data.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetLeaderData(LeaderData &aLeaderData);
@@ -514,11 +514,11 @@ public:
     /**
      * This method gets the network data.
      *
-     * @param[out]  aNetworkData   The network data.
+     * @param[out] aNetworkData  The network data.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetNetworkData(std::vector<uint8_t> &aNetworkData);
@@ -526,11 +526,11 @@ public:
     /**
      * This method gets the stable network data.
      *
-     * @param[out]  aNetworkData   The stable network data.
+     * @param[out] aNetworkData  The stable network data.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetStableNetworkData(std::vector<uint8_t> &aNetworkData);
@@ -538,11 +538,11 @@ public:
     /**
      * This method gets the node's local leader weight.
      *
-     * @param[out]  aWeight     The local leader weight.
+     * @param[out] aWeight  The local leader weight.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetLocalLeaderWeight(uint8_t &aWeight);
@@ -550,11 +550,11 @@ public:
     /**
      * This method gets the channel monitor sample count.
      *
-     * @param[out]  aSampleCount     The channel monitor sample count.
+     * @param[out] aSampleCount  The channel monitor sample count.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetChannelMonitorSampleCount(uint32_t &aSampleCount);
@@ -562,11 +562,11 @@ public:
     /**
      * This method gets the channel qualities
      *
-     * @param[out]  aChannelQualities     The channel qualities.
+     * @param[out] aChannelQualities  The channel qualities.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetChannelMonitorAllChannelQualities(std::vector<ChannelQuality> &aChannelQualities);
@@ -574,11 +574,11 @@ public:
     /**
      * This method gets the child table.
      *
-     * @param[out]  aChildTable     The child table.
+     * @param[out] aChildTable  The child table.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetChildTable(std::vector<ChildInfo> &aChildTable);
@@ -586,11 +586,11 @@ public:
     /**
      * This method gets the neighbor table.
      *
-     * @param[out]  aNeighborTable     The neighbor table.
+     * @param[out] aNeighborTable  The neighbor table.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetNeighborTable(std::vector<NeighborInfo> &aNeighborTable);
@@ -598,11 +598,11 @@ public:
     /**
      * This method gets the network's parition id.
      *
-     * @param[out]  aPartitionId      The partition id.
+     * @param[out] aPartitionId  The partition id.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetPartitionId(uint32_t &aPartitionId);
@@ -610,11 +610,11 @@ public:
     /**
      * This method gets the rssi of the latest packet.
      *
-     * @param[out]  aRssi      The rssi of the latest packet.
+     * @param[out] aRssi  The rssi of the latest packet.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetInstantRssi(int8_t &aRssi);
@@ -622,11 +622,11 @@ public:
     /**
      * This method gets the radio transmit power.
      *
-     * @param[out]  aTxPower    The radio transmit power.
+     * @param[out] aTxPower  The radio transmit power.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetRadioTxPower(int8_t &aTxPower);
@@ -634,11 +634,11 @@ public:
     /**
      * This method gets the external route table
      *
-     * @param[out]  aExternalRoutes   The external route table
+     * @param[out] aExternalRoutes  The external route table
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetExternalRoutes(std::vector<ExternalRoute> &aExternalRoutes);
@@ -646,11 +646,11 @@ public:
     /**
      * This method gets the active operational dataset
      *
-     * @param[out]  aDataset    The active operational dataset
+     * @param[out] aDataset  The active operational dataset
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetActiveDatasetTlvs(std::vector<uint8_t> &aDataset);
@@ -658,11 +658,11 @@ public:
     /**
      * This method gets the radio region.
      *
-     * @param[out]  aRadioRegion  The radio region.
+     * @param[out] aRadioRegion  The radio region.
      *
-     * @retval ERROR_NONE successfully performed the dbus function call
-     * @retval ERROR_DBUS dbus encode/decode error
-     * @retval ...        OpenThread defined error value otherwise
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
      *
      */
     ClientError GetRadioRegion(std::string &aRadioRegion);

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -486,11 +486,11 @@ constexpr otbrError ConvertToTuple(DBusMessageIter *aIter, std::tuple<FieldTypes
 /**
  * This function converts a value to a d-bus variant.
  *
- * @param[out]  aIter    The message iterator pointing to the variant.
- * @param[in]   aValue    The value input.
+ * @param[out] aIter   The message iterator pointing to the variant.
+ * @param[in]  aValue  The value input.
  *
- * @retval  OTBR_ERROR_NONE   Successfully encoded to the variant.
- * @retval  OTBR_ERROR_DBUS   Failed to encode to the variant.
+ * @retval OTBR_ERROR_NONE  Successfully encoded to the variant.
+ * @retval OTBR_ERROR_DBUS  Failed to encode to the variant.
  */
 template <typename ValueType> otbrError DBusMessageEncodeToVariant(DBusMessageIter *aIter, const ValueType &aValue)
 {
@@ -512,11 +512,11 @@ exit:
 /**
  * This function converts a d-bus variant to a value.
  *
- * @param[in]   aIter     The message iterator pointing to the variant.
- * @param[out]  aValue    The value output.
+ * @param[in]  aIter   The message iterator pointing to the variant.
+ * @param[out] aValue  The value output.
  *
- * @retval  OTBR_ERROR_NONE   Successfully decoded the variant.
- * @retval  OTBR_ERROR_DBUS   Failed to decode the variant.
+ * @retval OTBR_ERROR_NONE  Successfully decoded the variant.
+ * @retval OTBR_ERROR_DBUS  Failed to decode the variant.
  */
 template <typename ValueType> otbrError DBusMessageExtractFromVariant(DBusMessageIter *aIter, ValueType &aValue)
 {
@@ -535,11 +535,11 @@ exit:
 /**
  * This function converts a d-bus message to a tuple of C++ types.
  *
- * @param[in]   aMessage  The dbus message to decode.
- * @param[out]  aValues   The tuple output.
+ * @param[in]  aMessage  The dbus message to decode.
+ * @param[out] aValues   The tuple output.
  *
- * @retval  OTBR_ERROR_NONE   Successfully decoded the message.
- * @retval  OTBR_ERROR_DBUS   Failed to decode the message.
+ * @retval OTBR_ERROR_NONE  Successfully decoded the message.
+ * @retval OTBR_ERROR_DBUS  Failed to decode the message.
  */
 template <typename... FieldTypes>
 otbrError DBusMessageToTuple(DBusMessage &aMessage, std::tuple<FieldTypes...> &aValues)
@@ -558,11 +558,11 @@ exit:
 /**
  * This function converts a tuple of C++ types to a d-bus message.
  *
- * @param[out]  aMessage  The dbus message output.
- * @param[in]   aValues   The tuple to encode.
+ * @param[out] aMessage  The dbus message output.
+ * @param[in]  aValues   The tuple to encode.
  *
- * @retval  OTBR_ERROR_NONE   Successfully encoded the message.
- * @retval  OTBR_ERROR_DBUS   Failed to encode the message.
+ * @retval OTBR_ERROR_NONE  Successfully encoded the message.
+ * @retval OTBR_ERROR_DBUS  Failed to encode the message.
  */
 template <typename... FieldTypes>
 otbrError TupleToDBusMessage(DBusMessage &aMessage, const std::tuple<FieldTypes...> &aValues)
@@ -576,11 +576,11 @@ otbrError TupleToDBusMessage(DBusMessage &aMessage, const std::tuple<FieldTypes.
 /**
  * This function converts a d-bus message to a tuple of C++ types.
  *
- * @param[in]   aMessage  The dbus message to decode.
- * @param[out]  aValues   The tuple output.
+ * @param[in]  aMessage  The dbus message to decode.
+ * @param[out] aValues   The tuple output.
  *
- * @retval  OTBR_ERROR_NONE   Successfully decoded the message.
- * @retval  OTBR_ERROR_DBUS   Failed to decode the message.
+ * @retval OTBR_ERROR_NONE  Successfully decoded the message.
+ * @retval OTBR_ERROR_DBUS  Failed to decode the message.
  */
 template <typename... FieldTypes>
 otbrError DBusMessageToTuple(UniqueDBusMessage const &aMessage, std::tuple<FieldTypes...> &aValues)

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -56,7 +56,7 @@ public:
     /**
      * The constructor of dbus agent.
      *
-     * @param[in]  aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     DBusAgent(otbr::Ncp::ControllerOpenThread &aNcp);

--- a/src/dbus/server/dbus_object.hpp
+++ b/src/dbus/server/dbus_object.hpp
@@ -70,8 +70,8 @@ public:
     /**
      * The constructor of a d-bus object.
      *
-     * @param[in]   aConnection   The dbus-connection the object bounds to.
-     * @param[in]   aObjectPath   The path of the object.
+     * @param[in] aConnection  The dbus-connection the object bounds to.
+     * @param[in] aObjectPath  The path of the object.
      *
      */
     DBusObject(DBusConnection *aConnection, const std::string &aObjectPath);
@@ -81,8 +81,8 @@ public:
      *
      * This method will register the object to the d-bus library.
      *
-     * @retval  OTBR_ERROR_NONE   Successfully registered the object.
-     * @retval  OTBR_ERROR_DBUS   Failed to ragister an object.
+     * @retval OTBR_ERROR_NONE  Successfully registered the object.
+     * @retval OTBR_ERROR_DBUS  Failed to ragister an object.
      *
      */
     virtual otbrError Init(void);
@@ -90,9 +90,9 @@ public:
     /**
      * This method registers the method handler.
      *
-     * @param[in]   aInterfaceName    The interface name.
-     * @param[in]   aMethodName       The method name.
-     * @param[in]   aHandler          The method handler.
+     * @param[in] aInterfaceName  The interface name.
+     * @param[in] aMethodName     The method name.
+     * @param[in] aHandler        The method handler.
      *
      */
     void RegisterMethod(const std::string &      aInterfaceName,
@@ -102,9 +102,9 @@ public:
     /**
      * This method registers the get handler for a property.
      *
-     * @param[in]   aInterfaceName    The interface name.
-     * @param[in]   aMethodName       The method name.
-     * @param[in]   aHandler          The method handler.
+     * @param[in] aInterfaceName  The interface name.
+     * @param[in] aMethodName     The method name.
+     * @param[in] aHandler        The method handler.
      *
      */
     void RegisterGetPropertyHandler(const std::string &        aInterfaceName,
@@ -114,9 +114,9 @@ public:
     /**
      * This method registers the set handler for a property.
      *
-     * @param[in]   aInterfaceName    The interface name.
-     * @param[in]   aMethodName       The method name.
-     * @param[in]   aHandler          The method handler.
+     * @param[in] aInterfaceName  The interface name.
+     * @param[in] aMethodName     The method name.
+     * @param[in] aHandler        The method handler.
      *
      */
     void RegisterSetPropertyHandler(const std::string &        aInterfaceName,
@@ -126,9 +126,9 @@ public:
     /**
      * This method sends a signal.
      *
-     * @param[in]   aInterfaceName    The interface name.
-     * @param[in]   aSignalName       The signal name.
-     * @param[in]   aArgs             The tuple to be encoded into the signal.
+     * @param[in] aInterfaceName  The interface name.
+     * @param[in] aSignalName     The signal name.
+     * @param[in] aArgs           The tuple to be encoded into the signal.
      *
      * @retval OTBR_ERROR_NONE  Signal successfully sent.
      * @retval OTBR_ERROR_DBUS  Failed to send the signal.
@@ -155,9 +155,9 @@ public:
     /**
      * This method sends a property changed signal.
      *
-     * @param[in]   aInterfaceName    The interface name.
-     * @param[in]   aPropertyName     The property name.
-     * @param[in]   aValue            New value of the property.
+     * @param[in] aInterfaceName  The interface name.
+     * @param[in] aPropertyName   The property name.
+     * @param[in] aValue          New value of the property.
      *
      * @retval OTBR_ERROR_NONE  Signal successfully sent.
      * @retval OTBR_ERROR_DBUS  Failed to send the signal.

--- a/src/dbus/server/dbus_request.hpp
+++ b/src/dbus/server/dbus_request.hpp
@@ -55,8 +55,8 @@ public:
     /**
      * The constructor of dbus request.
      *
-     * @param[in]   aConnection   The dbus connection.
-     * @param[in]   aMessage      The incoming dbus message.
+     * @param[in] aConnection  The dbus connection.
+     * @param[in] aMessage     The incoming dbus message.
      *
      */
     DBusRequest(DBusConnection *aConnection, DBusMessage *aMessage)
@@ -70,7 +70,7 @@ public:
     /**
      * The copy constructor of dbus request.
      *
-     * @param[in]   aOther    The object to be copied from.
+     * @param[in] aOther  The object to be copied from.
      *
      */
     DBusRequest(const DBusRequest &aOther)
@@ -83,7 +83,7 @@ public:
     /**
      * The assignment operator of dbus request.
      *
-     * @param[in]   aOther    The object to be copied from.
+     * @param[in] aOther  The object to be copied from.
      *
      */
     DBusRequest &operator=(const DBusRequest &aOther)
@@ -95,7 +95,7 @@ public:
     /**
      * This method returns the message sent to call the d-bus method.
      *
-     * @returns   The dbus message.
+     * @returns The dbus message.
      *
      */
     DBusMessage *GetMessage(void) { return mMessage; }
@@ -103,7 +103,7 @@ public:
     /**
      * This method returns underlying d-bus connection.
      *
-     * @returns   The dbus connection.
+     * @returns The dbus connection.
      *
      */
     DBusConnection *GetConnection(void) { return mConnection; }

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -63,9 +63,9 @@ public:
     /**
      * This constructor of dbus thread object.
      *
-     * @param[in]       aConnection     The dbus connection.
-     * @param[in]       aInterfaceName  The dbus interface name.
-     * @param[in]       aNcp            The ncp controller
+     * @param[in] aConnection     The dbus connection.
+     * @param[in] aInterfaceName  The dbus interface name.
+     * @param[in] aNcp            The ncp controller
      *
      */
     DBusThreadObject(DBusConnection *                 aConnection,

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -50,13 +50,13 @@ namespace Mdns {
  * @addtogroup border-router-mdns
  *
  * @brief
- *   This module includes definition for mDNS service.
+ *   This module includes definition for mDNS publisher.
  *
  * @{
  */
 
 /**
- * This interface defines the functionality of mDNS service.
+ * This interface defines the functionality of mDNS publisher.
  *
  */
 class Publisher
@@ -143,10 +143,10 @@ public:
     };
 
     /**
-     * This function pointer is called when mDNS service state changed.
+     * This function pointer is called when mDNS publisher state changed.
      *
-     * @param[in]   aContext        A pointer to application-specific context.
-     * @param[in]   aState          The new state.
+     * @param[in] aContext  A pointer to application-specific context.
+     * @param[in] aState    The new state.
      *
      */
     typedef void (*StateHandler)(void *aContext, State aState);
@@ -154,10 +154,10 @@ public:
     /**
      * This method reports the result of a service publication.
      *
-     * @param[in]  aName     The service instance name.
-     * @param[in]  aType     The service type.
-     * @param[in]  aError    An error that indicates whether the service publication succeeds.
-     * @param[in]  aContext  A user context.
+     * @param[in] aName     The service instance name.
+     * @param[in] aType     The service type.
+     * @param[in] aError    An error that indicates whether the service publication succeeds.
+     * @param[in] aContext  A user context.
      *
      */
     typedef void (*PublishServiceHandler)(const std::string &aName,
@@ -168,9 +168,9 @@ public:
     /**
      * This method reports the result of a host publication.
      *
-     * @param[in]  aName     The host name.
-     * @param[in]  aError    An OTBR error that indicates whether the host publication succeeds.
-     * @param[in]  aContext  A user context.
+     * @param[in] aName     The host name.
+     * @param[in] aError    An OTBR error that indicates whether the host publication succeeds.
+     * @param[in] aContext  A user context.
      *
      */
     typedef void (*PublishHostHandler)(const std::string &aName, otbrError aError, void *aContext);
@@ -178,8 +178,8 @@ public:
     /**
      * This method sets the handler for service publication.
      *
-     * @param[in]  aHandler  A handler which will be called when a service publication is finished.
-     * @param[in]  aContext  A user context which is associated to @p aHandler.
+     * @param[in] aHandler  A handler which will be called when a service publication is finished.
+     * @param[in] aContext  A user context which is associated to @p aHandler.
      *
      */
     void SetPublishServiceHandler(PublishServiceHandler aHandler, void *aContext)
@@ -191,8 +191,8 @@ public:
     /**
      * This method sets the handler for host publication.
      *
-     * @param[in]  aHandler  A handler which will be called when a host publication is finished.
-     * @param[in]  aContext  A user context which is associated to @p aHandler.
+     * @param[in] aHandler  A handler which will be called when a host publication is finished.
+     * @param[in] aContext  A user context which is associated to @p aHandler.
      *
      */
     void SetPublishHostHandler(PublishHostHandler aHandler, void *aContext)
@@ -202,16 +202,16 @@ public:
     }
 
     /**
-     * This method starts the mDNS service.
+     * This method starts the mDNS publisher.
      *
-     * @retval OTBR_ERROR_NONE  Successfully started mDNS service;
-     * @retval OTBR_ERROR_MDNS  Failed to start mDNS service.
+     * @retval OTBR_ERROR_NONE  Successfully started mDNS publisher;
+     * @retval OTBR_ERROR_MDNS  Failed to start mDNS publisher.
      *
      */
     virtual otbrError Start(void) = 0;
 
     /**
-     * This method stops the mDNS service.
+     * This method stops the mDNS publisher.
      *
      */
     virtual void Stop(void) = 0;
@@ -219,8 +219,8 @@ public:
     /**
      * This method checks if publisher has been started.
      *
-     * @retval true     Already started.
-     * @retval false    Not started.
+     * @retval true   Already started.
+     * @retval false  Not started.
      *
      */
     virtual bool IsStarted(void) const = 0;
@@ -228,18 +228,18 @@ public:
     /**
      * This method publishes or updates a service.
      *
-     * @param[in]   aHostName           The name of the host which this service resides on. If an empty string is
-     *                                  provided, this service resides on local host and it is the implementation
-     *                                  to provide specific host name. Otherwise, the caller MUST publish the host
-     *                                  with method PublishHost.
-     * @param[in]   aPort               The port number of this service.
-     * @param[in]   aName               The name of this service.
-     * @param[in]   aType               The type of this service.
-     * @param[in]   aSubTypeList        A list of service subtypes.
-     * @param[in]   aTxtList            A list of TXT name/value pairs.
+     * @param[in] aHostName     The name of the host which this service resides on. If an empty string is
+     *                          provided, this service resides on local host and it is the implementation
+     *                          to provide specific host name. Otherwise, the caller MUST publish the host
+     *                          with method PublishHost.
+     * @param[in] aPort         The port number of this service.
+     * @param[in] aName         The name of this service.
+     * @param[in] aType         The type of this service.
+     * @param[in] aSubTypeList  A list of service subtypes.
+     * @param[in] aTxtList      A list of TXT name/value pairs.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
-     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     * @retval OTBR_ERROR_NONE   Successfully published or updated the service.
+     * @retval OTBR_ERROR_ERRNO  Failed to publish or update the service.
      *
      */
     virtual otbrError PublishService(const std::string &aHostName,
@@ -252,11 +252,11 @@ public:
     /**
      * This method un-publishes a service.
      *
-     * @param[in]   aName               The name of this service.
-     * @param[in]   aType               The type of this service.
+     * @param[in] aName  The name of this service.
+     * @param[in] aType  The type of this service.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully un-published the service.
-     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the service.
+     * @retval OTBR_ERROR_NONE   Successfully un-published the service.
+     * @retval OTBR_ERROR_ERRNO  Failed to un-publish the service.
      *
      */
     virtual otbrError UnpublishService(const std::string &aName, const std::string &aType) = 0;
@@ -267,12 +267,12 @@ public:
      * Publishing a host is advertising an AAAA RR for the host name. This method should be called
      * before a service with non-empty host name is published.
      *
-     * @param[in]  aName     The name of the host.
-     * @param[in]  aAddress  The address of the host.
+     * @param[in] aName     The name of the host.
+     * @param[in] aAddress  The address of the host.
      *
-     * @retval  OTBR_ERROR_NONE          Successfully published or updated the host.
-     * @retval  OTBR_ERROR_INVALID_ARGS  The arguments are not valid.
-     * @retval  OTBR_ERROR_ERRNO         Failed to publish or update the host.
+     * @retval OTBR_ERROR_NONE          Successfully published or updated the host.
+     * @retval OTBR_ERROR_INVALID_ARGS  The arguments are not valid.
+     * @retval OTBR_ERROR_ERRNO         Failed to publish or update the host.
      *
      */
     virtual otbrError PublishHost(const std::string &aName, const std::vector<uint8_t> &aAddress) = 0;
@@ -280,10 +280,10 @@ public:
     /**
      * This method un-publishes a host.
      *
-     * @param[in]  aName  A host name.
+     * @param[in] aName  A host name.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully un-published the host.
-     * @retval  OTBR_ERROR_ERRNO    Failed to un-publish the host.
+     * @retval OTBR_ERROR_NONE   Successfully un-published the host.
+     * @retval OTBR_ERROR_ERRNO  Failed to un-publish the host.
      *
      */
     virtual otbrError UnpublishHost(const std::string &aName) = 0;
@@ -298,8 +298,8 @@ public:
      * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same service or service
      * instance.
      *
-     * @param[in]  aType          The service type.
-     * @param[in]  aInstanceName  The service instance to subscribe, or empty to subscribe the service.
+     * @param[in] aType          The service type.
+     * @param[in] aInstanceName  The service instance to subscribe, or empty to subscribe the service.
      *
      */
     virtual void SubscribeService(const std::string &aType, const std::string &aInstanceName) = 0;
@@ -312,8 +312,8 @@ public:
      *
      * @note Discovery Proxy implementation guarantees no redundant unsubscription for a service or service instance.
      *
-     * @param[in]  aType          The service type.
-     * @param[in]  aInstanceName  The service instance to unsubscribe, or empty to unsubscribe the service.
+     * @param[in] aType          The service type.
+     * @param[in] aInstanceName  The service instance to unsubscribe, or empty to unsubscribe the service.
      *
      */
     virtual void UnsubscribeService(const std::string &aType, const std::string &aInstanceName) = 0;
@@ -325,7 +325,7 @@ public:
      *
      * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same host.
      *
-     * @param[in]  aHostName    The host name (without domain).
+     * @param[in] aHostName  The host name (without domain).
      *
      */
     virtual void SubscribeHost(const std::string &aHostName) = 0;
@@ -335,7 +335,7 @@ public:
      *
      * @note Discovery Proxy implementation guarantees no redundant unsubscription for a host.
      *
-     * @param[in]  aHostName    The host name (without domain).
+     * @param[in] aHostName  The host name (without domain).
      *
      */
     virtual void UnsubscribeHost(const std::string &aHostName) = 0;
@@ -343,8 +343,8 @@ public:
     /**
      * This method sets the callbacks for subscriptions.
      *
-     * @param[in] aInstanceCallback     The callback function to receive discovered service instances.
-     * @param[in] aHostCallback         The callback function to receive discovered hosts.
+     * @param[in] aInstanceCallback  The callback function to receive discovered service instances.
+     * @param[in] aHostCallback      The callback function to receive discovered hosts.
      *
      */
     void SetSubscriptionCallbacks(DiscoveredServiceInstanceCallback aInstanceCallback,
@@ -370,7 +370,7 @@ public:
     /**
      * This function destroys the mDNS publisher.
      *
-     * @param[in]   aPublisher          A pointer to the publisher.
+     * @param[in] aPublisher  A pointer to the publisher.
      *
      */
     static void Destroy(Publisher *aPublisher);
@@ -382,10 +382,10 @@ public:
      * and we can not compare if two service type are equal with `strcmp`. This function
      * ignores the trailing dot when comparing two service types.
      *
-     * @param[in]  aFirstType   The first service type.
-     * @param[in]  aSecondType  The second service type.
+     * @param[in] aFirstType   The first service type.
+     * @param[in] aSecondType  The second service type.
      *
-     * returns  A boolean that indicates whether the two service types are equal.
+     * @returns A boolean that indicates whether the two service types are equal.
      *
      */
     static bool IsServiceTypeEqual(std::string aFirstType, std::string aSecondType);
@@ -396,11 +396,11 @@ public:
      * The output data is in standard DNS-SD TXT data format.
      * See RFC 6763 for details: https://tools.ietf.org/html/rfc6763#section-6.
      *
-     * @param[in]     aTxtList    A TXT entry list.
-     * @param[out]    aTxtData    A TXT data buffer.
+     * @param[in]  aTxtList  A TXT entry list.
+     * @param[out] aTxtData  A TXT data buffer.
      *
-     * @retval  OTBR_ERROR_NONE          Successfully write the TXT entry list.
-     * @retval  OTBR_ERROR_INVALID_ARGS  The @p aTxtList includes invalid TXT entry.
+     * @retval OTBR_ERROR_NONE          Successfully write the TXT entry list.
+     * @retval OTBR_ERROR_INVALID_ARGS  The @p aTxtList includes invalid TXT entry.
      *
      */
     static otbrError EncodeTxtData(const TxtList &aTxtList, std::vector<uint8_t> &aTxtData);

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file implements mDNS service based on avahi.
+ *   This file implements mDNS publisher based on avahi.
  */
 
 #define OTBR_LOG_TAG "MDNS"

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definition for mDNS service based on avahi.
+ *   This file includes definition for mDNS publisher based on avahi.
  */
 
 #ifndef OTBR_AGENT_MDNS_AVAHI_HPP_
@@ -50,7 +50,7 @@
  * @addtogroup border-router-mdns
  *
  * @brief
- *   This module includes definition for avahi-based mDNS service.
+ *   This module includes definition for avahi-based mDNS publisher.
  *
  * @{
  */
@@ -71,11 +71,11 @@ struct AvahiWatch
     /**
      * The constructor to initialize an Avahi watch.
      *
-     * @param[in]   aFd         The file descriptor to watch.
-     * @param[in]   aEvents     The events to watch.
-     * @param[in]   aCallback   The function to be called when events happend on this file descriptor.
-     * @param[in]   aContext    A pointer to application-specific context.
-     * @param[in]   aPoller     The Poller this watcher belongs to.
+     * @param[in] aFd        The file descriptor to watch.
+     * @param[in] aEvents    The events to watch.
+     * @param[in] aCallback  The function to be called when events happend on this file descriptor.
+     * @param[in] aContext   A pointer to application-specific context.
+     * @param[in] aPoller    The Poller this watcher belongs to.
      *
      */
     AvahiWatch(int aFd, AvahiWatchEvent aEvents, AvahiWatchCallback aCallback, void *aContext, void *aPoller)
@@ -102,10 +102,10 @@ struct AvahiTimeout
     /**
      * The constructor to initialize an AvahiTimeout.
      *
-     * @param[in]   aTimeout    A pointer to the time after which the callback should be called.
-     * @param[in]   aCallback   The function to be called after timeout.
-     * @param[in]   aContext    A pointer to application-specific context.
-     * @param[in]   aPoller     The Poller this timeout belongs to.
+     * @param[in] aTimeout   A pointer to the time after which the callback should be called.
+     * @param[in] aCallback  The function to be called after timeout.
+     * @param[in] aContext   A pointer to application-specific context.
+     * @param[in] aPoller    The Poller this timeout belongs to.
      *
      */
     AvahiTimeout(const struct timeval *aTimeout, AvahiTimeoutCallback aCallback, void *aContext, void *aPoller);
@@ -170,7 +170,7 @@ private:
 };
 
 /**
- * This class implements mDNS service with avahi.
+ * This class implements mDNS publisher with avahi.
  *
  */
 class PublisherAvahi : public Publisher

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file implements mDNS service based on mDNSResponder.
+ *   This file implements mDNS publisher based on mDNSResponder.
  */
 
 #define OTBR_LOG_TAG "MDNS"

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definition for mDNS service.
+ *   This file includes definition for mDNS publisher.
  */
 
 #ifndef OTBR_AGENT_MDNS_MDNSSD_HPP_
@@ -52,7 +52,7 @@ namespace otbr {
 namespace Mdns {
 
 /**
- * This class implements mDNS service with mDNSResponder.
+ * This class implements mDNS publisher with mDNSResponder.
  *
  */
 class PublisherMDnsSd : public MainloopProcessor, public Publisher

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -62,9 +62,9 @@ public:
     /**
      * This constructor initializes this object.
      *
-     * @param[in]   aInterfaceName          A string of the NCP interface name.
-     * @param[in]   aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
-     * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
+     * @param[in] aInterfaceName          A string of the NCP interface name.
+     * @param[in] aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
+     * @param[in] aBackboneInterfaceName  The Backbone network interface name.
      *
      */
     ControllerOpenThread(const char *                     aInterfaceName,
@@ -74,7 +74,7 @@ public:
     /**
      * This method initalize the NCP controller.
      *
-     * @retval  OTBR_ERROR_NONE     Successfully initialized NCP controller.
+     * @retval OTBR_ERROR_NONE  Successfully initialized NCP controller.
      *
      */
     otbrError Init(void);
@@ -82,7 +82,7 @@ public:
     /**
      * This method get mInstance pointer.
      *
-     * @retval  the pointer of mInstance.
+     * @retval The pointer of mInstance.
      *
      */
     otInstance *GetInstance(void) { return mInstance; }
@@ -90,7 +90,7 @@ public:
     /**
      * This method gets the thread functionality helper.
      *
-     * @retval  the pointer to the helper object.
+     * @retval The pointer to the helper object.
      *
      */
     otbr::agent::ThreadHelper *GetThreadHelper(void) { return mThreadHelper.get(); }
@@ -101,8 +101,8 @@ public:
     /**
      * This method posts a task to the timer
      *
-     * @param[in]   aDelay  The delay in milliseconds before executing the task.
-     * @param[in]   aTask   The task function.
+     * @param[in] aDelay  The delay in milliseconds before executing the task.
+     * @param[in] aTask   The task function.
      *
      */
     void PostTimerTask(Milliseconds aDelay, TaskRunner::Task<void> aTask);
@@ -110,7 +110,7 @@ public:
     /**
      * This method registers a reset handler.
      *
-     * @param[in]   aHandler  The handler function.
+     * @param[in] aHandler  The handler function.
      *
      */
     void RegisterResetHandler(std::function<void(void)> aHandler);
@@ -118,7 +118,7 @@ public:
     /**
      * This method adds a event listener for Thread state changes.
      *
-     * @param[in]  aCallback  The callback to receive Thread state changed events.
+     * @param[in] aCallback  The callback to receive Thread state changed events.
      *
      */
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback);
@@ -132,7 +132,7 @@ public:
     /**
      * This method returns the Thread protocol version as a string.
      *
-     * @returns  A pointer to the Thread version string.
+     * @returns A pointer to the Thread version string.
      *
      */
     static const char *GetThreadVersion(void);
@@ -140,7 +140,7 @@ public:
     /**
      * This method returns the Thread network interface name.
      *
-     * @returns  A pointer to the Thread network interface name string.
+     * @returns A pointer to the Thread network interface name string.
      *
      */
     const char *GetInterfaceName(void) const { return mConfig.mInterfaceName; }

--- a/src/openwrt/ubus/otubus.hpp
+++ b/src/openwrt/ubus/otubus.hpp
@@ -77,15 +77,15 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aController  A pointer to OpenThread Controller structure.
-     * @param[in]  aMutex       A pointer to mutex.
+     * @param[in] aController  A pointer to OpenThread Controller structure.
+     * @param[in] aMutex       A pointer to mutex.
      */
     static void Initialize(Ncp::ControllerOpenThread *aController, std::mutex *aMutex);
 
     /**
      * This method return the instance of the global UbusServer.
      *
-     * @retval  the reference of the UbusServer Instance.
+     * @retval The reference of the UbusServer Instance.
      *
      */
     static UbusServer &GetInstance(void);
@@ -99,13 +99,13 @@ public:
     /**
      * This method handle ubus scan function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusScanHandler(struct ubus_context *     aContext,
@@ -117,13 +117,13 @@ public:
     /**
      * This method handle ubus get channel function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusChannelHandler(struct ubus_context *     aContext,
@@ -135,13 +135,13 @@ public:
     /**
      * This method handle ubus set channel function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetChannelHandler(struct ubus_context *     aContext,
@@ -153,13 +153,13 @@ public:
     /**
      * This method handle ubus get networkname function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusNetworknameHandler(struct ubus_context *     aContext,
@@ -171,13 +171,13 @@ public:
     /**
      * This method handle ubus set networkname function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetNetworknameHandler(struct ubus_context *     aContext,
@@ -189,13 +189,13 @@ public:
     /**
      * This method handle ubus get state function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusStateHandler(struct ubus_context *     aContext,
@@ -207,13 +207,13 @@ public:
     /**
      * This method handle ubus set state function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterSetStateHandler(struct ubus_context *     aContext,
@@ -225,13 +225,13 @@ public:
     /**
      * This method handle ubus get panid function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusPanIdHandler(struct ubus_context *     aContext,
@@ -243,13 +243,13 @@ public:
     /**
      * This method handle ubus set panid function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetPanIdHandler(struct ubus_context *     aContext,
@@ -261,13 +261,13 @@ public:
     /**
      * This method handle ubus get pskc function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusPskcHandler(struct ubus_context *     aContext,
@@ -279,13 +279,13 @@ public:
     /**
      * This method handle ubus set pskc function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetPskcHandler(struct ubus_context *     aContext,
@@ -297,13 +297,13 @@ public:
     /**
      * This method handle ubus get networkkey function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusNetworkkeyHandler(struct ubus_context *     aContext,
@@ -315,13 +315,13 @@ public:
     /**
      * This method handle ubus set networkkey function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetNetworkkeyHandler(struct ubus_context *     aContext,
@@ -333,13 +333,13 @@ public:
     /**
      * This method handle ubus get rloc16 function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusRloc16Handler(struct ubus_context *     aContext,
@@ -351,13 +351,13 @@ public:
     /**
      * This method handle ubus get extpanid function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusExtPanIdHandler(struct ubus_context *     aContext,
@@ -369,13 +369,13 @@ public:
     /**
      * This method handle ubus set extpanid function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetExtPanIdHandler(struct ubus_context *     aContext,
@@ -387,13 +387,13 @@ public:
     /**
      * This method handle ubus get mode function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusModeHandler(struct ubus_context *     aContext,
@@ -405,13 +405,13 @@ public:
     /**
      * This method handle ubus set mode function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusSetModeHandler(struct ubus_context *     aContext,
@@ -423,13 +423,13 @@ public:
     /**
      * This method handle ubus get partitionid function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusPartitionIdHandler(struct ubus_context *     aContext,
@@ -441,13 +441,13 @@ public:
     /**
      * This method handle ubus get leaderdata function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusLeaderdataHandler(struct ubus_context *     aContext,
@@ -459,13 +459,13 @@ public:
     /**
      * This method handle ubus get networkdata function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusNetworkdataHandler(struct ubus_context *     aContext,
@@ -477,13 +477,13 @@ public:
     /**
      * This method handle ubus get parent function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusParentHandler(struct ubus_context *     aContext,
@@ -495,13 +495,13 @@ public:
     /**
      * This method handle ubus get neighbor function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusNeighborHandler(struct ubus_context *     aContext,
@@ -513,13 +513,13 @@ public:
     /**
      * This method handle ubus start thread function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusThreadStartHandler(struct ubus_context *     aContext,
@@ -531,13 +531,13 @@ public:
     /**
      * This method handle ubus stop thread function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusThreadStopHandler(struct ubus_context *     aContext,
@@ -549,13 +549,13 @@ public:
     /**
      * This method handle ubus leave function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusLeaveHandler(struct ubus_context *     aContext,
@@ -567,13 +567,13 @@ public:
     /**
      * This method handle ubus get macfilter address function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterAddrHandler(struct ubus_context *     aContext,
@@ -585,13 +585,13 @@ public:
     /**
      * This method handle ubus get macfilter state function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterStateHandler(struct ubus_context *     aContext,
@@ -603,13 +603,13 @@ public:
     /**
      * This method handle ubus macfilter address add function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterAddHandler(struct ubus_context *     aContext,
@@ -621,13 +621,13 @@ public:
     /**
      * This method handle ubus macfilter address clear function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterClearHandler(struct ubus_context *     aContext,
@@ -639,13 +639,13 @@ public:
     /**
      * This method handle ubus macfilter address remove function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMacfilterRemoveHandler(struct ubus_context *     aContext,
@@ -657,13 +657,13 @@ public:
     /**
      * This method handle ubus start commissioner function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusCommissionerStartHandler(struct ubus_context *     aContext,
@@ -675,13 +675,13 @@ public:
     /**
      * This method handle ubus add joiner function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusJoinerAddHandler(struct ubus_context *     aContext,
@@ -693,13 +693,13 @@ public:
     /**
      * This method handle ubus remove joiner function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusJoinerRemoveHandler(struct ubus_context *     aContext,
@@ -711,13 +711,13 @@ public:
     /**
      * This method handle ubus get joiner information function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusJoinerNumHandler(struct ubus_context *     aContext,
@@ -729,13 +729,13 @@ public:
     /**
      * This method handle ubus mgmtset function request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     static int UbusMgmtsetHandler(struct ubus_context *     aContext,
@@ -747,10 +747,10 @@ public:
     /**
      * This method handle initial diagnostic get response.
      *
-     * @param[in]   aError          A error of receiving the diagnostic response.
-     * @param[in]   aMessage        A pointer to the message.
-     * @param[in]   aMessageInfo    A pointer to the message information.
-     * @param[in]   aContext        A pointer to the context.
+     * @param[in] aError        A error of receiving the diagnostic response.
+     * @param[in] aMessage      A pointer to the message.
+     * @param[in] aMessageInfo  A pointer to the message information.
+     * @param[in] aContext      A pointer to the context.
      *
      */
     static void HandleDiagnosticGetResponse(otError              aError,
@@ -761,9 +761,9 @@ public:
     /**
      * This method handle diagnosticget response.
      *
-     * @param[in]   aError          A error of receiving the diagnostic response.
-     * @param[in]   aMessage        A pointer to the message.
-     * @param[in]   aMessageInfo    A pointer to the message information.
+     * @param[in] aError       A error of receiving the diagnostic response.
+     * @param[in] aMessage     A pointer to the message.
+     * @param[in] aMessageInfo A pointer to the message information.
      *
      */
     void HandleDiagnosticGetResponse(otError aError, otMessage *aMessage, const otMessageInfo *aMessageInfo);
@@ -785,8 +785,8 @@ private:
     /**
      * Constructor
      *
-     * @param[in]  aController  The pointer to OpenThread Controller structure.
-     * @param[in]  aMutex       A pointer to mutex.
+     * @param[in] aController  The pointer to OpenThread Controller structure.
+     * @param[in] aMutex       A pointer to mutex.
      */
     UbusServer(Ncp::ControllerOpenThread *aController, std::mutex *aMutex);
 
@@ -799,13 +799,13 @@ private:
     /**
      * This method detailly start scan.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusScanHandlerDetail(struct ubus_context *     aContext,
@@ -817,8 +817,8 @@ private:
     /**
      * This method handle scan result (callback function).
      *
-     * @param[in]   aResult     A pointer to result.
-     * @param[in]   aContext    A pointer to context.
+     * @param[in] aResult   A pointer to result.
+     * @param[in] aContext  A pointer to context.
      *
      */
     static void HandleActiveScanResult(otActiveScanResult *aResult, void *aContext);
@@ -826,7 +826,7 @@ private:
     /**
      * This method detailly handler the scan result, called by HandleActiveScanResult.
      *
-     * @param[in]   aResult     A pointer to result.
+     * @param[in] aResult  A pointer to result.
      *
      */
     void HandleActiveScanResultDetail(otActiveScanResult *aResult);
@@ -834,13 +834,13 @@ private:
     /**
      * This method detailly handler get neighbor information.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusNeighborHandlerDetail(struct ubus_context *     aContext,
@@ -852,13 +852,13 @@ private:
     /**
      * This method detailly handler get parent information.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusParentHandlerDetail(struct ubus_context *     aContext,
@@ -870,13 +870,13 @@ private:
     /**
      * This method handle mgmtset request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusMgmtset(struct ubus_context *     aContext,
@@ -888,13 +888,13 @@ private:
     /**
      * This method handle leave request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusLeaveHandlerDetail(struct ubus_context *     aContext,
@@ -906,14 +906,14 @@ private:
     /**
      * This method handle thread related request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
-     * @param[in]   aAction     A pointer to the action needed.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
+     * @param[in] aAction   A pointer to the action needed.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusThreadHandler(struct ubus_context *     aContext,
@@ -926,14 +926,14 @@ private:
     /**
      * This method handle get information request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
-     * @param[in]   aAction     A pointer to the action needed.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
+     * @param[in] aAction   A pointer to the action needed.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusGetInformation(struct ubus_context *     aContext,
@@ -946,14 +946,14 @@ private:
     /**
      * This method handle set information request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
-     * @param[in]   aAction     A pointer to the action needed.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
+     * @param[in] aAction   A pointer to the action needed.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusSetInformation(struct ubus_context *     aContext,
@@ -964,16 +964,16 @@ private:
                            const char *              aAction);
 
     /**
-     * This method handle conmmissioner related request.
+     * This method handle commissioner related request.
      *
-     * @param[in]   aContext    A pointer to the ubus context.
-     * @param[in]   aObj        A pointer to the ubus object.
-     * @param[in]   aRequest    A pointer to the ubus request.
-     * @param[in]   aMethod     A pointer to the ubus method.
-     * @param[in]   aMsg        A pointer to the ubus message.
-     * @param[in]   aAction     A pointer to the action needed.
+     * @param[in] aContext  A pointer to the ubus context.
+     * @param[in] aObj      A pointer to the ubus object.
+     * @param[in] aRequest  A pointer to the ubus request.
+     * @param[in] aMethod   A pointer to the ubus method.
+     * @param[in] aMsg      A pointer to the ubus message.
+     * @param[in] aAction   A pointer to the action needed.
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int UbusCommissioner(struct ubus_context *     aContext,
@@ -986,8 +986,8 @@ private:
     /**
      * This method handle conmmissione state change (callback function).
      *
-     * @param[in]   aState      The state of commissioner.
-     * @param[in]   aContext    A pointer to the ubus context.
+     * @param[in] aState    The state of commissioner.
+     * @param[in] aContext  A pointer to the ubus context.
      *
      */
     static void HandleStateChanged(otCommissionerState aState, void *aContext);
@@ -995,7 +995,7 @@ private:
     /**
      * This method handle conmmissione state change.
      *
-     * @param[in]   aState      The state of commissioner.
+     * @param[in] aState  The state of commissioner.
      *
      */
     void HandleStateChanged(otCommissionerState aState);
@@ -1003,10 +1003,10 @@ private:
     /**
      * This method handle joiner event (callback function).
      *
-     * @param[in]  aEvent       The joiner event type.
-     * @param[in]  aJoinerInfo  A pointer to the Joiner Info.
-     * @param[in]  aJoinerId    A pointer to the Joiner ID (if not known, it will be NULL).
-     * @param[in]  aContext     A pointer to application-specific context.
+     * @param[in] aEvent       The joiner event type.
+     * @param[in] aJoinerInfo  A pointer to the Joiner Info.
+     * @param[in] aJoinerId    A pointer to the Joiner ID (if not known, it will be NULL).
+     * @param[in] aContext     A pointer to application-specific context.
      *
      */
     static void HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
@@ -1017,9 +1017,9 @@ private:
     /**
      * This method handle joiner event.
      *
-     * @param[in]  aEvent       The joiner event type.
-     * @param[in]  aJoinerInfo  A pointer to the Joiner Info.
-     * @param[in]  aJoinerId    A pointer to the Joiner ID (if not known, it will be NULL).
+     * @param[in] aEvent       The joiner event type.
+     * @param[in] aJoinerInfo  A pointer to the Joiner Info.
+     * @param[in] aJoinerId    A pointer to the Joiner ID (if not known, it will be NULL).
      *
      */
     void HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
@@ -1029,8 +1029,8 @@ private:
     /**
      * This method convert thread network state to string.
      *
-     * @param[in]   aInstance   A pointer to the instance.
-     * @param[out]  aState      A pointer to the string address.
+     * @param[in]  aInstance  A pointer to the instance.
+     * @param[out] aState     A pointer to the string address.
      *
      */
     void GetState(otInstance *aInstance, char *aState);
@@ -1044,7 +1044,7 @@ private:
     /**
      * This method set ubus reconnect time.
      *
-     * @param[in]   aTimeout    A pointer to the timeout.
+     * @param[in] aTimeout  A pointer to the timeout.
      *
      */
     static void UbusReconnTimer(struct uloop_timeout *aTimeout);
@@ -1052,7 +1052,7 @@ private:
     /**
      * This method detailly handle ubus reconnect time.
      *
-     * @param[in]   aTimeout    A pointer to the timeout.
+     * @param[in] aTimeout  A pointer to the timeout.
      *
      */
     void UbusReconnTimerDetail(struct uloop_timeout *aTimeout);
@@ -1060,7 +1060,7 @@ private:
     /**
      * This method handle ubus connection lost.
      *
-     * @param[in]   aContext    A pointer to the context.
+     * @param[in] aContext  A pointer to the context.
      *
      */
     static void UbusConnectionLost(struct ubus_context *aContext);
@@ -1068,9 +1068,9 @@ private:
     /**
      * This method connect and display ubus.
      *
-     * @param[in]   aPath   A pointer to the ubus server path(default is nullptr).
+     * @param[in] aPath  A pointer to the ubus server path(default is nullptr).
      *
-     * @retval 0   Successfully handler the request.
+     * @retval 0  Successfully handler the request.
      *
      */
     int DisplayUbusInit(const char *aPath);
@@ -1084,8 +1084,8 @@ private:
     /**
      * This method parses an ASCII string as a long.
      *
-     * @param[in]   aString  A pointer to the ASCII string.
-     * @param[out]  aLong    A reference to where the parsed long is placed.
+     * @param[in]  aString  A pointer to the ASCII string.
+     * @param[out] aLong    A reference to where the parsed long is placed.
      *
      * @retval OT_ERROR_NONE   Successfully parsed the ASCII string.
      * @retval OT_ERROR_PARSE  Could not parse the ASCII string.
@@ -1096,9 +1096,9 @@ private:
     /**
      * This method converts a hex string to binary.
      *
-     * @param[in]   aHex        A pointer to the hex string.
-     * @param[out]  aBin        A pointer to where the binary representation is placed.
-     * @param[in]   aBinLength  Maximum length of the binary representation.
+     * @param[in]  aHex        A pointer to the hex string.
+     * @param[out] aBin        A pointer to where the binary representation is placed.
+     * @param[in]  aBinLength  Maximum length of the binary representation.
      *
      * @returns The number of bytes in the binary representation.
      */
@@ -1107,9 +1107,9 @@ private:
     /**
      * This method output bytes into char*.
      *
-     * @param[in]   aBytes  A pointer to the bytes need to be convert.
-     * @param[in]   aLength The length of the bytes.
-     * @param[out]  aOutput A pointer to the char* string.
+     * @param[in]  aBytes   A pointer to the bytes need to be convert.
+     * @param[in]  aLength  The length of the bytes.
+     * @param[out] aOutput  A pointer to the char* string.
      *
      */
     void OutputBytes(const uint8_t *aBytes, uint8_t aLength, char *aOutput);
@@ -1117,9 +1117,9 @@ private:
     /**
      * This method append result in message passed to ubus.
      *
-     * @param[in]   aError      The error type of the message.
-     * @param[in]   aContext    A pointer to the context.
-     * @param[in]   aRequest    A pointer to the request.
+     * @param[in] aError    The error type of the message.
+     * @param[in] aContext  A pointer to the context.
+     * @param[in] aRequest  A pointer to the request.
      *
      */
     void AppendResult(otError aError, struct ubus_context *aContext, struct ubus_request_data *aRequest);
@@ -1131,7 +1131,7 @@ public:
     /**
      * The constructor to initialize the UBus agent.
      *
-     * @param[in]  aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     UBusAgent(otbr::Ncp::ControllerOpenThread &aNcp)

--- a/src/rest/connection.hpp
+++ b/src/rest/connection.hpp
@@ -56,10 +56,12 @@ public:
     /**
      * The constructor is to initialize a socket connection instance.
      *
-     * @param[in]   aStartTime  The reference start time of a conneciton which is set when created for the first time
-     * and maybe reset when transfer to wait callback or wait write state.
-     * @param[in]   aResource   A pointer to the resource handler.
-     * @param[in]   aFd         The file descriptor for the conneciton.
+     * @param[in] aStartTime  The reference start time of a connection which
+     *                        is set when created for the first time and maybe
+     *                        reset when transfer to wait callback or wait write
+     *                        state.
+     * @param[in] aResource   A pointer to the resource handler.
+     * @param[in] aFd         The file descriptor for the connection.
      *
      */
     Connection(steady_clock::time_point aStartTime, Resource *aResource, int aFd);
@@ -83,8 +85,8 @@ public:
     /**
      * This method indicates whether this connection no longer need to be processed.
      *
-     * @retval  true     This connection could be released in next loop.
-     * @retval  false    This connection still needs to be processed in next loop.
+     * @retval TRUE   This connection could be released in next loop.
+     * @retval FALSE  This connection still needs to be processed in next loop.
      *
      */
     bool IsComplete(void) const;

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -53,9 +53,9 @@ namespace Json {
 /**
  * This method formats an integer to a Json number and serialize it to a string.
  *
- * @param[in]   aNumber  an integer need to be format.
+ * @param[in] aNumber  An integer need to be format.
  *
- * @returns     a string serlialized by a Json number.
+ * @returns A string of serialized Json number.
  *
  */
 std::string Number2JsonString(const uint32_t &aNumber);
@@ -63,9 +63,9 @@ std::string Number2JsonString(const uint32_t &aNumber);
 /**
  * This method formats a Bytes array to a Json string and serialize it to a string.
  *
- * @param[in]   aBytes  A Bytes array representing a hex number.
+ * @param[in] aBytes  A Bytes array representing a hex number.
  *
- * @returns     A string serlialized by a Json string.
+ * @returns A string of serialized Json string.
  *
  */
 std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength);
@@ -73,9 +73,9 @@ std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength);
 /**
  * This method formats a C string to a Json string and serialize it to a string.
  *
- * @param[in]   aCString  A char pointer pointing to a C string.
+ * @param[in] aCString  A char pointer pointing to a C string.
  *
- * @returns     A string serlialized by a Json string.
+ * @returns A string of serialized Json string.
  *
  */
 std::string CString2JsonString(const char *aCString);
@@ -83,9 +83,9 @@ std::string CString2JsonString(const char *aCString);
 /**
  * This method formats a string to a Json string and serialize it to a string.
  *
- * @param[in]   aString  A string.
+ * @param[in] aString  A string.
  *
- * @returns     a string serlialized by a Json string.
+ * @returns A string of serialized Json string.
  *
  */
 std::string String2JsonString(const std::string &aString);
@@ -93,19 +93,19 @@ std::string String2JsonString(const std::string &aString);
 /**
  * This method formats a Node object to a Json object and serialize it to a string.
  *
- * @param[in]   aNode  A Node object.
+ * @param[in] aNode  A Node object.
  *
- * @returns     a string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string Node2JsonString(const NodeInfo &aNode);
 
 /**
- * This method formats a vector including serveral Diagnostic object to a Json array and serialize it to a string.
+ * This method formats a vector of diagnostic objects to a Json array and serialize it to a string.
  *
- * @param[in]   aDiagSet  A vector including serveral Diagnostic object.
+ * @param[in] aDiagSet  A vector of diagnostic objects.
  *
- * @returns     A string serlialized by a Json array.
+ * @returns A string of serialized Json array.
  *
  */
 std::string Diag2JsonString(const std::vector<std::vector<otNetworkDiagTlv>> &aDiagSet);
@@ -113,9 +113,9 @@ std::string Diag2JsonString(const std::vector<std::vector<otNetworkDiagTlv>> &aD
 /**
  * This method formats an Ipv6Address to a Json string and serialize it to a string.
  *
- * @param[in]   aAddress  An Ip6Address object.
+ * @param[in] aAddress  An Ip6Address object.
  *
- * @returns     A string serlialized by a Json string.
+ * @returns A string of serialized Json string.
  *
  */
 std::string IpAddr2JsonString(const otIp6Address &aAddress);
@@ -123,9 +123,9 @@ std::string IpAddr2JsonString(const otIp6Address &aAddress);
 /**
  * This method formats a LinkModeConfig object to a Json object and serialize it to a string.
  *
- * @param[in]   aMode  A LinkModeConfig object.
+ * @param[in] aMode  A LinkModeConfig object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string Mode2JsonString(const otLinkModeConfig &aMode);
@@ -133,9 +133,9 @@ std::string Mode2JsonString(const otLinkModeConfig &aMode);
 /**
  * This method formats a Connectivity object to a Json object and serialize it to a string.
  *
- * @param[in]   aConnectivity  A Connectivity object.
+ * @param[in] aConnectivity  A Connectivity object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string Connectivity2JsonString(const otNetworkDiagConnectivity &aConnectivity);
@@ -143,9 +143,9 @@ std::string Connectivity2JsonString(const otNetworkDiagConnectivity &aConnectivi
 /**
  * This method formats a Route object to a Json object and serialize it to a string.
  *
- * @param[in]   aRoute  A Route object.
+ * @param[in] aRoute  A Route object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string Route2JsonString(const otNetworkDiagRoute &aRoute);
@@ -153,9 +153,9 @@ std::string Route2JsonString(const otNetworkDiagRoute &aRoute);
 /**
  * This method formats a RouteData object to a Json object and serialize it to a string.
  *
- * @param[in]   aRouteData  A RouteData object.
+ * @param[in] aRouteData  A RouteData object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string RouteData2JsonString(const otNetworkDiagRouteData &aRouteData);
@@ -163,9 +163,9 @@ std::string RouteData2JsonString(const otNetworkDiagRouteData &aRouteData);
 /**
  * This method formats a LeaderData object to a Json object and serialize it to a string.
  *
- * @param[in]   aLeaderData  A LeaderData object.
+ * @param[in] aLeaderData  A LeaderData object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string LeaderData2JsonString(const otLeaderData &aLeaderData);
@@ -173,9 +173,9 @@ std::string LeaderData2JsonString(const otLeaderData &aLeaderData);
 /**
  * This method formats a MacCounters object to a Json object and serialize it to a string.
  *
- * @param[in]   aMacCounters  A MacCounters object.
+ * @param[in] aMacCounters  A MacCounters object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string MacCounters2JsonString(const otNetworkDiagMacCounters &aMacCounters);
@@ -183,9 +183,9 @@ std::string MacCounters2JsonString(const otNetworkDiagMacCounters &aMacCounters)
 /**
  * This method formats a ChildEntry object to a Json object and serialize it to a string.
  *
- * @param[in]   aChildEntry  A ChildEntry object.
+ * @param[in] aChildEntry  A ChildEntry object.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string ChildTableEntry2JsonString(const otNetworkDiagChildEntry &aChildEntry);
@@ -193,10 +193,10 @@ std::string ChildTableEntry2JsonString(const otNetworkDiagChildEntry &aChildEntr
 /**
  * This method formats an error code and an error message to a Json object and serialize it to a string.
  *
- * @param[in]   aErrorCode  An enum HttpStatusCode  such as '404'.
- * @param[in]   aErrorMessage  Error message such as '404 Not Found'.
+ * @param[in] aErrorCode     An enum HttpStatusCode  such as '404'.
+ * @param[in] aErrorMessage  Error message such as '404 Not Found'.
  *
- * @returns     A string serlialized by a Json object.
+ * @returns A string of serialized Json object.
  *
  */
 std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessage);

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -57,7 +57,7 @@ public:
     /**
      * The constructor of a http request parser instance.
      *
-     * @param[in]   aRequest  A pointer to a request instance.
+     * @param[in] aRequest  A pointer to a request instance.
      *
      */
     Parser(Request *aRequest);
@@ -71,8 +71,8 @@ public:
     /**
      * This method performs a parse process.
      *
-     * @param[in]    aBuf      A pointer pointing to read buffer.
-     * @param[in]    aLength   An integer indicates how much data is to be processed by parser.
+     * @param[in] aBuf     A pointer pointing to read buffer.
+     * @param[in] aLength  An integer indicates how much data is to be processed by parser.
      *
      */
     void Process(const char *aBuf, size_t aLength);

--- a/src/rest/request.hpp
+++ b/src/rest/request.hpp
@@ -59,8 +59,8 @@ public:
     /**
      * This method sets the Url field of a request.
      *
-     * @param[in]  aString    A pointer points to url string.
-     * @param[in]  aLength    Length of the url string
+     * @param[in] aString  A pointer points to url string.
+     * @param[in] aLength  Length of the url string
      *
      */
     void SetUrl(const char *aString, size_t aLength);
@@ -68,8 +68,8 @@ public:
     /**
      * This method sets the body field of a request.
      *
-     * @param[in]  aString    A pointer points to body string.
-     * @param[in]  aLength    Length of the body string
+     * @param[in] aString  A pointer points to body string.
+     * @param[in] aLength  Length of the body string
      *
      */
     void SetBody(const char *aString, size_t aLength);
@@ -77,7 +77,7 @@ public:
     /**
      * This method sets the content-length field of a request.
      *
-     * @param[in]  aContentLength    An unsigned integer representing content-length.
+     * @param[in] aContentLength  An unsigned integer representing content-length.
      *
      */
     void SetContentLength(size_t aContentLength);
@@ -85,7 +85,7 @@ public:
     /**
      * This method sets the method of the parsed request.
      *
-     * @param[in]  aMethod    An integer representing request method.
+     * @param[in] aMethod  An integer representing request method.
      *
      */
     void SetMethod(int32_t aMethod);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -60,7 +60,7 @@ public:
     /**
      * The constructor initializes the resource handler instance.
      *
-     * @param[in]   aNcp  A pointer to the NCP controller.
+     * @param[in] aNcp  A pointer to the NCP controller.
      *
      */
     Resource(ControllerOpenThread *aNcp);
@@ -76,8 +76,8 @@ public:
      * This method is the main entry of resource handler, which find corresponding handler according to request url
      * find the resource and set the content of response.
      *
-     * @param[in]      aRequest  A request instance referred by the Resource handler.
-     * @param[inout]   aResponse  A response instance will be set by the Resource handler.
+     * @param[in]    aRequest  A request instance referred by the Resource handler.
+     * @param[inout] aResponse  A response instance will be set by the Resource handler.
      *
      */
     void Handle(Request &aRequest, Response &aResponse) const;
@@ -85,8 +85,8 @@ public:
     /**
      * This method distributes a callback handler for each connection needs a callback.
      *
-     * @param[in]      aRequest  A request instance referred by the Resource handler.
-     * @param[inout]   aResponse  A response instance will be set by the Resource handler.
+     * @param[in]    aRequest   A request instance referred by the Resource handler.
+     * @param[inout] aResponse  A response instance will be set by the Resource handler.
      *
      */
     void HandleCallback(Request &aRequest, Response &aResponse);
@@ -95,8 +95,8 @@ public:
      * This method provides a quick handler, which could directly set response code of a response and set error code and
      * error message to the request body.
      *
-     * @param[in]      aRequest  A request instance referred by the Resource handler.
-     * @param[inout]   aErrorCode  An enum class represents the status code.
+     * @param[in]    aRequest    A request instance referred by the Resource handler.
+     * @param[inout] aErrorCode  An enum class represents the status code.
      *
      */
     void ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) const;

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * This method set the response body.
      *
-     * @param[in] aBody A string to be set as response body.
+     * @param[in] aBody  A string to be set as response body.
      *
      */
     void SetBody(std::string &aBody);
@@ -81,7 +81,7 @@ public:
     /**
      * This method set the response code.
      *
-     * @param[in] aCode A string representing response code such as "404 not found".
+     * @param[in] aCode  A string representing response code such as "404 not found".
      *
      */
     void SetResponsCode(std::string &aCode);
@@ -96,7 +96,7 @@ public:
     /**
      * This method checks whether this response need to be processed by callback handler later.
      *
-     * @returns  A bool value indicates whether this response need to be processed by callback handler later.
+     * @returns A bool value indicates whether this response need to be processed by callback handler later.
      */
     bool NeedCallback(void);
 
@@ -109,7 +109,7 @@ public:
     /**
      * This method checks whether this response is ready to be written to buffer.
      *
-     * @returns  A bool value indicates whether this response is ready to be written to buffer..
+     * @returns A bool value indicates whether this response is ready to be written to buffer..
      */
     bool IsComplete();
 
@@ -117,21 +117,21 @@ public:
      * This method is used to set a timestamp. when a callback is needed and this field tells callback handler when to
      * collect all the data and form the response.
      *
-     * @param[in] aStartTime A timestamp indicates when the response start to wait for callback.
+     * @param[in] aStartTime  A timestamp indicates when the response start to wait for callback.
      */
     void SetStartTime(steady_clock::time_point aStartTime);
 
     /**
      * This method returns a timestamp of start time.
      *
-     * @returns  A timepoint object indicates start time.
+     * @returns A timepoint object indicates start time.
      */
     steady_clock::time_point GetStartTime() const;
 
     /**
      * This method serialize a response to a string that could be sent by socket later.
      *
-     * @returns  A string contains status line, headers and body of a response.
+     * @returns A string contains status line, headers and body of a response.
      */
     std::string Serialize(void) const;
 

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -57,7 +57,7 @@ public:
     /**
      * The constructor to initialize a REST server.
      *
-     * @param[in]  aNcp  A reference to the NCP controller.
+     * @param[in] aNcp  A reference to the NCP controller.
      *
      */
     RestWebServer(ControllerOpenThread &aNcp);

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -56,8 +56,8 @@ public:
     /**
      * This constructor initializes the Advertising Proxy object.
      *
-     * @param[in]  aNcp        A reference to the NCP controller.
-     * @param[in]  aPublisher  A reference to the mDNS publisher.
+     * @param[in] aNcp        A reference to the NCP controller.
+     * @param[in] aPublisher  A reference to the mDNS publisher.
      *
      */
     explicit AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
@@ -65,8 +65,8 @@ public:
     /**
      * This method starts the Advertising Proxy.
      *
-     * @retval  OTBR_ERROR_NONE  Successfully started the Advertising Proxy.
-     * @retval  ...              Failed to start the Advertising Proxy.
+     * @retval OTBR_ERROR_NONE  Successfully started the Advertising Proxy.
+     * @retval ...              Failed to start the Advertising Proxy.
      *
      */
     otbrError Start(void);

--- a/src/utils/crc16.hpp
+++ b/src/utils/crc16.hpp
@@ -56,7 +56,7 @@ public:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aPolynomial  The polynomial value.
+     * @param[in] aPolynomial  The polynomial value.
      *
      */
     Crc16(Polynomial aPolynomial);
@@ -67,10 +67,10 @@ public:
      */
     void Init(void) { mCrc = 0; }
 
-    /*c*
+    /**
      * This method feeds a byte value into the CRC16 computation.
      *
-     * @param[in]  aByte  The byte value.
+     * @param[in] aByte  The byte value.
      *
      */
     void Update(uint8_t aByte);

--- a/src/utils/pskc.hpp
+++ b/src/utils/pskc.hpp
@@ -62,9 +62,9 @@ public:
     /**
      * This method computes the PSKc.
      *
-     * @param[in]  aExtPanId      a pointer to extended PAN ID.
-     * @param[in]  aNetworkName   a pointer to network name.
-     * @param[in]  aPassphrase    a pointer to passphrase.
+     * @param[in] aExtPanId     A pointer to extended PAN ID.
+     * @param[in] aNetworkName  A pointer to network name.
+     * @param[in] aPassphrase   A pointer to passphrase.
      *
      * @returns The pointer to PSKc value.
      *

--- a/src/utils/socket_utils.hpp
+++ b/src/utils/socket_utils.hpp
@@ -47,14 +47,13 @@ enum SocketBlockOption
 /**
  * This function creates a socket with SOCK_CLOEXEC flag set.
  *
- * @param[in]   aDomain       The communication domain.
- * @param[in]   aType         The semantics of communication.
- * @param[in]   aProtocol     The protocol to use.
- * @param[in]   aBlockOption  Whether to add nonblock flags.
+ * @param[in] aDomain       The communication domain.
+ * @param[in] aType         The semantics of communication.
+ * @param[in] aProtocol     The protocol to use.
+ * @param[in] aBlockOption  Whether to add nonblock flags.
  *
- * @returns The file descriptor of the created socket.
- *
- * @retval  -1  Failed to create socket.
+ * @retval -1   Failed to create socket.
+ * @retval ...  The file descriptor of the created socket.
  *
  */
 int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption);

--- a/src/utils/steering_data.hpp
+++ b/src/utils/steering_data.hpp
@@ -57,7 +57,7 @@ public:
     /**
      * This method initializes the bloom filter.
      *
-     * @param[in]   aLength         Length of the bloom filter in bytes.
+     * @param[in] aLength  The length of the bloom filter in bytes.
      *
      */
     void Init(uint8_t aLength);
@@ -77,7 +77,7 @@ public:
     /**
      * This method sets bit @p aBit.
      *
-     * @param[in]  aBit  The bit offset.
+     * @param[in] aBit  The bit offset.
      *
      */
     void SetBit(uint8_t aBit) { mBloomFilter[mLength - 1 - (aBit / 8)] |= 1 << (aBit % 8); }
@@ -85,7 +85,7 @@ public:
     /**
      * This method computes the Bloom Filter.
      *
-     * @param[in]  aJoinerId  Extended address
+     * @param[in] aJoinerId  Extended address
      *
      */
     void ComputeBloomFilter(const uint8_t *aJoinerId);
@@ -93,8 +93,8 @@ public:
     /**
      * This method computes joiner id from EUI64.
      *
-     * @param[in]   aEui64      A pointer to EUI64.
-     * @param[out]  aJoinerId   A pointer to receive joiner id. This pointer can be the same as @p aEui64.
+     * @param[in]  aEui64     A pointer to EUI64.
+     * @param[out] aJoinerId  A pointer to receive joiner id. This pointer can be the same as @p aEui64.
      *
      */
     static void ComputeJoinerId(const uint8_t *aEui64, uint8_t *aJoinerId);

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -70,8 +70,8 @@ public:
     /**
      * The constructor of a Thread helper.
      *
-     * @param[in]   aInstance  The Thread instance.
-     * @param[in]   aNcp       The ncp controller.
+     * @param[in] aInstance  The Thread instance.
+     * @param[in] aNcp       The ncp controller.
      *
      */
     ThreadHelper(otInstance *aInstance, otbr::Ncp::ControllerOpenThread *aNcp);
@@ -79,7 +79,7 @@ public:
     /**
      * This method adds a callback for device role change.
      *
-     * @param[in]   aHandler  The device role handler.
+     * @param[in] aHandler  The device role handler.
      *
      */
     void AddDeviceRoleHandler(DeviceRoleHandler aHandler);
@@ -87,8 +87,8 @@ public:
     /**
      * This method permits unsecure join on port.
      *
-     * @param[in]   aPort     The port number.
-     * @param[in]   aSeconds  The timeout to close the port, 0 for never close.
+     * @param[in] aPort     The port number.
+     * @param[in] aSeconds  The timeout to close the port, 0 for never close.
      *
      * @returns The error value of underlying OpenThread api calls.
      *
@@ -98,7 +98,7 @@ public:
     /**
      * This method performs a Thread network scan.
      *
-     * @param[in]   aHandler  The scan result handler.
+     * @param[in] aHandler  The scan result handler.
      *
      */
     void Scan(ScanHandler aHandler);
@@ -108,13 +108,13 @@ public:
      *
      * @note The joiner start and the attach proccesses are exclusive
      *
-     * @param[in]   aNetworkName    The network name.
-     * @param[in]   aPanId          The pan id, UINT16_MAX for random.
-     * @param[in]   aExtPanId       The extended pan id, UINT64_MAX for random.
-     * @param[in]   aNetworkKey     The network key, empty for random.
-     * @param[in]   aPSKc           The pre-shared commissioner key, empty for random.
-     * @param[in]   aChannelMask    A bitmask for valid channels, will random select one.
-     * @param[in]   aHandler        The attach result handler.
+     * @param[in] aNetworkName  The network name.
+     * @param[in] aPanId        The pan id, UINT16_MAX for random.
+     * @param[in] aExtPanId     The extended pan id, UINT64_MAX for random.
+     * @param[in] aNetworkKey   The network key, empty for random.
+     * @param[in] aPSKc         The pre-shared commissioner key, empty for random.
+     * @param[in] aChannelMask  A bitmask for valid channels, will random select one.
+     * @param[in] aHandler      The attach result handler.
      *
      */
     void Attach(const std::string &         aNetworkName,
@@ -139,7 +139,7 @@ public:
      * @note The joiner start and the attach proccesses are exclusive, and the
      *       network parameter will be set through the active dataset.
      *
-     * @param[in]   aHandler        The attach result handler.
+     * @param[in] aHandler  The attach result handler.
      *
      */
     void Attach(ResultHandler aHandler);
@@ -166,13 +166,13 @@ public:
      *
      * @note The joiner start and the attach proccesses are exclusive
      *
-     * @param[in]   aPskd             The pre-shared key for device.
-     * @param[in]   aProvisioningUrl  The provision url.
-     * @param[in]   aVendorName       The vendor name.
-     * @param[in]   aVendorModel      The vendor model.
-     * @param[in]   aVendorSwVersion  The vendor software version.
-     * @param[in]   aVendorData       The vendor custom data.
-     * @param[in]   aHandler          The join result handler.
+     * @param[in] aPskd             The pre-shared key for device.
+     * @param[in] aProvisioningUrl  The provision url.
+     * @param[in] aVendorName       The vendor name.
+     * @param[in] aVendorModel      The vendor model.
+     * @param[in] aVendorSwVersion  The vendor software version.
+     * @param[in] aVendorData       The vendor custom data.
+     * @param[in] aHandler          The join result handler.
      *
      */
     void JoinerStart(const std::string &aPskd,
@@ -202,7 +202,7 @@ public:
     /**
      * This method handles OpenThread state changed notification.
      *
-     * @param[in]  aFlags    A bit-field indicating specific state that has changed.  See `OT_CHANGED_*` definitions.
+     * @param[in] aFlags    A bit-field indicating specific state that has changed.  See `OT_CHANGED_*` definitions.
      *
      */
     void StateChangedCallback(otChangedFlags aFlags);
@@ -210,8 +210,8 @@ public:
     /**
      * This method logs OpenThread action result.
      *
-     * @param[in] aAction   The action OpenThread performs.
-     * @param[in] aError    The action result.
+     * @param[in] aAction  The action OpenThread performs.
+     * @param[in] aError   The action result.
      *
      */
     static void LogOpenThreadResult(const char *aAction, otError aError);

--- a/src/web/web-service/ot_client.hpp
+++ b/src/web/web-service/ot_client.hpp
@@ -70,7 +70,7 @@ public:
     /**
      * This constructor creates an OpenThread client.
      *
-     * @param[in]   aNetifName  The Thread network interface name.
+     * @param[in] aNetifName  The Thread network interface name.
      *
      */
     OpenThreadClient(const char *aNetifName);
@@ -84,8 +84,8 @@ public:
     /**
      * This method connects to OpenThread daemon.
      *
-     * @retval  true    Successfully connected to the daemon.
-     * @retval  false   Failed to connected to the daemon.
+     * @retval TRUE   Successfully connected to the daemon.
+     * @retval FALSE  Failed to connected to the daemon.
      *
      */
     bool Connect(void);
@@ -93,8 +93,8 @@ public:
     /**
      * This method executes OpenThread CLI.
      *
-     * @param[in]   aFormat     C style format string.
-     * @param[in]   ...         C style format arguments.
+     * @param[in] aFormat  C style format string.
+     * @param[in] ...      C style format arguments.
      *
      * @returns A pointer to the output if succeeded, otherwise nullptr.
      *
@@ -104,8 +104,8 @@ public:
     /**
      * This method reads from OpenThread CLI.
      *
-     * @param[in]   aResponse    The expected read response.
-     * @param[in]   aTimeout     Timeout for the read, in ms.
+     * @param[in] aResponse  The expected read response.
+     * @param[in] aTimeout   Timeout for the read, in ms.
      *
      * @returns A pointer to the output if the expected response is found, otherwise nullptr.
      *
@@ -115,8 +115,8 @@ public:
     /**
      * This method scans Thread network.
      *
-     * @param[out]  aNetworks   A pointer to the buffer to store network information.
-     * @param[in]   aLength     Number of entries in @p aNetworks.
+     * @param[out] aNetworks  A pointer to the buffer to store network information.
+     * @param[in]  aLength    Number of entries in @p aNetworks.
      *
      * @returns Number of entries found. 0 if none found.
      *

--- a/src/web/web-service/web_server.hpp
+++ b/src/web/web-service/web_server.hpp
@@ -81,9 +81,9 @@ public:
     /**
      * This method starts the Web Server.
      *
-     * @param[in]  aIfName     The pointer to the Thread interface name.
-     * @param[in]  aListenAddr The http server listen address, can be nullptr for any address.
-     * @param[in]  aPort       The port of http server.
+     * @param[in] aIfName      The pointer to the Thread interface name.
+     * @param[in] aListenAddr  The http server listen address, can be nullptr for any address.
+     * @param[in] aPort        The port of http server.
      *
      */
     void StartWebServer(const char *aIfName, const char *aListenAddr, uint16_t aPort);

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -148,7 +148,7 @@ public:
     /**
      * This method sets the Thread interface name.
      *
-     * @param[in]  aIfName  The pointer to the Thread interface name.
+     * @param[in] aIfName  The pointer to the Thread interface name.
      *
      */
     void SetInterfaceName(const char *aIfName)
@@ -160,12 +160,12 @@ public:
     /**
      * This method gets status of wpan service.
      *
-     * @param[inout]  aNetworkName  The pointer to the network name.
-     * @param[inout]  aIfName       The pointer to the extended PAN ID.
+     * @param[inout] aNetworkName  The pointer to the network name.
+     * @param[inout] aIfName       The pointer to the extended PAN ID.
      *
-     * @retval kWpanStatus_OK        Successfully started the Thread service.
-     * @retval kWpanStatus_Offline   Not started the Thread service.
-     * @retval kWpanStatus_Down      The Thread service was down.
+     * @retval kWpanStatus_OK       Successfully started the Thread service.
+     * @retval kWpanStatus_Offline  Not started the Thread service.
+     * @retval kWpanStatus_Down     The Thread service was down.
      *
      */
     int GetWpanServiceStatus(std::string &aNetworkName, std::string &aExtPanId) const;
@@ -173,8 +173,8 @@ public:
     /**
      * This method starts commissioner and wait for a device to join
      *
-     * @param[in]  aPskd                Joiner pskd
-     * @param[in]  aNetworkPassword     Network password
+     * @param[in] aPskd             Joiner pskd
+     * @param[in] aNetworkPassword  Network password
      *
      * @returns The string to the http response of getting available networks.
      *


### PR DESCRIPTION
There are different numbers of spaces among parameter tag (i.e. `@param`), the parameter
and parameter comment. This PR unifies the spaces:
1. Use 1 space after tags (e.g. @param @returns).
2. Use 2 spaces between the parameter/retval and comment.
3. Capitalizing the first char of the param and return value comment.

An example of the new documentation is:
```c++
    /**
     * This method publishes or updates a service.
     *
     * @param[in] aHostName     The name of the host which this service resides on. If an empty string is
     *                          provided, this service resides on local host and it is the implementation
     *                          to provide specific host name. Otherwise, the caller MUST publish the host
     *                          with method PublishHost.
     * @param[in] aPort         The port number of this service.
     * @param[in] aName         The name of this service.
     * @param[in] aType         The type of this service.
     * @param[in] aSubTypeList  A list of service subtypes.
     * @param[in] aTxtList      A list of TXT name/value pairs.
     *
     * @retval OTBR_ERROR_NONE   Successfully published or updated the service.
     * @retval OTBR_ERROR_ERRNO  Failed to publish or update the service.
     *
     */
```

This PR also fixes trivial typos.

------
This PR depends on https://github.com/openthread/ot-br-posix/pull/1073 so please reviews only the third commit.