### PR TITLE
[border-agent] don't treat `OTBR_ERROR_ABORTED` as an error in logs

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -309,8 +309,19 @@ void BorderAgent::PublishMeshCopService(void)
 
     mPublisher->PublishService(/* aHostName */ "", mServiceInstanceName, kBorderAgentServiceType,
                                Mdns::Publisher::SubTypeList{}, port, txtList, [this](otbrError aError) {
-                                   otbrLogResult(aError, "Result of publish meshcop service %s.%s.local",
-                                                 mServiceInstanceName.c_str(), kBorderAgentServiceType);
+                                   if (aError == OTBR_ERROR_ABORTED)
+                                   {
+                                       // OTBR_ERROR_ABORTED is thrown when an ongoing service registration is
+                                       // cancelled. This can happen when the meshcop service is being updated
+                                       // frequently. To avoid false alarms, it should not be logged like a real error.
+                                       otbrLogInfo("Cancelled previous publishing meshcop service %s.%s.local",
+                                                   mServiceInstanceName.c_str(), kBorderAgentServiceType);
+                                   }
+                                   else
+                                   {
+                                       otbrLogResult(aError, "Result of publish meshcop service %s.%s.local",
+                                                     mServiceInstanceName.c_str(), kBorderAgentServiceType);
+                                   }
                                    if (aError == OTBR_ERROR_DUPLICATED)
                                    {
                                        // Try to unpublish current service in case we are trying to register


### PR DESCRIPTION
otbr-agent generates `WARNING` level logs when there are frequent meshcop service updates: 
```
otbr-agent[2638658]: [WARN]-BA------: Result of publish meshcop service OpenThread BorderRouter._meshcop._udp.local: Aborted
otbr-agent[2638658]: [WARN]-BA------: Result of publish meshcop service OpenThread BorderRouter._meshcop._udp.local: Aborted
```
Such a log line is generated because an ongoing meshcop service registration is canceled for some reason (a newer registration preempts the previous registration, or border agent wants to stop advertising the service). However, this behavior is working as expected and shouldn't be regarded as an error. Hence I lowered the log level to `INFO` in such cases.