### PR TITLE
[dbus] add debugging log for UpdateMeshcopTxtHandler

### DIFF
--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -104,6 +104,20 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
     }
 }
 
+#if OTBR_ENABLE_DBUS_SERVER
+void ThreadHelper::OnUpdateMeshCopTxt(std::map<std::string, std::vector<uint8_t>> aUpdate)
+{
+    if (mUpdateMeshCopTxtHandler)
+    {
+        mUpdateMeshCopTxtHandler(std::move(aUpdate));
+    }
+    else
+    {
+        otbrLogErr("No UpdateMeshCopTxtHandler");
+    }
+}
+#endif
+
 void ThreadHelper::AddDeviceRoleHandler(DeviceRoleHandler aHandler)
 {
     mDeviceRoleHandlers.emplace_back(aHandler);

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -236,13 +236,7 @@ public:
      * @param[in] aUpdate  The key-value pairs to be updated in the TXT record.
      *
      */
-    void OnUpdateMeshCopTxt(std::map<std::string, std::vector<uint8_t>> aUpdate)
-    {
-        if (mUpdateMeshCopTxtHandler)
-        {
-            mUpdateMeshCopTxtHandler(std::move(aUpdate));
-        }
-    }
+    void OnUpdateMeshCopTxt(std::map<std::string, std::vector<uint8_t>> aUpdate);
 #endif
 
     /**


### PR DESCRIPTION
It should be considered an error case if the `UpdateMeshcopTxtHandler` is not properly set.