### PR TITLE
Fix build error when compiling with GCC 12.2.0

### DIFF
--- a/third_party/Simple-web-server/repo/server_http.hpp
+++ b/third_party/Simple-web-server/repo/server_http.hpp
@@ -101,6 +101,9 @@ namespace SimpleWeb {
         class Request {
             friend class ServerBase<socket_type>;
             friend class Server<socket_type>;
+
+            boost::asio::streambuf streambuf;
+
         public:
             std::string method, path, http_version;
 
@@ -121,8 +124,6 @@ namespace SimpleWeb {
                 }
                 catch(...) {}
             }
-            
-            boost::asio::streambuf streambuf;
         };
         
         class Config {


### PR DESCRIPTION
It seems that GCC 12.2 is a bit more picky when it comes to initialization order:

```
In file included from /home/sag/projects/openthread/ot-br-posix/src/web/web-service/web_server.cpp:42: /home/sag/projects/openthread/ot-br-posix/third_party/Simple-web-server/repo/server_http.hpp: In instantiation of ‘SimpleWeb::ServerBase<socket_type>::Request::Request(const socket_type&) [with socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp>]’:
/home/sag/projects/openthread/ot-br-posix/third_party/Simple-web-server/repo/server_http.hpp:460:74:   required from here
/home/sag/projects/openthread/ot-br-posix/third_party/Simple-web-server/repo/server_http.hpp:119:57: error: member ‘SimpleWeb::ServerBase<boost::asio::basic_stream_socket<boost::asio::ip::tcp> >::Request::streambuf’ is used uninitialized [-Werror=uninitialized]
  119 |             Request(const socket_type &socket): content(streambuf) {
      |                                                         ^~~~~~~~~
```