### PR TITLE
[mdns-avahi] use assert to make sure Service Resolver is valid

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1077,8 +1077,6 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
     otbrLogInfo("resolve service reply: protocol %d event %d %s.%s.%s = host %s address %s port %d flags %d", aProtocol,
                 aEvent, aName, aType, aDomain, aHostName, addrBuf, aPort, aFlags);
 
-    VerifyOrExit(mServiceResolvers.find(aServiceResolver) != mServiceResolvers.end());
-
     RemoveServiceResolver(aServiceResolver);
 
     VerifyOrExit(
@@ -1130,6 +1128,8 @@ void PublisherAvahi::ServiceSubscription::AddServiceResolver(AvahiServiceResolve
 void PublisherAvahi::ServiceSubscription::RemoveServiceResolver(AvahiServiceResolver *aServiceResolver)
 {
     assert(aServiceResolver != nullptr);
+    assert(mServiceResolvers.find(aServiceResolver) != mServiceResolvers.end());
+
     avahi_service_resolver_free(aServiceResolver);
     mServiceResolvers.erase(aServiceResolver);
 }


### PR DESCRIPTION
Background:
We used to use `assert` in `HandleResolveResult` to make sure the Avahi resolver is a valid resolver, which make sense because only valid resolvers can have callbacks. But there was a crash issue with the original code so we changed to use `VerifyOrExit`. Turn out the actual issue is that we should call `RemoveServiceResolver` as early as possible so that the resolver won't be freed twice. 