### PR TITLE
[docker] remove unused arguments from Docker entrypoint

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -58,14 +58,6 @@ function parse_args()
                 shift
                 shift
                 ;;
-            --disable-default-prefix-route)
-                AUTO_PREFIX_ROUTE=false
-                shift
-                ;;
-            --disable-default-prefix-slaac)
-                AUTO_PREFIX_SLAAC=false
-                shift
-                ;;
             *)
                 shift
                 ;;
@@ -79,8 +71,6 @@ parse_args "$@"
 [ -n "$TREL_URL" ] || TREL_URL=""
 [ -n "$TUN_INTERFACE_NAME" ] || TUN_INTERFACE_NAME="wpan0"
 [ -n "$BACKBONE_INTERFACE" ] || BACKBONE_INTERFACE="eth0"
-[ -n "$AUTO_PREFIX_ROUTE" ] || AUTO_PREFIX_ROUTE=true
-[ -n "$AUTO_PREFIX_SLAAC" ] || AUTO_PREFIX_SLAAC=true
 [ -n "$NAT64_PREFIX" ] || NAT64_PREFIX="64:ff9b::/96"
 
 echo "RADIO_URL:" $RADIO_URL
@@ -88,8 +78,6 @@ echo "TREL_URL:" $TREL_URL
 echo "TUN_INTERFACE_NAME:" $TUN_INTERFACE_NAME
 echo "BACKBONE_INTERFACE: $BACKBONE_INTERFACE"
 echo "NAT64_PREFIX:" $NAT64_PREFIX
-echo "AUTO_PREFIX_ROUTE:" $AUTO_PREFIX_ROUTE
-echo "AUTO_PREFIX_SLAAC:" $AUTO_PREFIX_SLAAC
 
 NAT64_PREFIX=${NAT64_PREFIX/\//\\\/}
 


### PR DESCRIPTION
Both, --disable-default-prefix-route and --disable-default-prefix-slaac
have been used for wpantund which is no longer supported by the Docker
entrypoint script. Remove them to avoid confusion.