### PR TITLE
[border-router] start mDNS daemon before starting otbr-agent

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -64,6 +64,14 @@ endif()
 set(OTBR_AGENT_USER "root" CACHE STRING "set the username running otbr-agent service")
 set(OTBR_AGENT_GROUP "root" CACHE STRING "set the group using otbr-agent client")
 
+if(OTBR_MDNS STREQUAL "mDNSResponder")
+    set(EXEC_START_PRE "ExecStartPre=service mdns start\n")
+elseif(OTBR_MDNS STREQUAL "avahi")
+    set(EXEC_START_PRE "ExecStartPre=service avahi-daemon start\n")
+else()
+    message(WARNING "OTBR_MDNS=\"${OTBR_MDNS}\" is not supported")
+endif()
+
 if(OTBR_DBUS)
     configure_file(otbr-agent.conf.in otbr-agent.conf)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/otbr-agent.conf

--- a/src/agent/otbr-agent.service.in
+++ b/src/agent/otbr-agent.service.in
@@ -4,7 +4,7 @@ ConditionPathExists=@CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent
 
 [Service]
 EnvironmentFile=-@CMAKE_INSTALL_FULL_SYSCONFDIR@/default/otbr-agent
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent $OTBR_AGENT_OPTS
+@EXEC_START_PRE@ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/otbr-agent $OTBR_AGENT_OPTS
 Restart=on-failure
 RestartSec=5
 RestartPreventExitStatus=SIGKILL


### PR DESCRIPTION
This PR updates the `.service` file to start the mDNS daemon before starting otbr-agent. 

This PR fixes #1138 . 