### PR TITLE
[rest] remove superfluous space in HTTP status line

### DIFF
--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -45,7 +45,7 @@ Response::Response(void)
     , mComplete(false)
 {
     // HTTP protocol
-    mProtocol = "HTTP/1.1 ";
+    mProtocol = "HTTP/1.1";
 
     // Pre-defined headers
     mHeaders["Content-Type"]                 = OT_REST_RESPONSE_CONTENT_TYPE_JSON;


### PR DESCRIPTION
A space is already added in Response::Serialize(). According to the HTTP specification there should only be a single space between the protcol version and the status code.