### PR TITLE
[web-service] flush any lingering output before issuing command

### DIFF
--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -110,6 +110,32 @@ exit:
     return ret == 0;
 }
 
+void OpenThreadClient::DiscardRead(void)
+{
+    fd_set  readFdSet;
+    timeval timeout = {0, 0};
+    ssize_t count;
+    int     ret;
+
+    for (;;)
+    {
+        FD_ZERO(&readFdSet);
+        FD_SET(mSocket, &readFdSet);
+
+        ret = select(mSocket + 1, &readFdSet, nullptr, nullptr, &timeout);
+        if (ret <= 0)
+        {
+            break;
+        }
+
+        count = read(mSocket, mBuffer, sizeof(mBuffer));
+        if (count <= 0)
+        {
+            break;
+        }
+    }
+}
+
 char *OpenThreadClient::Execute(const char *aFormat, ...)
 {
     va_list args;
@@ -117,6 +143,8 @@ char *OpenThreadClient::Execute(const char *aFormat, ...)
     char *  rval = nullptr;
     ssize_t count;
     size_t  rxLength = 0;
+
+    DiscardRead();
 
     va_start(args, aFormat);
     ret = vsnprintf(&mBuffer[1], sizeof(mBuffer) - 1, aFormat, args);

--- a/src/web/web-service/ot_client.hpp
+++ b/src/web/web-service/ot_client.hpp
@@ -131,6 +131,7 @@ public:
 
 private:
     void Disconnect(void);
+    void DiscardRead(void);
 
     enum
     {


### PR DESCRIPTION
This commit ensures to flush any received CLI output before issuing
the command to make parsing the output of the command more reliable.