### PR TITLE
[meshcop] append last 2 bytes of ext addr to service instance name

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -44,6 +44,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <iomanip>
 #include <random>
 #include <sstream>
 
@@ -107,7 +108,6 @@ BorderAgent::BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp)
 #if OTBR_ENABLE_TREL
     , mTrelDnssd(aNcp, *mPublisher)
 #endif
-    , mServiceInstanceName(kBorderAgentServiceInstanceName)
 {
 }
 
@@ -125,6 +125,8 @@ void BorderAgent::Init(void)
         });
     });
 #endif
+
+    mServiceInstanceName = BaseServiceInstanceName();
 
     Start();
 }
@@ -388,6 +390,18 @@ bool BorderAgent::IsThreadStarted(void) const
     return role == OT_DEVICE_ROLE_CHILD || role == OT_DEVICE_ROLE_ROUTER || role == OT_DEVICE_ROLE_LEADER;
 }
 
+std::string BorderAgent::BaseServiceInstanceName() const
+{
+    const otExtAddress *extAddress = otLinkGetExtendedAddress(mNcp.GetInstance());
+    std::stringstream   ss;
+
+    ss << kBorderAgentServiceInstanceName << " #";
+    ss << std::uppercase << std::hex << std::setfill('0');
+    ss << std::setw(2) << static_cast<int>(extAddress->m8[6]);
+    ss << std::setw(2) << static_cast<int>(extAddress->m8[7]);
+    return ss.str();
+}
+
 std::string BorderAgent::GetAlternativeServiceInstanceName() const
 {
     std::random_device                      r;
@@ -396,7 +410,7 @@ std::string BorderAgent::GetAlternativeServiceInstanceName() const
     uint16_t                                rand = uniform_dist(engine);
     std::stringstream                       ss;
 
-    ss << kBorderAgentServiceInstanceName << " (" << rand << ")";
+    ss << BaseServiceInstanceName() << " (" << rand << ")";
     return ss.str();
 }
 

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -159,6 +159,7 @@ private:
     void HandleThreadStateChanged(otChangedFlags aFlags);
 
     bool        IsThreadStarted(void) const;
+    std::string BaseServiceInstanceName() const;
     std::string GetAlternativeServiceInstanceName() const;
 
     otbr::Ncp::ControllerOpenThread &mNcp;

--- a/tests/scripts/meshcop
+++ b/tests/scripts/meshcop
@@ -104,7 +104,7 @@ readonly OT_NETWORK_NAME=MyTestNetwork
 readonly TUN_NAME=wpan0
 
 # The default meshcop service instance name
-readonly OT_SERVICE_INSTANCE='OpenThread\(\\032\| \)BorderRouter'
+readonly OT_SERVICE_INSTANCE='OpenThread\(\\032\| \)BorderRouter\(\\032\| \)#[0-9A-F][0-9A-F][0-9A-F][0-9A-F]'
 
 echo "ORIGIN_PWD: ${ORIGIN_PWD}"
 echo "TEST_BASE: ${TEST_BASE}"


### PR DESCRIPTION
This PR appends last 2 bytes of extended address to the MeshCoP service instance name. This is used for reducing service instance name conflicts when there are two BRs of the same model connected to the same wifi.

An example of the new service instance name is `OpenThread BorderRouter #B76D`. 