### PR TITLE
[script] don't use cached version strings if re-installing OTBR

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -70,6 +70,9 @@ otbr_install()
         "-DOTBR_SRP_ADVERTISING_PROXY=ON"
         "-DOTBR_INFRA_IF_NAME=${INFRA_IF_NAME}"
         "-DOTBR_MDNS=${OTBR_MDNS:=mDNSResponder}"
+        # Force re-evaluation of version strings
+        "-DOTBR_VERSION="
+        "-DOT_PACKAGE_VERSION="
         "${otbr_options[@]}"
     )
 


### PR DESCRIPTION
Force re-evaluation of OTBR version strings (both OTBR version for otbr-agent daemon and OT version for the POSIX stack) if not supplied by the user.  This prevents them from using previously cached values from CMakeCache in case the project is being re-built over a previously installed / cached version.