### PR TITLE
[mdns-avahi] fix potential invalid memory access

### DIFF
--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -37,6 +37,7 @@
 #define OTBR_LOG_TAG "UTILS"
 #endif
 
+#include <memory>
 #include <stdlib.h>
 
 #include "common/logging.hpp"
@@ -154,5 +155,10 @@
 
 #define OTBR_NOOP
 #define OTBR_UNUSED_VARIABLE(variable) ((void)(variable))
+
+template <typename T, typename... Args> std::unique_ptr<T> MakeUnique(Args &&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 #endif // OTBR_COMMON_CODE_UTILS_HPP_

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -34,6 +34,7 @@
 #ifndef OTBR_AGENT_MDNS_AVAHI_HPP_
 #define OTBR_AGENT_MDNS_AVAHI_HPP_
 
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -350,9 +351,9 @@ private:
         AvahiRecordBrowser *mRecordBrowser;
     };
 
-    typedef std::vector<Host>                Hosts;
-    typedef std::vector<ServiceSubscription> ServiceSubscriptionList;
-    typedef std::vector<HostSubscription>    HostSubscriptionList;
+    typedef std::vector<Host>                                 Hosts;
+    typedef std::vector<std::unique_ptr<ServiceSubscription>> ServiceSubscriptionList;
+    typedef std::vector<std::unique_ptr<HostSubscription>>    HostSubscriptionList;
 
     static void HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext);
     void        HandleClientState(AvahiClient *aClient, AvahiClientState aState);


### PR DESCRIPTION
We are passing a pointer to the `ServiceSubscription` to Avahi methods like `avahi_service_browser_new` and `avahi_service_resolver_new` as the userdata. 
However, since `ServiceSubscription` objects were directly stored in a `vector<ServiceSubscription>`, any update to the vector causes the `ServiceSubscription` objects to move, leading to potential invalid pointer access. 

This commit fixes this issue by storing `ServiceSubscription` pointers in the vector. 

This commit also fixes the bug that the `ServiceSubscription` and `HostSubscription` objects may be freed in resolved callbacks. 