### PR TITLE
[agent] refine booting logs

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -26,6 +26,8 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define OTBR_LOG_TAG "AGENT"
+
 #include <openthread-br/config.h>
 
 #include <fstream>
@@ -117,19 +119,17 @@ static otbrLogLevel GetDefaultLogLevel(void)
     return level;
 }
 
-static void PrintRadioVersion(otInstance *aInstance)
-{
-    printf("%s\n", otPlatRadioGetVersionString(aInstance));
-}
-
 static void PrintRadioVersionAndExit(const std::vector<const char *> &aRadioUrls)
 {
     otbr::Ncp::ControllerOpenThread ncpOpenThread{/* aInterfaceName */ "", aRadioUrls, /* aBackboneInterfaceName */ "",
                                                   /* aDryRun */ true};
+    const char *                    radioVersion;
 
     ncpOpenThread.Init();
 
-    PrintRadioVersion(ncpOpenThread.GetInstance());
+    radioVersion = otPlatRadioGetVersionString(ncpOpenThread.GetInstance());
+    otbrLogNotice("Radio version: %s", radioVersion);
+    printf("%s\n", radioVersion);
 
     ncpOpenThread.Deinit();
 
@@ -192,14 +192,14 @@ static int realmain(int argc, char *argv[])
     }
 
     otbrLogInit(kSyslogIdent, logLevel, verbose);
-    otbrLogInfo("Running %s", OTBR_PACKAGE_VERSION);
-    otbrLogInfo("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
-    otbrLogInfo("Thread interface: %s", interfaceName);
-    otbrLogInfo("Backbone interface: %s", backboneInterfaceName);
+    otbrLogNotice("Running %s", OTBR_PACKAGE_VERSION);
+    otbrLogNotice("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
+    otbrLogNotice("Thread interface: %s", interfaceName);
+    otbrLogNotice("Backbone interface: %s", backboneInterfaceName);
 
     for (int i = optind; i < argc; i++)
     {
-        otbrLogInfo("Radio URL: %s", argv[i]);
+        otbrLogNotice("Radio URL: %s", argv[i]);
         radioUrls.push_back(argv[i]);
     }
 


### PR DESCRIPTION
This commit refine the booting logs fore better debugging:
- Use `NOTE` log level instead of `INFO` since the log information is important
- Combine multiple logs to one log

An example of final log:
```
[NOTE]-AGENT---: Running version 0.3.0-7f48d63a4b; Thread version: 1.2.0, interface: wpan0; Backbone interface: eth0; Radio URL: spinel+hdlc+forkpty:///home/pi/bin/ot-rcp?forkpty-arg=1 trel://eth0
```