### PR TITLE
[dbus] implement D-BUS API `GetBorderRoutingCounters`

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -42,6 +42,11 @@ endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
 
+option(OTBR_BORDER_ROUTING_COUNTERS "Enable Border Routing COUNTERS" ON)
+if (OTBR_BORDER_ROUTING AND OTBR_BORDER_ROUTING_COUNTERS)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING_COUNTERS=1)
+endif()
+
 option(OTBR_DBUS "Enable DBus support" OFF)
 if(OTBR_DBUS)
     pkg_check_modules(DBUS REQUIRED dbus-1)

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -42,7 +42,7 @@ endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
 
-option(OTBR_BORDER_ROUTING_COUNTERS "Enable Border Routing COUNTERS" ON)
+option(OTBR_BORDER_ROUTING_COUNTERS "Enable Border Routing Counters" ON)
 if (OTBR_BORDER_ROUTING AND OTBR_BORDER_ROUTING_COUNTERS)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING_COUNTERS=1)
 endif()

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -79,7 +79,7 @@ ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-c
   libnetfilter-queue-dev
 
 # Required for OpenThread Backbone CI
-ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential
+ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential python3-dbus
 
 # Required and installed during build (script/bootstrap) when RELEASE=1, could be removed
 ENV OTBR_NORELEASE_DEPS \

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -105,6 +105,7 @@
 #define OTBR_DBUS_PROPERTY_RCP_INTERFACE_METRICS "RcpInterfaceMetrics"
 #define OTBR_DBUS_PROPERTY_UPTIME "Uptime"
 #define OTBR_DBUS_PROPERTY_RADIO_COEX_METRICS "RadioCoexMetrics"
+#define OTBR_DBUS_PROPERTY_BORDER_ROUTING_COUNTERS "BorderRoutingCounters"
 
 #define OTBR_ROLE_NAME_DISABLED "disabled"
 #define OTBR_ROLE_NAME_DETACHED "detached"

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -95,6 +95,10 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const RcpInterfaceMetrics &a
 otbrError DBusMessageExtract(DBusMessageIter *aIter, RcpInterfaceMetrics &aRcpInterfaceMetrics);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const RadioCoexMetrics &aRadioCoexMetrics);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, RadioCoexMetrics &aRadioCoexMetrics);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const BorderRoutingCounters::PacketsAndBytes &aPacketAndBytes);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, BorderRoutingCounters::PacketsAndBytes &aPacketAndBytes);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const BorderRoutingCounters &aBorderRoutingCounters);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, BorderRoutingCounters &aBorderRoutingCounters);
 
 template <typename T> struct DBusTypeTrait;
 
@@ -284,6 +288,15 @@ template <> struct DBusTypeTrait<RadioCoexMetrics>
     //             uint32, uint32, uint32, uint32, uint32, uint32, uint32, uint32,
     //             uint32, uint32, bool }
     static constexpr const char *TYPE_AS_STRING = "(uuuuuuuuuuuuuuuuuub)";
+};
+
+template <> struct DBusTypeTrait<BorderRoutingCounters>
+{
+    // struct of { struct of { uint64, uint64 },
+    //             struct of { uint64, uint64 },
+    //             struct of { uint64, uint64 },
+    //             struct of { uint64, uint64 } }
+    static constexpr const char *TYPE_AS_STRING = "((tt)(tt)(tt)(tt))";
 };
 
 template <> struct DBusTypeTrait<int8_t>

--- a/src/dbus/common/dbus_message_helper_openthread.cpp
+++ b/src/dbus/common/dbus_message_helper_openthread.cpp
@@ -873,5 +873,73 @@ exit:
     return error;
 }
 
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const BorderRoutingCounters::PacketsAndBytes &aPacketsAndBytes)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+
+    SuccessOrExit(error = DBusMessageEncode(&sub, aPacketsAndBytes.mPackets));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aPacketsAndBytes.mBytes));
+
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub), error = OTBR_ERROR_DBUS);
+
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, BorderRoutingCounters::PacketsAndBytes &aPacketsAndBytes)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    dbus_message_iter_recurse(aIter, &sub);
+
+    SuccessOrExit(error = DBusMessageExtract(&sub, aPacketsAndBytes.mPackets));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aPacketsAndBytes.mBytes));
+
+    dbus_message_iter_next(aIter);
+
+exit:
+    return error;
+}
+
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const BorderRoutingCounters &aBorderRoutingCounters)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+
+    SuccessOrExit(error = DBusMessageEncode(&sub, aBorderRoutingCounters.mInboundUnicast));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aBorderRoutingCounters.mInboundMulticast));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aBorderRoutingCounters.mOutboundUnicast));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aBorderRoutingCounters.mOutboundMulticast));
+
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub), error = OTBR_ERROR_DBUS);
+
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, BorderRoutingCounters &aBorderRoutingCounters)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    dbus_message_iter_recurse(aIter, &sub);
+
+    SuccessOrExit(error = DBusMessageExtract(&sub, aBorderRoutingCounters.mInboundUnicast));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aBorderRoutingCounters.mInboundMulticast));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aBorderRoutingCounters.mOutboundUnicast));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aBorderRoutingCounters.mOutboundMulticast));
+
+    dbus_message_iter_next(aIter);
+
+exit:
+    return error;
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -619,6 +619,20 @@ struct RadioCoexMetrics
     bool     mStopped;                            ///< Stats collection stopped due to saturation.
 };
 
+struct BorderRoutingCounters
+{
+    struct PacketsAndBytes
+    {
+        uint64_t mPackets; ///< The number of packets.
+        uint64_t mBytes;   ///< The number of bytes.
+    };
+
+    PacketsAndBytes mInboundUnicast;    ///< The counters for inbound unicast.
+    PacketsAndBytes mInboundMulticast;  ///< The counters for inbound multicast.
+    PacketsAndBytes mOutboundUnicast;   ///< The counters for outbound unicast.
+    PacketsAndBytes mOutboundMulticast; ///< The counters for outbound multicast.
+};
+
 } // namespace DBus
 } // namespace otbr
 

--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -253,6 +253,8 @@ otbrError DBusThreadObject::Init(void)
                                std::bind(&DBusThreadObject::GetUptimeHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_RADIO_COEX_METRICS,
                                std::bind(&DBusThreadObject::GetRadioCoexMetrics, this, _1));
+    RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_BORDER_ROUTING_COUNTERS,
+                               std::bind(&DBusThreadObject::GetBorderRoutingCountersHandler, this, _1));
 
     SuccessOrExit(error = Signal(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_SIGNAL_READY, std::make_tuple()));
 
@@ -1557,6 +1559,36 @@ otError DBusThreadObject::GetRadioCoexMetrics(DBusMessageIter &aIter)
 
 exit:
     return error;
+}
+
+otError DBusThreadObject::GetBorderRoutingCountersHandler(DBusMessageIter &aIter)
+{
+#if OTBR_ENABLE_BORDER_ROUTING_COUNTERS
+    auto                           threadHelper = mNcp->GetThreadHelper();
+    auto                           instance     = threadHelper->GetInstance();
+    otError                        error        = OT_ERROR_NONE;
+    BorderRoutingCounters          borderRoutingCounters;
+    const otBorderRoutingCounters *otBorderRoutingCounters = otIp6GetBorderRoutingCounters(instance);
+
+    borderRoutingCounters.mInboundUnicast.mPackets    = otBorderRoutingCounters->mInboundUnicast.mPackets;
+    borderRoutingCounters.mInboundUnicast.mBytes      = otBorderRoutingCounters->mInboundUnicast.mBytes;
+    borderRoutingCounters.mInboundMulticast.mPackets  = otBorderRoutingCounters->mInboundMulticast.mPackets;
+    borderRoutingCounters.mInboundMulticast.mBytes    = otBorderRoutingCounters->mInboundMulticast.mBytes;
+    borderRoutingCounters.mOutboundUnicast.mPackets   = otBorderRoutingCounters->mOutboundUnicast.mPackets;
+    borderRoutingCounters.mOutboundUnicast.mBytes     = otBorderRoutingCounters->mOutboundUnicast.mBytes;
+    borderRoutingCounters.mOutboundMulticast.mPackets = otBorderRoutingCounters->mOutboundMulticast.mPackets;
+    borderRoutingCounters.mOutboundMulticast.mBytes   = otBorderRoutingCounters->mOutboundMulticast.mBytes;
+
+    VerifyOrExit(DBusMessageEncodeToVariant(&aIter, borderRoutingCounters) == OTBR_ERROR_NONE,
+                 error = OT_ERROR_INVALID_ARGS);
+
+exit:
+    return error;
+#else
+    OTBR_UNUSED_VARIABLE(aIter);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 void DBusThreadObject::ActiveDatasetChangeHandler(const otOperationalDatasetTlvs &aDatasetTlvs)

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -155,6 +155,7 @@ private:
     otError GetRcpInterfaceMetricsHandler(DBusMessageIter &aIter);
     otError GetUptimeHandler(DBusMessageIter &aIter);
     otError GetRadioCoexMetrics(DBusMessageIter &aIter);
+    otError GetBorderRoutingCountersHandler(DBusMessageIter &aIter);
 
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
     void ReplyEnergyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otEnergyScanResult> &aResult);

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -720,6 +720,32 @@
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
+    <!-- BorderRoutingCounters: The counters for inbound/outbound packets
+    <literallayout>
+        struct {
+          struct {  // inbound unicast
+            uint64 packets
+            uint64 bytes
+          }
+          struct {  // inbound multicast
+            uint64 packets
+            uint64 bytes
+          }
+          struct {  // outbound unicast
+            uint64 packets
+            uint64 bytes
+          }
+          struct {  // outbound multicast
+            uint64 packets
+            uint64 bytes
+          }
+        }
+    </literallayout>
+    -->
+    <property name="BorderRoutingCounters" type="((tt)(tt)(tt)(tt))" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
   </interface>
 
   <interface name="org.freedesktop.DBus.Properties">

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -29,6 +29,7 @@
 set(OT_BORDER_AGENT ON CACHE BOOL "enable border agent" FORCE)
 set(OT_BORDER_ROUTER ON CACHE BOOL "enable border router feature" FORCE)
 set(OT_BORDER_ROUTING ${OTBR_BORDER_ROUTING} CACHE BOOL "enable border routing feature" FORCE)
+set(OT_BORDER_ROUTING_COUNTERS ${OTBR_BORDER_ROUTING_COUNTERS} CACHE BOOL "enable border routing counters feature" FORCE)
 set(OT_BUILD_EXECUTABLES OFF CACHE BOOL "disable building executables" FORCE)
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "diable mbedTLS management" FORCE)
 set(OT_COMMISSIONER ON CACHE BOOL "enable commissioner")


### PR DESCRIPTION
This PR implements the D-BUS API `GetBorderRoutingCounters`. 

Test covered in https://github.com/openthread/openthread/pull/8341.