### PR TITLE
[trel-dnssd] fix wrong instance name size

### DIFF
--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -229,12 +229,12 @@ std::string TrelDnssd::GetTrelInstanceName(void)
 {
     const otExtAddress *extaddr = otLinkGetExtendedAddress(mNcp.GetInstance());
     std::string         name;
-    char                nameBuf[sizeof(extaddr) * 2 + 1];
+    char                nameBuf[sizeof(otExtAddress) * 2 + 1];
 
-    Utils::Bytes2Hex(extaddr->m8, sizeof(extaddr), nameBuf);
+    Utils::Bytes2Hex(extaddr->m8, sizeof(otExtAddress), nameBuf);
     name = StringUtils::ToLowercase(nameBuf);
 
-    assert(name.length() == sizeof(extaddr) * 2);
+    assert(name.length() == sizeof(otExtAddress) * 2);
 
     otbrLogDebug("Using instance name %s", name.c_str());
     return name;


### PR DESCRIPTION
The pointer size was misused as the extended address size. They happen to be the same(8 bytes) on 64-bit machines but can cause stack overflow on other platforms.