### PR TITLE
[web-service] ot-client: add needed header for fd_set() call

### DIFF
--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>


### PR DESCRIPTION
The select.h header file is needed for fd_set(). Depending on the
compiler and libc combinations this will result in an error when
not included. I saw the error with gcc and musl on our builds.

Signed-off-by: Stefan Schmidt <stefan.schmidt@huawei.com>