### PR TITLE
[advertising-proxy] fix uninitialized variable

### DIFF
--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -203,7 +203,7 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     uint8_t                    hostAddressNum;
     bool                       hostDeleted;
     const otSrpServerService * service;
-    otSrpServerServiceUpdateId updateId;
+    otSrpServerServiceUpdateId updateId     = 0;
     bool                       hasUpdate    = false;
     std::string                fullHostName = otSrpServerHostGetFullName(aHost);
 


### PR DESCRIPTION
This PR fixes https://github.com/openthread/ot-br-posix/issues/1251.

I'll add a build test to cover uninitialized variables. 