### PR TITLE
[certification] disable auto Thread attaching for Reference Device

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -95,6 +95,7 @@ otbr_install()
 
     if [[ ${REFERENCE_DEVICE} == "1" ]]; then
         otbr_options+=(
+            "-DOTBR_NO_AUTO_ATTACH=1"
             "-DOT_REFERENCE_DEVICE=ON"
             "-DOT_DHCP6_CLIENT=ON"
             "-DOT_DHCP6_SERVER=ON"

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -95,6 +95,8 @@ elseif(NOT OTBR_OPENWRT)
         RENAME otbr-agent)
 endif()
 
+set(OTBR_NO_AUTO_ATTACH "0" CACHE STRING "Set to 1 to disable auto Thread attach")
+
 configure_file(otbr-agent.default.in otbr-agent.default)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/otbr-agent.default
     DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/default

--- a/src/agent/otbr-agent.default.in
+++ b/src/agent/otbr-agent.default.in
@@ -2,3 +2,4 @@
 
 # Options to pass to otbr-agent
 OTBR_AGENT_OPTS="-I wpan0 -B @OTBR_INFRA_IF_NAME@ spinel+hdlc+uart:///dev/ttyACM0 trel://@OTBR_INFRA_IF_NAME@"
+OTBR_NO_AUTO_ATTACH=@OTBR_NO_AUTO_ATTACH@

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -197,10 +197,23 @@ void ControllerOpenThread::Process(const MainloopContext &aMainloop)
 
     otSysMainloopProcess(mInstance, &aMainloop);
 
-    if (getenv("OTBR_NO_AUTO_ATTACH") == nullptr && mThreadHelper->TryResumeNetwork() == OT_ERROR_NONE)
+    if (IsAutoAttachEnabled() && mThreadHelper->TryResumeNetwork() == OT_ERROR_NONE)
     {
-        setenv("OTBR_NO_AUTO_ATTACH", "1", 0);
+        DisableAutoAttach();
     }
+}
+
+bool ControllerOpenThread::IsAutoAttachEnabled(void)
+{
+    const char *val = getenv("OTBR_NO_AUTO_ATTACH");
+
+    // Auto Thread attaching is enabled if OTBR_NO_AUTO_ATTACH is unset, empty or "0"
+    return (val == nullptr || !strcmp(val, "") || !strcmp(val, "0"));
+}
+
+void ControllerOpenThread::DisableAutoAttach(void)
+{
+    setenv("OTBR_NO_AUTO_ATTACH", "1", 1);
 }
 
 void ControllerOpenThread::PostTimerTask(Milliseconds aDelay, TaskRunner::Task<void> aTask)

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -183,6 +183,10 @@ private:
     void        HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aAddress);
 #endif
 
+    static bool IsAutoAttachEnabled(void);
+
+    static void DisableAutoAttach(void);
+
     otInstance *mInstance;
 
     otPlatformConfig                           mConfig;


### PR DESCRIPTION
This commit enhances `OTBR_NO_AUTO_ATTACH` option to disable auto Thread attaching for Reference Device:
- Use `-DOTBR_NO_AUTO_ATTACH=1` to disable auto  Thread attaching