### PR TITLE
[tests] add a test case of D-BUS API `Reset`

### DIFF
--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -79,6 +79,18 @@ update_meshcop_txt_and_check()
     service="$(scan_meshcop_service)"
     grep --binary-files=text "A=abc" <<<"${service}"
     grep --binary-files=text "B=12" <<<"${service}"
+
+    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.Reset --object-path /io/openthread/BorderRouter/wpan0
+    sleep 5
+    service="$(scan_meshcop_service)"
+    grep --binary-files=text "A=abc" <<<"${service}"
+    grep --binary-files=text "B=12" <<<"${service}"
+
+    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('A',[97,99]),('B',[49,50])]"
+    sleep 5
+    service="$(scan_meshcop_service)"
+    grep --binary-files=text "A=ac" <<<"${service}"
+    grep --binary-files=text "B=12" <<<"${service}"
 }
 
 main()

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -133,10 +133,13 @@ case "$(uname)" in
         fi
 
         if [ "${OTBR_MDNS-}" == 'mDNSResponder' ]; then
-            SOURCE_NAME=mDNSResponder-878.30.4
+            SOURCE_NAME=mDNSResponder-1310.80.1
             wget https://opensource.apple.com/tarballs/mDNSResponder/$SOURCE_NAME.tar.gz \
                 && tar xvf $SOURCE_NAME.tar.gz \
-                && cd $SOURCE_NAME/mDNSPosix \
+                && cd $SOURCE_NAME/Clients \
+                && sed -i '/#include <ctype.h>/a #include <stdarg.h>' dns-sd.c \
+                && sed -i '/#include <ctype.h>/a #include <sys/param.h>' dns-sd.c \
+                && cd ../mDNSPosix \
                 && make os=linux && sudo make install os=linux
         fi
 


### PR DESCRIPTION
This PR adds a test case to verify D-BUS APIs are working well after a `Reset` call.

This PR also updates the mDNSResponder to latest in `tests/scripts/bootstrap.sh`.