### PR TITLE
[mdns] downgrade the log level for `Bad Reference` error with `mDNSResponder`

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -340,7 +340,9 @@ void PublisherMDnsSd::Process(const MainloopContext &aMainloop)
 
         if (error != kDNSServiceErr_NoError)
         {
-            otbrLogWarning("DNSServiceProcessResult failed: %s (serviceRef = %p)", DNSErrorToString(error), serviceRef);
+            otbrLogLevel logLevel = (error == kDNSServiceErr_BadReference) ? OTBR_LOG_INFO : OTBR_LOG_WARNING;
+            otbrLog(logLevel, OTBR_LOG_TAG, "DNSServiceProcessResult failed: %s (serviceRef = %p)",
+                    DNSErrorToString(error), serviceRef);
         }
         if (error == kDNSServiceErr_ServiceNotRunning)
         {


### PR DESCRIPTION
Previously `otbr-agent` treats `Bad Reference` error as `Warning` level when logging. However, the `Bad Reference` is sometimes expected.

For example, when're querying PTR record via discovery proxy and there are multiple instances being discovered. 
1. `otbr-agent` calls `GetAddrInfo` on every discovered instance. `ServiceRef`s are created accordingly.
2. In a `Process` call:
   1. All ready `ServiceRef`s are pushed into `readyServices`. Then `otbr-agent` processes every `ServiceRef` in `readyServices`.
   2. When the first `GetAddrInfo` callback returns with a valid address, it finishes the resolution.
   3. Discovery proxy unsubscribes the service. The related `ServiceRefs` are all destructed. However, they are still being referenced in `readyServices`. When a destructed `ServiceRef` is processed, it will throw a `Bad Reference` error.