### PR TITLE
[mdnssd] call `DNSServiceProcessResult` at the end of `Process`

### DIFF
--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -122,7 +122,7 @@ private:
         }
 
         void Update(MainloopContext &aMainloop) const;
-        void Process(const MainloopContext &aMainloop) const;
+        void Process(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;
         void Release(void);
         void DeallocateServiceRef(void);
     };
@@ -209,7 +209,7 @@ private:
                      const std::string &aDomain);
         void RemoveInstanceResolution(ServiceInstanceResolution &aInstanceResolution);
         void UpdateAll(MainloopContext &aMainloop) const;
-        void ProcessAll(const MainloopContext &aMainloop) const;
+        void ProcessAll(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;
 
         static void HandleBrowseResult(DNSServiceRef       aServiceRef,
                                        DNSServiceFlags     aFlags,


### PR DESCRIPTION
This commit makes sure `DNSServiceProcessResult` is always called at the end of `Process`, so as to avoid potential memory issues.