### PR TITLE
[agent] save region code

### DIFF
--- a/script/test
+++ b/script/test
@@ -110,9 +110,10 @@ do_build()
         "-DCMAKE_INSTALL_PREFIX=/usr"
         "-DOT_THREAD_VERSION=1.3"
         "-DOTBR_DBUS=ON"
-        "-DOTBR_WEB=ON"
-        "-DOTBR_UNSECURE_JOIN=ON"
+        "-DOTBR_REGION_FILE=/tmp/otbr-region-file"
         "-DOTBR_TREL=ON"
+        "-DOTBR_UNSECURE_JOIN=ON"
+        "-DOTBR_WEB=ON"
         ${otbr_options[@]+"${otbr_options[@]}"}
     )
 

--- a/src/dbus/server/CMakeLists.txt
+++ b/src/dbus/server/CMakeLists.txt
@@ -35,6 +35,10 @@ add_custom_target(otbr-dbus-introspect-header ALL
 )
 
 option(OTBR_ENABLE_LEGACY "enable legacy support")
+set(OTBR_REGION_FILE "" CACHE STRING "file to save region code")
+if (OTBR_REGION_FILE)
+    target_compile_definitions(otbr-config INTERFACE "OTBR_REGION_FILE=\"${OTBR_REGION_FILE}\"")
+endif()
 
 add_library(otbr-dbus-server STATIC
     dbus_agent.cpp

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -208,7 +208,20 @@ int main()
 
     TEST_ASSERT(api->SetRadioRegion("US") == ClientError::ERROR_NONE);
     TEST_ASSERT(api->GetRadioRegion(region) == ClientError::ERROR_NONE);
+    printf("region is: %s\n", region.c_str());
     TEST_ASSERT(region == "US");
+#ifdef OTBR_REGION_FILE
+    {
+        char savedRegion[sizeof("US")];
+
+        printf("reading saved region code: ");
+        FILE *regionFile = fopen(OTBR_REGION_FILE, "r");
+        fscanf(regionFile, "%s", savedRegion);
+        fclose(regionFile);
+        printf("%s\n", savedRegion);
+        TEST_ASSERT(strcmp(savedRegion, "US") == 0);
+    }
+#endif
 
     api->EnergyScan(scanDuration, [&stepDone](const std::vector<EnergyScanResult> &aResult) {
         TEST_ASSERT(!aResult.empty());


### PR DESCRIPTION
This commit adds a feature for otbr-agent to save the region code set by d-bus
API and apply this region code after restart.

Verified by manual test and new integration test.