### PR TITLE
[web] call npm install when necessary

### DIFF
--- a/script/test
+++ b/script/test
@@ -128,7 +128,7 @@ do_clean()
 do_check()
 {
     (cd "${OTBR_TOP_BUILDDIR}" \
-        && sudo ninja install \
+        && ninja && sudo ninja install \
         && CTEST_OUTPUT_ON_FAILURE=1 ninja test)
 }
 

--- a/src/web/web-service/frontend/CMakeLists.txt
+++ b/src/web/web-service/frontend/CMakeLists.txt
@@ -41,8 +41,12 @@ set(NPM_JS_DEPENDENCIES
 )
 
 add_custom_target(otbr-web-frontend
+    DEPENDS ${NPM_CSS_DEPENDENCIES} ${NPM_JS_DEPENDENCIES})
+
+add_custom_command(OUTPUT ${NPM_CSS_DEPENDENCIES} ${NPM_JS_DEPENDENCIES}
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/package.json .
-    COMMAND npm install)
+    COMMAND npm install
+    DEPENDS package.json)
 
 install(FILES index.html join.dialog.html
     DESTINATION ${OTBR_WEB_DATADIR}/frontend)


### PR DESCRIPTION
This commit makes `npm install` only be called when necessary, i.e.
package.json is updated or the output files are not generated.
