### PR TITLE
[github-actions] add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,8 @@ updates:
       prefix: "submodule"
     rebase-strategy: "disabled"
     open-pull-requests-limit: 1
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add a Dependabot configuration that checks once a week if the GitHub Actions are still using the latest version. If not, it opens a PR to update them.

It will actually open few PRs, since only major versions are specified (like v3), so only on a major release (like v4) it will update and open a PR. But it helps actively keep GitHub Actions workflows up to date and secure.

See [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).