### PR TITLE
[rest] use correct Content-Type header for RESTful API

### DIFF
--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -187,6 +187,7 @@ void Resource::ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) cons
     std::string errorMessage = GetHttpStatus(aErrorCode);
     std::string body         = Json::Error2JsonString(aErrorCode, errorMessage);
 
+    aResponse.SetContentType(OT_REST_RESPONSE_CONTENT_TYPE_JSON);
     aResponse.SetResponsCode(errorMessage);
     aResponse.SetBody(body);
     aResponse.SetComplete();
@@ -222,6 +223,7 @@ void Resource::GetNodeInfo(Response &aResponse) const
     node.mRlocAddress = *otThreadGetRloc(mInstance);
 
     body = Json::Node2JsonString(node);
+    aResponse.SetContentType(OT_REST_RESPONSE_CONTENT_TYPE_JSON);
     aResponse.SetBody(body);
 
 exit:
@@ -539,6 +541,7 @@ exit:
 
     if (error == OTBR_ERROR_NONE)
     {
+        aResponse.SetContentType(OT_REST_RESPONSE_CONTENT_TYPE_JSON);
         aResponse.SetStartTime(steady_clock::now());
         aResponse.SetCallback();
     }

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -30,6 +30,8 @@
 
 #include <stdio.h>
 
+#define OT_REST_RESPONSE_CONTENT_TYPE_HEADER "Content-Type"
+
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN "*"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
@@ -41,21 +43,16 @@ namespace rest {
 
 Response::Response(void)
     : mCallback(false)
-    , mContentType(OT_REST_RESPONSE_CONTENT_TYPE_TEXT)
     , mComplete(false)
 {
     // HTTP protocol
     mProtocol = "HTTP/1.1 ";
 
     // Pre-defined headers
-    mHeaderField.push_back("Access-Control-Allow-Origin");
-    mHeaderValue.push_back(OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN);
-
-    mHeaderField.push_back("Access-Control-Allow-Methods");
-    mHeaderValue.push_back(OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD);
-
-    mHeaderField.push_back("Access-Control-Allow-Headers");
-    mHeaderValue.push_back(OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS);
+    mHeader[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = OT_REST_RESPONSE_CONTENT_TYPE_TEXT;
+    mHeader["Access-Control-Allow-Origin"]        = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
+    mHeader["Access-Control-Allow-Methods"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
+    mHeader["Access-Control-Allow-Headers"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
 }
 
 void Response::SetComplete()
@@ -90,12 +87,12 @@ void Response::SetCallback(void)
 
 void Response::SetContentType(const std::string &aContentType)
 {
-    mContentType = aContentType;
+    mHeader[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = aContentType;
 }
 
 std::string Response::GetContentType() const
 {
-    return mContentType;
+    return mHeader.find(OT_REST_RESPONSE_CONTENT_TYPE_HEADER)->second;
 }
 
 void Response::SetBody(std::string &aBody)
@@ -115,14 +112,12 @@ bool Response::NeedCallback(void)
 
 std::string Response::Serialize(void) const
 {
-    size_t      index;
     std::string spacer = "\r\n";
     std::string ret(mProtocol + " " + mCode);
 
-    ret += (spacer + "Content-Type: " + mContentType);
-    for (index = 0; index < mHeaderField.size(); index++)
+    for (const auto &header : mHeader)
     {
-        ret += (spacer + mHeaderField[index] + ": " + mHeaderValue[index]);
+        ret += (spacer + header.first + ": " + header.second);
     }
     ret += spacer + "Content-Length: " + std::to_string(mBody.size());
     ret += (spacer + spacer + mBody);

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 
-#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN "*"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
@@ -42,15 +41,13 @@ namespace rest {
 
 Response::Response(void)
     : mCallback(false)
+    , mContentType(OT_REST_RESPONSE_CONTENT_TYPE_TEXT)
     , mComplete(false)
 {
     // HTTP protocol
     mProtocol = "HTTP/1.1 ";
 
     // Pre-defined headers
-    mHeaderField.push_back("Content-Type");
-    mHeaderValue.push_back(OT_REST_RESPONSE_CONTENT_TYPE_JSON);
-
     mHeaderField.push_back("Access-Control-Allow-Origin");
     mHeaderValue.push_back(OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN);
 
@@ -91,6 +88,16 @@ void Response::SetCallback(void)
     mCallback = true;
 }
 
+void Response::SetContentType(const std::string &aContentType)
+{
+    mContentType = aContentType;
+}
+
+std::string Response::GetContentType() const
+{
+    return mContentType;
+}
+
 void Response::SetBody(std::string &aBody)
 {
     mBody = aBody;
@@ -112,6 +119,7 @@ std::string Response::Serialize(void) const
     std::string spacer = "\r\n";
     std::string ret(mProtocol + " " + mCode);
 
+    ret += (spacer + "Content-Type: " + mContentType);
     for (index = 0; index < mHeaderField.size(); index++)
     {
         ret += (spacer + mHeaderField[index] + ": " + mHeaderValue[index]);

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -35,8 +35,8 @@
 #define OTBR_REST_RESPONSE_HPP_
 
 #include <chrono>
+#include <map>
 #include <string>
-#include <vector>
 
 #include "rest/types.hpp"
 
@@ -154,15 +154,13 @@ public:
     std::string Serialize(void) const;
 
 private:
-    bool                     mCallback;
-    std::vector<std::string> mHeaderField;
-    std::vector<std::string> mHeaderValue;
-    std::string              mCode;
-    std::string              mProtocol;
-    std::string              mContentType;
-    std::string              mBody;
-    bool                     mComplete;
-    steady_clock::time_point mStartTime;
+    bool                               mCallback;
+    std::map<std::string, std::string> mHeader;
+    std::string                        mCode;
+    std::string                        mProtocol;
+    std::string                        mBody;
+    bool                               mComplete;
+    steady_clock::time_point           mStartTime;
 };
 
 } // namespace rest

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -40,6 +40,9 @@
 
 #include "rest/types.hpp"
 
+#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
+#define OT_REST_RESPONSE_CONTENT_TYPE_TEXT "plain/text"
+
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::seconds;
@@ -62,6 +65,21 @@ public:
      *
      */
     Response(void);
+
+    /**
+     * This method sets the response Content-Type header.
+     *
+     * @param[in] aContentType  A string to be set as response Content-Type header.
+     *
+     */
+    void SetContentType(const std::string &aContentType);
+
+    /**
+     * This method returns a string of the response Content-Type.
+     *
+     * @returns A string containing the Content-Type.
+     */
+    std::string GetContentType(void) const;
 
     /**
      * This method set the response body.
@@ -141,6 +159,7 @@ private:
     std::vector<std::string> mHeaderValue;
     std::string              mCode;
     std::string              mProtocol;
+    std::string              mContentType;
     std::string              mBody;
     bool                     mComplete;
     steady_clock::time_point mStartTime;


### PR DESCRIPTION
Set the content type to `text/plain` by default, and `application/json` where needed.