### PR TITLE
[certification] return ipv6 in testharness-discovery script

### DIFF
--- a/tools/reference_device/testharness-discovery
+++ b/tools/reference_device/testharness-discovery
@@ -53,7 +53,7 @@ def if_nametoindex(name):
 
 
 def get_ipaddr():
-    for line in os.popen(f'ip addr list dev {IFNAME} | grep inet | grep global'):
+    for line in os.popen(f'ip addr list dev {IFNAME} | grep inet6 | grep \'scope link\' '):
         addr = line.strip().split()[1]
         return addr.split('/')[0]
 


### PR DESCRIPTION
Current implementation returns on Windows platforms by default IPv4 address and with this PR we will start to return IPv6 link local.