### PR TITLE
[mdns] remove ServiceRegistration before invoking the callback

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -388,7 +388,13 @@ protected:
         virtual ~Registration(void);
 
         // Completes the service registration with given result/error.
-        void Complete(otbrError aError) { std::move(mCallback)(aError); }
+        void Complete(otbrError aError)
+        {
+            if (!IsCompleted())
+            {
+                std::move(mCallback)(aError);
+            }
+        }
 
         // Tells whether the service registration has been completed (typically by calling
         // `ServiceRegistration::Complete`).
@@ -421,7 +427,6 @@ protected:
             , mTxtList(SortTxtList(std::move(aTxtList)))
         {
         }
-
         ~ServiceRegistration(void) override = default;
 
         // Tells whether this `ServiceRegistration` object is outdated comparing to the given parameters.
@@ -462,8 +467,8 @@ protected:
     static std::string MakeFullServiceName(const std::string &aName, const std::string &aType);
     static std::string MakeFullHostName(const std::string &aName);
 
-    void                 AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
-    void                 RemoveServiceRegistration(const std::string &aName, const std::string &aType);
+    void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
+    void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
     void                 OnServiceResolved(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo);
     void OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType, const std::string &aInstanceName);
@@ -485,7 +490,7 @@ protected:
                                                    ResultCallback &&           aCallback);
 
     void              AddHostRegistration(HostRegistrationPtr &&aHostReg);
-    void              RemoveHostRegistration(const std::string &aName);
+    void              RemoveHostRegistration(const std::string &aName, otbrError aError);
     HostRegistration *FindHostRegistration(const std::string &aName);
 
     ServiceRegistrationMap mServiceRegistrations;

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -485,18 +485,24 @@ void PublisherAvahi::CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrErro
 
     if ((serviceReg = FindServiceRegistration(aGroup)) != nullptr)
     {
-        serviceReg->Complete(aError);
-        if (aError != OTBR_ERROR_NONE)
+        if (aError == OTBR_ERROR_NONE)
         {
-            RemoveServiceRegistration(serviceReg->mName, serviceReg->mType);
+            serviceReg->Complete(aError);
+        }
+        else
+        {
+            RemoveServiceRegistration(serviceReg->mName, serviceReg->mType, aError);
         }
     }
     else if ((hostReg = FindHostRegistration(aGroup)) != nullptr)
     {
-        hostReg->Complete(aError);
-        if (aError != OTBR_ERROR_NONE)
+        if (aError == OTBR_ERROR_NONE)
         {
-            RemoveHostRegistration(hostReg->mName);
+            hostReg->Complete(aError);
+        }
+        else
+        {
+            RemoveHostRegistration(hostReg->mName, aError);
         }
     }
     else
@@ -663,7 +669,7 @@ exit:
 
 void PublisherAvahi::UnpublishService(const std::string &aName, const std::string &aType, ResultCallback &&aCallback)
 {
-    RemoveServiceRegistration(aName, aType);
+    RemoveServiceRegistration(aName, aType, OTBR_ERROR_ABORTED);
     std::move(aCallback)(OTBR_ERROR_NONE);
 }
 
@@ -719,7 +725,7 @@ exit:
 
 void PublisherAvahi::UnpublishHost(const std::string &aName, ResultCallback &&aCallback)
 {
-    RemoveHostRegistration(aName);
+    RemoveHostRegistration(aName, OTBR_ERROR_ABORTED);
     std::move(aCallback)(OTBR_ERROR_NONE);
 }
 


### PR DESCRIPTION
Current implementation invokes the service/host registration callback before removing the
`ServiceRegistraion` entry from the `ServiceRegistraionMap`. This will result in invalid access
to the `ServiceRegistration` entry when it's freed from the callback. This commit changes to
invoke the callback after removing the entry.