### PR TITLE
[dbus] implement D-BUS API `GetSrpServerInfo`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
       BUILD_TARGET: check
       OTBR_BUILD_TYPE: ${{ matrix.build_type }}
       OTBR_MDNS: ${{ matrix.mdns }}
+      OTBR_OPTIONS: "-DOTBR_SRP_ADVERTISING_PROXY=ON"
       OTBR_COVERAGE: 1
     steps:
     - uses: actions/checkout@v2
@@ -97,6 +98,8 @@ jobs:
     env:
       BUILD_TARGET: check
       OTBR_REST: ${{ matrix.rest }}
+      OTBR_MDNS: mDNSResponder
+      OTBR_OPTIONS: "-DOTBR_SRP_ADVERTISING_PROXY=ON"
       OTBR_COVERAGE: 1
     steps:
     - uses: actions/checkout@v2

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -633,6 +633,11 @@ ClientError ThreadApiDBus::GetRadioRegion(std::string &aRadioRegion)
     return GetProperty(OTBR_DBUS_PROPERTY_RADIO_REGION, aRadioRegion);
 }
 
+ClientError ThreadApiDBus::GetSrpServerInfo(SrpServerInfo &aSrpServerInfo)
+{
+    return GetProperty(OTBR_DBUS_PROPERTY_SRP_SERVER_INFO, aSrpServerInfo);
+}
+
 std::string ThreadApiDBus::GetInterfaceName(void)
 {
     return mInterfaceName;

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -706,6 +706,18 @@ public:
     ClientError GetRadioRegion(std::string &aRadioRegion);
 
     /**
+     * This method gets the SRP server information.
+     *
+     * @param[out] aSrpServerInfo  The SRP server information.
+     *
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
+     *
+     */
+    ClientError GetSrpServerInfo(SrpServerInfo &aSrpServerInfo);
+
+    /**
      * This method returns the network interface name the client is bound to.
      *
      * @returns The network interface name.

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -91,6 +91,7 @@
 #define OTBR_DBUS_PROPERTY_ON_MESH_PREFIXES "OnMeshPrefixes"
 #define OTBR_DBUS_PROPERTY_ACTIVE_DATASET_TLVS "ActiveDatasetTlvs"
 #define OTBR_DBUS_PROPERTY_RADIO_REGION "RadioRegion"
+#define OTBR_DBUS_PROPERTY_SRP_SERVER_INFO "SrpServerInfo"
 
 #define OTBR_ROLE_NAME_DISABLED "disabled"
 #define OTBR_ROLE_NAME_DETACHED "detached"

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -77,6 +77,12 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const ChannelQuality &aQuali
 otbrError DBusMessageExtract(DBusMessageIter *aIter, ChannelQuality &aQuality);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const TxtEntry &aTxtEntry);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, TxtEntry &aTxtEntry);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo::Registration &aRegistration);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo::Registration &aRegistration);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo::ResponseCounters &aResponseCounters);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo::ResponseCounters &aResponseCounters);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo &aSrpServerInfo);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo &aSrpServerInfo);
 
 template <typename T> struct DBusTypeTrait;
 
@@ -209,6 +215,27 @@ template <> struct DBusTypeTrait<std::vector<TxtEntry>>
 {
     // array of struct of { string, array<uint8> }
     static constexpr const char *TYPE_AS_STRING = "a(say)";
+};
+
+template <> struct DBusTypeTrait<SrpServerState>
+{
+    static constexpr int         TYPE           = DBUS_TYPE_BYTE;
+    static constexpr const char *TYPE_AS_STRING = DBUS_TYPE_BYTE_AS_STRING;
+};
+
+template <> struct DBusTypeTrait<SrpServerAddressMode>
+{
+    static constexpr int         TYPE           = DBUS_TYPE_BYTE;
+    static constexpr const char *TYPE_AS_STRING = DBUS_TYPE_BYTE_AS_STRING;
+};
+
+template <> struct DBusTypeTrait<SrpServerInfo>
+{
+    // struct of { uint8, uint16, uint8,
+    //              struct of { uint32, uint32, uint64, uint64, uint64, uint64 },
+    //              struct of { uint32, uint32, uint64, uint64, uint64, uint64 },
+    //              struct of { uint32, uint32, uint32, uint32, uint32, uint32} }
+    static constexpr const char *TYPE_AS_STRING = "(yqy(uutttt)(uutttt)(uuuuuu))";
 };
 
 template <> struct DBusTypeTrait<int8_t>

--- a/src/dbus/common/dbus_message_helper_openthread.cpp
+++ b/src/dbus/common/dbus_message_helper_openthread.cpp
@@ -512,5 +512,102 @@ exit:
     return error;
 }
 
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo::Registration &aRegistration)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+    auto args = std::tie(aRegistration.mFreshCount, aRegistration.mDeletedCount, aRegistration.mLeaseTimeTotal,
+                         aRegistration.mKeyLeaseTimeTotal, aRegistration.mRemainingLeaseTimeTotal,
+                         aRegistration.mRemainingKeyLeaseTimeTotal);
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+    SuccessOrExit(error = ConvertToDBusMessage(&sub, args));
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub) == true, error = OTBR_ERROR_DBUS);
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo::Registration &aRegistration)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+    auto args = std::tie(aRegistration.mFreshCount, aRegistration.mDeletedCount, aRegistration.mLeaseTimeTotal,
+                         aRegistration.mKeyLeaseTimeTotal, aRegistration.mRemainingLeaseTimeTotal,
+                         aRegistration.mRemainingKeyLeaseTimeTotal);
+
+    VerifyOrExit(dbus_message_iter_get_arg_type(aIter) == DBUS_TYPE_STRUCT, error = OTBR_ERROR_DBUS);
+    dbus_message_iter_recurse(aIter, &sub);
+    SuccessOrExit(error = ConvertToTuple(&sub, args));
+    dbus_message_iter_next(aIter);
+exit:
+    return error;
+}
+
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo::ResponseCounters &aResponseCounters)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+    auto args = std::tie(aResponseCounters.mSuccess, aResponseCounters.mServerFailure, aResponseCounters.mFormatError,
+                         aResponseCounters.mNameExists, aResponseCounters.mRefused, aResponseCounters.mOther);
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+    SuccessOrExit(error = ConvertToDBusMessage(&sub, args));
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub) == true, error = OTBR_ERROR_DBUS);
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo::ResponseCounters &aResponseCounters)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+    auto args = std::tie(aResponseCounters.mSuccess, aResponseCounters.mServerFailure, aResponseCounters.mFormatError,
+                         aResponseCounters.mNameExists, aResponseCounters.mRefused, aResponseCounters.mOther);
+
+    VerifyOrExit(dbus_message_iter_get_arg_type(aIter) == DBUS_TYPE_STRUCT, error = OTBR_ERROR_DBUS);
+    dbus_message_iter_recurse(aIter, &sub);
+    SuccessOrExit(error = ConvertToTuple(&sub, args));
+    dbus_message_iter_next(aIter);
+exit:
+    return error;
+}
+
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo &aSrpServerInfo)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mState));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mPort));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mAddressMode));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mHosts));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mServices));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aSrpServerInfo.mResponseCounters));
+
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub), error = OTBR_ERROR_DBUS);
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo &aSrpServerInfo)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    dbus_message_iter_recurse(aIter, &sub);
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mState));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mPort));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mAddressMode));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mHosts));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mServices));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aSrpServerInfo.mResponseCounters));
+
+    dbus_message_iter_next(aIter);
+exit:
+    return error;
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -41,6 +41,8 @@
 #include <string>
 #include <vector>
 
+#include <openthread/srp_server.h>
+
 namespace otbr {
 namespace DBus {
 
@@ -515,6 +517,61 @@ struct TxtEntry
 {
     std::string          mKey;
     std::vector<uint8_t> mValue;
+};
+
+enum SrpServerState : uint8_t
+{
+    OTBR_SRP_SERVER_STATE_DISABLED = 0, ///< The SRP server is disabled.
+    OTBR_SRP_SERVER_STATE_RUNNING  = 1, ///< The SRP server is running.
+    OTBR_SRP_SERVER_STATE_STOPPED  = 2, ///< The SRP server is stopped.
+};
+
+static_assert(OTBR_SRP_SERVER_STATE_DISABLED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_DISABLED),
+              "OTBR_SRP_SERVER_STATE_DISABLED value is incorrect");
+static_assert(OTBR_SRP_SERVER_STATE_RUNNING == static_cast<uint8_t>(OT_SRP_SERVER_STATE_RUNNING),
+              "OTBR_SRP_SERVER_STATE_RUNNING value is incorrect");
+static_assert(OTBR_SRP_SERVER_STATE_STOPPED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_STOPPED),
+              "OTBR_SRP_SERVER_STATE_STOPPED value is incorrect");
+
+enum SrpServerAddressMode : uint8_t
+{
+    OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST = 0, ///< Unicast address mode.
+    OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST = 1, ///< Anycast address mode.
+};
+
+static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_UNICAST),
+              "OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST value is incorrect");
+static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_ANYCAST),
+              "OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST value is incorrect");
+
+struct SrpServerInfo
+{
+    struct Registration
+    {
+        uint32_t mFreshCount;
+        uint32_t mDeletedCount;
+        uint64_t mLeaseTimeTotal;
+        uint64_t mKeyLeaseTimeTotal;
+        uint64_t mRemainingLeaseTimeTotal;
+        uint64_t mRemainingKeyLeaseTimeTotal;
+    };
+
+    struct ResponseCounters
+    {
+        uint32_t mSuccess;
+        uint32_t mServerFailure;
+        uint32_t mFormatError;
+        uint32_t mNameExists;
+        uint32_t mRefused;
+        uint32_t mOther;
+    };
+
+    SrpServerState       mState;
+    uint16_t             mPort;
+    SrpServerAddressMode mAddressMode;
+    Registration         mHosts;
+    Registration         mServices;
+    ResponseCounters     mResponseCounters;
 };
 
 } // namespace DBus

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -132,6 +132,7 @@ private:
     otError GetOnMeshPrefixesHandler(DBusMessageIter &aIter);
     otError GetActiveDatasetTlvsHandler(DBusMessageIter &aIter);
     otError GetRadioRegionHandler(DBusMessageIter &aIter);
+    otError GetSrpServerInfoHandler(DBusMessageIter &aIter);
 
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
     void ReplyEnergyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otEnergyScanResult> &aResult);

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -511,6 +511,43 @@
     <property name="RadioRegion" type="s" access="readwrite">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
+
+    <!-- SrpServerInfo: The SRP server information.
+      <literallayout>
+        struct {
+          uint8 state
+          uint16 port
+          uint8 address_mode
+          struct {  // hosts
+            uint32 fresh_count
+            uint32 deleted_count
+            uint64 lease_time_total
+            uint64 key_lease_time_total
+            uint64 remaining_lease_time_total
+            uint64 remaining_key_lease_time_total
+          }
+          struct {  // services
+            uint32 fresh_count
+            uint32 deleted_count
+            uint64 lease_time_total
+            uint64 key_lease_time_total
+            uint64 remaining_lease_time_total
+            uint64 remaining_key_lease_time_total
+          }
+          struct {  // response counters
+            uint32 success
+            uint32 server_failure
+            uint32 format_error
+            uint32 name_exists
+            uint32 refused
+            uint32 other
+          }
+        }
+      </literallayout>
+    -->
+    <property name="SrpServerInfo" type="(yqy(uutttt)(uutttt)(uuuuuu))" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
   </interface>
 
   <interface name="org.freedesktop.DBus.Properties">

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -48,6 +48,7 @@ using otbr::DBus::ExternalRoute;
 using otbr::DBus::Ip6Prefix;
 using otbr::DBus::LinkModeConfig;
 using otbr::DBus::OnMeshPrefix;
+using otbr::DBus::SrpServerInfo;
 using otbr::DBus::ThreadApiDBus;
 using otbr::DBus::TxtEntry;
 
@@ -119,6 +120,34 @@ static void CheckOnMeshPrefix(ThreadApiDBus *aApi)
     TEST_ASSERT(aApi->RemoveOnMeshPrefix(prefix.mPrefix) == OTBR_ERROR_NONE);
     TEST_ASSERT(aApi->GetOnMeshPrefixes(onMeshPrefixes) == OTBR_ERROR_NONE);
     TEST_ASSERT(onMeshPrefixes.empty());
+}
+
+void CheckSrpServerInfo(ThreadApiDBus *aApi)
+{
+    SrpServerInfo srpServerInfo;
+
+    TEST_ASSERT(aApi->GetSrpServerInfo(srpServerInfo) == OTBR_ERROR_NONE);
+    otbrLogInfo("vcd vcd vcd xd vcd %d %d %d ", srpServerInfo.mState, srpServerInfo.mPort, srpServerInfo.mAddressMode);
+    TEST_ASSERT(srpServerInfo.mState == otbr::DBus::OTBR_SRP_SERVER_STATE_RUNNING);
+    TEST_ASSERT(srpServerInfo.mPort != 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mFreshCount == 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mDeletedCount == 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mKeyLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mRemainingLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mHosts.mRemainingKeyLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mFreshCount == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mDeletedCount == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mKeyLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mRemainingLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mServices.mRemainingKeyLeaseTimeTotal == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mSuccess == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mServerFailure == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mFormatError == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mNameExists == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mRefused == 0);
+    TEST_ASSERT(srpServerInfo.mResponseCounters.mOther == 0);
 }
 
 int main()
@@ -222,6 +251,7 @@ int main()
                             TEST_ASSERT(api->GetInstantRssi(rssi) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetRadioTxPower(txPower) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetActiveDatasetTlvs(activeDataset) == OTBR_ERROR_NONE);
+                            CheckSrpServerInfo(api.get());
                             api->FactoryReset(nullptr);
                             TEST_ASSERT(api->GetNetworkName(name) == OTBR_ERROR_NONE);
                             TEST_ASSERT(rloc16 != 0xffff);

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -54,6 +54,8 @@ send "ifconfig up\r\n"
 expect "Done"
 send "thread start\r\n"
 expect "Done"
+send "srp server disable\r\n"
+expect "Done"
 wait
 EOF
     trap on_exit EXIT


### PR DESCRIPTION
This PR implements the D-BUS API `GetSrpServerInfo` for getting the information of the SRP server. 

This PR depends on the new SRP server APIs introduced in https://github.com/openthread/openthread/pull/7680 which is not merged yet. Hence it cannot pass the CI for now. 