### PR TITLE
[advertising-proxy] don't publish mesh local addresses for hosts

### DIFF
--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -102,6 +102,8 @@ private:
     static Mdns::Publisher::SubTypeList MakeSubTypeList(const otSrpServerService *aSrpService);
     void                                OnMdnsPublishResult(otSrpServerServiceUpdateId aUpdateId, otbrError aError);
 
+    std::vector<Ip6Address> GetEligibleAddresses(const otIp6Address *aHostAddresses, uint8_t aHostAddressNum);
+
     /**
      * This method publishes a specified host and its services.
      *


### PR DESCRIPTION
This PR lets advertising proxy filter out mesh local addresses when publishing SRP hosts. If an SRP host only has mesh local addresses, the advertising proxy will register the service by mDNS with no address.