### PR TITLE
[advertising-proxy] support publishing multiple host addresses

### DIFF
--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -92,9 +92,9 @@ protected:
                                  uint16_t           aPort,
                                  const TxtList &    aTxtList,
                                  ResultCallback &&  aCallback) override;
-    void      PublishHostImpl(const std::string &         aName,
-                              const std::vector<uint8_t> &aAddress,
-                              ResultCallback &&           aCallback) override;
+    void      PublishHostImpl(const std::string &            aName,
+                              const std::vector<Ip6Address> &aAddresses,
+                              ResultCallback &&              aCallback) override;
     void      OnServiceResolveFailedImpl(const std::string &aType,
                                          const std::string &aInstanceName,
                                          int32_t            aErrorCode) override;
@@ -139,12 +139,12 @@ private:
     class AvahiHostRegistration : public HostRegistration
     {
     public:
-        AvahiHostRegistration(const std::string &         aName,
-                              const std::vector<uint8_t> &aAddress,
-                              ResultCallback &&           aCallback,
-                              AvahiEntryGroup *           aEntryGroup,
-                              PublisherAvahi *            aPublisher)
-            : HostRegistration(aName, aAddress, std::move(aCallback), aPublisher)
+        AvahiHostRegistration(const std::string &            aName,
+                              const std::vector<Ip6Address> &aAddresses,
+                              ResultCallback &&              aCallback,
+                              AvahiEntryGroup *              aEntryGroup,
+                              PublisherAvahi *               aPublisher)
+            : HostRegistration(aName, aAddresses, std::move(aCallback), aPublisher)
             , mEntryGroup(aEntryGroup)
         {
         }

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -89,9 +89,9 @@ protected:
                                  uint16_t           aPort,
                                  const TxtList &    aTxtList,
                                  ResultCallback &&  aCallback) override;
-    void      PublishHostImpl(const std::string &         aName,
-                              const std::vector<uint8_t> &aAddress,
-                              ResultCallback &&           aCallback) override;
+    void      PublishHostImpl(const std::string &            aName,
+                              const std::vector<Ip6Address> &aAddress,
+                              ResultCallback &&              aCallback) override;
     void      OnServiceResolveFailedImpl(const std::string &aType,
                                          const std::string &aInstanceName,
                                          int32_t            aErrorCode) override;
@@ -135,25 +135,29 @@ private:
     class DnssdHostRegistration : public HostRegistration
     {
     public:
-        DnssdHostRegistration(const std::string &         aName,
-                              const std::vector<uint8_t> &aAddress,
-                              ResultCallback &&           aCallback,
-                              DNSServiceRef               aServiceRef,
-                              DNSRecordRef                aRecordRef,
-                              Publisher *                 aPublisher)
-            : HostRegistration(aName, aAddress, std::move(aCallback), aPublisher)
+        DnssdHostRegistration(const std::string &            aName,
+                              const std::vector<Ip6Address> &aAddresses,
+                              ResultCallback &&              aCallback,
+                              DNSServiceRef                  aServiceRef,
+                              Publisher *                    aPublisher)
+            : HostRegistration(aName, aAddresses, std::move(aCallback), aPublisher)
             , mServiceRef(aServiceRef)
-            , mRecordRef(aRecordRef)
+            , mRecordRefMap()
+            , mCallbackCount(aAddresses.size())
         {
         }
 
         ~DnssdHostRegistration(void) override;
-        const DNSServiceRef &GetServiceRef() const { return mServiceRef; }
-        const DNSRecordRef & GetRecordRef() const { return mRecordRef; }
+        const DNSServiceRef &                     GetServiceRef() const { return mServiceRef; }
+        const std::map<DNSRecordRef, Ip6Address> &GetRecordRefMap() const { return mRecordRefMap; }
+        std::map<DNSRecordRef, Ip6Address> &      GetRecordRefMap() { return mRecordRefMap; }
 
     private:
         DNSServiceRef mServiceRef;
-        DNSRecordRef  mRecordRef;
+
+    public:
+        std::map<DNSRecordRef, Ip6Address> mRecordRefMap;
+        uint32_t                           mCallbackCount;
     };
 
     struct ServiceRef : private ::NonCopyable

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -300,16 +300,13 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
     if (!hostDeleted)
     {
         std::vector<Ip6Address> addresses;
-        std::vector<uint8_t>    firstHostAddress;
 
         // TODO: select a preferred address or advertise all addresses from SRP client.
         otbrLogDebug("Publish SRP host '%s'", fullHostName.c_str());
 
         addresses = GetEligibleAddresses(hostAddresses, hostAddressNum);
-        VerifyOrExit(!addresses.empty(), OnMdnsPublishResult(updateId, error = OTBR_ERROR_NONE));
-        firstHostAddress.assign(std::begin(addresses.front().m8), std::end(addresses.front().m8));
         mPublisher.PublishHost(
-            hostName, firstHostAddress,
+            hostName, addresses,
             Mdns::Publisher::ResultCallback([this, hasUpdate, updateId, fullHostName](otbrError aError) {
                 otbrLogResult(aError, "Handle publish SRP host '%s'", fullHostName.c_str());
                 if (hasUpdate)

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -84,10 +84,10 @@ int RunMainloop(void)
 
 void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State aState)
 {
-    uint8_t              xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t              extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    std::vector<uint8_t> hostAddr(16, 0);
-    const char           hostName[] = "custom-host";
+    uint8_t    xpanid[kSizeExtPanId]           = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t    extAddr[kSizeExtAddr]           = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t    hostAddr[OTBR_IP6_ADDRESS_SIZE] = {0};
+    const char hostName[]                      = "custom-host";
 
     hostAddr[0]  = 0x20;
     hostAddr[1]  = 0x02;
@@ -99,7 +99,7 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
 
-        sContext.mPublisher->PublishHost(hostName, hostAddr,
+        sContext.mPublisher->PublishHost(hostName, {Ip6Address(hostAddr)},
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
@@ -110,11 +110,11 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
 
 void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::State aState)
 {
-    uint8_t              xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    uint8_t              extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    std::vector<uint8_t> hostAddr(16, 0);
-    const char           hostName1[] = "custom-host-1";
-    const char           hostName2[] = "custom-host-2";
+    uint8_t    xpanid[kSizeExtPanId]           = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t    extAddr[kSizeExtAddr]           = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    uint8_t    hostAddr[OTBR_IP6_ADDRESS_SIZE] = {0};
+    const char hostName1[]                     = "custom-host-1";
+    const char hostName2[]                     = "custom-host-2";
 
     hostAddr[0]  = 0x20;
     hostAddr[1]  = 0x02;
@@ -126,7 +126,7 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
 
-        sContext.mPublisher->PublishHost(hostName1, hostAddr,
+        sContext.mPublisher->PublishHost(hostName1, {Ip6Address(hostAddr)},
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
@@ -137,8 +137,9 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
             hostName1, "MultipleService12", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second service"); });
 
-        sContext.mPublisher->PublishHost(
-            hostName2, hostAddr, [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second host"); });
+        sContext.mPublisher->PublishHost(hostName2, {Ip6Address(hostAddr)}, [](otbrError aError) {
+            SuccessOrDie(aError, "cannot publish the second host");
+        });
 
         sContext.mPublisher->PublishService(
             hostName2, "MultipleService21", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,


### PR DESCRIPTION
This PR:

- Allows Advertising Proxy to publish multiple host addresses. 
- Allows Publisher to publish multiple host addresses.

Test is covered in https://github.com/openthread/openthread/pull/8003/.