### PR TITLE
[nat64] fix the condition to enable ot nat64 translator and not install tayga

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -110,7 +110,7 @@ otbr_install()
         )
     fi
 
-    if [[ ${NAT64:-} == "1" && ${NAT64_SERVICE:-} == "openthread" ]]; then
+    if with NAT64 && [[ ${NAT64_SERVICE:-} == "openthread" ]]; then
         otbr_options+=(
             "-DOT_NAT64_TRANSLATOR=ON"
             "-DOT_NAT64_BORDER_ROUTING=ON"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -71,7 +71,7 @@ install_packages_apt()
 
     # nat64
     without NAT64 || {
-        "$NAT64_SERVICE" != "tayga" || sudo apt-get install --no-install-recommends -y tayga
+        [ "$NAT64_SERVICE" != "tayga" ] || sudo apt-get install --no-install-recommends -y tayga
         sudo apt-get install --no-install-recommends -y iptables
     }
 
@@ -128,7 +128,7 @@ install_packages_rpm()
     sudo $PM install -y dbus-devel
     sudo $PM install -y avahi avahi-devel
     sudo $PM install -y boost-devel boost-filesystem boost-system
-    "$NAT64_SERVICE" != "tayga" || sudo $PM install -y tayga
+    [ "$NAT64_SERVICE" != "tayga" ] || sudo $PM install -y tayga
     sudo $PM install -y iptables
     sudo $PM install -y jsoncpp-devel
     sudo $PM install -y wget


### PR DESCRIPTION
This PR fixes the conditions to enable the openthread NAT64 and to disable installing tayga.