### PR TITLE
[signals] handle `SIGINT` same as `SIGTERM`

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -134,6 +134,7 @@ otbrError Application::Run(void)
 
     // allow quitting elegantly
     signal(SIGTERM, HandleSignal);
+    signal(SIGINT, HandleSignal);
 
     while (!sShouldTerminate)
     {


### PR DESCRIPTION
This commit handles `SIGINT` so that `otbr-agent` exits gracefully under `Ctrl+C`. 