### PR TITLE
[mdns] handle mDNS daemon restart for mDNSResponder and Avahi

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -431,6 +431,9 @@ void PublisherAvahi::Stop(void)
     mServiceRegistrations.clear();
     mHostRegistrations.clear();
 
+    mSubscribedServices.clear();
+    mSubscribedHosts.clear();
+
     if (mClient)
     {
         avahi_client_free(mClient);
@@ -562,6 +565,8 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
         otbrLogErr("Avahi client failed to start: %s", avahi_strerror(avahi_client_errno(aClient)));
         mState = State::kIdle;
         mStateCallback(mState);
+        Stop();
+        Start();
         break;
 
     case AVAHI_CLIENT_S_COLLISION:

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -160,6 +160,8 @@ private:
         {
         }
 
+        ~ServiceSubscription() { Release(); }
+
         void Release(void);
         void Browse(void);
         void Resolve(uint32_t           aInterfaceIndex,
@@ -229,6 +231,8 @@ private:
             , mRecordBrowser(nullptr)
         {
         }
+
+        ~HostSubscription() { Release(); }
 
         void        Release(void);
         void        Resolve(void);

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -148,6 +148,8 @@ private:
         {
         }
 
+        ~ServiceRef() { Release(); }
+
         void Update(MainloopContext &aMainloop) const;
         void Process(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;
         void Release(void);


### PR DESCRIPTION
`otbr-agent` should reconnect to the mDNS service when the mDNS restarts. Basically, it should clear published services and subscribed services.

Test: https://github.com/openthread/openthread/pull/7363

