### PR TITLE
[nat64] enable NAT64 on start

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -92,6 +92,11 @@ if(OTBR_NOTIFY_UPSTART)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_NOTIFY_UPSTART=1)
 endif()
 
+option(OTBR_NAT64 "Enable NAT64 support" OFF)
+if(OTBR_NAT64)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_NAT64=1)
+endif()
+
 option(OTBR_VENDOR_INFRA_LINK_SELECT "Enable Vendor-specific infrastructure link selection rules" OFF)
 if(OTBR_VENDOR_INFRA_LINK_SELECT)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_VENDOR_INFRA_LINK_SELECT=1)

--- a/script/_otbr
+++ b/script/_otbr
@@ -112,8 +112,7 @@ otbr_install()
 
     if with NAT64 && [[ ${NAT64_SERVICE:-} == "openthread" ]]; then
         otbr_options+=(
-            "-DOT_NAT64_TRANSLATOR=ON"
-            "-DOT_NAT64_BORDER_ROUTING=ON"
+            "-DOTBR_NAT64=ON"
             "-DOT_POSIX_NAT64_CIDR=${NAT64_DYNAMIC_POOL:-192.168.255.0/24}"
         )
     fi

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -175,12 +175,11 @@ void ControllerOpenThread::Init(void)
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     otSrpServerSetEnabled(mInstance, /* aEnabled */ true);
 #endif
+#if OTBR_ENABLE_NAT64
+    otNat64SetEnabled(mInstance, /* aEnabled */ true);
+#endif
 
     mThreadHelper = std::unique_ptr<otbr::agent::ThreadHelper>(new otbr::agent::ThreadHelper(mInstance, this));
-
-#if OTBR_ENABLE_NAT64
-    otNat64SetEnabled(mInstance, true);
-#endif
 
 exit:
     SuccessOrDie(error, "Failed to initialize NCP!");

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -37,6 +37,7 @@
 #include <openthread/backbone_router_ftd.h>
 #include <openthread/dataset.h>
 #include <openthread/logging.h>
+#include <openthread/nat64.h>
 #include <openthread/srp_server.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
@@ -176,6 +177,10 @@ void ControllerOpenThread::Init(void)
 #endif
 
     mThreadHelper = std::unique_ptr<otbr::agent::ThreadHelper>(new otbr::agent::ThreadHelper(mInstance, this));
+
+#if OTBR_ENABLE_NAT64
+    otNat64SetEnabled(mInstance, true);
+#endif
 
 exit:
     SuccessOrDie(error, "Failed to initialize NCP!");

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -86,6 +86,9 @@ if (OTBR_DNSSD_DISCOVERY_PROXY)
     set(OT_DNSSD_SERVER ON CACHE BOOL "enable DNS-SD server support" FORCE)
 endif()
 
+set(OT_NAT64_TRANSLATOR ${OTBR_NAT64} CACHE BOOL "enable NAT64 translator" FORCE)
+set(OT_NAT64_BORDER_ROUTING ${OTBR_NAT64} CACHE BOOL "enable NAT64 in border routing manager" FORCE)
+
 if (NOT OT_POSIX_SETTINGS_PATH)
     set(OT_POSIX_SETTINGS_PATH "\"/var/lib/thread\"" CACHE STRING "set the directory to store Thread data" FORCE)
 endif()


### PR DESCRIPTION
This PR adds the OTBR_NAT64 flag since we cannot use OT_CONFIG_NAT64_* flags in ot-br-posix.

Note: We will remove tayga support later, and https://github.com/openthread/ot-br-posix/pull/1539/ is merged, so in `script/_otbr` we only enable OTBR_NAT64 when NAT64 is set and NAT64_SERVICE is openthread.