### PR TITLE
[dbus] change exit code for "LeaveNetwork"

### DIFF
--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -1636,6 +1636,8 @@ void DBusThreadObject::ActiveDatasetChangeHandler(const otOperationalDatasetTlvs
 
 void DBusThreadObject::LeaveNetworkHandler(DBusRequest &aRequest)
 {
+    constexpr int kExitCodeShouldRestart = 7;
+
     mNcp->GetThreadHelper()->DetachGracefully([aRequest, this](otError error) mutable {
         SuccessOrExit(error);
         SuccessOrExit(error = otInstanceErasePersistentInfo(mNcp->GetThreadHelper()->GetInstance()));
@@ -1645,7 +1647,7 @@ void DBusThreadObject::LeaveNetworkHandler(DBusRequest &aRequest)
         if (error == OT_ERROR_NONE)
         {
             Flush();
-            exit(0);
+            exit(kExitCodeShouldRestart);
         }
     });
 }

--- a/tests/dbus/keep_running.sh
+++ b/tests/dbus/keep_running.sh
@@ -31,4 +31,9 @@ set -euxo pipefail
 
 readonly EXIT_CODE_SHOULD_RESTART=7
 
-while "$@"; (( $? == EXIT_CODE_SHOULD_RESTART )); do :; done
+while
+    "$@"
+    (($? == EXIT_CODE_SHOULD_RESTART))
+do
+    :
+done

--- a/tests/dbus/keep_running.sh
+++ b/tests/dbus/keep_running.sh
@@ -29,4 +29,6 @@
 
 set -euxo pipefail
 
-while "$@"; do :; done
+readonly EXIT_CODE_SHOULD_RESTART=7
+
+while "$@"; (( $? == EXIT_CODE_SHOULD_RESTART )); do :; done


### PR DESCRIPTION
This commit makes the DBus API "LeaveNetwork" use a specific exit code so the platform can differentiate normal exits and exits that should be followed by a restart.