### PR TITLE
[tests] upgrade pip before installing cmake

### DIFF
--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -68,6 +68,7 @@ install_common_dependencies()
 
 install_openthread_binraries()
 {
+    pip3 install -U pip
     pip3 install -U cmake
     cd third_party/openthread/repo
     mkdir -p build && cd build


### PR DESCRIPTION
To avoid errors such as this: https://github.com/openthread/ot-br-posix/runs/7634987232?check_suite_focus=true