### PR TITLE
[continuous-integration] fix macOS CI

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -49,7 +49,11 @@ jobs:
         submodules: true
     - name: Bootstrap
       run: |
-        rm -f '/usr/local/bin/2to3'
+        rm -f /usr/local/bin/2to3
+        rm -f /usr/local/bin/idle3
+        rm -f /usr/local/bin/pydoc3
+        rm -f /usr/local/bin/python3
+        rm -f /usr/local/bin/python3-config
         brew update
         brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf
     - name: Build


### PR DESCRIPTION
This PR fixes the `brew link` error in macOS CI.