### PR TITLE
[utils] add `OTBR_DISALLOW_COPY_AND_ASSIGN`

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -41,6 +41,7 @@
 #if OTBR_ENABLE_BORDER_AGENT
 #include "border_agent/border_agent.hpp"
 #endif
+#include "common/code_utils.hpp"
 #include "ncp/ncp_openthread.hpp"
 #if OTBR_ENABLE_BACKBONE_ROUTER
 #include "backbone_router/backbone_agent.hpp"
@@ -76,6 +77,8 @@ namespace otbr {
 class Application
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(Application);
+
     /**
      * This constructor initializes the Application instance.
      *

--- a/src/agent/instance_params.hpp
+++ b/src/agent/instance_params.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_INSATNCE_PARAMS_HPP_
 #define OTBR_AGENT_INSATNCE_PARAMS_HPP_
 
+#include "common/code_utils.hpp"
+
 namespace otbr {
 
 /**
@@ -43,6 +45,8 @@ namespace otbr {
 class InstanceParams
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(InstanceParams);
+
     /**
      * This method gets the single `InstanceParams` instance.
      *

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -41,6 +41,7 @@
 #include "agent/instance_params.hpp"
 #include "backbone_router/dua_routing_manager.hpp"
 #include "backbone_router/nd_proxy.hpp"
+#include "common/code_utils.hpp"
 #include "ncp/ncp_openthread.hpp"
 
 namespace otbr {
@@ -62,6 +63,8 @@ namespace BackboneRouter {
 class BackboneAgent
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(BackboneAgent);
+
     static constexpr uint16_t kBackboneUdpPort = 61631; ///< The BBR port.
 
     /**

--- a/src/backbone_router/dua_routing_manager.hpp
+++ b/src/backbone_router/dua_routing_manager.hpp
@@ -40,6 +40,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "agent/instance_params.hpp"
+#include "common/code_utils.hpp"
 #include "ncp/ncp_openthread.hpp"
 #include "utils/system_utils.hpp"
 
@@ -62,6 +63,8 @@ namespace BackboneRouter {
 class DuaRoutingManager
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(DuaRoutingManager);
+
     /**
      * This constructor initializes a DUA routing manager instance.
      *

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -49,6 +49,7 @@
 
 #include <openthread/backbone_router_ftd.h>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
 #include "ncp/ncp_openthread.hpp"
@@ -72,6 +73,8 @@ namespace BackboneRouter {
 class NdProxyManager : public MainloopProcessor
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(NdProxyManager);
+
     /**
      * This constructor initializes a NdProxyManager instance.
      *

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -43,6 +43,7 @@
 #include <stdint.h>
 
 #include "agent/instance_params.hpp"
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "mdns/mdns.hpp"
 #include "ncp/ncp_openthread.hpp"
@@ -79,6 +80,8 @@ namespace otbr {
 class BorderAgent
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(BorderAgent);
+
     /**
      * The constructor to initialize the Thread border agent.
      *

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -161,4 +161,8 @@ template <typename T, typename... Args> std::unique_ptr<T> MakeUnique(Args &&...
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+#define OTBR_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName &) = delete;        \
+    void operator=(const TypeName &) = delete
+
 #endif // OTBR_COMMON_CODE_UTILS_HPP_

--- a/src/common/mainloop_manager.hpp
+++ b/src/common/mainloop_manager.hpp
@@ -40,6 +40,7 @@
 
 #include <list>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "ncp/ncp_openthread.hpp"
 
@@ -52,6 +53,8 @@ namespace otbr {
 class MainloopManager
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(MainloopManager);
+
     /**
      * The constructor to initialize the mainloop manager.
      *

--- a/src/common/task_runner.hpp
+++ b/src/common/task_runner.hpp
@@ -42,6 +42,7 @@
 #include <mutex>
 #include <queue>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/time.hpp"
 
@@ -55,6 +56,8 @@ namespace otbr {
 class TaskRunner : public MainloopProcessor
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(TaskRunner);
+
     /**
      * This type represents the generic executable task.
      *

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <sys/select.h>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
@@ -53,6 +54,8 @@ namespace DBus {
 class DBusAgent : public MainloopProcessor
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(DBusAgent);
+
     /**
      * The constructor of dbus agent.
      *

--- a/src/dbus/server/dbus_object.hpp
+++ b/src/dbus/server/dbus_object.hpp
@@ -63,6 +63,8 @@ namespace DBus {
 class DBusObject
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(DBusObject);
+
     using MethodHandlerType = std::function<void(DBusRequest &)>;
 
     using PropertyHandlerType = std::function<otError(DBusMessageIter &)>;

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -45,6 +45,7 @@
 #include <avahi-common/watch.h>
 
 #include "mdns.hpp"
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/time.hpp"
 
@@ -178,6 +179,8 @@ private:
 class PublisherAvahi : public Publisher
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(PublisherAvahi);
+
     /**
      * The constructor to initialize a Publisher.
      *
@@ -233,6 +236,8 @@ private:
 
     struct Subscription
     {
+        OTBR_DISALLOW_COPY_AND_ASSIGN(Subscription);
+
         PublisherAvahi *mPublisherAvahi;
 
         explicit Subscription(PublisherAvahi &aPublisherAvahi)

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -58,6 +58,8 @@ namespace Mdns {
 class PublisherMDnsSd : public MainloopProcessor, public Publisher
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(PublisherMDnsSd);
+
     /**
      * The constructor to initialize a Publisher.
      *
@@ -114,6 +116,8 @@ private:
 
     struct ServiceRef
     {
+        OTBR_DISALLOW_COPY_AND_ASSIGN(ServiceRef);
+
         DNSServiceRef mServiceRef;
 
         explicit ServiceRef(void)

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -41,6 +41,7 @@
 #include <openthread/instance.h>
 #include <openthread/srp_server.h>
 
+#include "common/code_utils.hpp"
 #include "mdns/mdns.hpp"
 #include "ncp/ncp_openthread.hpp"
 
@@ -53,6 +54,8 @@ namespace otbr {
 class AdvertisingProxy
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(AdvertisingProxy);
+
     /**
      * This constructor initializes the Advertising Proxy object.
      *

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -58,6 +58,8 @@ namespace Dnssd {
 class DiscoveryProxy
 {
 public:
+    OTBR_DISALLOW_COPY_AND_ASSIGN(DiscoveryProxy);
+
     /**
      * This constructor initializes the Discovery Proxy instance.
      *


### PR DESCRIPTION
This commit uses `OTBR_DISALLOW_COPY_AND_ASSIGN` to make sure certain objects are never copied.


Should choose the preferred one of https://github.com/openthread/ot-br-posix/pull/1177 and this PR.