### PR TITLE
[dbus] force quit if DBus fails to connect

### DIFF
--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -67,7 +67,7 @@ public:
      * @returns The intialization error.
      *
      */
-    otbrError Init(void);
+    void Init(void);
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;


### PR DESCRIPTION
This commit forces otbr-agent to quit if DBus fails to connect, so as to help avoid `DBusAgent` running with invalid DBus connection. 