### PR TITLE
[mdns] support multiple subscribers

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -35,6 +35,7 @@
 #define OTBR_AGENT_MDNS_HPP_
 
 #include <functional>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -350,13 +351,19 @@ public:
      * @param[in] aInstanceCallback  The callback function to receive discovered service instances.
      * @param[in] aHostCallback      The callback function to receive discovered hosts.
      *
+     * @returns  The Subscriber ID for the callbacks.
+     *
      */
-    void SetSubscriptionCallbacks(DiscoveredServiceInstanceCallback aInstanceCallback,
-                                  DiscoveredHostCallback            aHostCallback)
-    {
-        mDiscoveredServiceInstanceCallback = std::move(aInstanceCallback);
-        mDiscoveredHostCallback            = std::move(aHostCallback);
-    }
+    uint64_t AddSubscriptionCallbacks(DiscoveredServiceInstanceCallback aInstanceCallback,
+                                      DiscoveredHostCallback            aHostCallback);
+
+    /**
+     * This method cancels callbacks for subscriptions.
+     *
+     * @param[in] aSubscriberId  The Subscriber ID previously returned by `AddSubscriptionCallbacks`.
+     *
+     */
+    void RemoveSubscriptionCallbacks(uint64_t aSubscriberId);
 
     virtual ~Publisher(void) = default;
 
@@ -415,14 +422,18 @@ protected:
         kMaxTextEntrySize = 255,
     };
 
+    void OnServiceResolved(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo);
+    void OnHostResolved(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo);
+
     PublishServiceHandler mServiceHandler        = nullptr;
     void *                mServiceHandlerContext = nullptr;
 
     PublishHostHandler mHostHandler        = nullptr;
     void *             mHostHandlerContext = nullptr;
 
-    DiscoveredServiceInstanceCallback mDiscoveredServiceInstanceCallback = nullptr;
-    DiscoveredHostCallback            mDiscoveredHostCallback            = nullptr;
+    uint64_t mNextSubscriberId = 1;
+
+    std::map<uint64_t, std::pair<DiscoveredServiceInstanceCallback, DiscoveredHostCallback>> mDiscoveredCallbacks;
 };
 
 /**

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -883,30 +883,9 @@ void PublisherAvahi::UnsubscribeService(const std::string &aType, const std::str
                 mSubscribedServices.size());
 }
 
-void PublisherAvahi::OnServiceResolved(ServiceSubscription &aService)
-{
-    otbrLogInfo("Service %s is resolved successfully: %s host %s addresses %zu", aService.mType.c_str(),
-                aService.mInstanceInfo.mName.c_str(), aService.mInstanceInfo.mHostName.c_str(),
-                aService.mInstanceInfo.mAddresses.size());
-    if (mDiscoveredServiceInstanceCallback != nullptr)
-    {
-        mDiscoveredServiceInstanceCallback(aService.mType, aService.mInstanceInfo);
-    }
-}
-
 void PublisherAvahi::OnServiceResolveFailed(const ServiceSubscription &aService, int aErrorCode)
 {
     otbrLogWarning("Service %s resolving failed: code=%d", aService.mType.c_str(), aErrorCode);
-}
-
-void PublisherAvahi::OnHostResolved(HostSubscription &aHost)
-{
-    otbrLogInfo("Host %s is resolved successfully: host %s addresses %zu ttl %u", aHost.mHostName.c_str(),
-                aHost.mHostInfo.mHostName.c_str(), aHost.mHostInfo.mAddresses.size(), aHost.mHostInfo.mTtl);
-    if (mDiscoveredHostCallback != nullptr)
-    {
-        mDiscoveredHostCallback(aHost.mHostName, aHost.mHostInfo);
-    }
 }
 
 void PublisherAvahi::OnHostResolveFailed(const HostSubscription &aHost, int aErrorCode)
@@ -1113,7 +1092,7 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
 
     otbrLogDebug("resolve service reply: address=%s, ttl=%u", address.ToString().c_str(), mInstanceInfo.mTtl);
 
-    mPublisherAvahi->OnServiceResolved(*this);
+    mPublisherAvahi->OnServiceResolved(mType, mInstanceInfo);
 
 exit:
     if (avahi_client_errno(mPublisherAvahi->mClient) != AVAHI_OK)
@@ -1196,7 +1175,7 @@ void PublisherAvahi::HostSubscription::HandleResolveResult(AvahiRecordBrowser * 
     mHostInfo.mAddresses.push_back(std::move(address));
     // TODO: Use a more proper TTL
     mHostInfo.mTtl = kDefaultTtl;
-    mPublisherAvahi->OnHostResolved(*this);
+    mPublisherAvahi->OnHostResolved(mHostName, mHostInfo);
 
 exit:
     if (avahi_client_errno(mPublisherAvahi->mClient) != AVAHI_OK)

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -386,9 +386,7 @@ private:
 
     static std::string MakeFullName(const std::string &aName);
 
-    void        OnServiceResolved(ServiceSubscription &aService);
     static void OnServiceResolveFailed(const ServiceSubscription &aService, int aErrorCode);
-    void        OnHostResolved(HostSubscription &aHost);
     void        OnHostResolveFailed(const HostSubscription &aHost, int aErrorCode);
 
     AvahiClient *mClient;

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -786,32 +786,9 @@ void PublisherMDnsSd::UnsubscribeService(const std::string &aType, const std::st
                 mSubscribedServices.size());
 }
 
-void PublisherMDnsSd::OnServiceResolved(PublisherMDnsSd::ServiceSubscription &aService)
-{
-    otbrLogInfo("Service %s is resolved successfully: %s host %s addresses %zu", aService.mType.c_str(),
-                aService.mInstanceInfo.mName.c_str(), aService.mInstanceInfo.mHostName.c_str(),
-                aService.mInstanceInfo.mAddresses.size());
-
-    if (mDiscoveredServiceInstanceCallback != nullptr)
-    {
-        mDiscoveredServiceInstanceCallback(aService.mType, aService.mInstanceInfo);
-    }
-}
-
 void PublisherMDnsSd::OnServiceResolveFailed(const ServiceSubscription &aService, DNSServiceErrorType aErrorCode)
 {
     otbrLogWarning("Service %s resolving failed: code=%d", aService.mType.c_str(), aErrorCode);
-}
-
-void PublisherMDnsSd::OnHostResolved(PublisherMDnsSd::HostSubscription &aHost)
-{
-    otbrLogInfo("Host %s is resolved successfully: host %s addresses %zu ttl %u", aHost.mHostName.c_str(),
-                aHost.mHostInfo.mHostName.c_str(), aHost.mHostInfo.mAddresses.size(), aHost.mHostInfo.mTtl);
-
-    if (mDiscoveredHostCallback != nullptr)
-    {
-        mDiscoveredHostCallback(aHost.mHostName, aHost.mHostInfo);
-    }
 }
 
 void PublisherMDnsSd::OnHostResolveFailed(const PublisherMDnsSd::HostSubscription &aHost,
@@ -1044,7 +1021,7 @@ void PublisherMDnsSd::ServiceSubscription::HandleGetAddrInfoResult(DNSServiceRef
 
     otbrLogDebug("DNSServiceGetAddrInfo reply: address=%s, ttl=%u", address.ToString().c_str(), aTtl);
 
-    mMDnsSd->OnServiceResolved(*this);
+    mMDnsSd->OnServiceResolved(mType, mInstanceInfo);
 
 exit:
     if (aErrorCode != kDNSServiceErr_NoError)
@@ -1057,7 +1034,7 @@ exit:
     {
         otbrLogDebug("DNSServiceGetAddrInfo reply: no IPv6 address found");
         mInstanceInfo.mTtl = aTtl;
-        mMDnsSd->OnServiceResolved(*this);
+        mMDnsSd->OnServiceResolved(mType, mInstanceInfo);
     }
 }
 
@@ -1116,7 +1093,7 @@ void PublisherMDnsSd::HostSubscription::HandleResolveResult(DNSServiceRef       
 
     otbrLogDebug("DNSServiceGetAddrInfo reply: address=%s, ttl=%u", address.ToString().c_str(), aTtl);
 
-    mMDnsSd->OnHostResolved(*this);
+    mMDnsSd->OnHostResolved(mHostName, mHostInfo);
 
 exit:
     if (aErrorCode != kDNSServiceErr_NoError)
@@ -1129,7 +1106,7 @@ exit:
     {
         otbrLogDebug("DNSServiceGetAddrInfo reply: no IPv6 address found");
         mHostInfo.mTtl = aTtl;
-        mMDnsSd->OnHostResolved(*this);
+        mMDnsSd->OnHostResolved(mHostName, mHostInfo);
     }
 }
 

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -274,9 +274,7 @@ private:
     HostIterator    FindPublishedHost(const DNSRecordRef &aRecordRef);
     HostIterator    FindPublishedHost(const std::string &aHostName);
 
-    void        OnServiceResolved(ServiceSubscription &aService);
     static void OnServiceResolveFailed(const ServiceSubscription &aService, DNSServiceErrorType aErrorCode);
-    void        OnHostResolved(HostSubscription &aHost);
     void        OnHostResolveFailed(const HostSubscription &aHost, DNSServiceErrorType aErrorCode);
 
     Services      mServices;

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -100,6 +100,7 @@ private:
 
     Ncp::ControllerOpenThread &mNcp;
     Mdns::Publisher &          mMdnsPublisher;
+    uint64_t                   mSubscriberId = 0;
 };
 
 } // namespace Dnssd


### PR DESCRIPTION
Mdns::Publisher used to allow only one subscriber to add subscription callbacks via `SetSubscriptionCallbacks`. 

This PR enhances Mdns::Publisher to allow multiple subscribers to add and remove subscription callbacks. 

Hint: `Discovery Proxy` and `TREL DNSSD` will both need to add subscription callbacks. 