### PR TITLE
[scripts] fix: check if systemctl exists before using it

### DIFF
--- a/script/_disable_services
+++ b/script/_disable_services
@@ -44,13 +44,15 @@ bbb_disable_services()
     SERVICE_LIST="${SERVICE_LIST} nodered.service"
     SERVICE_LIST="${SERVICE_LIST} dnsmasq.service" # Disable well before bind9
 
-    for service in $SERVICE_LIST; do
-        if [ "$(sudo systemctl is-active "$service")" != "inactive" ]; then
-            for action in stop disable; do
-                sudo systemctl "$action" "$service"
-            done
-        fi
-    done
+    if have systemctl; then
+        for service in $SERVICE_LIST; do
+            if [ "$(sudo systemctl is-active "$service")" != "inactive" ]; then
+                for action in stop disable; do
+                    sudo systemctl "$action" "$service"
+                done
+            fi
+        done
+    fi
 
     # stop avahi from advertising for cloud9 and nodered
     sudo rm -rf /etc/avahi/services


### PR DESCRIPTION
There is no check for having `systemctl` in the[ _disable_services](https://github.com/openthread/ot-br-posix/blob/main/script/_disable_services) script even though this check exists all around the project. This causes the setup to fail if the machine does not have the `systemctl` command.

Added necessary condition before using `systemctl`.

Fixes #1607