### PR TITLE
[meshcop] publish OMR prefix in TXT record

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -42,6 +42,9 @@ if (OTBR_BACKBONE_ROUTER)
 endif()
 
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" OFF)
+if (OTBR_BORDER_ROUTING)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING=1)
+endif()
 
 option(OTBR_BORDER_ROUTING_COUNTERS "Enable Border Routing Counters" ON)
 if (OTBR_BORDER_ROUTING_COUNTERS)


### PR DESCRIPTION
The latest spec requires an OMR field in the TXT record of the MeshCoP mDNS service.