### PR TITLE
[build] correct the condition when complaining about DNS64

### DIFF
--- a/script/_dns64
+++ b/script/_dns64
@@ -38,7 +38,7 @@ DNS64_CONF="dns64 $(echo $NAT64_PREFIX | tr \"/\" \"/\") { clients { thread; }; 
 
 # Currently solution was verified only on raspbian and ubuntu.
 #
-without NAT64 || test "$PLATFORM" = ubuntu || test "$PLATFORM" = beagleboneblack || test "$PLATFORM" = raspbian || die "dns64 is not tested under $PLATFORM."
+without NAT64 || without DNS64 || test "$PLATFORM" = ubuntu || test "$PLATFORM" = beagleboneblack || test "$PLATFORM" = raspbian || die "dns64 is not tested under $PLATFORM."
 
 if [ "$PLATFORM" = raspbian ]; then
     RESOLV_CONF_HEAD=/etc/resolv.conf.head


### PR DESCRIPTION
When building on Debian with NAT64=1 and DNS64=0, the setup script will complain "dns64 is not tested on debian"

Since DNS64 is not necessary for NAT64, the script should continue in this case instead of die.