### PR TITLE
[build] fix the condition of enabling Border Routing counters

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -43,7 +43,7 @@ endif()
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
 
 option(OTBR_BORDER_ROUTING_COUNTERS "Enable Border Routing Counters" ON)
-if (OTBR_BORDER_ROUTING AND OTBR_BORDER_ROUTING_COUNTERS)
+if (OTBR_BORDER_ROUTING_COUNTERS)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING_COUNTERS=1)
 endif()
 


### PR DESCRIPTION
Fix an issue that Border Routing counters is not available when `OTBR_BORDER_ROUTING` is off but `OTBR_BACKBONE_ROUTER` is on.