### PR TITLE
[mdns] fix `kDNSServiceFlagsMoreComing` flag handling

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -849,7 +849,7 @@ void PublisherMDnsSd::ServiceSubscription::Browse(void)
     assert(mServiceRef == nullptr);
 
     otbrLogInfo("DNSServiceBrowse %s", mType.c_str());
-    DNSServiceBrowse(&mServiceRef, /* flags */ kDNSServiceFlagsTimeout, kDNSServiceInterfaceIndexAny, mType.c_str(),
+    DNSServiceBrowse(&mServiceRef, kDNSServiceFlagsTimeout, kDNSServiceInterfaceIndexAny, mType.c_str(),
                      /* domain */ nullptr, HandleBrowseResult, this);
 }
 
@@ -891,10 +891,6 @@ exit:
     {
         mMDnsSd->OnServiceResolveFailed(*this, aErrorCode);
     }
-    else if (!(aFlags & (kDNSServiceFlagsAdd | kDNSServiceFlagsMoreComing)))
-    {
-        mMDnsSd->OnServiceResolveFailed(*this, kDNSServiceErr_NoSuchName);
-    }
 }
 
 void PublisherMDnsSd::ServiceSubscription::Resolve(uint32_t           aInterfaceIndex,
@@ -905,7 +901,7 @@ void PublisherMDnsSd::ServiceSubscription::Resolve(uint32_t           aInterface
     assert(mServiceRef == nullptr);
 
     otbrLogInfo("DNSServiceResolve %s %s inf %d", aInstanceName.c_str(), aType.c_str(), aInterfaceIndex);
-    DNSServiceResolve(&mServiceRef, /* flags */ 0, aInterfaceIndex, aInstanceName.c_str(), aType.c_str(),
+    DNSServiceResolve(&mServiceRef, kDNSServiceFlagsTimeout, aInterfaceIndex, aInstanceName.c_str(), aType.c_str(),
                       aDomain.c_str(), HandleResolveResult, this);
 }
 
@@ -975,7 +971,7 @@ void PublisherMDnsSd::ServiceSubscription::GetAddrInfo(uint32_t aInterfaceIndex)
 
     otbrLogInfo("DNSServiceGetAddrInfo %s inf %d", mInstanceInfo.mHostName.c_str(), aInterfaceIndex);
 
-    DNSServiceGetAddrInfo(&mServiceRef, /* flags */ 0, aInterfaceIndex,
+    DNSServiceGetAddrInfo(&mServiceRef, kDNSServiceFlagsTimeout, aInterfaceIndex,
                           kDNSServiceProtocol_IPv6 | kDNSServiceProtocol_IPv4, mInstanceInfo.mHostName.c_str(),
                           HandleGetAddrInfoResult, this);
 }
@@ -1027,13 +1023,6 @@ exit:
     if (aErrorCode != kDNSServiceErr_NoError)
     {
         otbrLogWarning("DNSServiceGetAddrInfo failed: %d", aErrorCode);
-
-        mMDnsSd->OnServiceResolveFailed(*this, aErrorCode);
-    }
-    else if (mInstanceInfo.mAddresses.empty() && (aFlags & kDNSServiceFlagsMoreComing) == 0)
-    {
-        otbrLogDebug("DNSServiceGetAddrInfo reply: no IPv6 address found");
-        mInstanceInfo.mTtl = aTtl;
         mMDnsSd->OnServiceResolved(mType, mInstanceInfo);
     }
 }


### PR DESCRIPTION
`kDNSServiceFlagsMoreComing` does not mean there will be no more answers. 

So, we should not quit resolving when `kDNSServiceFlagsMoreComing` is not set.
- related change: use `kDNSServiceFlagsTimeout` to allow instance resolving to finish when timeout

Quote from dns_sd.h:

```c++
    /* MoreComing indicates to a callback that at least one more result is
     * queued and will be delivered following immediately after this one.
     * When the MoreComing flag is set, applications should not immediately
     * update their UI, because this can result in a great deal of ugly flickering
     * on the screen, and can waste a great deal of CPU time repeatedly updating
     * the screen with content that is then immediately erased, over and over.
     * Applications should wait until MoreComing is not set, and then
     * update their UI when no more changes are imminent.
     * When MoreComing is not set, that doesn't mean there will be no more
     * answers EVER, just that there are no more answers immediately
     * available right now at this instant. If more answers become available
     * in the future they will be delivered as usual.
     */
```