### PR TITLE
[continuous-integration] add an individual CI step for MATN test cases

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -62,10 +62,16 @@ jobs:
             border_routing: 1
             otbr_mdns: "avahi"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
+          - name: "Border Router MATN (mDNSResponder)"
+            otbr_options: "-DOT_TREL=OFF -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON -DOT_DUA=ON"
+            border_routing: 1
+            otbr_mdns: "mDNSResponder"
+            cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py
           - name: "Backbone Router"
             otbr_options: "-DOT_TREL=OFF -DOT_DUA=ON -DOT_MLR=ON -DOTBR_COVERAGE=ON -DOT_SRP_SERVER=ON -DOT_ECDSA=ON -DOT_SERVICE=ON -DOTBR_DUA_ROUTING=ON"
             border_routing: 0
             cert_scripts: ./tests/scripts/thread-cert/backbone/*.py
+
 
     name: ${{ matrix.name }}
     env:


### PR DESCRIPTION
MATN test cases often takes long time. We'd better move them to a separate GitHub action so that we don't have to rerun MATN cases every time a border router action fails.

See also: https://github.com/openthread/openthread/pull/7308