### PR TITLE
[rest] add Operational Dataset API

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -40,16 +40,6 @@ namespace otbr {
 namespace rest {
 namespace Json {
 
-std::string Bytes2HexString(const uint8_t *aBytes, uint8_t aLength)
-{
-    char hex[2 * aLength + 1];
-
-    otbr::Utils::Bytes2Hex(aBytes, aLength, hex);
-    hex[2 * aLength] = '\0';
-
-    return std::string(hex);
-}
-
 static cJSON *Bytes2HexJson(const uint8_t *aBytes, uint8_t aLength)
 {
     char hex[2 * aLength + 1];

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -676,6 +676,7 @@ bool JsonString2Dataset(const std::string &aJsonDataset, otOperationalDataset &a
     bool        ret = true;
 
     VerifyOrExit((jsonDataset = cJSON_Parse(aJsonDataset.c_str())) != nullptr, ret = false);
+    VerifyOrExit(cJSON_IsObject(jsonDataset), ret = false);
 
     value = cJSON_GetObjectItemCaseSensitive(jsonDataset, "ActiveTimestamp");
     if (cJSON_IsObject(value))

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -40,6 +40,16 @@ namespace otbr {
 namespace rest {
 namespace Json {
 
+std::string Bytes2HexString(const uint8_t *aBytes, uint8_t aLength)
+{
+    char hex[2 * aLength + 1];
+
+    otbr::Utils::Bytes2Hex(aBytes, aLength, hex);
+    hex[2 * aLength] = '\0';
+
+    return std::string(hex);
+}
+
 static cJSON *Bytes2HexJson(const uint8_t *aBytes, uint8_t aLength)
 {
     char hex[2 * aLength + 1];

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -864,7 +864,8 @@ bool JsonPendingDatasetString2Dataset(const std::string &aJsonPendingDataset, ot
         otOperationalDatasetTlvs datasetTlvs;
         int                      len;
 
-        len = Hex2BytesJsonString(std::string(value->valuestring), datasetTlvs.mTlvs, OT_OPERATIONAL_DATASET_MAX_LENGTH);
+        len =
+            Hex2BytesJsonString(std::string(value->valuestring), datasetTlvs.mTlvs, OT_OPERATIONAL_DATASET_MAX_LENGTH);
         VerifyOrExit(len > 0, ret = false);
         datasetTlvs.mLength = len;
 

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -662,7 +662,7 @@ std::string ActiveDataset2JsonString(const otOperationalDataset &aActiveDataset)
     std::string ret;
 
     node = ActiveDataset2Json(aActiveDataset);
-    ret = Json2String(node);
+    ret  = Json2String(node);
     cJSON_Delete(node);
 
     return ret;

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -861,8 +861,14 @@ bool JsonPendingDatasetString2Dataset(const std::string &aJsonPendingDataset, ot
     }
     else if (cJSON_IsString(value))
     {
-        // TODO: Parse Dataset TLV
-        ExitNow(ret = false);
+        otOperationalDatasetTlvs datasetTlvs;
+        int                      len;
+
+        len = Hex2BytesJsonString(std::string(value->valuestring), datasetTlvs.mTlvs, OT_OPERATIONAL_DATASET_MAX_LENGTH);
+        VerifyOrExit(len > 0, ret = false);
+        datasetTlvs.mLength = len;
+
+        VerifyOrExit(otDatasetParseTlvs(&datasetTlvs, &aDataset) == OT_ERROR_NONE, ret = false);
     }
     else
     {

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -213,6 +213,16 @@ std::string ChildTableEntry2JsonString(const otNetworkDiagChildEntry &aChildEntr
  */
 std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessage);
 
+/**
+ * This method formats a Json object from a dataset.
+ *
+ * @param[in] aDataset  A dataset struct.
+ *
+ * @returns A string of serialized Json object.
+ *
+ */
+std::string Dataset2JsonString(const otOperationalDataset &aDataset);
+
 }; // namespace Json
 
 } // namespace rest

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -72,16 +72,6 @@ std::string Number2JsonString(const uint32_t &aNumber);
 std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength);
 
 /**
- * This method formats a Bytes array to a plain string.
- *
- * @param[in] aBytes  A Bytes array representing a hex number.
- *
- * @returns A plain string.
- *
- */
-std::string Bytes2HexString(const uint8_t *aBytes, uint8_t aLength);
-
-/**
  * This method parses a hex string as byte array.
  *
  * @param[in] aHexString String of bytes in hex.

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -72,6 +72,16 @@ std::string Number2JsonString(const uint32_t &aNumber);
 std::string Bytes2HexJsonString(const uint8_t *aBytes, uint8_t aLength);
 
 /**
+ * This method formats a Bytes array to a plain string.
+ *
+ * @param[in] aBytes  A Bytes array representing a hex number.
+ *
+ * @returns A plain string.
+ *
+ */
+std::string Bytes2HexString(const uint8_t *aBytes, uint8_t aLength);
+
+/**
  * This method parses a hex string as byte array.
  *
  * @param[in] aHexString String of bytes in hex.

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -34,6 +34,7 @@
 #ifndef OTBR_REST_JSON_HPP_
 #define OTBR_REST_JSON_HPP_
 
+#include "openthread/dataset.h"
 #include "openthread/link.h"
 #include "openthread/thread_ftd.h"
 
@@ -222,6 +223,19 @@ std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessag
  *
  */
 std::string Dataset2JsonString(const otOperationalDataset &aDataset);
+
+/**
+ * This method parses a Json string and fills the provided dataset. Fields
+ * set to null are cleared (set to not present). Non-present fields are left
+ * as is.
+ *
+ * @param[in] aJsonDataset  The Json string to be parsed.
+ * @param[in] aDataset      The dataset struct to be filled.
+ *
+ * @returns If the Json string has been successfully parsed.
+ *
+ */
+bool JsonString2Dataset(const std::string &aJsonDataset, otOperationalDataset &aDataset);
 
 }; // namespace Json
 

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -215,27 +215,50 @@ std::string ChildTableEntry2JsonString(const otNetworkDiagChildEntry &aChildEntr
 std::string Error2JsonString(HttpStatusCode aErrorCode, std::string aErrorMessage);
 
 /**
- * This method formats a Json object from a dataset.
+ * This method formats a Json object from an active dataset.
  *
  * @param[in] aDataset  A dataset struct.
  *
  * @returns A string of serialized Json object.
  *
  */
-std::string Dataset2JsonString(const otOperationalDataset &aDataset);
+std::string ActiveDataset2JsonString(const otOperationalDataset &aDataset);
+
+/**
+ * This method formats a Json object from a pending dataset.
+ *
+ * @param[in] aDataset  A dataset struct.
+ *
+ * @returns A string of serialized Json object.
+ *
+ */
+std::string PendingDataset2JsonString(const otOperationalDataset &aPendingDataset);
 
 /**
  * This method parses a Json string and fills the provided dataset. Fields
  * set to null are cleared (set to not present). Non-present fields are left
  * as is.
  *
- * @param[in] aJsonDataset  The Json string to be parsed.
- * @param[in] aDataset      The dataset struct to be filled.
+ * @param[in] aJsonActiveDataset  The Json string to be parsed.
+ * @param[in] aDataset            The dataset struct to be filled.
  *
  * @returns If the Json string has been successfully parsed.
  *
  */
-bool JsonString2Dataset(const std::string &aJsonDataset, otOperationalDataset &aDataset);
+bool JsonActiveDatasetString2Dataset(const std::string &aJsonActiveDataset, otOperationalDataset &aDataset);
+
+/**
+ * This method parses a Json string and fills the provided dataset. Fields
+ * set to null are cleared (set to not present). Non-present fields are left
+ * as is.
+ *
+ * @param[in] aJsonActiveDataset  The Json string to be parsed.
+ * @param[in] aDataset            The dataset struct to be filled.
+ *
+ * @returns If the Json string has been successfully parsed.
+ *
+ */
+bool JsonPendingDatasetString2Dataset(const std::string &aJsonPendingDataset, otOperationalDataset &aDataset);
 
 }; // namespace Json
 

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1,0 +1,455 @@
+openapi: 3.0.3
+info:
+  title: Swagger OpenThread REST API
+  description: |-
+    This describes the OpenThread Border Router RETS API. The API is provided by the otbr-agent, if the cmake flag `OTBR_REST=ON` is set. By default
+    the REST API listens on any address on port 8081.
+
+    Some useful links:
+    - [OpenThread Border Router repository](github.com/openthread/ot-br-posix/)
+  license:
+    name: BSD 3-Clause
+    url: https://github.com/openthread/ot-br-posix/blob/main/LICENSE
+  version: 0.3.0
+servers:
+  - url: http://localhost:8081
+tags:
+  - name: node
+    description: Thread parameters of this node.
+  - name: diagnostics
+    description: Thread network diagnostic.
+paths:
+  /diagnostics:
+    get:
+      tags:
+        - diagnostics
+      summary: Get Thread network diagnostics
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+  /node:
+    get:
+      tags:
+        - node
+      summary: Get current active node parameters
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+  /node/rloc:
+    get:
+      tags:
+        - node
+      summary: Routing Locator IPv6 address of this Thread node.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: RLOC IPv6 address
+                example: "fda4:728e:4b39:bc4a:0:ff:fe00:1000"
+  /node/rloc16:
+    get:
+      tags:
+        - node
+      summary: Routing Locator Router and Child ID (RLOC16).
+      description: Last 16-bit of the Routing Locator IPv6 consisting of the Router ID and a Child ID.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: number
+                description: RLOC16 address
+                example: 4096
+  /node/ext-address:
+    get:
+      tags:
+        - node
+      summary: IEEE 802.15.4 Extended Address (EUI-64).
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: 8-byte IEEE 802.15.4 Extended Address of this node as hex string.
+                example: "C21F906BE0352A4C"
+  /node/state:
+    get:
+      tags:
+        - node
+      summary: Get current Thread state.
+      description: |-
+        State describing the current Thread role of this Thread node.
+        - 0: disabled
+        - 1: detached
+        - 2: child
+        - 3: router
+        - 4: leader
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: number
+                description: Current state
+                example: 4
+  /node/network-name:
+    get:
+      tags:
+        - node
+      summary: Thread network name this node is part of.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Thread network name.
+                example: "OpenThread-e445"
+  /node/leader-data:
+    get:
+      tags:
+        - node
+      summary: Gets the network's leader data.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeaderData"
+  /node/ext-panid:
+    get:
+      tags:
+        - node
+      summary: Extended PAN ID.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: 8-byte extended PAN ID as hex string.
+                example: "3CAB144450CF407E"
+  /node/num-of-router:
+    get:
+      tags:
+        - node
+      summary: Get number of router devices
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: number
+                description: Number of routers
+                example: 1
+  /node/dataset/active:
+    get:
+      tags:
+        - node
+      summary: Get current active operational dataset
+      responses:
+        "200":
+          description: Returns currently active opertional dataset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dataset"
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/TlvDataset"
+        "204":
+          description: No active operational dataset
+    post:
+      tags:
+        - node
+      summary: Create new active opertional dataset
+      description: |-
+        Creates new active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
+        pending dataset if you would like to change the current active opertional dataset if the Thread node is active.
+
+        Default parameters are choosen for parameters not set in the request body.
+      requestBody:
+        description: |-
+          Operational dataset object that will be stored as active operational dataset. JSON keys which are not set will be initialized with
+          default or random values.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Dataset"
+      responses:
+        "202":
+          description: Successfully created the active operational dataset.
+        "400":
+          description: Invalid request body.
+    put:
+      tags:
+        - node
+      summary: Update current active opertional dataset
+      description: |-
+        Updates the current active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
+        pending dataset if you would like to change the current active opertional dataset if the Thread node is active.
+      requestBody:
+        description: |-
+          Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
+          (dataset in TLV format as hex string) or `application/json` (dataset in JSOn format, JSON keys which are not set will be
+          initialized with default or random values).
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Dataset"
+          plain/text:
+            schema:
+              $ref: "#/components/schemas/TlvDataset"
+      responses:
+        "202":
+          description: Successfully updated the active operational dataset.
+        "400":
+          description: Invalid request body.
+        "404":
+          description: No active opertional dataset to update.
+  /node/dataset/pending:
+    get:
+      tags:
+        - node
+      summary: Get current pending operational dataset
+      responses:
+        "200":
+          description: Returns currently pending opertional dataset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dataset"
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/TlvDataset"
+        "204":
+          description: No pending operational dataset
+    post:
+      tags:
+        - node
+      summary: Create new pending opertional dataset
+      description: |-
+        Creates new pending operational dataset on the current node. If the delay timer is specified, the new pending operational dataset
+        will become active after the time elapsed. The pending dataset will become empty.
+
+        Default parameters are choosen for parameters not set in the request body. By default, the delay timer is *not* set.
+
+        Note: To be considered as a valid active opertional dataset the ActiveTimestamp needs to be newer than the current active operational
+        dataset.
+      requestBody:
+        description: |-
+          Operational dataset object that will be stored as pending operational dataset. JSON keys which are not set will be initialized with
+          default or random values.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Dataset"
+      responses:
+        "202":
+          description: Successfully created the active operational dataset.
+        "400":
+          description: Invalid request body.
+    put:
+      tags:
+        - node
+      summary: Update current pending opertional dataset
+      description: |-
+        Updates the current pending operational dataset on the current node.
+      requestBody:
+        description: |-
+          Operational dataset object that will be stored as pending operational dataset. Supports request body Content-Type `text/plain`
+          (dataset in TLV format as hex string) or `application/json` (dataset in JSOn format, JSON keys which are not set will be
+          initialized with default or random values).
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Dataset"
+          plain/text:
+            schema:
+              $ref: "#/components/schemas/TlvDataset"
+      responses:
+        "202":
+          description: Successfully updated the pending operational dataset.
+        "400":
+          description: Invalid request body.
+        "404":
+          description: No pending opertional dataset to update.
+components:
+  schemas:
+    LeaderData:
+      type: object
+      properties:
+        PartitionId:
+          type: number
+          format: uint32
+          description: Partition ID
+          example: 1230046604
+        Weighting:
+          type: number
+          format: uint8
+          description: Leader Weight
+          example: 64
+        DataVersion:
+          type: number
+          description: Full network data version
+          example: 244
+        StableDataVersion:
+          type: number
+          format: uint8
+          description: Stable Network Data Version
+          example: 186
+        LeaderRouterId:
+          type: number
+          format: uint8
+          description: Leader Router ID
+          example: 4
+    Dataset:
+      type: object
+      properties:
+        ActiveTimestamp:
+          type: integer
+          description: Active timestamp
+          format: uint64
+          example: 10
+          default: 1
+        PendingTimestamp:
+          type: integer
+          description: Pending timestamp
+          format: int32
+          example: 10
+          default: not set
+        NetworkKey:
+          type: string
+          description: Network key, 16 bytes long, formatted as a hexadecimal string
+          example: 08277229F21FB7342D705D3CEFDC042A
+          default: random
+        NetworkName:
+          type: string
+          description: Network name, 16 bytes long
+          example: OpenThread-e445
+          default: OpenThread-<PanId>
+        ExtPanId:
+          type: string
+          description: Extended PAN ID, 8 bytes long
+          example: 996D3BEE320097A3
+          default: random
+        MeshLocalPrefix:
+          type: string
+          description: Mesh local IPv6 prefix
+          example: fd33:d3b9:89e3:72e4::/64
+          default: random
+        Delay:
+          type: integer
+          description: Delay timer in miliseconds
+          format: uint32
+          example: 30000
+          default: not set
+        PanId:
+          type: integer
+          description: IEEE 802.15.4 PAN ID of the Thread network
+          format: uint16
+          example: 58437
+          default: random
+        Channel:
+          type: integer
+          description: IEEE 802.15.4 channel of the Thread network
+          format: uint16
+          example: 21
+          default: random
+        PSKc:
+          type: string
+          description: The pre-shared commissioner key
+          example: FD943ECA225A28979B991EFAC1218A72
+          default: random
+        SecurityPolicy:
+          $ref: "#/components/schemas/SecurityPolicy"
+        ChannelMask:
+          type: integer
+          description: Channel mask
+          format: uint32
+          example: 134215680
+          default: 134215680
+    SecurityPolicy:
+      type: object
+      properties:
+        RotationTime:
+          type: integer
+          description: Thread key rotation time in hours
+          format: uint16
+          example: 672
+          default: 672
+        ObtainNetworkKey:
+          type: boolean
+          description: Obtaining the Network Key for out-of-band commissioning is enabled
+          example: true
+          default: true
+        NativeCommissioning:
+          type: boolean
+          description: Native Commissioning using PSKc is allowed
+          example: true
+          default: true
+        Routers:
+          type: boolean
+          description: Thread 1.0/1.1.x Routers are enabled
+          example: true
+          default: true
+        ExternalCommissioning:
+          type: boolean
+          description: External Commissioner authentication is allowed
+          example: true
+          default: true
+        CommercialCommissioning:
+          type: boolean
+          description: Commercial Commissioning is enabled
+          example: false
+          default: false
+        AutonomousEnrollment:
+          type: boolean
+          description: Autonomous Enrollment is enabled
+          example: false
+          default: false
+        NetworkKeyProvisioning:
+          type: boolean
+          description: Network Key Provisioning is enabled
+          example: false
+          default: false
+        TobleLink:
+          type: boolean
+          description: ToBLE link is enabled
+          example: false
+          default: false
+        NonCcmRouters:
+          type: boolean
+          description: Non-CCM Routers enabled
+          example: false
+          default: false
+    TlvDataset:
+      type: string
+      description: Operational dataset as hex-encoded TLVs.
+      example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8
+  requestBodies:
+    Dataset:
+      description: Operational dataset object that will be stored
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Dataset"

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -330,17 +330,9 @@ components:
       type: object
       properties:
         ActiveTimestamp:
-          type: integer
-          description: Active timestamp
-          format: uint64
-          example: 10
-          default: 1
+          $ref: "#/components/schemas/Timestamp"
         PendingTimestamp:
-          type: integer
-          description: Pending timestamp
-          format: uint64
-          example: 10
-          default: not set
+          $ref: "#/components/schemas/Timestamp"
         NetworkKey:
           type: string
           description: Network key, 16 bytes long, formatted as a hexadecimal string
@@ -444,6 +436,25 @@ components:
         NonCcmRouters:
           type: boolean
           description: Non-CCM Routers enabled
+          example: false
+          default: false
+    Timestamp:
+      type: object
+      properties:
+        Seconds:
+          type: integer
+          description: Timestamp seconds
+          format: uint64
+          example: 10
+          default: 1
+        Ticks:
+          type: integer
+          description: Timestamp ticks
+          format: uint16
+          example: 0
+          default: 0
+        Authoritative:
+          type: boolean
           example: false
           default: false
     DatasetTlv:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -196,7 +196,7 @@ paths:
             schema:
               $ref: "#/components/schemas/Dataset"
       responses:
-        "202":
+        "201":
           description: Successfully created the active operational dataset.
         "400":
           description: Invalid request body.
@@ -213,7 +213,8 @@ paths:
         description: |-
           Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
           (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
-          initialized with default or random values).
+          initialized with default or random values). This method allows to create a new dataset as well if Content-Type is `text/plain`
+          (dataset in TLV format as hex string).
         content:
           application/json:
             schema:
@@ -222,7 +223,7 @@ paths:
             schema:
               $ref: "#/components/schemas/DatasetTlv"
       responses:
-        "202":
+        "200":
           description: Successfully updated the active operational dataset.
         "400":
           description: Invalid request body.
@@ -268,8 +269,8 @@ paths:
             schema:
               $ref: "#/components/schemas/Dataset"
       responses:
-        "202":
-          description: Successfully created the active operational dataset.
+        "201":
+          description: Successfully created the pending operational dataset.
         "400":
           description: Invalid request body.
     put:
@@ -282,7 +283,8 @@ paths:
         description: |-
           Operational dataset object that will be stored as pending operational dataset. Supports request body Content-Type `text/plain`
           (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
-          initialized with default or random values).
+          initialized with default or random values). This method allows to create a new dataset as well if Content-Type is `text/plain`
+          (dataset in TLV format as hex string).
         content:
           application/json:
             schema:
@@ -291,7 +293,7 @@ paths:
             schema:
               $ref: "#/components/schemas/DatasetTlv"
       responses:
-        "202":
+        "200":
           description: Successfully updated the pending operational dataset.
         "400":
           description: Invalid request body.

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -175,7 +175,7 @@ paths:
                 $ref: "#/components/schemas/Dataset"
             text/plain:
               schema:
-                $ref: "#/components/schemas/TlvDataset"
+                $ref: "#/components/schemas/DatasetTlv"
         "204":
           description: No active operational dataset
     post:
@@ -218,7 +218,7 @@ paths:
               $ref: "#/components/schemas/Dataset"
           plain/text:
             schema:
-              $ref: "#/components/schemas/TlvDataset"
+              $ref: "#/components/schemas/DatasetTlv"
       responses:
         "202":
           description: Successfully updated the active operational dataset.
@@ -240,7 +240,7 @@ paths:
                 $ref: "#/components/schemas/Dataset"
             text/plain:
               schema:
-                $ref: "#/components/schemas/TlvDataset"
+                $ref: "#/components/schemas/DatasetTlv"
         "204":
           description: No pending operational dataset
     post:
@@ -285,7 +285,7 @@ paths:
               $ref: "#/components/schemas/Dataset"
           plain/text:
             schema:
-              $ref: "#/components/schemas/TlvDataset"
+              $ref: "#/components/schemas/DatasetTlv"
       responses:
         "202":
           description: Successfully updated the pending operational dataset.
@@ -442,7 +442,7 @@ components:
           description: Non-CCM Routers enabled
           example: false
           default: false
-    TlvDataset:
+    DatasetTlv:
       type: string
       description: Operational dataset as hex-encoded TLVs.
       example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -253,10 +253,10 @@ paths:
         - node
       summary: Create new pending operational dataset
       description: |-
-        Creates new pending operational dataset on the current node. If the delay timer is specified, the new pending operational dataset
-        will become active after the time elapsed. The pending dataset will become empty.
+        Creates new pending operational dataset on the current node. The delay timer is mandatory and defines when the new pending operational
+        dataset will become active. Once active, the pending dataset will become empty.
 
-        Default parameters are chosen for parameters not set in the request body. By default, the delay timer is *not* set.
+        Default parameters are chosen for parameters not set in the request body.
 
         Note: To be considered as a valid active operational dataset the ActiveTimestamp needs to be newer than the current active operational
         dataset.

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -168,7 +168,7 @@ paths:
       summary: Get current active operational dataset
       responses:
         "200":
-          description: Returns currently active opertional dataset
+          description: Returns currently active operational dataset
           content:
             application/json:
               schema:
@@ -181,12 +181,12 @@ paths:
     post:
       tags:
         - node
-      summary: Create new active opertional dataset
+      summary: Create new active operational dataset
       description: |-
         Creates new active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
-        pending dataset if you would like to change the current active opertional dataset if the Thread node is active.
+        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
 
-        Default parameters are choosen for parameters not set in the request body.
+        Default parameters are chosen for parameters not set in the request body.
       requestBody:
         description: |-
           Operational dataset object that will be stored as active operational dataset. JSON keys which are not set will be initialized with
@@ -205,10 +205,10 @@ paths:
     put:
       tags:
         - node
-      summary: Update current active opertional dataset
+      summary: Update current active operational dataset
       description: |-
         Updates the current active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
-        pending dataset if you would like to change the current active opertional dataset if the Thread node is active.
+        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
       requestBody:
         description: |-
           Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
@@ -227,7 +227,7 @@ paths:
         "400":
           description: Invalid request body.
         "404":
-          description: No active opertional dataset to update.
+          description: No active operational dataset to update.
         "409":
           description: Writing active operational dataset rejected because Thread network is active.
   /node/dataset/pending:
@@ -237,7 +237,7 @@ paths:
       summary: Get current pending operational dataset
       responses:
         "200":
-          description: Returns currently pending opertional dataset
+          description: Returns currently pending operational dataset
           content:
             application/json:
               schema:
@@ -250,14 +250,14 @@ paths:
     post:
       tags:
         - node
-      summary: Create new pending opertional dataset
+      summary: Create new pending operational dataset
       description: |-
         Creates new pending operational dataset on the current node. If the delay timer is specified, the new pending operational dataset
         will become active after the time elapsed. The pending dataset will become empty.
 
-        Default parameters are choosen for parameters not set in the request body. By default, the delay timer is *not* set.
+        Default parameters are chosen for parameters not set in the request body. By default, the delay timer is *not* set.
 
-        Note: To be considered as a valid active opertional dataset the ActiveTimestamp needs to be newer than the current active operational
+        Note: To be considered as a valid active operational dataset the ActiveTimestamp needs to be newer than the current active operational
         dataset.
       requestBody:
         description: |-
@@ -275,7 +275,7 @@ paths:
     put:
       tags:
         - node
-      summary: Update current pending opertional dataset
+      summary: Update current pending operational dataset
       description: |-
         Updates the current pending operational dataset on the current node.
       requestBody:
@@ -296,7 +296,7 @@ paths:
         "400":
           description: Invalid request body.
         "404":
-          description: No pending opertional dataset to update.
+          description: No pending operational dataset to update.
 components:
   schemas:
     LeaderData:
@@ -355,7 +355,7 @@ components:
           default: random
         Delay:
           type: integer
-          description: Delay timer in miliseconds
+          description: Delay timer in milliseconds
           format: uint32
           example: 30000
           default: not set

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -178,43 +178,19 @@ paths:
                 $ref: "#/components/schemas/DatasetTlv"
         "204":
           description: No active operational dataset
-    post:
-      tags:
-        - node
-      summary: Create new active operational dataset
-      description: |-
-        Creates new active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
-        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
-
-        Default parameters are chosen for parameters not set in the request body.
-      requestBody:
-        description: |-
-          Operational dataset object that will be stored as active operational dataset. JSON keys which are not set will be initialized with
-          default or random values.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Dataset"
-      responses:
-        "201":
-          description: Successfully created the active operational dataset.
-        "400":
-          description: Invalid request body.
-        "409":
-          description: Writing active operational dataset rejected because Thread network is active.
     put:
       tags:
         - node
-      summary: Update current active operational dataset
+      summary: Creates or updates the active operational dataset
       description: |-
-        Updates the current active operational dataset on the current node. Only allowed if the Thread node is inactive. Create a
-        pending dataset if you would like to change the current active operational dataset if the Thread node is active.
+        Creates or updates the the active operational dataset on the current node. Only allowed if the Thread node
+        is inactive. If the Thread node is active, a pending dataset should be used to update the current active
+        operational dataset.
       requestBody:
         description: |-
-          Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
-          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
-          initialized with default or random values). This method allows to create a new dataset as well if Content-Type is `text/plain`
-          (dataset in TLV format as hex string).
+          Operational dataset that will be stored as active operational dataset. Supports request body Content-Type
+          `text/plain` (dataset in TLV format as hex string) or `application/json` (dataset in JSON format). In both
+          cases keys which are not set will be initialized with defaults.
         content:
           application/json:
             schema:
@@ -225,10 +201,10 @@ paths:
       responses:
         "200":
           description: Successfully updated the active operational dataset.
+        "201":
+          description: Successfully created the active operational dataset.
         "400":
           description: Invalid request body.
-        "404":
-          description: No active operational dataset to update.
         "409":
           description: Writing active operational dataset rejected because Thread network is active.
   /node/dataset/pending:
@@ -248,43 +224,18 @@ paths:
                 $ref: "#/components/schemas/DatasetTlv"
         "204":
           description: No pending operational dataset
-    post:
-      tags:
-        - node
-      summary: Create new pending operational dataset
-      description: |-
-        Creates new pending operational dataset on the current node. The delay timer is mandatory and defines when the new pending operational
-        dataset will become active. Once active, the pending dataset will become empty.
-
-        Default parameters are chosen for parameters not set in the request body.
-
-        Note: To be considered as a valid active operational dataset the ActiveTimestamp needs to be newer than the current active operational
-        dataset.
-      requestBody:
-        description: |-
-          Operational dataset object that will be stored as pending operational dataset. JSON keys which are not set will be initialized with
-          default or random values.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Dataset"
-      responses:
-        "201":
-          description: Successfully created the pending operational dataset.
-        "400":
-          description: Invalid request body.
     put:
       tags:
         - node
-      summary: Update current pending operational dataset
+      summary: Creates or updates the pending operational dataset
       description: |-
-        Updates the current pending operational dataset on the current node.
+        Creates or updates the the pending operational dataset on the current node. Delay needs to be set to let
+        the pending dataset apply as active dataset in the near future.
       requestBody:
         description: |-
-          Operational dataset object that will be stored as pending operational dataset. Supports request body Content-Type `text/plain`
-          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
-          initialized with default or random values). This method allows to create a new dataset as well if Content-Type is `text/plain`
-          (dataset in TLV format as hex string).
+          Operational dataset that will be stored as pending operational dataset. Supports request body Content-Type
+          `text/plain` (dataset in TLV format as hex string) or `application/json` (dataset in JSON format). In both
+          cases keys which are not set will be initialized with defaults.
         content:
           application/json:
             schema:
@@ -295,10 +246,10 @@ paths:
       responses:
         "200":
           description: Successfully updated the pending operational dataset.
+        "201":
+          description: Successfully created the pending operational dataset.
         "400":
           description: Invalid request body.
-        "404":
-          description: No pending operational dataset to update.
 components:
   schemas:
     LeaderData:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -200,6 +200,8 @@ paths:
           description: Successfully created the active operational dataset.
         "400":
           description: Invalid request body.
+        "409":
+          description: Writing active operational dataset rejected because Thread network is active.
     put:
       tags:
         - node
@@ -226,6 +228,8 @@ paths:
           description: Invalid request body.
         "404":
           description: No active opertional dataset to update.
+        "409":
+          description: Writing active operational dataset rejected because Thread network is active.
   /node/dataset/pending:
     get:
       tags:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Swagger OpenThread REST API
   description: |-
-    This describes the OpenThread Border Router RETS API. The API is provided by the otbr-agent, if the cmake flag `OTBR_REST=ON` is set. By default
+    This describes the OpenThread Border Router REST API. The API is provided by the otbr-agent, if the cmake flag `OTBR_REST=ON` is set. By default
     the REST API listens on any address on port 8081.
 
     Some useful links:
@@ -210,7 +210,7 @@ paths:
       requestBody:
         description: |-
           Operational dataset object that will be stored as active operational dataset. Supports request body Content-Type `text/plain`
-          (dataset in TLV format as hex string) or `application/json` (dataset in JSOn format, JSON keys which are not set will be
+          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
           initialized with default or random values).
         content:
           application/json:
@@ -277,7 +277,7 @@ paths:
       requestBody:
         description: |-
           Operational dataset object that will be stored as pending operational dataset. Supports request body Content-Type `text/plain`
-          (dataset in TLV format as hex string) or `application/json` (dataset in JSOn format, JSON keys which are not set will be
+          (dataset in TLV format as hex string) or `application/json` (dataset in JSON format, JSON keys which are not set will be
           initialized with default or random values).
         content:
           application/json:
@@ -334,7 +334,7 @@ components:
         PendingTimestamp:
           type: integer
           description: Pending timestamp
-          format: int32
+          format: uint64
           example: 10
           default: not set
         NetworkKey:
@@ -349,7 +349,7 @@ components:
           default: OpenThread-<PanId>
         ExtPanId:
           type: string
-          description: Extended PAN ID, 8 bytes long
+          description: Extended PAN ID, 8 bytes long, formatted as a hexadecimal string
           example: 996D3BEE320097A3
           default: random
         MeshLocalPrefix:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -194,7 +194,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Dataset"
+              $ref: "#/components/schemas/ActiveDataset"
           plain/text:
             schema:
               $ref: "#/components/schemas/DatasetTlv"
@@ -218,7 +218,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Dataset"
+                $ref: "#/components/schemas/PendingDataset"
             text/plain:
               schema:
                 $ref: "#/components/schemas/DatasetTlv"
@@ -239,8 +239,8 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Dataset"
-          plain/text:
+              $ref: "#/components/schemas/PendingDataset"
+          text/plain:
             schema:
               $ref: "#/components/schemas/DatasetTlv"
       responses:
@@ -279,12 +279,10 @@ components:
           format: uint8
           description: Leader Router ID
           example: 4
-    Dataset:
+    ActiveDataset:
       type: object
       properties:
         ActiveTimestamp:
-          $ref: "#/components/schemas/Timestamp"
-        PendingTimestamp:
           $ref: "#/components/schemas/Timestamp"
         NetworkKey:
           type: string
@@ -306,12 +304,6 @@ components:
           description: Mesh local IPv6 prefix
           example: fd33:d3b9:89e3:72e4::/64
           default: random
-        Delay:
-          type: integer
-          description: Delay timer in milliseconds
-          format: uint32
-          example: 30000
-          default: not set
         PanId:
           type: integer
           description: IEEE 802.15.4 PAN ID of the Thread network
@@ -337,6 +329,21 @@ components:
           format: uint32
           example: 134215680
           default: 134215680
+    PendingDataset:
+      type: object
+      properties:
+        ActiveDataset:
+          oneOf:
+            - $ref: "#/components/schemas/ActiveDataset"
+            - $ref: "#/components/schemas/DatasetTlv"
+        PendingTimestamp:
+          $ref: "#/components/schemas/Timestamp"
+        Delay:
+          type: integer
+          description: Delay timer in milliseconds
+          format: uint32
+          example: 30000
+          default: not set
     SecurityPolicy:
       type: object
       properties:
@@ -414,10 +421,3 @@ components:
       type: string
       description: Operational dataset as hex-encoded TLVs.
       example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8
-  requestBodies:
-    Dataset:
-      description: Operational dataset object that will be stored
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Dataset"

--- a/src/rest/parser.cpp
+++ b/src/rest/parser.cpp
@@ -87,6 +87,30 @@ static int OnHandlerData(http_parser *, const char *, size_t)
     return 0;
 }
 
+static int OnHeaderField(http_parser *parser, const char *at, size_t len)
+{
+    Request *request = reinterpret_cast<Request *>(parser->data);
+
+    if (len > 0)
+    {
+        request->SetNextHeaderField(at, len);
+    }
+
+    return 0;
+}
+
+static int OnHeaderData(http_parser *parser, const char *at, size_t len)
+{
+    Request *request = reinterpret_cast<Request *>(parser->data);
+
+    if (len > 0)
+    {
+        request->SetHeaderValue(at, len);
+    }
+
+    return 0;
+}
+
 Parser::Parser(Request *aRequest)
 {
     mParser.data = aRequest;
@@ -97,8 +121,8 @@ void Parser::Init(void)
     mSettings.on_message_begin    = OnMessageBegin;
     mSettings.on_url              = OnUrl;
     mSettings.on_status           = OnHandlerData;
-    mSettings.on_header_field     = OnHandlerData;
-    mSettings.on_header_value     = OnHandlerData;
+    mSettings.on_header_field     = OnHeaderField;
+    mSettings.on_header_value     = OnHeaderData;
     mSettings.on_body             = OnBody;
     mSettings.on_headers_complete = OnHeaderComplete;
     mSettings.on_message_complete = OnMessageComplete;

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -56,6 +56,16 @@ void Request::SetMethod(int32_t aMethod)
     mMethod = aMethod;
 }
 
+void Request::SetNextHeaderField(const char *aString, size_t aLength)
+{
+    mNextHeaderField = std::string(aString, aLength);
+}
+
+void Request::SetHeaderValue(const char *aString, size_t aLength)
+{
+    mHeaders[mNextHeaderField] = std::string(aString, aLength);
+}
+
 HttpMethod Request::GetMethod() const
 {
     return static_cast<HttpMethod>(mMethod);
@@ -85,6 +95,11 @@ std::string Request::GetUrl(void) const
 
 exit:
     return url;
+}
+
+std::string Request::GetHeaderValue(const std::string aHeaderField) const
+{
+    return mHeaders.at(aHeaderField);
 }
 
 void Request::SetReadComplete(void)

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -102,10 +102,7 @@ std::string Request::GetHeaderValue(const std::string aHeaderField) const
 {
     auto it = mHeaders.find(StringUtils::ToLowercase(aHeaderField));
 
-    if (it == mHeaders.end())
-        return "";
-    else
-        return it->second;
+    return (it == mHeaders.end()) ? "" : it->second;
 }
 
 void Request::SetReadComplete(void)

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "rest/request.hpp"
+#include "utils/string_utils.hpp"
 
 namespace otbr {
 namespace rest {
@@ -58,7 +59,7 @@ void Request::SetMethod(int32_t aMethod)
 
 void Request::SetNextHeaderField(const char *aString, size_t aLength)
 {
-    mNextHeaderField = std::string(aString, aLength);
+    mNextHeaderField = StringUtils::ToLowercase(std::string(aString, aLength));
 }
 
 void Request::SetHeaderValue(const char *aString, size_t aLength)
@@ -99,7 +100,12 @@ exit:
 
 std::string Request::GetHeaderValue(const std::string aHeaderField) const
 {
-    return mHeaders.at(aHeaderField);
+    auto it = mHeaders.find(StringUtils::ToLowercase(aHeaderField));
+
+    if (it == mHeaders.end())
+        return "";
+    else
+        return it->second;
 }
 
 void Request::SetReadComplete(void)

--- a/src/rest/request.hpp
+++ b/src/rest/request.hpp
@@ -34,8 +34,8 @@
 #ifndef OTBR_REST_REQUEST_HPP_
 #define OTBR_REST_REQUEST_HPP_
 
+#include <map>
 #include <string>
-#include <vector>
 
 #include "common/code_utils.hpp"
 #include "rest/types.hpp"
@@ -91,6 +91,24 @@ public:
     void SetMethod(int32_t aMethod);
 
     /**
+     * This method sets the next header field of a request.
+     *
+     * @param[in] aString  A pointer points to body string.
+     * @param[in] aLength  Length of the body string
+     *
+     */
+    void SetNextHeaderField(const char *aString, size_t aLength);
+
+    /**
+     * This method sets the header value of the previously set header of a request.
+     *
+     * @param[in] aString  A pointer points to body string.
+     * @param[in] aLength  Length of the body string
+     *
+     */
+    void SetHeaderValue(const char *aString, size_t aLength);
+
+    /**
      * This method labels the request as complete which means it no longer need to be parsed one more time .
      *
      */
@@ -124,6 +142,14 @@ public:
     std::string GetUrl(void) const;
 
     /**
+     * This method returns the specified header field for this request.
+     *
+     * @param[in] aHeaderField  A header field.
+     * @returns A string contains the header value of this request.
+     */
+    std::string GetHeaderValue(const std::string aHeaderField) const;
+
+    /**
      * This method indicates whether this request is parsed completely.
      *
      *
@@ -131,11 +157,13 @@ public:
     bool IsComplete(void) const;
 
 private:
-    int32_t     mMethod;
-    size_t      mContentLength;
-    std::string mUrl;
-    std::string mBody;
-    bool        mComplete;
+    int32_t                            mMethod;
+    size_t                             mContentLength;
+    std::string                        mUrl;
+    std::string                        mBody;
+    std::string                        mNextHeaderField;
+    std::map<std::string, std::string> mHeaders;
+    bool                               mComplete;
 };
 
 } // namespace rest

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -657,6 +657,11 @@ void Resource::Dataset(DatasetType aDatasetType, const Request &aRequest, Respon
     case HttpMethod::kPut:
         SetDataset(aDatasetType, aRequest, aResponse, false);
         break;
+    case HttpMethod::kOptions:
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+        aResponse.SetResponsCode(errorCode);
+        aResponse.SetComplete();
+        break;
     default:
         ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
         break;

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -528,7 +528,7 @@ void Resource::GetDataset(DatasetType aDatasetType, const Request &aRequest, Res
         }
 
         aResponse.SetContentType(OT_REST_CONTENT_TYPE_PLAIN);
-        body = Json::Bytes2HexString(datasetTlvs.mTlvs, datasetTlvs.mLength);
+        body = Utils::Bytes2Hex(datasetTlvs.mTlvs, datasetTlvs.mLength);
     }
     else
     {

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -630,6 +630,7 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
         }
         else if (aDatasetType == DatasetType::kPending)
         {
+            VerifyOrExit(dataset.mComponents.mIsDelayPresent, error = OTBR_ERROR_INVALID_ARGS);
             VerifyOrExit(otDatasetSetPending(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
         }
     }

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -95,7 +95,7 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     case HttpStatusCode::kStatusAccepted:
         httpStatus = OT_REST_HTTP_STATUS_202;
         break;
-    case HttpStatusCode::kNoContent:
+    case HttpStatusCode::kStatusNoContent:
         httpStatus = OT_REST_HTTP_STATUS_204;
         break;
     case HttpStatusCode::kStatusBadRequest:
@@ -553,7 +553,7 @@ exit:
     }
     else if (error == OTBR_ERROR_NOT_FOUND)
     {
-        errorCode = GetHttpStatus(HttpStatusCode::kNoContent);
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
         aResponse.SetResponsCode(errorCode);
     }
     else

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -53,7 +53,7 @@
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_PREFIX "/networks/current/prefix"
 
 #define OT_REST_HTTP_STATUS_200 "200 OK"
-#define OT_REST_HTTP_STATUS_202 "202 Accepted"
+#define OT_REST_HTTP_STATUS_201 "201 Created"
 #define OT_REST_HTTP_STATUS_204 "204 No Content"
 #define OT_REST_HTTP_STATUS_400 "400 Bad Request"
 #define OT_REST_HTTP_STATUS_404 "404 Not Found"
@@ -93,8 +93,8 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     case HttpStatusCode::kStatusOk:
         httpStatus = OT_REST_HTTP_STATUS_200;
         break;
-    case HttpStatusCode::kStatusAccepted:
-        httpStatus = OT_REST_HTTP_STATUS_202;
+    case HttpStatusCode::kStatusCreated:
+        httpStatus = OT_REST_HTTP_STATUS_201;
         break;
     case HttpStatusCode::kStatusNoContent:
         httpStatus = OT_REST_HTTP_STATUS_204;
@@ -568,10 +568,11 @@ exit:
 
 void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const
 {
-    otbrError                error = OTBR_ERROR_NONE;
-    struct NodeInfo          node;
-    std::string              body;
-    std::string              errorCode;
+    otbrError       error = OTBR_ERROR_NONE;
+    struct NodeInfo node;
+    std::string     body;
+    std::string     errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+    ;
     otOperationalDataset     dataset;
     otOperationalDatasetTlvs datasetTlvs;
     int                      ret;
@@ -607,6 +608,7 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
         if (create)
         {
             VerifyOrExit(otDatasetCreateNewNetwork(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
+            errorCode = GetHttpStatus(HttpStatusCode::kStatusCreated);
         }
         else
         {
@@ -632,7 +634,6 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
         }
     }
 
-    errorCode = GetHttpStatus(HttpStatusCode::kStatusAccepted);
     aResponse.SetResponsCode(errorCode);
 
 exit:

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -539,12 +539,13 @@ void Resource::GetDataset(DatasetType aDatasetType, const Request &aRequest, Res
         if (aDatasetType == DatasetType::kActive)
         {
             VerifyOrExit(otDatasetGetActive(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
+            body = Json::ActiveDataset2JsonString(dataset);
         }
         else if (aDatasetType == DatasetType::kPending)
         {
             VerifyOrExit(otDatasetGetPending(mInstance, &dataset) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
+            body = Json::PendingDataset2JsonString(dataset);
         }
-        body = Json::Dataset2JsonString(dataset);
     }
 
     aResponse.SetBody(body);
@@ -609,7 +610,16 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
     }
     else
     {
-        VerifyOrExit(Json::JsonString2Dataset(aRequest.GetBody(), dataset), error = OTBR_ERROR_INVALID_ARGS);
+        if (aDatasetType == DatasetType::kActive)
+        {
+            VerifyOrExit(Json::JsonActiveDatasetString2Dataset(aRequest.GetBody(), dataset),
+                         error = OTBR_ERROR_INVALID_ARGS);
+        }
+        else if (aDatasetType == DatasetType::kPending)
+        {
+            VerifyOrExit(Json::JsonPendingDatasetString2Dataset(aRequest.GetBody(), dataset),
+                         error = OTBR_ERROR_INVALID_ARGS);
+        }
     }
 
     if (aDatasetType == DatasetType::kActive)

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -141,7 +141,7 @@ private:
     void GetDataExtendedPanId(Response &aResponse) const;
     void GetDataRloc(Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
-    void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const;
+    void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -125,7 +125,6 @@ private:
     void Rloc16(const Request &aRequest, Response &aResponse) const;
     void ExtendedPanId(const Request &aRequest, Response &aResponse) const;
     void Rloc(const Request &aRequest, Response &aResponse) const;
-    void ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
     void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void DatasetActive(const Request &aRequest, Response &aResponse) const;
     void DatasetPending(const Request &aRequest, Response &aResponse) const;
@@ -141,8 +140,6 @@ private:
     void GetDataRloc16(Response &aResponse) const;
     void GetDataExtendedPanId(Response &aResponse) const;
     void GetDataRloc(Response &aResponse) const;
-    void GetActiveDatasetTlvs(Response &aResponse) const;
-    void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const;
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -144,7 +144,7 @@ private:
     void GetActiveDatasetTlvs(Response &aResponse) const;
     void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, Response &aResponse) const;
-    void CreateDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
+    void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -39,6 +39,8 @@
 #include <openthread/border_router.h>
 
 #include "ncp/ncp_openthread.hpp"
+#include "openthread/dataset.h"
+#include "openthread/dataset_ftd.h"
 #include "rest/json.hpp"
 #include "rest/request.hpp"
 #include "rest/response.hpp"
@@ -142,6 +144,7 @@ private:
     void GetActiveDatasetTlvs(Response &aResponse) const;
     void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, Response &aResponse) const;
+    void CreateDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -102,6 +102,16 @@ public:
     void ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) const;
 
 private:
+    /**
+     * This enumeration represents the Dataset type (active or pending).
+     *
+     */
+    enum DatasetType : uint8_t
+    {
+        kActive,  ///< Active Dataset
+        kPending, ///< Pending Dataset
+    };
+
     typedef void (Resource::*ResourceHandler)(const Request &aRequest, Response &aResponse) const;
     typedef void (Resource::*ResourceCallbackHandler)(const Request &aRequest, Response &aResponse);
     void NodeInfo(const Request &aRequest, Response &aResponse) const;
@@ -114,6 +124,9 @@ private:
     void ExtendedPanId(const Request &aRequest, Response &aResponse) const;
     void Rloc(const Request &aRequest, Response &aResponse) const;
     void ActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
+    void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
+    void DatasetActive(const Request &aRequest, Response &aResponse) const;
+    void DatasetPending(const Request &aRequest, Response &aResponse) const;
     void Diagnostic(const Request &aRequest, Response &aResponse) const;
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
@@ -128,6 +141,7 @@ private:
     void GetDataRloc(Response &aResponse) const;
     void GetActiveDatasetTlvs(Response &aResponse) const;
     void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
+    void GetDataset(DatasetType aDatasetType, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -108,7 +108,7 @@ private:
      * This enumeration represents the Dataset type (active or pending).
      *
      */
-    enum DatasetType : uint8_t
+    enum class DatasetType : uint8_t
     {
         kActive,  ///< Active Dataset
         kPending, ///< Pending Dataset

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -143,7 +143,7 @@ private:
     void GetDataRloc(Response &aResponse) const;
     void GetActiveDatasetTlvs(Response &aResponse) const;
     void SetActiveDatasetTlvs(const Request &aRequest, Response &aResponse) const;
-    void GetDataset(DatasetType aDatasetType, Response &aResponse) const;
+    void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse, bool create) const;
 
     void DeleteOutDatedDiagnostic(void);

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -34,7 +34,7 @@
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, POST, PUT"
+#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, PUT"
 #define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -30,7 +30,7 @@
 
 #include <stdio.h>
 
-#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
+#define OT_REST_RESPONSE_CONTENT_TYPE_HEADER "Content-Type"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN "*"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
@@ -49,11 +49,11 @@ Response::Response(void)
     mProtocol = "HTTP/1.1";
 
     // Pre-defined headers
-    mHeaders["Content-Type"]                 = OT_REST_RESPONSE_CONTENT_TYPE_JSON;
-    mHeaders["Access-Control-Allow-Origin"]  = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
-    mHeaders["Access-Control-Allow-Methods"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
-    mHeaders["Access-Control-Allow-Headers"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
-    mHeaders["Connection"]                   = OT_REST_RESPONSE_CONNECTION;
+    mHeaders[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = OT_REST_RESPONSE_CONTENT_TYPE_JSON;
+    mHeaders["Access-Control-Allow-Origin"]        = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
+    mHeaders["Access-Control-Allow-Methods"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
+    mHeaders["Access-Control-Allow-Headers"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
+    mHeaders["Connection"]                         = OT_REST_RESPONSE_CONNECTION;
 }
 
 void Response::SetComplete()
@@ -79,6 +79,11 @@ bool Response::IsComplete()
 void Response::SetResponsCode(std::string &aCode)
 {
     mCode = aCode;
+}
+
+void Response::SetContentType(const std::string &aContentType)
+{
+    mHeaders[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = aContentType;
 }
 
 void Response::SetCallback(void)

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -82,7 +82,7 @@ void Response::SetResponsCode(std::string &aCode)
 
 void Response::SetContentType(const std::string &aContentType)
 {
-    mHeaders[OT_REST_CONTENT_TYPE_JSON] = aContentType;
+    mHeaders[OT_REST_CONTENT_TYPE_HEADER] = aContentType;
 }
 
 void Response::SetCallback(void)

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 
-#define OT_REST_RESPONSE_CONTENT_TYPE_HEADER "Content-Type"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN "*"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
@@ -49,11 +48,11 @@ Response::Response(void)
     mProtocol = "HTTP/1.1";
 
     // Pre-defined headers
-    mHeaders[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = OT_REST_RESPONSE_CONTENT_TYPE_JSON;
-    mHeaders["Access-Control-Allow-Origin"]        = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
-    mHeaders["Access-Control-Allow-Methods"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
-    mHeaders["Access-Control-Allow-Headers"]       = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
-    mHeaders["Connection"]                         = OT_REST_RESPONSE_CONNECTION;
+    mHeaders[OT_REST_CONTENT_TYPE_HEADER]    = OT_REST_CONTENT_TYPE_JSON;
+    mHeaders["Access-Control-Allow-Origin"]  = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
+    mHeaders["Access-Control-Allow-Methods"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
+    mHeaders["Access-Control-Allow-Headers"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
+    mHeaders["Connection"]                   = OT_REST_RESPONSE_CONNECTION;
 }
 
 void Response::SetComplete()
@@ -83,7 +82,7 @@ void Response::SetResponsCode(std::string &aCode)
 
 void Response::SetContentType(const std::string &aContentType)
 {
-    mHeaders[OT_REST_RESPONSE_CONTENT_TYPE_HEADER] = aContentType;
+    mHeaders[OT_REST_CONTENT_TYPE_JSON] = aContentType;
 }
 
 void Response::SetCallback(void)

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -34,7 +34,7 @@
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET"
+#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, POST, PUT"
 #define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -40,6 +40,9 @@
 
 #include "rest/types.hpp"
 
+#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
+#define OT_REST_RESPONSE_CONTENT_TYPE_PLAIN "text/plain"
+
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::seconds;
@@ -85,6 +88,14 @@ public:
      *
      */
     void SetResponsCode(std::string &aCode);
+
+    /**
+     * This method sets the content type.
+     *
+     * @param[in] aCode  A string representing response content type such as text/plain.
+     *
+     */
+    void SetContentType(const std::string &aContentType);
 
     /**
      * This method labels the response as need callback.

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -40,9 +40,6 @@
 
 #include "rest/types.hpp"
 
-#define OT_REST_RESPONSE_CONTENT_TYPE_JSON "application/json"
-#define OT_REST_RESPONSE_CONTENT_TYPE_PLAIN "text/plain"
-
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::seconds;

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -65,7 +65,7 @@ enum class HttpMethod : std::uint8_t
 enum class HttpStatusCode : std::uint16_t
 {
     kStatusOk                  = 200,
-    kStatusAccepted            = 202,
+    kStatusCreated             = 201,
     kStatusNoContent           = 204,
     kStatusBadRequest          = 400,
     kStatusResourceNotFound    = 404,

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -71,6 +71,7 @@ enum class HttpStatusCode : std::uint16_t
     kStatusResourceNotFound    = 404,
     kStatusMethodNotAllowed    = 405,
     kStatusRequestTimeout      = 408,
+    kStatusConflict            = 409,
     kStatusInternalServerError = 500,
 };
 

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -60,6 +60,7 @@ enum class HttpStatusCode : std::uint16_t
 {
     kStatusOk                  = 200,
     kStatusAccepted            = 202,
+    kNoContent                 = 204,
     kStatusBadRequest          = 400,
     kStatusResourceNotFound    = 404,
     kStatusMethodNotAllowed    = 405,

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -40,6 +40,11 @@
 
 #include "openthread/netdiag.h"
 
+#define OT_REST_CONTENT_TYPE_HEADER "Content-Type"
+
+#define OT_REST_CONTENT_TYPE_JSON "application/json"
+#define OT_REST_CONTENT_TYPE_PLAIN "text/plain"
+
 using std::chrono::steady_clock;
 
 namespace otbr {

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -66,7 +66,7 @@ enum class HttpStatusCode : std::uint16_t
 {
     kStatusOk                  = 200,
     kStatusAccepted            = 202,
-    kNoContent                 = 204,
+    kStatusNoContent           = 204,
     kStatusBadRequest          = 400,
     kStatusResourceNotFound    = 404,
     kStatusMethodNotAllowed    = 405,

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -40,6 +40,7 @@
 
 #include "openthread/netdiag.h"
 
+#define OT_REST_ACCEPT_HEADER "Accept"
 #define OT_REST_CONTENT_TYPE_HEADER "Content-Type"
 
 #define OT_REST_CONTENT_TYPE_JSON "application/json"

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -109,6 +109,18 @@ size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
     return strlen(aHex);
 }
 
+std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength)
+{
+    char        hex[2 * aBytesLength + 1];
+    std::string s;
+    size_t      len;
+
+    len = Bytes2Hex(aBytes, aBytesLength, hex);
+    s   = std::string(hex, len);
+
+    return s;
+}
+
 size_t Long2Hex(const uint64_t aLong, char *aHex)
 {
     char     byteHex[3];

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -138,7 +138,7 @@ size_t Long2Hex(const uint64_t aLong, char *aHex)
         longValue = longValue >> 8;
     }
 
-        return strlen(aHex);
+    return strlen(aHex);
 }
 
 } // namespace Utils

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -96,34 +96,36 @@ size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
 {
     char byteHex[3];
 
-    std::string hexString;
-    uint8_t     cur[aBytesLength];
-
-    memcpy(cur, aBytes, aBytesLength);
+    // Make sure strcat appends at the beginning of the output buffer even
+    // if uninitialized.
+    aHex[0] = '\0';
 
     for (int i = 0; i < aBytesLength; i++)
     {
-        snprintf(byteHex, sizeof(byteHex), "%02X", cur[i]);
-        hexString += byteHex;
+        snprintf(byteHex, sizeof(byteHex), "%02X", aBytes[i]);
+        strcat(aHex, byteHex);
     }
-    strcpy(aHex, hexString.c_str());
+
     return strlen(aHex);
 }
 
 size_t Long2Hex(const uint64_t aLong, char *aHex)
 {
-    std::string hexString;
-    char        byteHex[3];
-    uint64_t    longValue = aLong;
+    char     byteHex[3];
+    uint64_t longValue = aLong;
+
+    // Make sure strcat appends at the beginning of the output buffer even
+    // if uninitialized.
+    aHex[0] = '\0';
 
     for (uint8_t i = 0; i < sizeof(uint64_t); i++)
     {
         uint8_t byte = longValue & 0xff;
         snprintf(byteHex, sizeof(byteHex), "%02X", byte);
-        hexString += byteHex;
+        strcat(aHex, byteHex);
         longValue = longValue >> 8;
     }
-    strcpy(aHex, hexString.c_str());
+
     return strlen(aHex);
 }
 

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -138,7 +138,7 @@ size_t Long2Hex(const uint64_t aLong, char *aHex)
         longValue = longValue >> 8;
     }
 
-    return strlen(aHex);
+        return strlen(aHex);
 }
 
 } // namespace Utils

--- a/src/utils/hex.hpp
+++ b/src/utils/hex.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-br/config.h"
 
+#include <string>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -65,6 +67,16 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
  * @return The length of the resulting hexadecimal string.
  */
 size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex);
+
+/**
+ * @brief Converts a byte array to a hexadecimal string.
+ *
+ * @param[in]  aBytes A pointer to the byte array to be converted.
+ * @param[in]  aBytesLength The length of the byte array.
+ *
+ * @return The hexadecimal string.
+ */
+std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength);
 
 /**
  * @brief Converts a 64-bit integer to a hexadecimal string.

--- a/src/utils/hex.hpp
+++ b/src/utils/hex.hpp
@@ -43,10 +43,38 @@ namespace otbr {
 
 namespace Utils {
 
+/**
+ * @brief Converts a hexadecimal string to a byte array.
+ *
+ * @param hexString A pointer to the hexadecimal string to be converted.
+ * @param bytes A pointer to an array to store the resulting byte values.
+ * @param maxBytesLength The maximum number of bytes that can be stored in the `bytes` array.
+ *
+ * @return The number of bytes stored in the `bytes` array, or -1 if an error occurred.
+ */
 int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
 
+/**
+ * @brief Converts a byte array to a hexadecimal string.
+ *
+ * @param[in]  aBytes A pointer to the byte array to be converted.
+ * @param[in]  aBytesLength The length of the byte array.
+ * @param[out] aHex A character array to store the resulting hexadecimal string.
+ *                  Must be at least 2 * @param aBytesLength + 1 long.
+ *
+ * @return The length of the resulting hexadecimal string.
+ */
 size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex);
 
+/**
+ * @brief Converts a 64-bit integer to a hexadecimal string.
+ *
+ * @param[in]  aLong The 64-bit integer to be converted.
+ * @param[out] aHex A character array to store the resulting hexadecimal string.
+ *                  Must be at least 17 bytes long.
+ *
+ * @return The length of the resulting hexadecimal string.
+ */
 size_t Long2Hex(const uint64_t aLong, char *aHex);
 
 } // namespace Utils


### PR DESCRIPTION
This PR extends the REST API to support reading and writing Active and Pending Operational Datasets. It largely implements what has been discussed in https://github.com/openthread/openthread/discussions/8567.

It adds the following endpoints and methods:

* /node/dataset/active [`GET`, `OPTIONS`, `POST`, `PUT`]
* /node/dataset/pending [`GET`, `OPTIONS`, `POST`, `PUT`]

The `GET` method returns current datasets, `POST` allows to create a new dataset (with defaults as initialized by the OpenThread implementation just like `ot-ctl dataset init new`). Any fields provided with `POST` will overwrite the defaults, hence a call like

```
curl -X POST http://localhost:8081/node/dataset/pending -d '{ "Delay": 30000, "ActiveTimestamp": 10 }'
```

Is equivalent to:

```
ot-ctl dataset init new
ot-ctl dataset delay 30000
ot-ctl dataset activetimestamp 10
ot-ctl dataset commit pending
```

`PUT` requests do not initialize a new dataset (which makes the call idempotent as defined in HTTP). `PUT` simply loads the current dataset and updates it with the new values provided by the JSON body. When using the TLV format PUT is a simple write to the active/pending dataset.

Datasets can be read and written using a straight forward JSON format or alternatively using the Dataset TLV format. This is implemented in a RESTful manor by using the same endpoints but `Content-Type` to distinguish the two data formats. The `application/json` type is used for JSON and `plain/text` for Dataset TLV format.

The API is documented by a OpenAPI Specification (Swagger). The YAML description file is stored at `src/rest/openapi.yaml`. Swagger UI allows to test all the variants described above as well. To start Swagger UI locally the following command can be used:

```
docker run -p 8082:8080 -e SWAGGER_JSON=/openapi.yaml -v $(pwd)/src/rest/openapi.yaml:/openapi.yaml swaggerapi/swagger-ui
```

The following things are open/tbd at this point:

- No method to change state of the OTBR (probably best done in a separate PR)
- Automatic/implicit `ActiveTimestamp` support (or should this be left to the client)
- Generate Swagger UI API in GitHub actions/deploy GitHub pages?
- Additional testing/unit tests?

The PR also removes the `/node/active-dataset-tlvs` endpoint as it is obsolete with this much more capable endpoints.
