### PR TITLE
[meshcop] enforce vo entry when vendor specific entry is set

### DIFF
--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -33,6 +33,13 @@ set -euxo pipefail
 
 readonly OTBR_DBUS_SERVER_CONF=otbr-test-agent.conf
 
+die()
+{
+    exit_message="$*"
+    echo " *** ERROR: $*"
+    exit 1
+}
+
 on_exit()
 {
     local status=$?
@@ -43,7 +50,7 @@ on_exit()
     sudo killall ot-cli-mtd || true
     sudo rm "/etc/dbus-1/system.d/${OTBR_DBUS_SERVER_CONF}" || true
 
-    grep -iE 'ot-cli|otbr' </var/log/syslog
+    grep -iE --binary-files=text 'ot-cli|otbr-agent' </var/log/syslog
 
     return "${status}"
 }
@@ -64,7 +71,19 @@ update_meshcop_txt_and_check()
     service="$(scan_meshcop_service)"
     grep --binary-files=text "nn=OpenThread" <<<"${service}"
 
-    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('vn',[118,101,110,100,111,114])]"
+    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('vaa',[97])]" || true
+    sleep 5
+    service="$(scan_meshcop_service)"
+    if grep --binary-files=text "vaa=" <<<"${service}"; then
+        die "Setting a vendor entry without 'vo' entry present should fail."
+    fi
+
+    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('vaa',[97]),('vo',[11,11])]" || true
+    sleep 5
+    service="$(scan_meshcop_service)"
+    grep --binary-files=text "vaa=" <<<"${service}"
+
+    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('vn',[118,101,110,100,111,114]),('vo',[11])]"
     sleep 5
     service="$(scan_meshcop_service)"
     grep --binary-files=text "vn=vendor" <<<"${service}"


### PR DESCRIPTION
According to the spec, we need to include the vo entry when the there is any other vendor specific entry present. 