### PR TITLE
[docs] add dependency when building dbus docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -51,7 +51,7 @@ if (DOXYGEN_FOUND)
             COMMAND cp ${DBUS_DOC_SRC} ${DBUS_DOC_TARGET}
             VERBATIM
         )
-        add_dependencies(otbr-dbus-server-doc-copy otbr-dbus-server-doc)
+        add_dependencies(otbr-dbus-server-doc-copy doxygen otbr-dbus-server-doc)
         add_dependencies(otbr-doc otbr-dbus-server-doc-copy)
     endif()
 else()


### PR DESCRIPTION
The `otbr-dbus-server-doc-copy` target depends on the output of the
Doxygen build. Add a dependency on the Doxgyen build.

---

Fixes the following error:
```
Doxygen build started
-- Configuring done
-- Generating done
-- Build files have been written to: /home/runner/work/ot-br-posix/ot-br-posix/build-doc
Writing index.html for refentry(gdbus-io.openthread.BorderRouter)
Built target otbr-dbus-server-doc
cp: cannot create regular file '/home/runner/work/ot-br-posix/ot-br-posix/build-doc/doc/html/dbus-api.html': No such file or directory
make[3]: *** [doc/CMakeFiles/otbr-dbus-server-doc-copy.dir/build.make:70: doc/CMakeFiles/otbr-dbus-server-doc-copy] Error 1
make[2]: *** [CMakeFiles/Makefile2:1942: doc/CMakeFiles/otbr-dbus-server-doc-copy.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:1897: doc/CMakeFiles/otbr-doc.dir/rule] Error 2
make: *** [Makefile:696: otbr-doc] Error 2
Error: Process completed with exit code 2.
```
https://github.com/openthread/ot-br-posix/runs/4343969249?check_suite_focus=true