### PR TITLE
[common] add OnceCallback which can be invoked for at most once

### DIFF
--- a/src/common/callback.hpp
+++ b/src/common/callback.hpp
@@ -1,0 +1,97 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_COMMON_CALLBACK_HPP_
+#define OTBR_COMMON_CALLBACK_HPP_
+
+#include <functional>
+#include <type_traits>
+
+namespace otbr {
+
+template <class T> class OnceCallback;
+
+/**
+ * A callback which can be invoked at most once.
+ *
+ * IsNull is guaranteed to return true once the callback has been invoked.
+ *
+ * Example usage:
+ *  OnceCallback<int(int)> square([](int x) { return x * x; });
+ *  std::move(square)(5); // Returns 25.
+ *  std::move(square)(6); // Crashes since `square` has already run.
+ *  square(7); // Compiling error.
+ *
+ * Inspired by Chromium base::OnceCallback
+ * (https://chromium.googlesource.com/chromium/src.git/+/refs/heads/main/base/callback.h).
+ *
+ */
+template <typename R, typename... Args> class OnceCallback<R(Args...)>
+{
+public:
+    // Constructs a new `OnceCallback` instance with a callable.
+    //
+    // This constructor is for matching std::function<> and lambda and the
+    // `std::enable_if_t` check is only required for working around gcc 4.x
+    // compiling issue which trying to instantiate this template constructor
+    // for use cases like `::mOnceCallback(aOnceCallback)`.
+    template <typename T, typename = typename std::enable_if<!std::is_same<OnceCallback, T>::value>::type>
+    OnceCallback(T &&func)
+        : mFunc(std::forward<T>(func))
+    {
+    }
+
+    OnceCallback(const OnceCallback &) = delete;
+    OnceCallback &operator=(const OnceCallback &) = delete;
+    OnceCallback(OnceCallback &&) noexcept        = default;
+    OnceCallback &operator=(OnceCallback &&) noexcept = default;
+
+    R operator()(Args...) const &
+    {
+        static_assert(!sizeof(*this), "OnceCallback::() can only be invoked on a non-const "
+                                      "rvalue, i.e. std::move(callback)().");
+    }
+
+    R operator()(Args... args) &&
+    {
+        // Move `this` to a local variable to clear internal state
+        // before invoking the callback function.
+        OnceCallback cb = std::move(*this);
+
+        return cb.mFunc(std::forward<Args>(args)...);
+    }
+
+    bool IsNull() const { return mFunc == nullptr; }
+
+private:
+    std::function<R(Args...)> mFunc;
+};
+
+} // namespace otbr
+
+#endif // OTBR_COMMON_CALLBACK_HPP_

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(otbr-test-unit
     main.cpp
     test_dns_utils.cpp
     test_logging.cpp
+    test_once_callback.cpp
     test_pskc.cpp
     test_task_runner.cpp
 )

--- a/tests/unit/test_once_callback.cpp
+++ b/tests/unit/test_once_callback.cpp
@@ -1,0 +1,67 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "common/callback.hpp"
+
+#include <CppUTest/TestHarness.h>
+
+TEST_GROUP(IsNull){};
+
+TEST(IsNull, NullptrIsNull)
+{
+    otbr::OnceCallback<void(void)> noop = nullptr;
+
+    CHECK_TRUE(noop.IsNull());
+}
+
+TEST(IsNull, NonNullptrIsNotNull)
+{
+    otbr::OnceCallback<void(void)> noop = [](void) {};
+
+    CHECK_FALSE(noop.IsNull());
+}
+
+TEST(IsNull, IsNullAfterInvoking)
+{
+    otbr::OnceCallback<int(int)> square = [](int x) { return x * x; };
+
+    std::move(square)(5);
+
+    CHECK_TRUE(square.IsNull());
+}
+
+TEST_GROUP(VerifyInvocation){};
+
+TEST(VerifyInvocation, CallbackResultIsExpected)
+{
+    otbr::OnceCallback<int(int)> square = [](int x) { return x * x; };
+
+    int ret = std::move(square)(5);
+
+    CHECK_EQUAL(ret, 25);
+}


### PR DESCRIPTION
This commit adds a new facility which wraps up a std::function
and makes sure that a function can be invoked for at most once.

This is useful for async operations to guarantee that the callback
for receiving the result will be only invoked once.