### PR TITLE
[agent] refactor radio version printing

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -42,32 +42,37 @@ namespace otbr {
 bool                 Application::sShouldTerminate = false;
 const struct timeval Application::kPollTimeout     = {10, 0};
 
-Application::Application(Ncp::ControllerOpenThread &aOpenThread)
-    : mPlaceHolder(aOpenThread)
+Application::Application(const std::string &              aInterfaceName,
+                         const std::string &              aBackboneInterfaceName,
+                         const std::vector<const char *> &aRadioUrls)
+    : mInterfaceName(aInterfaceName)
+    , mBackboneInterfaceName(aBackboneInterfaceName)
+    , mNcp(mInterfaceName.c_str(), aRadioUrls, mBackboneInterfaceName.c_str(), /* aDryRun */ false)
 #if OTBR_ENABLE_BORDER_AGENT
-    , mBorderAgent(aOpenThread)
+    , mBorderAgent(mNcp)
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
-    , mBackboneAgent(aOpenThread)
+    , mBackboneAgent(mNcp)
 #endif
 #if OTBR_ENABLE_OPENWRT
-    , mUbusAgent(aOpenThread)
+    , mUbusAgent(mNcp)
 #endif
 #if OTBR_ENABLE_REST_SERVER
-    , mRestWebServer(aOpenThread)
+    , mRestWebServer(mNcp)
 #endif
 #if OTBR_ENABLE_DBUS_SERVER
-    , mDBusAgent(aOpenThread)
+    , mDBusAgent(mNcp)
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
-    , mVendorServer(aOpenThread)
+    , mVendorServer(mNcp)
 #endif
 {
-    OTBR_UNUSED_VARIABLE(mPlaceHolder);
 }
 
 void Application::Init(void)
 {
+    mNcp.Init();
+
 #if OTBR_ENABLE_BORDER_AGENT
     mBorderAgent.Init();
 #endif

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -82,7 +82,9 @@ public:
      * @param[in] aOpenThread  A reference to the OpenThread instance.
      *
      */
-    explicit Application(Ncp::ControllerOpenThread &aOpenThread);
+    explicit Application(const std::string &              aInterfaceName,
+                         const std::string &              aBackboneInterfaceName,
+                         const std::vector<const char *> &aRadioUrls);
 
     /**
      * This method initializes the Application instance.
@@ -105,7 +107,9 @@ private:
 
     static void HandleSignal(int aSignal);
 
-    Ncp::ControllerOpenThread &mPlaceHolder;
+    std::string               mInterfaceName;
+    std::string               mBackboneInterfaceName;
+    Ncp::ControllerOpenThread mNcp;
 #if OTBR_ENABLE_BORDER_AGENT
     BorderAgent mBorderAgent;
 #endif

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -43,6 +43,7 @@
 #include <stdint.h>
 
 #include "agent/instance_params.hpp"
+#include "backbone_router/backbone_agent.hpp"
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "mdns/mdns.hpp"

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -86,7 +86,7 @@ ControllerOpenThread::~ControllerOpenThread(void)
     otSysDeinit();
 }
 
-otbrError ControllerOpenThread::Init(void)
+void ControllerOpenThread::Init(void)
 {
     otbrError  error = OTBR_ERROR_NONE;
     otLogLevel level = OT_LOG_LEVEL_NONE;
@@ -138,7 +138,7 @@ otbrError ControllerOpenThread::Init(void)
     mThreadHelper = std::unique_ptr<otbr::agent::ThreadHelper>(new otbr::agent::ThreadHelper(mInstance, this));
 
 exit:
-    return error;
+    SuccessOrDie(error, "Failed to initialize NCP!");
 }
 
 void ControllerOpenThread::HandleStateChanged(otChangedFlags aFlags)

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -37,6 +37,8 @@
 #include <chrono>
 #include <memory>
 
+#include <assert.h>
+
 #include <openthread/backbone_router_ftd.h>
 #include <openthread/cli.h>
 #include <openthread/instance.h>
@@ -74,12 +76,10 @@ public:
                          bool                             aDryRun);
 
     /**
-     * This method initalize the NCP controller.
-     *
-     * @retval OTBR_ERROR_NONE  Successfully initialized NCP controller.
+     * This method initialize the NCP controller.
      *
      */
-    otbrError Init(void);
+    void Init(void);
 
     /**
      * This method get mInstance pointer.
@@ -87,7 +87,11 @@ public:
      * @retval The pointer of mInstance.
      *
      */
-    otInstance *GetInstance(void) { return mInstance; }
+    otInstance *GetInstance(void)
+    {
+        assert(mInstance != nullptr);
+        return mInstance;
+    }
 
     /**
      * This method gets the thread functionality helper.
@@ -95,7 +99,11 @@ public:
      * @retval The pointer to the helper object.
      *
      */
-    otbr::agent::ThreadHelper *GetThreadHelper(void) { return mThreadHelper.get(); }
+    otbr::agent::ThreadHelper *GetThreadHelper(void)
+    {
+        assert(mThreadHelper != nullptr);
+        return mThreadHelper.get();
+    }
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -105,10 +105,9 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
 }
 
 Resource::Resource(ControllerOpenThread *aNcp)
-    : mNcp(aNcp)
+    : mInstance(nullptr)
+    , mNcp(aNcp)
 {
-    mInstance = mNcp->GetThreadHelper()->GetInstance();
-
     // Resource Handler
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOETIC, &Resource::Diagnostic);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE, &Resource::NodeInfo);
@@ -127,6 +126,7 @@ Resource::Resource(ControllerOpenThread *aNcp)
 
 void Resource::Init(void)
 {
+    mInstance = mNcp->GetThreadHelper()->GetInstance();
 }
 
 void Resource::Handle(Request &aRequest, Response &aResponse) const


### PR DESCRIPTION
This commit refactors radio version printing:
- Use a dedicated function for printing radio version
- Make `ControllerOpenThread` a member of `Application` so that `Application` is always properly constructed before initializing OpenThread instances. 