### PR TITLE
[mdns] replace the source of mDNSResponder

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -58,8 +58,9 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y libavahi-client3 libavahi-common-dev libavahi-client-dev avahi-daemon
     (MDNS_RESPONDER_SOURCE_NAME=mDNSResponder-1310.80.1 \
         && cd /tmp \
-        && wget -4 --no-check-certificate https://opensource.apple.com/tarballs/mDNSResponder/$MDNS_RESPONDER_SOURCE_NAME.tar.gz \
-        && tar xvf $MDNS_RESPONDER_SOURCE_NAME.tar.gz \
+        && wget -4 --no-check-certificate https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$MDNS_RESPONDER_SOURCE_NAME.tar.gz \
+        && mkdir -p $MDNS_RESPONDER_SOURCE_NAME \
+        && tar xvf $MDNS_RESPONDER_SOURCE_NAME.tar.gz -C $MDNS_RESPONDER_SOURCE_NAME --strip-components=1 \
         && cd /tmp/$MDNS_RESPONDER_SOURCE_NAME/Clients \
         && sed -i '/#include <ctype.h>/a #include <stdarg.h>' dns-sd.c \
         && sed -i '/#include <ctype.h>/a #include <sys/param.h>' dns-sd.c \

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -138,8 +138,9 @@ case "$(uname)" in
 
         if [ "${OTBR_MDNS-}" == 'mDNSResponder' ]; then
             SOURCE_NAME=mDNSResponder-1310.80.1
-            wget https://opensource.apple.com/tarballs/mDNSResponder/$SOURCE_NAME.tar.gz \
-                && tar xvf $SOURCE_NAME.tar.gz \
+            wget https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$SOURCE_NAME.tar.gz \
+                && mkdir -p $SOURCE_NAME \
+                && tar xvf $SOURCE_NAME.tar.gz -C $SOURCE_NAME --strip-components=1 \
                 && cd $SOURCE_NAME/Clients \
                 && sed -i '/#include <ctype.h>/a #include <stdarg.h>' dns-sd.c \
                 && sed -i '/#include <ctype.h>/a #include <sys/param.h>' dns-sd.c \

--- a/tests/scripts/check-android-build
+++ b/tests/scripts/check-android-build
@@ -420,8 +420,9 @@ prepare_libmdnssd()
 
     [[ ${OTBR_MDNS} == mDNSResponder ]] || return 0
 
-    wget --tries 4 --no-check-certificate --quiet "https://opensource.apple.com/tarballs/mDNSResponder/${MDNSRESPONDER_SOURCE}.tar.gz"
-    tar xvf "${MDNSRESPONDER_SOURCE}.tar.gz"
+    wget --tries 4 --no-check-certificate --quiet "https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/${MDNSRESPONDER_SOURCE}.tar.gz"
+    mkdir -p ${MDNSRESPONDER_SOURCE}
+    tar xvf "${MDNSRESPONDER_SOURCE}.tar.gz" -C ${MDNSRESPONDER_SOURCE} --strip-components=1
     cat >"${MDNSRESPONDER_SOURCE}/Android.mk" <<EOF
 LOCAL_PATH:= \$(call my-dir)
 


### PR DESCRIPTION
Fetch mDNSResponder's source code from https://github.com/apple-oss-distributions/mDNSResponder.

Fixes https://github.com/openthread/ot-br-posix/issues/1591.