### PR TITLE
[nat64] configure nat64 prefix in Tayga

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -54,31 +54,31 @@ jobs:
       matrix:
         include:
           - name: "Border Router (mDNSResponder)"
-            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_BORDER_ROUTING_NAT64=ON"
+            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_BORDER_ROUTING_NAT64=ON"
             border_routing: 1
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router (Avahi)"
-            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_BORDER_ROUTING_NAT64=ON"
+            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_BORDER_ROUTING_NAT64=ON"
             border_routing: 1
             otbr_mdns: "avahi"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router TREL (mDNSResponder)"
-            otbr_options: "-DOT_TREL=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_BORDER_ROUTING_NAT64=ON"
+            otbr_options: "-DOT_TREL=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_BORDER_ROUTING_NAT64=ON"
             border_routing: 1
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 2
           - name: "Border Router TREL (Avahi)"
-            otbr_options: "-DOT_TREL=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_BORDER_ROUTING_NAT64=ON"
+            otbr_options: "-DOT_TREL=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_BORDER_ROUTING_NAT64=ON"
             border_routing: 1
             otbr_mdns: "avahi"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 2
           - name: "Border Router MATN (mDNSResponder)"
-            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_BORDER_ROUTING_NAT64=ON"
+            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_BORDER_ROUTING_NAT64=ON"
             border_routing: 1
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(OTBR_PRODUCT_NAME "BorderRouter" CACHE STRING "The product name")
 set(OTBR_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The package name")
 set(OTBR_MESHCOP_SERVICE_INSTANCE_NAME "${OTBR_VENDOR_NAME} ${OTBR_PRODUCT_NAME}" CACHE STRING "The OTBR MeshCoP service instance name")
 set(OTBR_MDNS "avahi" CACHE STRING "mDNS publisher provider")
+set(OTBR_NAT64_SERVICE "tayga" CACHE STRING "NAT64 service")
 set(OTBR_TAYGA_RESTART_CMD "systemctl restart tayga" CACHE STRING "The platform specific command to restart Tayga service")
 set(OTBR_TAYGA_STOP_CMD "systemctl stop tayga" CACHE STRING "The platform specific command to stop Tayga service")
 set(OTBR_SYSLOG_FACILITY_ID LOG_USER CACHE STRING "Syslog logging facility")
@@ -100,6 +101,10 @@ target_compile_definitions(otbr-config INTERFACE
 
 if(BUILD_SHARED_LIBS)
     target_link_libraries(otbr-config INTERFACE -Wl,--unresolved-symbols=ignore-in-shared-libs)
+endif()
+
+if(OTBR_BORDER_ROUTING_NAT64 AND OTBR_NAT64_SERVICE STREQUAL "tayga")
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TAYGA_NAT64=1)
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ set(OTBR_PRODUCT_NAME "BorderRouter" CACHE STRING "The product name")
 set(OTBR_NAME "${OTBR_VENDOR_NAME}_${OTBR_PRODUCT_NAME}" CACHE STRING "The package name")
 set(OTBR_MESHCOP_SERVICE_INSTANCE_NAME "${OTBR_VENDOR_NAME} ${OTBR_PRODUCT_NAME}" CACHE STRING "The OTBR MeshCoP service instance name")
 set(OTBR_MDNS "avahi" CACHE STRING "mDNS publisher provider")
+set(OTBR_TAYGA_RESTART_CMD "systemctl restart tayga" CACHE STRING "The platform specific command to restart Tayga service")
+set(OTBR_TAYGA_STOP_CMD "systemctl stop tayga" CACHE STRING "The platform specific command to stop Tayga service")
 set(OTBR_SYSLOG_FACILITY_ID LOG_USER CACHE STRING "Syslog logging facility")
 
 set_property(CACHE OTBR_MDNS PROPERTY STRINGS "avahi" "mDNSResponder")
@@ -91,6 +93,8 @@ target_compile_definitions(otbr-config INTERFACE
     "OTBR_PACKAGE_NAME=\"${OTBR_NAME}\""
     "OTBR_PACKAGE_VERSION=\"${OTBR_VERSION}\""
     "OTBR_MESHCOP_SERVICE_INSTANCE_NAME=\"${OTBR_MESHCOP_SERVICE_INSTANCE_NAME}\""
+    "OTBR_TAYGA_RESTART_CMD=\"${OTBR_TAYGA_RESTART_CMD}\""
+    "OTBR_TAYGA_STOP_CMD=\"${OTBR_TAYGA_STOP_CMD}\""
     "OTBR_SYSLOG_FACILITY_ID=${OTBR_SYSLOG_FACILITY_ID}"
 )
 

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -42,6 +42,11 @@ endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
 
+option(OTBR_TAYGA_NAT64 "Enable NAT64 support via TAYGA" OFF)
+if(OTBR_TAYGA_NAT64)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TAYGA_NAT64=1)
+endif()
+
 option(OTBR_DBUS "Enable DBus support" OFF)
 if(OTBR_DBUS)
     pkg_check_modules(DBUS REQUIRED dbus-1)
@@ -69,7 +74,7 @@ if (OTBR_SRP_ADVERTISING_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_SRP_ADVERTISING_PROXY=1)
 endif()
 
-option(OTBR_DNSSD_DISCOVERY_PROXY   "Enable DNS-SD Discovery Proxy support" OFF)
+option(OTBR_DNSSD_DISCOVERY_PROXY  "Enable DNS-SD Discovery Proxy support" OFF)
 if (OTBR_DNSSD_DISCOVERY_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_DNSSD_DISCOVERY_PROXY=1)
 endif()

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -42,10 +42,7 @@ endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
 
-option(OTBR_TAYGA_NAT64 "Enable NAT64 support via TAYGA" OFF)
-if(OTBR_TAYGA_NAT64)
-    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TAYGA_NAT64=1)
-endif()
+option(OTBR_BORDER_ROUTING_NAT64 "Enable NAT64 support in Border Routing Manager" OFF)
 
 option(OTBR_DBUS "Enable DBus support" OFF)
 if(OTBR_DBUS)
@@ -74,7 +71,7 @@ if (OTBR_SRP_ADVERTISING_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_SRP_ADVERTISING_PROXY=1)
 endif()
 
-option(OTBR_DNSSD_DISCOVERY_PROXY  "Enable DNS-SD Discovery Proxy support" OFF)
+option(OTBR_DNSSD_DISCOVERY_PROXY   "Enable DNS-SD Discovery Proxy support" OFF)
 if (OTBR_DNSSD_DISCOVERY_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_DNSSD_DISCOVERY_PROXY=1)
 endif()

--- a/script/_nat64
+++ b/script/_nat64
@@ -43,7 +43,7 @@ WLAN_IFNAMES="${INFRA_IF_NAME:-eth0}"
 
 # Currently solution was verified only on raspbian and ubuntu.
 #
-#without NAT64 || test $PLATFORM = ubuntu || test $PLATFORM = raspbian || die "nat64 is not tested under $PLATFORM."
+# without NAT64 || test $PLATFORM = ubuntu || test $PLATFORM = raspbian || die "nat64 is not tested under $PLATFORM."
 
 tayga_install()
 {

--- a/script/_otbr
+++ b/script/_otbr
@@ -83,6 +83,13 @@ otbr_install()
         )
     fi
 
+    if with DOCKER; then
+        otbr_options+=(
+            "-DOTBR_TAYGA_RESTART_CMD=service tayga restart"
+            "-DOTBR_TAYGA_STOP_CMD=service tayga stop"
+        )
+    fi
+
     if with REST_API; then
         otbr_options+=("-DOTBR_REST=ON")
     fi

--- a/script/_otbr
+++ b/script/_otbr
@@ -70,6 +70,7 @@ otbr_install()
         "-DOTBR_SRP_ADVERTISING_PROXY=ON"
         "-DOTBR_INFRA_IF_NAME=${INFRA_IF_NAME}"
         "-DOTBR_MDNS=${OTBR_MDNS:=mDNSResponder}"
+        "-DOTBR_NAT64_SERVICE=${NAT64_SERVICE:=tayga}"
         "${otbr_options[@]}"
     )
 
@@ -81,6 +82,11 @@ otbr_install()
         otbr_options+=(
             "-DOTBR_BORDER_ROUTING=ON"
         )
+        if with NAT64; then
+            otbr_options+=(
+                "-DOTBR_BORDER_ROUTING_NAT64=ON"
+            )
+        fi
     fi
 
     if with DOCKER; then

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(otbr-agent PRIVATE
     otbr-ncp
     otbr-common
     otbr-utils
+    otbr-nat64
 )
 
 add_dependencies(otbr-agent ot-ctl print-ot-config otbr-sdp-proxy otbr-utils otbr-ncp)

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -40,6 +40,7 @@
 #include "agent/application.hpp"
 #include "common/code_utils.hpp"
 #include "common/mainloop_manager.hpp"
+#include "nat64/tayga_helper.hpp"
 
 namespace otbr {
 
@@ -133,6 +134,10 @@ otbrError Application::Run(void)
             otbrLogWarning("Failed to notify Upstart.");
         }
     }
+#endif
+
+#if OTBR_ENABLE_TAYGA_NAT64
+    Tayga::ConfigTaygaNat64Prefix(mNcp.GetInstance());
 #endif
 
     // allow quitting elegantly

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -62,7 +62,6 @@
 #include "common/logging.hpp"
 #include "common/tlv.hpp"
 #include "common/types.hpp"
-#include "utils/hex.hpp"
 
 namespace otbr {
 
@@ -147,7 +146,6 @@ void BorderAgent::Start(void)
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
     mDiscoveryProxy.Start();
 #endif
-
 exit:
     otbrLogResult(error, "Start Thread Border Agent");
 }

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -62,6 +62,7 @@
 #include "common/logging.hpp"
 #include "common/tlv.hpp"
 #include "common/types.hpp"
+#include "utils/hex.hpp"
 
 namespace otbr {
 
@@ -146,6 +147,7 @@ void BorderAgent::Start(void)
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
     mDiscoveryProxy.Start();
 #endif
+
 exit:
     otbrLogResult(error, "Start Thread Border Agent");
 }

--- a/src/nat64/CMakeLists.txt
+++ b/src/nat64/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2020-2021, The OpenThread Authors.
+#  Copyright (c) 2022, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,38 +26,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_subdirectory(agent)
-if(OTBR_BORDER_AGENT)
-    add_subdirectory(border_agent)
-endif()
-add_subdirectory(common)
-add_subdirectory(ncp)
-add_subdirectory(nat64)
-add_subdirectory(sdp_proxy)
-add_subdirectory(trel_dnssd)
-
-if(OTBR_DBUS)
-    add_subdirectory(dbus)
-endif()
-
-if(OTBR_MDNS)
-    add_subdirectory(mdns)
-endif()
-
-add_subdirectory(utils)
-
-if(OTBR_OPENWRT)
-    add_subdirectory(openwrt)
-endif()
-
-if(OTBR_WEB)
-    add_subdirectory(web)
-endif()
-
-if(OTBR_REST)
-    add_subdirectory(rest)
-endif()
-
-if (OTBR_BACKBONE_ROUTER)
-    add_subdirectory(backbone_router)
-endif()
+add_library(otbr-nat64
+    tayga_helper.cpp
+)
+target_link_libraries(otbr-nat64 PRIVATE
+    otbr-common
+    otbr-utils
+)

--- a/src/nat64/tayga_helper.cpp
+++ b/src/nat64/tayga_helper.cpp
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (c) 2022, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if OTBR_ENABLE_TAYGA_NAT64
+
+#include <fstream>
+
+#include <openthread/border_router.h>
+
+#include "common/code_utils.hpp"
+#include "common/types.hpp"
+#include "nat64/tayga_helper.hpp"
+#include "utils/system_utils.hpp"
+
+namespace otbr {
+namespace Tayga {
+namespace {
+
+static const char kTaygaConf[]       = "/etc/tayga.conf";
+static const char kTaygaConfTmp[]    = "/etc/tayga_tmp.conf";
+static const char kTaygaRestartCmd[] = OTBR_TAYGA_RESTART_CMD;
+static const char kTaygaStopCmd[]    = OTBR_TAYGA_STOP_CMD;
+static const char kPrefixLineStart[] = "prefix ";
+
+bool UpdatePrefix(const std::string &prefix)
+{
+    bool          is_copied  = false;
+    bool          is_updated = false;
+    std::ifstream file(kTaygaConf);
+    std::ofstream tmp_file(kTaygaConfTmp);
+    std::string   line;
+
+    VerifyOrExit(file && tmp_file);
+
+    while (std::getline(file, line))
+    {
+        if (line.find(kPrefixLineStart, 0) == 0)
+        {
+            VerifyOrExit(line.find(prefix, 0) == std::string::npos, is_updated = false);
+
+            line       = kPrefixLineStart + prefix;
+            is_updated = true;
+        }
+        tmp_file << line << std::endl;
+        VerifyOrExit(tmp_file.good(), is_updated = false);
+    }
+
+    VerifyOrExit(file.eof(), is_updated = false);
+
+    file.close();
+    tmp_file.close();
+    is_copied = true;
+
+    if (is_updated)
+    {
+        VerifyOrExit(remove(kTaygaConf) == 0 && rename(kTaygaConfTmp, kTaygaConf) == 0, is_updated = false);
+    }
+
+exit:
+    if (!is_copied)
+    {
+        file.close();
+        tmp_file.close();
+    }
+
+    if (!is_updated)
+    {
+        remove(kTaygaConfTmp);
+    }
+
+    otbrLogInfo("NAT64 prefix in Tayga configuration file %s updated", is_updated ? "is" : "isn't");
+
+    return is_updated;
+}
+
+} // namespace
+
+void ConfigTaygaNat64Prefix(otInstance *aInstance)
+{
+    otbrError   error      = OTBR_ERROR_NONE;
+    bool        is_updated = false;
+    otIp6Prefix nat64Prefix;
+    Ip6Prefix   prefix;
+
+    VerifyOrExit(otBorderRoutingGetNat64Prefix(aInstance, &nat64Prefix) == OT_ERROR_NONE,
+                 error = OTBR_ERROR_OPENTHREAD);
+
+    prefix.Set(nat64Prefix);
+    is_updated = UpdatePrefix(prefix.ToString());
+
+    VerifyOrExit(is_updated && SystemUtils::ExecuteCommand(kTaygaRestartCmd) == 0, error = OTBR_ERROR_ERRNO);
+
+exit:
+    if (error == OTBR_ERROR_OPENTHREAD)
+    {
+        otbrLogInfo("Failed to get nat64 prefix. Stopping Tayga...");
+        SystemUtils::ExecuteCommand(kTaygaStopCmd);
+    }
+    else if (error == OTBR_ERROR_ERRNO)
+    {
+        otbrLogInfo("Didn't re-configure Tayga: %s", otbrErrorString(error));
+    }
+    else
+    {
+        otbrLogInfo("Configured Tayga with NAT64 prefix: %s", prefix.ToString().c_str());
+    }
+}
+
+} // namespace Tayga
+} // namespace otbr
+#endif // OTBR_ENABLE_TAYGA_NAT64

--- a/src/nat64/tayga_helper.hpp
+++ b/src/nat64/tayga_helper.hpp
@@ -1,0 +1,61 @@
+/*
+ *    Copyright (c) 2022, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file implements helper functions for TAYGA.
+ */
+
+#ifndef OTBR_AGENT_TAYGA_HELPER_HPP_
+#define OTBR_AGENT_TAYGA_HELPER_HPP_
+
+#ifndef OTBR_TAYGA_RESTART_CMD
+#define OTBR_TAYGA_RESTART_CMD "systemctl restart tayga"
+#endif
+
+#ifndef OTBR_TAYGA_STOP_CMD
+#define OTBR_TAYGA_STOP_CMD "systemctl stop tayga"
+#endif
+
+#include <openthread/instance.h>
+
+namespace otbr {
+namespace Tayga {
+
+/**
+ * This function configures the nat64 prefix for Tayga.
+ *
+ * @param aInstance A pointer to an OpenThread instance.
+ *
+ */
+void ConfigTaygaNat64Prefix(otInstance *aInstance);
+
+} // namespace Tayga
+} // namespace otbr
+
+#endif // OTBR_AGENT_TAYGA_HELPER_HPP_

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -29,6 +29,7 @@
 set(OT_BORDER_AGENT ON CACHE BOOL "enable border agent" FORCE)
 set(OT_BORDER_ROUTER ON CACHE BOOL "enable border router feature" FORCE)
 set(OT_BORDER_ROUTING ${OTBR_BORDER_ROUTING} CACHE BOOL "enable border routing feature" FORCE)
+set(OT_BORDER_ROUTING_NAT64 ${OTBR_TAYGA_NAT64}&&${OTBR_BORDER_ROUTING} CACHE BOOL "enable border routing NAT64 feature" FORCE)
 set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "disable building executables" FORCE)
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "diable mbedTLS management" FORCE)
 set(OT_COMMISSIONER ON CACHE BOOL "enable commissioner")

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -29,7 +29,7 @@
 set(OT_BORDER_AGENT ON CACHE BOOL "enable border agent" FORCE)
 set(OT_BORDER_ROUTER ON CACHE BOOL "enable border router feature" FORCE)
 set(OT_BORDER_ROUTING ${OTBR_BORDER_ROUTING} CACHE BOOL "enable border routing feature" FORCE)
-set(OT_BORDER_ROUTING_NAT64 ${OTBR_TAYGA_NAT64}&&${OTBR_BORDER_ROUTING} CACHE BOOL "enable border routing NAT64 feature" FORCE)
+set(OT_BORDER_ROUTING_NAT64 ${OTBR_BORDER_ROUTING_NAT64} CACHE BOOL "enable NAT64 support in routing manager" FORCE)
 set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "disable building executables" FORCE)
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "diable mbedTLS management" FORCE)
 set(OT_COMMISSIONER ON CACHE BOOL "enable commissioner")


### PR DESCRIPTION
This commits configures nat64 prefix /etc/tayga.conf when starting border agent. Tayga is restarted after configuration.

The _nat64 script is also updated to be compatible with prefix configuration by otbr-agent.

OTBR_TAYGA_NAT64 & OTBR_ENABLE_TAYGA_NAT64 are defined to guard the enablement of configuration.

Tests will be updated in a following PR.