### PR TITLE
[tests] upgrade CI docker base image to `ubuntu:focal`

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -25,7 +25,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-ARG BASE_IMAGE=ubuntu:bionic
+ARG BASE_IMAGE=ubuntu:focal
 FROM ${BASE_IMAGE}
 
 ARG INFRA_IF_NAME
@@ -75,7 +75,7 @@ ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-c
   libnetfilter-queue-dev
 
 # Required for OpenThread Backbone CI
-ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential
+ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential iproute2 net-tools
 
 # Required and installed during build (script/bootstrap) when RELEASE=1, could be removed
 ENV OTBR_NORELEASE_DEPS \


### PR DESCRIPTION
The main reason I'm upgrading the base image is to leverage the `zeroconf` library. Latest few versions of `zeroconf` require python version >= 3.7 and `ubuntu:focal` uses python 3.8 as default. 