### PR TITLE
[dbus] return delay timer from `AttachAllNodesTo`

### DIFF
--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -175,4 +175,62 @@ protected:
     NonCopyable(void) = default;
 };
 
+template <typename T> class Optional
+{
+public:
+    constexpr Optional(void) = default;
+
+    Optional(T aValue)
+    {
+        new (&mStorage) T(aValue);
+        mHasValue = true;
+    }
+
+    ~Optional(void)
+    {
+        if (mHasValue)
+        {
+            GetValue().~T();
+        }
+    }
+
+    Optional(const Optional &aOther)
+    {
+        if (aOther.mHasValue)
+        {
+            new (&mStorage) T(aOther.GetValue());
+        }
+        mHasValue = aOther.mHasValue;
+    }
+
+    Optional &operator=(const Optional &aOther)
+    {
+        if (mHasValue)
+        {
+            GetValue().~T();
+        }
+        if (aOther.mHasValue)
+        {
+            new (&mStorage) T(aOther.GetValue());
+        }
+        mHasValue = aOther.mHasValue;
+    }
+
+    constexpr const T *operator->(void)const { return &GetValue(); }
+
+    constexpr const T &operator*(void)const { return GetValue(); }
+
+    constexpr bool HasValue(void) const { return mHasValue; }
+
+private:
+    T &GetValue(void) const
+    {
+        VerifyOrDie(mHasValue, "Optional doesn't contain a value");
+        return *const_cast<T *>(reinterpret_cast<const T *>(&mStorage));
+    }
+
+    alignas(T) unsigned char mStorage[sizeof(T)];
+    bool mHasValue = false;
+};
+
 #endif // OTBR_COMMON_CODE_UTILS_HPP_

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -180,41 +180,13 @@ template <typename T> class Optional
 public:
     constexpr Optional(void) = default;
 
-    Optional(T aValue)
-    {
-        new (&mStorage) T(aValue);
-        mHasValue = true;
-    }
+    Optional(T aValue) { SetValue(aValue); }
 
-    ~Optional(void)
-    {
-        if (mHasValue)
-        {
-            GetValue().~T();
-        }
-    }
+    ~Optional(void) { ClearValue(); }
 
-    Optional(const Optional &aOther)
-    {
-        if (aOther.mHasValue)
-        {
-            new (&mStorage) T(aOther.GetValue());
-        }
-        mHasValue = aOther.mHasValue;
-    }
+    Optional(const Optional &aOther) { AssignFrom(aOther); }
 
-    Optional &operator=(const Optional &aOther)
-    {
-        if (mHasValue)
-        {
-            GetValue().~T();
-        }
-        if (aOther.mHasValue)
-        {
-            new (&mStorage) T(aOther.GetValue());
-        }
-        mHasValue = aOther.mHasValue;
-    }
+    Optional &operator=(const Optional &aOther) { AssignFrom(aOther); }
 
     constexpr const T *operator->(void)const { return &GetValue(); }
 
@@ -227,6 +199,31 @@ private:
     {
         VerifyOrDie(mHasValue, "Optional doesn't contain a value");
         return *const_cast<T *>(reinterpret_cast<const T *>(&mStorage));
+    }
+
+    void ClearValue(void)
+    {
+        if (mHasValue)
+        {
+            GetValue().~T();
+            mHasValue = false;
+        }
+    }
+
+    void SetValue(const T &aValue)
+    {
+        ClearValue();
+        new (&mStorage) T(aValue);
+        mHasValue = true;
+    }
+
+    void AssignFrom(const Optional &aOther)
+    {
+        ClearValue();
+        if (aOther.mHasValue)
+        {
+            SetValue(aOther.GetValue());
+        }
     }
 
     alignas(T) unsigned char mStorage[sizeof(T)];

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -37,6 +37,7 @@
 #define OTBR_LOG_TAG "UTILS"
 #endif
 
+#include <assert.h>
 #include <memory>
 #include <stdlib.h>
 
@@ -197,7 +198,7 @@ public:
 private:
     T &GetValue(void) const
     {
-        VerifyOrDie(mHasValue, "Optional doesn't contain a value");
+        assert(mHasValue);
         return *const_cast<T *>(reinterpret_cast<const T *>(&mStorage));
     }
 

--- a/src/dbus/server/dbus_request.hpp
+++ b/src/dbus/server/dbus_request.hpp
@@ -164,6 +164,7 @@ public:
         {
             reply = UniqueDBusMessage(dbus_message_new_error(mMessage, ConvertToDBusErrorName(aError), nullptr));
         }
+        VerifyOrDie(reply != nullptr, "Failed to allocate message");
 
         if (aResult.HasValue())
         {
@@ -172,17 +173,10 @@ public:
 
             dbus_message_iter_init_append(reply.get(), &replyIter);
             error = DBusMessageEncode(&replyIter, *aResult);
-            if (error != OTBR_ERROR_NONE)
-            {
-                otbrLogErr("Failed to encode result: %s", otbrErrorString(error));
-            }
+            VerifyOrDie(error == OTBR_ERROR_NONE, "Failed to encode result");
         }
 
-        VerifyOrExit(reply != nullptr);
         dbus_connection_send(mConnection, reply.get(), nullptr);
-
-    exit:
-        return;
     }
 
     /**

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -336,7 +336,11 @@ void DBusThreadObject::AttachHandler(DBusRequest &aRequest)
 
     if (IsDBusMessageEmpty(*aRequest.GetMessage()))
     {
-        threadHelper->Attach([aRequest](otError aError) mutable { aRequest.ReplyOtResult(aError); });
+        threadHelper->Attach([aRequest](otError aError, int64_t aAttachDelayMs) mutable {
+            OT_UNUSED_VARIABLE(aAttachDelayMs);
+
+            aRequest.ReplyOtResult(aError);
+        });
     }
     else if (DBusMessageToTuple(*aRequest.GetMessage(), args) != OTBR_ERROR_NONE)
     {
@@ -345,7 +349,11 @@ void DBusThreadObject::AttachHandler(DBusRequest &aRequest)
     else
     {
         threadHelper->Attach(name, panid, extPanId, networkKey, pskc, channelMask,
-                             [aRequest](otError aError) mutable { aRequest.ReplyOtResult(aError); });
+                             [aRequest](otError aError, int64_t aAttachDelayMs) mutable {
+                                 OT_UNUSED_VARIABLE(aAttachDelayMs);
+
+                                 aRequest.ReplyOtResult(aError);
+                             });
     }
 }
 
@@ -358,8 +366,9 @@ void DBusThreadObject::AttachAllNodesToHandler(DBusRequest &aRequest)
 
     VerifyOrExit(DBusMessageToTuple(*aRequest.GetMessage(), args) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
-    mNcp->GetThreadHelper()->AttachAllNodesTo(dataset,
-                                              [aRequest](otError error) mutable { aRequest.ReplyOtResult(error); });
+    mNcp->GetThreadHelper()->AttachAllNodesTo(dataset, [aRequest](otError error, int64_t aAttachDelayMs) mutable {
+        aRequest.ReplyOtResult<int64_t>(error, aAttachDelayMs);
+    });
 
 exit:
     if (error != OT_ERROR_NONE)

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -60,9 +60,11 @@
     <!-- AttachAllNodesTo: Request to attach all nodes to the specified Thread network.
       @dataset: The Operational Dataset that contains parameter values of the Thread network
                 to attach to. It must be a full dataset.
+      @delay_ms: The delay between the method returns and the dataset takes effect, in milliseconds.
     -->
     <method name="AttachAllNodesTo">
       <arg name="dataset" type="ay"/>
+      <arg name="delay_ms" type="x" direction="out"/>
     </method>
 
     <!-- Detach: Detach the current device from the Thread network. -->

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -60,7 +60,11 @@
     <!-- AttachAllNodesTo: Request to attach all nodes to the specified Thread network.
       @dataset: The Operational Dataset that contains parameter values of the Thread network
                 to attach to. It must be a full dataset.
-      @delay_ms: The delay between the method returns and the dataset takes effect, in milliseconds.
+      @delay_ms: The delay between the method returns and the dataset takes effect, in
+                 milliseconds. If this value is 0, then the node is attached to the given network
+                 when this method returns. If this value is not 0, then the node is attached to
+                 its existing network when this method returns, and will attach to the given
+                 network after the delay.
     -->
     <method name="AttachAllNodesTo">
       <arg name="dataset" type="ay"/>

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -583,15 +583,15 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, At
         if (hasActiveDataset)
         {
             mAttachDelayMs            = kDelayTimerMilliseconds;
-            mAttachHandler            = aHandler;
             mAttachPendingDatasetTlvs = datasetTlvs;
-            ExitNow();
         }
         else
         {
-            aHandler(OT_ERROR_NONE, 0);
-            ExitNow();
+            mAttachDelayMs            = 0;
+            mAttachPendingDatasetTlvs = {};
         }
+        mAttachHandler = aHandler;
+        ExitNow();
     }
 
     SuccessOrExit(error = otDatasetSendMgmtPendingSet(mInstance, &emptyDataset, datasetTlvs.mTlvs, datasetTlvs.mLength,

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -94,10 +94,10 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
             {
                 if (mAttachPendingDatasetTlvs.mLength == 0)
                 {
-                    ResultHandler handler = mAttachHandler;
+                    AttachHandler handler = mAttachHandler;
 
                     mAttachHandler = nullptr;
-                    handler(OT_ERROR_NONE);
+                    handler(OT_ERROR_NONE, mAttachDelayMs);
                 }
                 else
                 {
@@ -107,11 +107,11 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
                                                     mAttachPendingDatasetTlvs.mLength, MgmtSetResponseHandler, this);
                     if (error != OT_ERROR_NONE)
                     {
-                        ResultHandler handler = mAttachHandler;
+                        AttachHandler handler = mAttachHandler;
 
                         mAttachHandler            = nullptr;
                         mAttachPendingDatasetTlvs = {};
-                        handler(error);
+                        handler(error, 0);
                     }
                 }
             }
@@ -281,7 +281,7 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
                           const std::vector<uint8_t> &aNetworkKey,
                           const std::vector<uint8_t> &aPSKc,
                           uint32_t                    aChannelMask,
-                          ResultHandler               aHandler)
+                          AttachHandler               aHandler)
 
 {
     otError         error = OT_ERROR_NONE;
@@ -358,6 +358,7 @@ void ThreadHelper::Attach(const std::string &         aNetworkName,
     SuccessOrExit(error = otThreadSetPskc(mInstance, &pskc));
 
     SuccessOrExit(error = otThreadSetEnabled(mInstance, true));
+    mAttachDelayMs = 0;
     mAttachHandler = aHandler;
 
 exit:
@@ -365,12 +366,12 @@ exit:
     {
         if (aHandler)
         {
-            aHandler(error);
+            aHandler(error, 0);
         }
     }
 }
 
-void ThreadHelper::Attach(ResultHandler aHandler)
+void ThreadHelper::Attach(AttachHandler aHandler)
 {
     otError error = OT_ERROR_NONE;
 
@@ -388,7 +389,7 @@ exit:
     {
         if (aHandler)
         {
-            aHandler(error);
+            aHandler(error, 0);
         }
     }
 }
@@ -499,7 +500,7 @@ void ThreadHelper::LogOpenThreadResult(const char *aAction, otError aError)
     }
 }
 
-void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, ResultHandler aHandler)
+void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, AttachHandler aHandler)
 {
     constexpr uint32_t kDelayTimerMilliseconds = 300 * 1000;
 
@@ -581,25 +582,27 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, Re
 
         if (hasActiveDataset)
         {
+            mAttachDelayMs            = kDelayTimerMilliseconds;
             mAttachHandler            = aHandler;
             mAttachPendingDatasetTlvs = datasetTlvs;
             ExitNow();
         }
         else
         {
-            aHandler(OT_ERROR_NONE);
+            aHandler(OT_ERROR_NONE, 0);
             ExitNow();
         }
     }
 
     SuccessOrExit(error = otDatasetSendMgmtPendingSet(mInstance, &emptyDataset, datasetTlvs.mTlvs, datasetTlvs.mLength,
                                                       MgmtSetResponseHandler, this));
+    mAttachDelayMs = kDelayTimerMilliseconds;
     mAttachHandler = aHandler;
 
 exit:
     if (error != OT_ERROR_NONE)
     {
-        aHandler(error);
+        aHandler(error, 0);
     }
 }
 
@@ -610,7 +613,8 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult, void *aContext)
 
 void ThreadHelper::MgmtSetResponseHandler(otError aResult)
 {
-    ResultHandler handler;
+    AttachHandler handler;
+    int64_t       attachDelayMs;
 
     LogOpenThreadResult("MgmtSetResponseHandler()", aResult);
 
@@ -626,10 +630,19 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult)
         break;
     }
 
+    attachDelayMs             = mAttachDelayMs;
     handler                   = mAttachHandler;
+    mAttachDelayMs            = 0;
     mAttachHandler            = nullptr;
     mAttachPendingDatasetTlvs = {};
-    handler(aResult);
+    if (aResult == OT_ERROR_NONE)
+    {
+        handler(aResult, attachDelayMs);
+    }
+    else
+    {
+        handler(aResult, 0);
+    }
 }
 
 #if OTBR_ENABLE_UNSECURE_JOIN

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -67,6 +67,7 @@ public:
     using ScanHandler             = std::function<void(otError, const std::vector<otActiveScanResult> &)>;
     using EnergyScanHandler       = std::function<void(otError, const std::vector<otEnergyScanResult> &)>;
     using ResultHandler           = std::function<void(otError)>;
+    using AttachHandler           = std::function<void(otError, int64_t)>;
     using UpdateMeshCopTxtHandler = std::function<void(std::map<std::string, std::vector<uint8_t>>)>;
 
     /**
@@ -134,7 +135,7 @@ public:
                 const std::vector<uint8_t> &aNetworkKey,
                 const std::vector<uint8_t> &aPSKc,
                 uint32_t                    aChannelMask,
-                ResultHandler               aHandler);
+                AttachHandler               aHandler);
 
     /**
      * This method detaches the device from the Thread network.
@@ -153,7 +154,7 @@ public:
      * @param[in] aHandler  The attach result handler.
      *
      */
-    void Attach(ResultHandler aHandler);
+    void Attach(AttachHandler aHandler);
 
     /**
      * This method makes all nodes in the current network attach to the network specified by the dataset TLVs.
@@ -162,7 +163,7 @@ public:
      * @param[in] aHandler      The result handler.
      *
      */
-    void AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, ResultHandler aHandler);
+    void AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, AttachHandler aHandler);
 
     /**
      * This method resets the OpenThread stack.
@@ -277,7 +278,8 @@ private:
 
     std::map<uint16_t, size_t> mUnsecurePortRefCounter;
 
-    ResultHandler mAttachHandler;
+    int64_t       mAttachDelayMs = 0;
+    AttachHandler mAttachHandler;
     ResultHandler mJoinerHandler;
 
     otOperationalDatasetTlvs mAttachPendingDatasetTlvs = {};

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -237,6 +237,7 @@ EOF
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
         | grep "int64 0"
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep "leader"
 
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
     sleep 1

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -219,7 +219,8 @@ EOF
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
-        "array:byte:${dataset}"
+        "array:byte:${dataset}" \
+        | grep "int64 300000"
 
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset pending | grep "Active Timestamp: 2"
 
@@ -227,6 +228,15 @@ EOF
 
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset active | grep "Active Timestamp: 2"
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl networkkey | grep be3bd244ae6d997020a882a24a8040e2
+
+    sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
+    sleep 1
+
+    sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
+        io.openthread.BorderRouter.AttachAllNodesTo \
+        "array:byte:${dataset}" \
+        | grep "int64 0"
 
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl factoryreset
     sleep 1
@@ -249,7 +259,8 @@ EOF
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
-        "array:byte:${dataset}"
+        "array:byte:${dataset}" \
+        | grep "int64 300000"
 
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl state | grep "leader"
     sudo "${CMAKE_BINARY_DIR}"/third_party/openthread/repo/src/posix/ot-ctl dataset pending | grep "Active Timestamp: 2"


### PR DESCRIPTION
This commit:
1. Makes the DBus API `AttachAllNodesTo` return the delay between the method returns and the dataset takes effect.
2. Ensures that when `AttachAllNodesTo` returns, the node is attached.