### PR TITLE
[application] de-initialize `Application` and OpenThread instance 

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -93,6 +93,15 @@ void Application::Init(void)
 #endif
 }
 
+void Application::Deinit(void)
+{
+#if OTBR_ENABLE_BORDER_AGENT
+    mBorderAgent.Deinit();
+#endif
+
+    mNcp.Deinit();
+}
+
 otbrError Application::Run(void)
 {
     otbrError error = OTBR_ERROR_NONE;

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -93,6 +93,12 @@ public:
     void Init(void);
 
     /**
+     * This method de-initializes the Application instance.
+     *
+     */
+    void Deinit(void);
+
+    /**
      * This method runs the application until exit.
      *
      * @retval OTBR_ERROR_NONE  The application exited without any error.

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -130,6 +130,9 @@ static void PrintRadioVersionAndExit(const std::vector<const char *> &aRadioUrls
     ncpOpenThread.Init();
 
     PrintRadioVersion(ncpOpenThread.GetInstance());
+
+    ncpOpenThread.Deinit();
+
     exit(EXIT_SUCCESS);
 }
 
@@ -214,7 +217,9 @@ static int realmain(int argc, char *argv[])
 
         app.Init();
 
-        SuccessOrExit(ret = app.Run());
+        ret = app.Run();
+
+        app.Deinit();
     }
 
     otbrLogDeinit();

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -117,6 +117,11 @@ void BorderAgent::Init(void)
     Start();
 }
 
+void BorderAgent::Deinit(void)
+{
+    Stop();
+}
+
 void BorderAgent::Start(void)
 {
     otbrError error = OTBR_ERROR_NONE;
@@ -151,8 +156,6 @@ void BorderAgent::Stop(void)
 
 BorderAgent::~BorderAgent(void)
 {
-    Stop();
-
     if (mPublisher != nullptr)
     {
         delete mPublisher;

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -97,6 +97,12 @@ public:
      */
     void Init(void);
 
+    /**
+     * This method de-initializes border agent service.
+     *
+     */
+    void Deinit(void);
+
 private:
     enum : uint8_t
     {

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -83,7 +83,8 @@ ControllerOpenThread::ControllerOpenThread(const char *                     aInt
 
 ControllerOpenThread::~ControllerOpenThread(void)
 {
-    otSysDeinit();
+    // Make sure OpenThread Instance was gracefully de-initialized.
+    assert(mInstance == nullptr);
 }
 
 void ControllerOpenThread::Init(void)
@@ -139,6 +140,14 @@ void ControllerOpenThread::Init(void)
 
 exit:
     SuccessOrDie(error, "Failed to initialize NCP!");
+}
+
+void ControllerOpenThread::Deinit(void)
+{
+    assert(mInstance != nullptr);
+
+    otSysDeinit();
+    mInstance = nullptr;
 }
 
 void ControllerOpenThread::HandleStateChanged(otChangedFlags aFlags)

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -82,6 +82,12 @@ public:
     void Init(void);
 
     /**
+     * This method deinitialize the NCP controller.
+     *
+     */
+    void Deinit(void);
+
+    /**
      * This method get mInstance pointer.
      *
      * @retval The pointer of mInstance.


### PR DESCRIPTION
Background:
- OpenThread Instance was the last member to destruct in Application, and `otSysDeinit` will be called when destructing OpenThread Instance. However, `otSysDeinit` may call methods of other Application members, which have been destructed at the moment. 

This commit introduces the `Deinit()` method to `ControllerOpenThread` and other classes to make sure OpenThread are properly de-initialized before destructing `Application`. The advantages are:
- `ControllerOpenThread` initializes OT instance in `Init`, so adding `Deinit` makes it symmetrical with `Init`. 
- Provide a predictable runtime environment (Application object fully constructed) for OT instance from `otSysInit` to `otSysDeinit`, making sure OT can safely access Application members during its lifetime.