### PR TITLE
[continuous-integration] use the openthread repo's border router & backbone router workflows

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -46,81 +46,177 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       if: "github.ref != 'refs/heads/main'"
 
-  border-router:
+  backbone-router:
     runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        include:
-          - name: "Border Router (mDNSResponder)"
-            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=OFF"
-            border_routing: 1
-            otbr_mdns: "mDNSResponder"
-            cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
-          - name: "Border Router (Avahi)"
-            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=OFF"
-            border_routing: 1
-            otbr_mdns: "avahi"
-            cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
-          - name: "Backbone Router"
-            otbr_options: "-DOT_TREL=OFF -DOT_DUA=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON"
-            border_routing: 0
-            cert_scripts: ./tests/scripts/thread-cert/backbone/*.py
-
-    name: ${{ matrix.name }}
     env:
+      REFERENCE_DEVICE: 1
+      VIRTUAL_TIME: 0
       PACKET_VERIFICATION: 1
       THREAD_VERSION: 1.2
-      VIRTUAL_TIME: 0
+      INTER_OP: 1
+      COVERAGE: 1
+      MULTIPLY: 1
       PYTHONUNBUFFERED: 1
-      REFERENCE_DEVICE: 1
-      OTBR_COVERAGE: 1
-      READLINE: readline
-      INTER_OP: 0
-      INTER_OP_BBR: 0
-      BORDER_ROUTING: ${{ matrix.border_routing }}
+      VERBOSE: 1
+      # The Border Routing and DUA feature can coexist, but current wireshark
+      # packet verification can't handle it because of the order of context ID
+      # of OMR prefix and Domain prefix is not deterministic.
+      BORDER_ROUTING: 0
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Build OTBR Docker Image
+    - name: Build OTBR Docker
+    - working-directory: third_party/openthread/repo
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
-        # We need the `-DOT_SRP_SERVER=ON` option because the `bbr_5_11_01.py` script is referring SRP server.
-        # This should be fixed by enhancing the test script to handle SRP server situations properly.
-        otbr_options="${{ matrix.otbr_options }}"
-        otbr_image_name="otbr-ot12-backbone-ci"
-        docker build -t "${otbr_image_name}" -f etc/docker/Dockerfile . \
-          --build-arg BORDER_ROUTING=${{ matrix.border_routing }} \
-          --build-arg INFRA_IF_NAME=eth0 \
-          --build-arg BACKBONE_ROUTER=1 \
-          --build-arg REFERENCE_DEVICE=1 \
-          --build-arg OT_BACKBONE_CI=1 \
-          --build-arg NAT64=0 \
-          --build-arg MDNS="${{ matrix.otbr_mdns }}" \
-          --build-arg OTBR_OPTIONS="${otbr_options} -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF=1'"
-    - name: Bootstrap OpenThread Test
+        LOCAL_OTBR_DIR="../../../" ./script/test build_otbr_docker
+    - name: Bootstrap
+    - working-directory: third_party/openthread/repo
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat nodejs npm
-        python3 -m pip install -r third_party/openthread/repo/tests/scripts/thread-cert/requirements.txt
-    - name: Build OpenThread
+        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
+        python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
+    - name: Build
+    - working-directory: third_party/openthread/repo
       run: |
-        (cd third_party/openthread/repo && ./script/test build)
+        ./script/test build
     - name: Get Thread-Wireshark
+    - working-directory: third_party/openthread/repo
       run: |
-        (cd third_party/openthread/repo && ./script/test get_thread_wireshark)
-    - name: Run Test
+        ./script/test get_thread_wireshark
+    - name: Run
+    - working-directory: third_party/openthread/repo
       run: |
-        export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e OTBR_COVERAGE"
+        export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
-        (cd third_party/openthread/repo && sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r *.log *.json *.pcap && false))
+        sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: cov-thread-1-2-backbone-docker
+#        path: /tmp/coverage/
+#    - uses: actions/upload-artifact@v2
+#      if: ${{ failure() }}
+#      with:
+#        name: thread-1-2-backbone-results
+#        path: |
+#          *.pcap
+#          *.json
+#          *.log
+#    - name: Generate Coverage
+#      run: |
+#        ./script/test generate_coverage gcc
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: cov-thread-1-2-backbone
+#        path: tmp/coverage.info
+
+  thread-border-router:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - otbr_mdns: "mDNSResponder"
+            otbr_trel: 0
+          - otbr_mdns: "mDNSResponder"
+            otbr_trel: 1
+          - otbr_mdns: "avahi"
+            otbr_trel: 0
+    name: BR (${{ matrix.otbr_mdns }}, TREL=${{matrix.otbr_trel}})
+    env:
+      REFERENCE_DEVICE: 1
+      VIRTUAL_TIME: 0
+      PACKET_VERIFICATION: 1
+      THREAD_VERSION: 1.2
+      INTER_OP: 1
+      COVERAGE: 1
+      MULTIPLY: 1
+      OTBR_MDNS: ${{ matrix.otbr_mdns }}
+      PYTHONUNBUFFERED: 1
+      VERBOSE: 1
+      BORDER_ROUTING: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build OTBR Docker
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        TREL: ${{ matrix.otbr_trel }}
+      working-directory: third_party/openthread/repo
+      run: |
+        LOCAL_OTBR_DIR="../../../" ./script/test build_otbr_docker
+    - name: Bootstrap
+      working-directory: third_party/openthread/repo
+      run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
+        python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
+    - name: Build
+      working-directory: third_party/openthread/repo
+      run: |
+        ./script/test build
+    - name: Get Thread-Wireshark
+      working-directory: third_party/openthread/repo
+      run: |
+        ./script/test get_thread_wireshark
+    - name: Run
+      working-directory: third_party/openthread/repo
+      run: |
+        export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
+        echo "CI_ENV=${CI_ENV}"
+        sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/border_router/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
+    - uses: actions/upload-artifact@v2
+      with:
+        name: cov-thread-border-router-docker
+        path: /tmp/coverage/
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: thread-1-2-backbone-results
+        name: thread-border-router-results
         path: |
-          third_party/openthread/repo/*.pcap
-          third_party/openthread/repo/*.json
-          third_party/openthread/repo/*.log
-    - name: Codecov
-      uses: codecov/codecov-action@v1
+          *.pcap
+          *.json
+          *.log
+#    - name: Generate Coverage
+#      working-directory: third_party/openthread/repo
+#      run: |
+#        ./script/test generate_coverage gcc
+#    - uses: actions/upload-artifact@v2
+#      working-directory: third_party/openthread/repo
+#      with:
+#        name: cov-thread-border-router
+#        path: tmp/coverage.info
+#
+#  upload-coverage:
+#    needs:
+#    - backbone-router
+#    - thread-border-router
+#    runs-on: ubuntu-20.04
+#    steps:
+#    - uses: actions/checkout@v2
+#      with:
+#        submodules: true
+#    - name: Bootstrap
+#      run: |
+#        sudo apt-get --no-install-recommends install -y lcov
+#    - uses: actions/download-artifact@v2
+#      with:
+#        path: coverage/
+#    - name: Combine Coverage
+#      run: |
+#        script/test combine_coverage
+#    - name: Upload Coverage
+#      uses: codecov/codecov-action@v1
+#      with:
+#        files: final.info
+#        fail_ci_if_error: true
+#
+#  delete-coverage-artifacts:
+#    needs: upload-coverage
+#    if: always()
+#    runs-on: ubuntu-20.04
+#    steps:
+#    - uses: geekyeggo/delete-artifact@1-glob-support
+#      with:
+#        name: cov-*
+#        useGlob: true


### PR DESCRIPTION
This is a **hotfix** for the border router test cases in CI. The CI failed in `test_firewall.py` because it hasn't turned on the DUA routing.

I thought the border router CI behave the same in ot-br-posix and openthread repos but that wasn't the case. 