### PR TITLE
[dbus] fix OTBR's behavior when `Reset` is invoked

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -119,6 +119,11 @@ void BorderAgent::Init(void)
     mNcp.GetThreadHelper()->SetUpdateMeshCopTxtHandler([this](std::map<std::string, std::vector<uint8_t>> aUpdate) {
         HandleUpdateVendorMeshCoPTxtEntries(std::move(aUpdate));
     });
+    mNcp.RegisterResetHandler([this]() {
+        mNcp.GetThreadHelper()->SetUpdateMeshCopTxtHandler([this](std::map<std::string, std::vector<uint8_t>> aUpdate) {
+            HandleUpdateVendorMeshCoPTxtEntries(std::move(aUpdate));
+        });
+    });
 #endif
 
     Start();

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -97,6 +97,8 @@ AdvertisingProxy::AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publis
     : mNcp(aNcp)
     , mPublisher(aPublisher)
 {
+    mNcp.RegisterResetHandler(
+        [this]() { otSrpServerSetServiceUpdateHandler(GetInstance(), AdvertisingHandler, this); });
 }
 
 otbrError AdvertisingProxy::Start(void)

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -62,6 +62,10 @@ DiscoveryProxy::DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher 
     : mNcp(aNcp)
     , mMdnsPublisher(aPublisher)
 {
+    mNcp.RegisterResetHandler([this]() {
+        otDnssdQuerySetCallbacks(mNcp.GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
+                                 &DiscoveryProxy::OnDiscoveryProxyUnsubscribe, this);
+    });
 }
 
 void DiscoveryProxy::Start(void)


### PR DESCRIPTION
When the D-BUS API `Reset` is invoked, 

- re-register `UpdateMeshCopTxtHandler`
- reset advertising proxy callbacks
- reset discovery proxy callbacks