### PR TITLE
[nat64] link libanl library to the otbr-agent module in Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -151,6 +151,7 @@ LOCAL_STATIC_LIBRARIES += \
     libopenthread-mbedtls \
 
 LOCAL_LDLIBS := \
+    -lanl \
     -lutil
 
 ifeq ($(OTBR_MDNS),mDNSResponder)


### PR DESCRIPTION
This PR links the `libanl` library to the otbr-agent module in Android.mk. This library is needed for properly referencing the `getaddrinfo_a` function in openthread/src/posix/platform/netif.cpp