### PR TITLE
[mdns-mdnssd] fix `kDNSServiceFlagsMoreComing` flag handling (part 2)

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -1092,12 +1092,6 @@ exit:
 
         mMDnsSd->OnHostResolveFailed(*this, aErrorCode);
     }
-    else if (mHostInfo.mAddresses.empty() && (aFlags & kDNSServiceFlagsMoreComing) == 0)
-    {
-        otbrLogDebug("DNSServiceGetAddrInfo reply: no IPv6 address found");
-        mHostInfo.mTtl = aTtl;
-        mMDnsSd->OnHostResolved(mHostName, mHostInfo);
-    }
 }
 
 } // namespace Mdns


### PR DESCRIPTION
`kDNSServiceFlagsMoreComing` is meant to make UI rendering more efficiently. 
```
    /* MoreComing indicates to a callback that at least one more result is
     * queued and will be delivered following immediately after this one.
     * When the MoreComing flag is set, applications should not immediately
     * update their UI, because this can result in a great deal of ugly flickering
     * on the screen, and can waste a great deal of CPU time repeatedly updating
     * the screen with content that is then immediately erased, over and over.
     * Applications should wait until MoreComing is not set, and then
     * update their UI when no more changes are imminent.
     * When MoreComing is not set, that doesn't mean there will be no more
     * answers EVER, just that there are no more answers immediately
     * available right now at this instant. If more answers become available
     * in the future they will be delivered as usual.
     */

```
It has nothing to do with whether there will be more A or AAAA RR records. 