### PR TITLE
[platform] de-init application in `otPlatReset` and verify `Publisher` state in public methods

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -68,7 +68,8 @@ enum
     OTBR_OPT_RADIO_VERSION,
 };
 
-static jmp_buf sResetJump;
+static jmp_buf            sResetJump;
+static otbr::Application *gApp = nullptr;
 
 void                       __gcov_flush();
 static const struct option kOptions[] = {
@@ -211,6 +212,7 @@ static int realmain(int argc, char *argv[])
     {
         otbr::Application app(interfaceName, backboneInterfaceName, radioUrls);
 
+        gApp = &app;
         app.Init();
 
         ret = app.Run();
@@ -230,7 +232,9 @@ void otPlatReset(otInstance *aInstance)
 
     gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
 
-    otSysDeinit();
+    VerifyOrDie(gApp != nullptr, "gApp is null");
+    gApp->Deinit();
+    gApp = nullptr;
 
     longjmp(sResetJump, 1);
     assert(false);


### PR DESCRIPTION
When `otPlatReset` is called on `otbr-agent`, it should de-init the old `otbr::Application` so that the resources will be properly disposed, otherwise there will be dangling resources. Also, `otbr::Application` should de-init the TREL module when itself is de-initing.

One example is that if we call `ot-ctl factoryreset`, the old `otbr::Application` won't be destructed so that the publisher will keep the old mDNS service registrations until the process exits. In such a situation, there will be two different MeshCoP services published by the same `otbr-agent` process. This test case is introduced in https://github.com/openthread/openthread/pull/7592.

Also, this PR adds a verification at `Publisher` public methods to ensure that `Publisher` is at `kReady` state.