### PR TITLE
[dbus] fix `dbus/common/types.hpp`

### DIFF
--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -83,10 +83,8 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo::Respons
 otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo::ResponseCounters &aResponseCounters);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const SrpServerInfo &aSrpServerInfo);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, SrpServerInfo &aSrpServerInfo);
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const DnssdCounters &aDnssdCounters);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, DnssdCounters &aDnssdCounters);
-#endif
 
 template <typename T> struct DBusTypeTrait;
 
@@ -242,13 +240,11 @@ template <> struct DBusTypeTrait<SrpServerInfo>
     static constexpr const char *TYPE_AS_STRING = "(yqy(uutttt)(uutttt)(uuuuuu))";
 };
 
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 template <> struct DBusTypeTrait<DnssdCounters>
 {
     // struct of { uint32, uint32, uint32, uint32, uint32, uint32, uint32 }
     static constexpr const char *TYPE_AS_STRING = "(uuuuuuu)";
 };
-#endif
 
 template <> struct DBusTypeTrait<int8_t>
 {

--- a/src/dbus/common/dbus_message_helper_openthread.cpp
+++ b/src/dbus/common/dbus_message_helper_openthread.cpp
@@ -609,7 +609,6 @@ exit:
     return error;
 }
 
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const DnssdCounters &aDnssdCounters)
 {
     DBusMessageIter sub;
@@ -651,7 +650,6 @@ otbrError DBusMessageExtract(DBusMessageIter *aIter, DnssdCounters &aDnssdCounte
 exit:
     return error;
 }
-#endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -41,9 +41,6 @@
 #include <string>
 #include <vector>
 
-#include <openthread/dnssd_server.h>
-#include <openthread/srp_server.h>
-
 namespace otbr {
 namespace DBus {
 
@@ -527,57 +524,57 @@ enum SrpServerState : uint8_t
     OTBR_SRP_SERVER_STATE_STOPPED  = 2, ///< The SRP server is stopped.
 };
 
-static_assert(OTBR_SRP_SERVER_STATE_DISABLED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_DISABLED),
-              "OTBR_SRP_SERVER_STATE_DISABLED value is incorrect");
-static_assert(OTBR_SRP_SERVER_STATE_RUNNING == static_cast<uint8_t>(OT_SRP_SERVER_STATE_RUNNING),
-              "OTBR_SRP_SERVER_STATE_RUNNING value is incorrect");
-static_assert(OTBR_SRP_SERVER_STATE_STOPPED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_STOPPED),
-              "OTBR_SRP_SERVER_STATE_STOPPED value is incorrect");
-
 enum SrpServerAddressMode : uint8_t
 {
     OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST = 0, ///< Unicast address mode.
     OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST = 1, ///< Anycast address mode.
 };
 
-static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_UNICAST),
-              "OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST value is incorrect");
-static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_ANYCAST),
-              "OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST value is incorrect");
-
 struct SrpServerInfo
 {
     struct Registration
     {
-        uint32_t mFreshCount;
-        uint32_t mDeletedCount;
-        uint64_t mLeaseTimeTotal;
-        uint64_t mKeyLeaseTimeTotal;
-        uint64_t mRemainingLeaseTimeTotal;
-        uint64_t mRemainingKeyLeaseTimeTotal;
+        uint32_t mFreshCount;        ///< The number of active hosts/services registered on the SRP server
+        uint32_t mDeletedCount;      ///< The number of hosts/services in 'Deleted' state on the SRP server
+        uint64_t mLeaseTimeTotal;    ///< The sum of lease time in milliseconds of all active hosts/services
+                                     ///< on the SRP server
+        uint64_t mKeyLeaseTimeTotal; ///< The sum of key lease time in milliseconds of all active hosts/services on the
+                                     ///< SRP server
+        uint64_t mRemainingLeaseTimeTotal;    ///< The sum of remaining lease time in milliseconds of all active
+                                              ///< hosts/services on the SRP server
+        uint64_t mRemainingKeyLeaseTimeTotal; ///< The sum of remaining key lease time in milliseconds of all active
+                                              ///< hosts/services on the SRP server
     };
 
     struct ResponseCounters
     {
-        uint32_t mSuccess;
-        uint32_t mServerFailure;
-        uint32_t mFormatError;
-        uint32_t mNameExists;
-        uint32_t mRefused;
-        uint32_t mOther;
+        uint32_t mSuccess;       ///< The number of successful responses
+        uint32_t mServerFailure; ///< The number of server failure responses
+        uint32_t mFormatError;   ///< The number of format error responses
+        uint32_t mNameExists;    ///< The number of 'name exists' responses
+        uint32_t mRefused;       ///< The number of refused responses
+        uint32_t mOther;         ///< The number of other responses
     };
 
-    SrpServerState       mState;
-    uint16_t             mPort;
-    SrpServerAddressMode mAddressMode;
-    Registration         mHosts;
-    Registration         mServices;
-    ResponseCounters     mResponseCounters;
+    SrpServerState       mState;            ///< The state of the SRP server
+    uint16_t             mPort;             ///< The listening port number
+    SrpServerAddressMode mAddressMode;      ///< The address mode {unicast, anycast} of the SRP server
+    Registration         mHosts;            ///< The registration information of hosts on the SRP server
+    Registration         mServices;         ///< The registration information of services on the SRP server
+    ResponseCounters     mResponseCounters; ///< The counters of response codes sent by the SRP server
 };
 
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-typedef otDnssdCounters DnssdCounters;
-#endif
+struct DnssdCounters
+{
+    uint32_t mSuccessResponse;        ///< The number of successful responses
+    uint32_t mServerFailureResponse;  ///< The number of server failure responses
+    uint32_t mFormatErrorResponse;    ///< The number of format error responses
+    uint32_t mNameErrorResponse;      ///< The number of name error responses
+    uint32_t mNotImplementedResponse; ///< The number of 'not implemented' responses
+    uint32_t mOtherResponse;          ///< The number of other responses
+
+    uint32_t mResolvedBySrp; ///< The number of queries completely resolved by the local SRP server
+};
 
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -1254,10 +1254,20 @@ exit:
 otError DBusThreadObject::GetDnssdCountersHandler(DBusMessageIter &aIter)
 {
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    auto          threadHelper  = mNcp->GetThreadHelper();
-    auto          instance      = threadHelper->GetInstance();
-    otError       error         = OT_ERROR_NONE;
-    DnssdCounters dnssdCounters = *otDnssdGetCounters(instance);
+    auto            threadHelper = mNcp->GetThreadHelper();
+    auto            instance     = threadHelper->GetInstance();
+    otError         error        = OT_ERROR_NONE;
+    DnssdCounters   dnssdCounters;
+    otDnssdCounters otDnssdCounters = *otDnssdGetCounters(instance);
+
+    dnssdCounters.mSuccessResponse        = otDnssdCounters.mSuccessResponse;
+    dnssdCounters.mServerFailureResponse  = otDnssdCounters.mServerFailureResponse;
+    dnssdCounters.mFormatErrorResponse    = otDnssdCounters.mFormatErrorResponse;
+    dnssdCounters.mNameErrorResponse      = otDnssdCounters.mNameErrorResponse;
+    dnssdCounters.mNotImplementedResponse = otDnssdCounters.mNotImplementedResponse;
+    dnssdCounters.mOtherResponse          = otDnssdCounters.mOtherResponse;
+
+    dnssdCounters.mResolvedBySrp = otDnssdCounters.mResolvedBySrp;
 
     VerifyOrExit(DBusMessageEncodeToVariant(&aIter, dnssdCounters) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
@@ -1269,6 +1279,18 @@ exit:
     return OT_ERROR_NOT_IMPLEMENTED;
 #endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 }
+
+static_assert(OTBR_SRP_SERVER_STATE_DISABLED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_DISABLED),
+              "OTBR_SRP_SERVER_STATE_DISABLED value is incorrect");
+static_assert(OTBR_SRP_SERVER_STATE_RUNNING == static_cast<uint8_t>(OT_SRP_SERVER_STATE_RUNNING),
+              "OTBR_SRP_SERVER_STATE_RUNNING value is incorrect");
+static_assert(OTBR_SRP_SERVER_STATE_STOPPED == static_cast<uint8_t>(OT_SRP_SERVER_STATE_STOPPED),
+              "OTBR_SRP_SERVER_STATE_STOPPED value is incorrect");
+
+static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_UNICAST),
+              "OTBR_SRP_SERVER_ADDRESS_MODE_UNICAST value is incorrect");
+static_assert(OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST == static_cast<uint8_t>(OT_SRP_SERVER_ADDRESS_MODE_ANYCAST),
+              "OTBR_SRP_SERVER_ADDRESS_MODE_ANYCAST value is incorrect");
 
 } // namespace DBus
 } // namespace otbr

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -155,7 +155,7 @@ void CheckSrpServerInfo(ThreadApiDBus *aApi)
 
 void CheckDnssdCounters(ThreadApiDBus *aApi)
 {
-    OT_UNUSED_VARIABLE(aApi);
+    OTBR_UNUSED_VARIABLE(aApi);
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
     otbr::DBus::DnssdCounters dnssdCounters;
 


### PR DESCRIPTION
According to the convention, we should not use any openthread headers in this `dbus/common/types.hpp`. Introducing the openthread headers may sometimes break downstream builds.