### PR TITLE
[github-actions] pin to Thread Version 1.2

### DIFF
--- a/script/test
+++ b/script/test
@@ -108,6 +108,7 @@ do_build()
     otbr_options=(
         "-DCMAKE_BUILD_TYPE=${OTBR_BUILD_TYPE}"
         "-DCMAKE_INSTALL_PREFIX=/usr"
+        "-DOT_THREAD_VERSION=1.2"
         "-DOTBR_DBUS=ON"
         "-DOTBR_WEB=ON"
         "-DOTBR_UNSECURE_JOIN=ON"


### PR DESCRIPTION
Until the test scripts are updated to support Thread Version 1.3.

Fixes GitHub Actions failures in #1374 

Will submit a subsequent PR to move tests forward to Thread Version 1.3.