### PR TITLE
[github-actions] add NAT64 env

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -116,6 +116,7 @@ jobs:
       INTER_OP: 0
       INTER_OP_BBR: 0
       BORDER_ROUTING: ${{ matrix.border_routing }}
+      NAT64: ${{ matrix.nat64 }}
       MAX_JOBS: 3
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
To address this failure: https://github.com/openthread/ot-br-posix/runs/7861845103?check_suite_focus=true

```
======================================================================
FAIL: test (__main__.Nat64MultiBorderRouter)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py", line 118, in test
    self.assertEqual(nat64_prefix, br2_infra_nat64_prefix)
AssertionError: 'fd67:b595:c3ab:2:0:0::/96' != 'fdf9:4f70:b5e2:2:0:0::/96'
- fd67:b595:c3ab:2:0:0::/96
+ fdf9:4f70:b5e2:2:0:0::/96


----------------------------------------------------------------------
```