### PR TITLE
[web-service] update usage notes around `passphrase`

### DIFF
--- a/src/web/web-service/frontend/index.html
+++ b/src/web/web-service/frontend/index.html
@@ -165,7 +165,7 @@
                   <input required md-maxlength="16" name="networkName" ng-model="thread.networkName">
                   <div ng-messages="threadForm.networkName.$error">
                     <div ng-message="required">This is required.</div>
-                    <div ng-message="md-maxlength">The Netowork Name must be no more than 16 characters long.</div>
+                    <div ng-message="md-maxlength">The Network Name must be no more than 16 characters long.</div>
                   </div>
                 </md-input-container>
 
@@ -190,10 +190,11 @@
                 </md-input-container>
 
                 <md-input-container flex="50">
-                  <label>Passphrase</label>
-                  <input required name="passphrase" ng-model="thread.passphrase">
+                  <label>Passphrase/Commissioner Credential</label>
+                  <input required name="passphrase" ng-minlength="6" maxlength="255" ng-model="thread.passphrase">
                   <div ng-messages="threadForm.passphrase.$error">
                     <div ng-message="required">This is required.</div>
+                    <div ng-message="minlength">The Passphrase must be a string between 6 and 255 characters.</div>
                   </div>
                 </md-input-container>
               </div>

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -93,7 +93,7 @@
             networkName: 'OpenThreadDemo',
             extPanId: '1111111122222222',
             panId: '0x1234',
-            passphrase: '123456',
+            passphrase: 'j01Nme',
             networkKey: '00112233445566778899aabbccddeeff',
             channel: 15,
             prefix: 'fd11:22::',


### PR DESCRIPTION
- Updated Passphrase label for clarity
- Added minLength requirement to Passphrase (6 minimum)
- Updated default Passphrase from `123456` to `j01Nme` to show that this field allows numbers/upper/lower characters

Let me know if this looks good; happy to make any changes.