### PR TITLE
[advertising-proxy] unpublish services before unpublishing a SRP host

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -615,10 +615,6 @@ void PublisherAvahi::PublishService(const std::string &aHostName,
 
     if (!aHostName.empty())
     {
-        HostRegistration *hostReg = Publisher::FindHostRegistration(aHostName);
-
-        // Make sure that the host has been published.
-        VerifyOrExit(hostReg != nullptr, error = OTBR_ERROR_INVALID_ARGS);
         fullHostName = MakeFullHostName(aHostName);
     }
 

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -470,10 +470,6 @@ void PublisherMDnsSd::PublishService(const std::string &aHostName,
 
     if (!aHostName.empty())
     {
-        HostRegistration *hostReg = Publisher::FindHostRegistration(aHostName);
-
-        // Make sure that the host has been published.
-        VerifyOrExit(hostReg != nullptr, ret = OTBR_ERROR_INVALID_ARGS);
         fullHostName = MakeFullHostName(aHostName);
     }
 

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -227,35 +227,6 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
         }
     }
 
-    if (!hostDeleted)
-    {
-        std::vector<uint8_t> firstHostAddress{std::begin(hostAddress[0].mFields.m8),
-                                              std::end(hostAddress[0].mFields.m8)};
-
-        // TODO: select a preferred address or advertise all addresses from SRP client.
-        otbrLogDebug("Publish SRP host '%s'", fullHostName.c_str());
-        mPublisher.PublishHost(
-            hostName, firstHostAddress,
-            Mdns::Publisher::ResultCallback([this, hasUpdate, updateId, fullHostName](otbrError aError) {
-                otbrLogResult(aError, "Handle publish SRP host '%s'", fullHostName.c_str());
-                if (hasUpdate)
-                {
-                    OnMdnsPublishResult(updateId, aError);
-                }
-            }));
-    }
-    else
-    {
-        otbrLogDebug("Unpublish SRP host '%s'", fullHostName.c_str());
-        mPublisher.UnpublishHost(hostName, [this, hasUpdate, updateId, fullHostName](otbrError aError) {
-            otbrLogResult(aError, "Handle unpublish SRP host '%s'", fullHostName.c_str());
-            if (hasUpdate)
-            {
-                OnMdnsPublishResult(updateId, aError);
-            }
-        });
-    }
-
     service = nullptr;
     while ((service = otSrpServerHostFindNextService(aHost, service, OT_SRP_SERVER_FLAGS_BASE_TYPE_SERVICE_ONLY,
                                                      /* aServiceName */ nullptr, /* aInstanceName */ nullptr)))
@@ -295,6 +266,35 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
                     }
                 });
         }
+    }
+
+    if (!hostDeleted)
+    {
+        std::vector<uint8_t> firstHostAddress{std::begin(hostAddress[0].mFields.m8),
+                                              std::end(hostAddress[0].mFields.m8)};
+
+        // TODO: select a preferred address or advertise all addresses from SRP client.
+        otbrLogDebug("Publish SRP host '%s'", fullHostName.c_str());
+        mPublisher.PublishHost(
+            hostName, firstHostAddress,
+            Mdns::Publisher::ResultCallback([this, hasUpdate, updateId, fullHostName](otbrError aError) {
+                otbrLogResult(aError, "Handle publish SRP host '%s'", fullHostName.c_str());
+                if (hasUpdate)
+                {
+                    OnMdnsPublishResult(updateId, aError);
+                }
+            }));
+    }
+    else
+    {
+        otbrLogDebug("Unpublish SRP host '%s'", fullHostName.c_str());
+        mPublisher.UnpublishHost(hostName, [this, hasUpdate, updateId, fullHostName](otbrError aError) {
+            otbrLogResult(aError, "Handle unpublish SRP host '%s'", fullHostName.c_str());
+            if (hasUpdate)
+            {
+                OnMdnsPublishResult(updateId, aError);
+            }
+        });
     }
 
 exit:


### PR DESCRIPTION
We should publish/unpublish SRP services before publishing/unpublishing
a SRP host because we have no guarantee of either the `otSrpHost` object
will be released or not after calling `Mdns::Publisher::UnpublishHost`.
Tests are covered in https://github.com/openthread/openthread/pull/7440.

------
Fixes: https://github.com/openthread/ot-br-posix/issues/1272