### PR TITLE
[agent] remove potential data race on `sShouldTerminate`

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -43,8 +43,8 @@
 
 namespace otbr {
 
-bool                 Application::sShouldTerminate = false;
-const struct timeval Application::kPollTimeout     = {10, 0};
+std::atomic_bool     Application::sShouldTerminate(false);
+const struct timeval Application::kPollTimeout = {10, 0};
 
 Application::Application(const std::string &              aInterfaceName,
                          const std::string &              aBackboneInterfaceName,

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -34,6 +34,7 @@
 #ifndef OTBR_AGENT_APPLICATION_HPP_
 #define OTBR_AGENT_APPLICATION_HPP_
 
+#include <atomic>
 #include <signal.h>
 #include <stdint.h>
 #include <vector>
@@ -135,7 +136,7 @@ private:
     vendor::VendorServer mVendorServer;
 #endif
 
-    static bool sShouldTerminate;
+    static std::atomic_bool sShouldTerminate;
 };
 
 /**


### PR DESCRIPTION
This commit remove potential data race on `sShouldTerminate`, which is accessed in both main loop and the signal handler. 