### PR TITLE
[github-actions] set `fail-fast: false` for matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         build_type: ["Debug", "Release"]
         mdns: ["mDNSResponder", "avahi"]
@@ -93,6 +94,7 @@ jobs:
   rest-check:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         rest: ["rest-off", ""]
     env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
   docker-check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rcp_bus: ["UART", "SPI"]
     env:
@@ -69,6 +70,7 @@ jobs:
   buildx:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - image_tag: "latest"

--- a/.github/workflows/meshcop.yml
+++ b/.github/workflows/meshcop.yml
@@ -49,6 +49,7 @@ jobs:
   meshcop:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         mdns: ["mDNSResponder", "avahi"]
     steps:


### PR DESCRIPTION
This commit sets `fail-fast: false` for matrix in GitHub Actions so
that tests in a matrix do not fail all at once. It's more convenient
now that we can re-run failed tests.