### PR TITLE
[srp-server] support `AutoEnableMode` for SRP server in OTBR 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       BUILD_TARGET: check
       OTBR_BUILD_TYPE: ${{ matrix.build_type }}
       OTBR_MDNS: ${{ matrix.mdns }}
-      OTBR_OPTIONS: "-DOTBR_SRP_ADVERTISING_PROXY=ON -DOTBR_BORDER_ROUTING=ON -DOTBR_NAT64=1"
+      OTBR_OPTIONS: "-DOTBR_SRP_ADVERTISING_PROXY=ON -DOTBR_BORDER_ROUTING=ON -DOTBR_NAT64=1 -DOTBR_SRP_SERVER_AUTO_ENABLE=OFF"
       OTBR_COVERAGE: 1
     steps:
     - uses: actions/checkout@v3

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -26,6 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+include(CMakeDependentOption)
 find_package(PkgConfig)
 
 option(OTBR_DOC "Build documentation" OFF)
@@ -77,6 +78,11 @@ endif()
 option(OTBR_SRP_ADVERTISING_PROXY "Enable Advertising Proxy" OFF)
 if (OTBR_SRP_ADVERTISING_PROXY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_SRP_ADVERTISING_PROXY=1)
+endif()
+
+cmake_dependent_option(OTBR_SRP_SERVER_AUTO_ENABLE "Enable SRP server auto enable mode" ON "OTBR_SRP_ADVERTISING_PROXY;OTBR_BORDER_ROUTING" OFF)
+if (OTBR_SRP_SERVER_AUTO_ENABLE)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_SRP_SERVER_AUTO_ENABLE_MODE=1)
 endif()
 
 option(OTBR_DNSSD_DISCOVERY_PROXY   "Enable DNS-SD Discovery Proxy support" OFF)

--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -176,8 +176,15 @@ void ControllerOpenThread::Init(void)
     }
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_SRP_SERVER_AUTO_ENABLE_MODE
+    // Let SRP server use auto-enable mode. The auto-enable mode delegates the control of SRP server to the Border
+    // Routing Manager. SRP server automatically starts when bi-directional connectivity is ready.
+    otSrpServerSetAutoEnableMode(mInstance, /* aEnabled */ true);
+#else
     otSrpServerSetEnabled(mInstance, /* aEnabled */ true);
 #endif
+#endif
+
 #if OTBR_ENABLE_NAT64
     otNat64SetEnabled(mInstance, /* aEnabled */ true);
 #endif


### PR DESCRIPTION
The `AutoEnableMode` delegates the control of SRP server to the Border Routing Manager.

The `AutoEnableMode` was introduced to openthread in https://github.com/openthread/openthread/pull/8129.