### PR TITLE
[continuous-integration] replace `Hirsute` with `Jammy` as the Ubuntu release in docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,8 +83,8 @@ jobs:
             build_args: ""
             platforms: "linux/amd64,linux/arm64"
             push: yes
-          - image_tag: "hirsute"
-            base_image: "ubuntu:hirsute"
+          - image_tag: "jammy"
+            base_image: "ubuntu:jammy"
             build_args: ""
             platforms: "linux/amd64,linux/arm64"
             push: yes


### PR DESCRIPTION
`Hirsute` has reached end of life: https://fridge.ubuntu.com/2022/01/21/ubuntu-21-04-hirsute-hippo-end-of-life-reached-on-january-20-2022. It causes CI failures like https://github.com/openthread/ot-br-posix/runs/7494641990?check_suite_focus=true. 
We should test it on the latest Ubuntu LTS `Jammy` instead. 