### PR TITLE
[build] link `netfilter_queue` on demand

### DIFF
--- a/src/backbone_router/CMakeLists.txt
+++ b/src/backbone_router/CMakeLists.txt
@@ -35,5 +35,5 @@ add_library(otbr-backbone-router
 target_link_libraries(otbr-backbone-router PRIVATE
     otbr-common
     otbr-utils
-    netfilter_queue
+    $<$<BOOL:${OTBR_DUA_ROUTING}>:netfilter_queue>
 )


### PR DESCRIPTION
Link `netfilter_queue` library only when `OTBR_DUA_ROUTING` is on. 