### PR TITLE
[mdns-avahi] support mDNS service removing

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -116,6 +116,24 @@ void Publisher::OnServiceResolved(const std::string &aType, const DiscoveredInst
     }
 }
 
+void Publisher::OnServiceRemoved(const std::string &aType, const std::string &aInstanceName)
+{
+    DiscoveredInstanceInfo instanceInfo;
+
+    otbrLogInfo("Service %s.%s is removed.", aInstanceName.c_str(), aType.c_str());
+
+    instanceInfo.mRemoved = true;
+    instanceInfo.mName    = aInstanceName;
+
+    for (const auto &subCallback : mDiscoveredCallbacks)
+    {
+        if (subCallback.second.first != nullptr)
+        {
+            subCallback.second.first(aType, instanceInfo);
+        }
+    }
+}
+
 void Publisher::OnHostResolved(const std::string &aHostName, const Publisher::DiscoveredHostInfo &aHostInfo)
 {
     otbrLogInfo("Host %s is resolved successfully: host %s addresses %zu ttl %u", aHostName.c_str(),

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -98,14 +98,15 @@ public:
      */
     struct DiscoveredInstanceInfo
     {
-        std::string             mName;         ///< Instance name.
-        std::string             mHostName;     ///< Full host name.
-        std::vector<Ip6Address> mAddresses;    ///< IPv6 addresses.
-        uint16_t                mPort     = 0; ///< Port.
-        uint16_t                mPriority = 0; ///< Service priority.
-        uint16_t                mWeight   = 0; ///< Service weight.
-        std::vector<uint8_t>    mTxtData;      ///< TXT RDATA bytes.
-        uint32_t                mTtl = 0;      ///< Service TTL.
+        bool                    mRemoved = false; ///< The Service Instance is removed.
+        std::string             mName;            ///< Instance name.
+        std::string             mHostName;        ///< Full host name.
+        std::vector<Ip6Address> mAddresses;       ///< IPv6 addresses.
+        uint16_t                mPort     = 0;    ///< Port.
+        uint16_t                mPriority = 0;    ///< Service priority.
+        uint16_t                mWeight   = 0;    ///< Service weight.
+        std::vector<uint8_t>    mTxtData;         ///< TXT RDATA bytes.
+        uint32_t                mTtl = 0;         ///< Service TTL.
     };
 
     /**
@@ -423,6 +424,7 @@ protected:
     };
 
     void OnServiceResolved(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo);
+    void OnServiceRemoved(const std::string &aType, const std::string &aInstanceName);
     void OnHostResolved(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo);
 
     PublishServiceHandler mServiceHandler        = nullptr;

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -995,7 +995,7 @@ void PublisherAvahi::ServiceSubscription::HandleBrowseResult(AvahiServiceBrowser
         Resolve(aInterfaceIndex, aProtocol, aName, aType);
         break;
     case AVAHI_BROWSER_REMOVE:
-        // TODO: handle service removing
+        mPublisherAvahi->OnServiceRemoved(aType, aName);
         break;
     case AVAHI_BROWSER_CACHE_EXHAUSTED:
     case AVAHI_BROWSER_ALL_FOR_NOW:

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -67,7 +67,10 @@ void DiscoveryProxy::Start(void)
 
     mSubscriberId = mMdnsPublisher.AddSubscriptionCallbacks(
         [this](const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo) {
-            OnServiceDiscovered(aType, aInstanceInfo);
+            if (!aInstanceInfo.mRemoved)
+            {
+                OnServiceDiscovered(aType, aInstanceInfo);
+            }
         },
 
         [this](const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aHostInfo) {


### PR DESCRIPTION
This commit enhance mDNS implementation over Avahi to support notification of service removing. 

mDNSResponder support will be implemented in a future PR. 

Required by #1109 