### PR TITLE
[github-actions] disable `meshcop (mDNSResponder)` check

### DIFF
--- a/.github/workflows/meshcop.yml
+++ b/.github/workflows/meshcop.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mdns: ["mDNSResponder", "avahi"]
+        mdns: ["avahi"]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Check is currently failing for unknown reasons: https://github.com/openthread/ot-br-posix/actions/runs/3518681133/attempts/15