### PR TITLE
[rest] add active dataset API

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -372,6 +372,11 @@ std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength)
     return ret;
 }
 
+int Hex2BytesJsonString(const std::string &aHexString, uint8_t *aBytes, uint8_t aMaxLength)
+{
+    return otbr::Utils::Hex2Bytes(aHexString.c_str(), aBytes, aMaxLength);
+}
+
 std::string Number2JsonString(const uint32_t &aNumber)
 {
     cJSON      *number = cJSON_CreateNumber(aNumber);

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -71,6 +71,18 @@ std::string Number2JsonString(const uint32_t &aNumber);
 std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength);
 
 /**
+ * This method parses a hex string as byte array.
+ *
+ * @param[in] aHexString String of bytes in hex.
+ * @param[in] aBytes     Byte array to write to. Must be at least  @p aMaxLength.
+ * @param[in] aMaxLength Maximum length to parse (in bytes).
+ *
+ * @returns Number of bytes effectively parsed.
+ *
+ */
+int Hex2BytesJsonString(const std::string &aHexString, uint8_t *aBytes, uint8_t aMaxLength);
+
+/**
  * This method formats a C string to a Json string and serialize it to a string.
  *
  * @param[in] aCString  A char pointer pointing to a C string.

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -45,6 +45,7 @@
 #define OT_REST_RESOURCE_PATH_NODE_LEADERDATA "/node/leader-data"
 #define OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER "/node/num-of-router"
 #define OT_REST_RESOURCE_PATH_NODE_EXTPANID "/node/ext-panid"
+#define OT_REST_RESOURCE_PATH_NODE_ACTIVE_DATASET_TLVS "/node/active-dataset-tlvs"
 #define OT_REST_RESOURCE_PATH_NETWORK "/networks"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT "/networks/current"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_COMMISSION "/networks/commission"
@@ -118,6 +119,7 @@ Resource::Resource(ControllerOpenThread *aNcp)
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_LEADERDATA, &Resource::LeaderData);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER, &Resource::NumOfRoute);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_EXTPANID, &Resource::ExtendedPanId);
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_ACTIVE_DATASET_TLVS, &Resource::ActiveDatasetTlvs);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_RLOC, &Resource::Rloc);
 
     // Resource callback handler
@@ -482,6 +484,42 @@ void Resource::Rloc(const Request &aRequest, Response &aResponse) const
     if (aRequest.GetMethod() == HttpMethod::kGet)
     {
         GetDataRloc(aResponse);
+    }
+    else
+    {
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+    }
+}
+
+void Resource::GetActiveDatasetTlvs(Response &aResponse) const
+{
+    otOperationalDatasetTlvs datasetTlvs;
+    otError                  error = OT_ERROR_NONE;
+    std::string              body;
+    std::string              errorCode;
+
+    SuccessOrExit(error = otDatasetGetActiveTlvs(mInstance, &datasetTlvs));
+
+    body = Json::Bytes2HexJsonString(datasetTlvs.mTlvs, datasetTlvs.mLength);
+
+    aResponse.SetBody(body);
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+    aResponse.SetResponsCode(errorCode);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to get active dataset: %s", otThreadErrorToString(error));
+    }
+}
+
+void Resource::ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const
+{
+    std::string errorCode;
+
+    if (aRequest.GetMethod() == HttpMethod::kGet)
+    {
+        GetActiveDatasetTlvs(aResponse);
     }
     else
     {

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -127,6 +127,7 @@ private:
     void GetDataExtendedPanId(Response &aResponse) const;
     void GetDataRloc(Response &aResponse) const;
     void GetActiveDatasetTlvs(Response &aResponse) const;
+    void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -113,6 +113,7 @@ private:
     void Rloc16(const Request &aRequest, Response &aResponse) const;
     void ExtendedPanId(const Request &aRequest, Response &aResponse) const;
     void Rloc(const Request &aRequest, Response &aResponse) const;
+    void ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
     void Diagnostic(const Request &aRequest, Response &aResponse) const;
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
@@ -125,6 +126,7 @@ private:
     void GetDataRloc16(Response &aResponse) const;
     void GetDataExtendedPanId(Response &aResponse) const;
     void GetDataRloc(Response &aResponse) const;
+    void GetActiveDatasetTlvs(Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -59,6 +59,8 @@ enum class HttpMethod : std::uint8_t
 enum class HttpStatusCode : std::uint16_t
 {
     kStatusOk                  = 200,
+    kStatusAccepted            = 202,
+    kStatusBadRequest          = 400,
     kStatusResourceNotFound    = 404,
     kStatusMethodNotAllowed    = 405,
     kStatusRequestTimeout      = 408,


### PR DESCRIPTION
Support getting and setting the active dataset via REST. The active data set is returned as operational dataset encoded as TLV hex string. The `PUT` method along with the body with the dataset encoded in the same format can be used to set the current active dataset.