### PR TITLE
[meshcop] add OMR field in meshcop TXT record

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -41,6 +41,9 @@ if (OTBR_BACKBONE_ROUTER)
 endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
+if (OTBR_BORDER_ROUTING)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING=1)
+endif()
 
 option(OTBR_DBUS "Enable DBus support" OFF)
 if(OTBR_DBUS)

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -75,7 +75,7 @@ ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-c
   libnetfilter-queue-dev
 
 # Required for OpenThread Backbone CI
-ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential iproute2 net-tools
+ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential iproute2 net-tools python3-zeroconf
 
 # Required and installed during build (script/bootstrap) when RELEASE=1, could be removed
 ENV OTBR_NORELEASE_DEPS \

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -25,7 +25,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-ARG BASE_IMAGE=ubuntu:bionic
+ARG BASE_IMAGE=ubuntu:focal
 FROM ${BASE_IMAGE}
 
 ARG INFRA_IF_NAME
@@ -75,7 +75,7 @@ ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-c
   libnetfilter-queue-dev
 
 # Required for OpenThread Backbone CI
-ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential
+ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential iproute2 net-tools
 
 # Required and installed during build (script/bootstrap) when RELEASE=1, could be removed
 ENV OTBR_NORELEASE_DEPS \


### PR DESCRIPTION
As required by the latest spec, the border agent needs to publish an `omr` entry in the meshcop TXT record. If there are multiple OMR prefixes in netdata, the borderagent should publish the smallest one.

This PR contains https://github.com/openthread/ot-br-posix/pull/1263, please review the second commit only.

This PR also depends on https://github.com/openthread/openthread/pull/7432.
Tested by: https://github.com/openthread/openthread/pull/7433