### PR TITLE
[build] fixes for Thread Version configuration

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -91,6 +91,11 @@ otbr_install()
         otbr_options+=(
             "-DOTBR_BACKBONE_ROUTER=ON"
         )
+        if [[ ${REFERENCE_DEVICE} == "1" ]]; then
+            otbr_options+=(
+                "-DOTBR_DUA_ROUTING=ON"
+            )
+        fi
     fi
 
     if [[ ${REFERENCE_DEVICE} == "1" ]]; then

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -67,12 +67,14 @@ if (OTBR_SRP_ADVERTISING_PROXY)
 endif()
 
 if (OTBR_BACKBONE_ROUTER)
-    set(OT_THREAD_VERSION 1.2 CACHE STRING "Backbone Router requires Thread 1.2 or higher" FORCE)
     set(OT_BACKBONE_ROUTER ON CACHE BOOL "Enable Backbone Router feature in OpenThread" FORCE)
     set(OT_SERVICE ON CACHE BOOL "Backbone Router requires Thread network service" FORCE)
 endif()
 
-if (OT_THREAD_VERSION STREQUAL "1.2")
+if (NOT OT_THREAD_VERSION STREQUAL "1.1")
+    if (OT_REFERENCE_DEVICE)
+        set(OT_DUA ON CACHE BOOL "Enable Thread 1.2 DUA for reference devices")
+    endif()
     set(OT_MLR ON CACHE BOOL "Enable Thread 1.2 MLR by default")
 endif()
 


### PR DESCRIPTION
1. Have the OTBR POSIX app use the default Thread version on the stack.
2. Turn on OTBR_DUA_ROUTING and OT_DUA for reference devices.
3. Fix check for version (not 1.1) for DUA and MLR options.