### PR TITLE
[dbus] allow `AttachAllNodesTo` when has active dataset but detached

### DIFF
--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -94,8 +94,10 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
             {
                 if (mAttachPendingDatasetTlvs.mLength == 0)
                 {
-                    mAttachHandler(OT_ERROR_NONE);
+                    ResultHandler handler = mAttachHandler;
+
                     mAttachHandler = nullptr;
+                    handler(OT_ERROR_NONE);
                 }
                 else
                 {
@@ -105,9 +107,11 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
                                                     mAttachPendingDatasetTlvs.mLength, MgmtSetResponseHandler, this);
                     if (error != OT_ERROR_NONE)
                     {
-                        mAttachHandler(error);
+                        ResultHandler handler = mAttachHandler;
+
                         mAttachHandler            = nullptr;
                         mAttachPendingDatasetTlvs = {};
+                        handler(error);
                     }
                 }
             }
@@ -606,6 +610,8 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult, void *aContext)
 
 void ThreadHelper::MgmtSetResponseHandler(otError aResult)
 {
+    ResultHandler handler;
+
     LogOpenThreadResult("MgmtSetResponseHandler()", aResult);
 
     assert(mAttachHandler != nullptr);
@@ -620,9 +626,10 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult)
         break;
     }
 
-    mAttachHandler(aResult);
+    handler                   = mAttachHandler;
     mAttachHandler            = nullptr;
     mAttachPendingDatasetTlvs = {};
+    handler(aResult);
 }
 
 #if OTBR_ENABLE_UNSECURE_JOIN

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -280,6 +280,8 @@ private:
     ResultHandler mAttachHandler;
     ResultHandler mJoinerHandler;
 
+    otOperationalDatasetTlvs mAttachPendingDatasetTlvs = {};
+
     std::random_device mRandomDevice;
 
 #if OTBR_ENABLE_DBUS_SERVER

--- a/tests/dbus/CMakeLists.txt
+++ b/tests/dbus/CMakeLists.txt
@@ -53,4 +53,4 @@ add_test(
 set_tests_properties(dbus-client PROPERTIES
     ENVIRONMENT CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
 )
-set_tests_properties(dbus-client PROPERTIES TIMEOUT 500)
+set_tests_properties(dbus-client PROPERTIES TIMEOUT 1000)

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -190,11 +190,43 @@ EOF
     dataset+="0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x30,0x36,0x62,0x37,0x01,"
     dataset+="0x02,0x06,0xb7,0x04,0x10,0xf9,0xc9,0x1b,0x11,0x45,0x02,0x54,0x67,0xbf,0x11,0xed,"
     dataset+="0xf9,0x01,0x1a,0x58,0x12,0x0c,0x04,0x02,0xa0,0xff,0xf8"
+
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}"
 
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset pending | grep "Active Timestamp: 2"
+
+    sleep 310
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset active | grep "Active Timestamp: 2"
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl networkkey | grep be3bd244ae6d997020a882a24a8040e2
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
+    sleep 1
+
+    sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
+        io.openthread.BorderRouter.Attach \
+        array:byte: \
+        uint16:0xffff \
+        string:OpenThread \
+        uint64:0xffffffffffffffff \
+        array:byte: \
+        uint32:0xffffffff
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep "leader"
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl thread stop
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep "disabled"
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset active | grep "Done"
+
+    sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
+        io.openthread.BorderRouter.AttachAllNodesTo \
+        "array:byte:${dataset}"
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep "leader"
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset pending | grep "Active Timestamp: 2"
 
     sleep 310


### PR DESCRIPTION
This PR changes the behavior of `AttachAllNodesTo` when there is an active dataset but the device isn't attached to it:

Before this PR: if the device is in `detached` or `disabled` state, and it has an active dataset, it returns an error.

After this PR: if the device is in `detached` or `disabled` state, and it has an active dataset, it attaches to the network specified by the active dataset, and then sends a `MGMT_PENDING_SET` command to set the pending dataset to the dataset specified by the argument.