### PR TITLE
[script] add `set -euxo pipefail` for startup scripts

### DIFF
--- a/script/_dhcpv6_pd
+++ b/script/_dhcpv6_pd
@@ -160,6 +160,8 @@ create_ncp_state_notifier_script()
 #       This script notifies about NCP state changes.
 #
 
+set -euxo pipefail
+
 PID=\$\$
 NAME="ncp_state_notifier"
 

--- a/script/_network_manager
+++ b/script/_network_manager
@@ -84,6 +84,8 @@ create_ap_helper_script()
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+set -euxo pipefail
+
 NAME="ap-helper"
 
 IFNAME=\$1
@@ -215,6 +217,8 @@ create_dhcpv6_helper_script()
 #   Description:
 #       This script manipulates DHCPv6-PD configuration.
 #
+
+set -euxo pipefail
 
 NAME="dhcpv6-helper"
 

--- a/script/console
+++ b/script/console
@@ -49,11 +49,13 @@ killall_services()
 on_exit()
 {
     killall_services
+    # shellcheck source=/dev/null
     . "$AFTER_HOOK"
 }
 
 main()
 {
+    # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
     if have systemctl; then
         sudo systemctl stop otbr-web otbr-agent || true

--- a/script/otbr-firewall
+++ b/script/otbr-firewall
@@ -44,6 +44,8 @@ OTBR_FORWARD_INGRESS_CHAIN="OTBR_FORWARD_INGRESS"
 . /lib/lsb/init-functions
 . /lib/init/vars.sh
 
+set -euxo pipefail
+
 ipset_destroy_if_exist()
 {
     if ipset list "$1"; then

--- a/script/server
+++ b/script/server
@@ -38,6 +38,7 @@
 
 main()
 {
+    # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
     sudo sysctl --system
     nat64_start || die 'Failed to start NAT64!'
@@ -60,6 +61,7 @@ main()
     else
         die 'Unable to find service manager. Try script/console to start in console mode!'
     fi
+    # shellcheck source=/dev/null
     . "$AFTER_HOOK"
 }
 

--- a/script/setup
+++ b/script/setup
@@ -47,6 +47,7 @@
 
 main()
 {
+    # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
     extend_sudo_timeout
     setup_swapfile
@@ -70,6 +71,7 @@ main()
     dhcpv6_pd_install
     border_routing_install
     otbr_install
+    # shellcheck source=/dev/null
     . "$AFTER_HOOK"
 }
 

--- a/script/update
+++ b/script/update
@@ -44,6 +44,7 @@ main()
 {
     ./script/bootstrap
 
+    # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
     otbr_uninstall
     dhcpv6_pd_uninstall
@@ -58,6 +59,7 @@ main()
     dns64_install
     dhcpv6_pd_install
     otbr_update
+    # shellcheck source=/dev/null
     . "$AFTER_HOOK"
 }
 


### PR DESCRIPTION
Add `set -euxo pipefail` to startup scripts. Then shellcheck complained about some issues in the unchanged shell scripts. I fixed the issues in this PR as well.