### PR TITLE
[adv-proxy] treat `NOT_FOUND` as success when unpublishing host/service

### DIFF
--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -261,6 +261,8 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
             otbrLogDebug("Unpublish SRP service '%s'", fullServiceName.c_str());
             mPublisher.UnpublishService(
                 serviceName, serviceType, [this, hasUpdate, updateId, fullServiceName](otbrError aError) {
+                    // Treat `NOT_FOUND` as success when unpublishing service
+                    aError = (aError == OTBR_ERROR_NOT_FOUND) ? OTBR_ERROR_NONE : aError;
                     otbrLogResult(aError, "Handle unpublish SRP service '%s'", fullServiceName.c_str());
                     if (hasUpdate)
                     {
@@ -291,6 +293,8 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     {
         otbrLogDebug("Unpublish SRP host '%s'", fullHostName.c_str());
         mPublisher.UnpublishHost(hostName, [this, hasUpdate, updateId, fullHostName](otbrError aError) {
+            // Treat `NOT_FOUND` as success when unpublishing host.
+            aError = (aError == OTBR_ERROR_NOT_FOUND) ? OTBR_ERROR_NONE : aError;
             otbrLogResult(aError, "Handle unpublish SRP host '%s'", fullHostName.c_str());
             if (hasUpdate)
             {


### PR DESCRIPTION
This commit updates `AdvertisingProxy` so that when it is unpublishing
a host or service entry on the underlying `Mdns::Publisher` if the
returned error is `OTBR_ERROR_NOT_FOUND` the error is treated as
success and reported as such to OT core `Srp::Server`. This ensures
that an SRP update request to remove a not previously registered
host/service is not rejected by the platform and therefore by the
`ot::Srp:Server`