### PR TITLE
[rest] allow to specify REST listen address

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -79,6 +79,7 @@ Application::Application(const std::string               &aInterfaceName,
     , mVendorServer(mNcp)
 #endif
 {
+    OTBR_UNUSED_VARIABLE(aRestListenAddress);
 }
 
 void Application::Init(void)

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -50,7 +50,8 @@ const struct timeval Application::kPollTimeout = {10, 0};
 Application::Application(const std::string               &aInterfaceName,
                          const std::vector<const char *> &aBackboneInterfaceNames,
                          const std::vector<const char *> &aRadioUrls,
-                         bool                             aEnableAutoAttach)
+                         bool                             aEnableAutoAttach,
+                         const std::string               &aRestListenAddress)
     : mInterfaceName(aInterfaceName)
 #if __linux__
     , mInfraLinkSelector(aBackboneInterfaceNames)
@@ -69,7 +70,7 @@ Application::Application(const std::string               &aInterfaceName,
     , mUbusAgent(mNcp)
 #endif
 #if OTBR_ENABLE_REST_SERVER
-    , mRestWebServer(mNcp)
+    , mRestWebServer(mNcp, aRestListenAddress)
 #endif
 #if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
     , mDBusAgent(mNcp, mBorderAgent.GetPublisher())

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -90,7 +90,8 @@ public:
     explicit Application(const std::string               &aInterfaceName,
                          const std::vector<const char *> &aBackboneInterfaceNames,
                          const std::vector<const char *> &aRadioUrls,
-                         bool                             aEnableAutoAttach);
+                         bool                             aEnableAutoAttach,
+                         const std::string               &aRestListenAddress);
 
     /**
      * This method initializes the Application instance.

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -72,6 +72,7 @@ enum
     OTBR_OPT_SHORTMAX                = 128,
     OTBR_OPT_RADIO_VERSION,
     OTBR_OPT_AUTO_ATTACH,
+    OTBR_OPT_REST_LISTEN_ADDR,
 };
 
 static jmp_buf            sResetJump;
@@ -87,6 +88,7 @@ static const struct option kOptions[] = {
     {"version", no_argument, nullptr, OTBR_OPT_VERSION},
     {"radio-version", no_argument, nullptr, OTBR_OPT_RADIO_VERSION},
     {"auto-attach", optional_argument, nullptr, OTBR_OPT_AUTO_ATTACH},
+    {"rest-listen-address", required_argument, nullptr, OTBR_OPT_REST_LISTEN_ADDR},
     {0, 0, 0, 0}};
 
 static bool ParseInteger(const char *aStr, long &aOutResult)
@@ -189,6 +191,7 @@ static int realmain(int argc, char *argv[])
     bool                      verbose           = false;
     bool                      printRadioVersion = false;
     bool                      enableAutoAttach  = true;
+    const char               *restListenAddress = "";
     std::vector<const char *> radioUrls;
     std::vector<const char *> backboneInterfaceNames;
     long                      parseResult;
@@ -243,6 +246,9 @@ static int realmain(int argc, char *argv[])
                 enableAutoAttach = parseResult;
             }
             break;
+        case OTBR_OPT_REST_LISTEN_ADDR:
+            restListenAddress = optarg;
+            break;
 
         default:
             PrintHelp(argv[0]);
@@ -274,7 +280,7 @@ static int realmain(int argc, char *argv[])
     }
 
     {
-        otbr::Application app(interfaceName, backboneInterfaceNames, radioUrls, enableAutoAttach);
+        otbr::Application app(interfaceName, backboneInterfaceNames, radioUrls, enableAutoAttach, restListenAddress);
 
         gApp = &app;
         app.Init();

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -30,6 +30,7 @@
 
 #include "rest/rest_web_server.hpp"
 
+#include <arpa/inet.h>
 #include <cerrno>
 
 #include <fcntl.h>
@@ -48,10 +49,19 @@ static const uint32_t kMaxServeNum = 500;
 // Port number used by Rest server.
 static const uint32_t kPortNumber = 8081;
 
-RestWebServer::RestWebServer(ControllerOpenThread &aNcp)
+RestWebServer::RestWebServer(ControllerOpenThread &aNcp, const std::string &aRestListenAddress)
     : mResource(Resource(&aNcp))
     , mListenFd(-1)
 {
+    mAddress.sin6_family = AF_INET6;
+    mAddress.sin6_addr   = in6addr_any;
+    mAddress.sin6_port   = htons(kPortNumber);
+
+    if (!aRestListenAddress.empty())
+    {
+        if (!ParseListenAddress(aRestListenAddress, &mAddress.sin6_addr))
+            otbrLogWarning("Parsing REST listen address failed, listening on any address.");
+    }
 }
 
 RestWebServer::~RestWebServer(void)
@@ -113,6 +123,24 @@ void RestWebServer::UpdateConnections(const fd_set &aReadFdSet)
     }
 }
 
+bool RestWebServer::ParseListenAddress(const std::string listenAddress, struct in6_addr *sin6_addr)
+{
+    const std::string ipv4_prefix       = "::FFFF:";
+    const std::string ipv4ListenAddress = ipv4_prefix + listenAddress;
+
+    if (inet_pton(AF_INET6, listenAddress.c_str(), sin6_addr) == 1)
+    {
+        return true;
+    }
+
+    if (inet_pton(AF_INET6, ipv4ListenAddress.c_str(), sin6_addr) == 1)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 void RestWebServer::InitializeListenFd(void)
 {
     otbrError   error = OTBR_ERROR_NONE;
@@ -121,10 +149,6 @@ void RestWebServer::InitializeListenFd(void)
     int32_t     err = errno;
     int32_t     yes = 1;
     int32_t     no  = 0;
-
-    mAddress.sin6_family = AF_INET6;
-    mAddress.sin6_addr   = in6addr_any;
-    mAddress.sin6_port   = htons(kPortNumber);
 
     mListenFd = SocketWithCloseExec(AF_INET6, SOCK_STREAM, 0, kSocketNonBlock);
     VerifyOrExit(mListenFd != -1, err = errno, error = OTBR_ERROR_REST, errorMessage = "socket");

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -60,7 +60,7 @@ RestWebServer::RestWebServer(ControllerOpenThread &aNcp, const std::string &aRes
     if (!aRestListenAddress.empty())
     {
         if (!ParseListenAddress(aRestListenAddress, &mAddress.sin6_addr))
-            otbrLogWarning("Parsing REST listen address failed, listening on any address.");
+            otbrLogWarning("Failed to parse REST listen address %s, listening on any address.", aRestListenAddress.c_str());
     }
 }
 

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -60,7 +60,8 @@ RestWebServer::RestWebServer(ControllerOpenThread &aNcp, const std::string &aRes
     if (!aRestListenAddress.empty())
     {
         if (!ParseListenAddress(aRestListenAddress, &mAddress.sin6_addr))
-            otbrLogWarning("Failed to parse REST listen address %s, listening on any address.", aRestListenAddress.c_str());
+            otbrLogWarning("Failed to parse REST listen address %s, listening on any address.",
+                           aRestListenAddress.c_str());
     }
 }
 

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -60,7 +60,7 @@ public:
      * @param[in] aNcp  A reference to the NCP controller.
      *
      */
-    RestWebServer(ControllerOpenThread &aNcp);
+    RestWebServer(ControllerOpenThread &aNcp, const std::string &aRestListenAddress);
 
     /**
      * The destructor destroys the server instance.
@@ -81,6 +81,7 @@ private:
     void      UpdateConnections(const fd_set &aReadFdSet);
     void      CreateNewConnection(int32_t &aFd);
     otbrError Accept(int32_t aListenFd);
+    bool      ParseListenAddress(const std::string listenAddress, struct in6_addr *sin6_addr);
     void      InitializeListenFd(void);
     bool      SetFdNonblocking(int32_t fd);
 


### PR DESCRIPTION
Allow to bind to a specific address to listen to for REST requests. This allows to limit access to the REST interface e.g. from localhost only.