### PR TITLE
[docker] retry reading syslog

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -92,8 +92,8 @@ echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d7 -p 80\"" >/etc/default/otbr-web
 
 /app/script/server
 
-for i in 1 2 3
-do
-    tail -f /var/log/syslog
+while [[ ! -f /var/log/syslog ]]; do
     sleep 1
 done
+
+tail -f /var/log/syslog

--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -92,4 +92,8 @@ echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d7 -p 80\"" >/etc/default/otbr-web
 
 /app/script/server
 
-tail -f /var/log/syslog
+for i in 1 2 3
+do
+    tail -f /var/log/syslog
+    sleep 1
+done


### PR DESCRIPTION
On some systems where I try to run the image, it seems that there is a race and sometimes the script tries to read the logs before syslog is ready.

I'm not sure if somebody else encountered this problem.

Here I propose a quick workaround.

Here is an example output where 1 retry was necessary:

```
...
++ printenv WEB_GUI
+ value=1
+ [[ -z 1 ]]
+ [[ 1 == 1 ]]
+ sudo service otbr-web status
 * otbr-web is not running
+ sudo service otbr-web start
 * Starting thread web interface otbr-web                                                                                                                                          [ OK ] 
+ . /dev/null
tail: cannot open '/var/log/syslog' for reading: No such file or directory
tail: no files remaining
Jan 20 11:39:34 nuc2 otbr-agent[129]: 00:00:00.039 [I] Platform------: Execute command `ipset add otbr-ingress-deny-src-swap fdde:ad00:beef:0::/64 -exist` = 0
Jan 20 11:39:34 nuc2 otbr-agent[129]: 00:00:00.040 [I] Platform------: Execute command `ipset swap otbr-ingress-deny-src-swap otbr-ingress-deny-src` = 0
Jan 20 11:39:34 nuc2 otbr-agent[129]: 00:00:00.042 [I] Platform------: Execute command `ipset swap otbr-ingress-allow-dst-swap otbr-ingress-allow-dst` = 0
Jan 20 11:39:34 nuc2 otbr-agent[129]: 00:00:00.042 [I] Platform------: MulticastRoutingManager: Disable: OK
Jan 20 11:39:34 nuc2 otbr-agent[129]: [INFO]-BA------: Publish meshcop service OpenThread BorderRouter #5444._meshcop._udp.local.
Jan 20 11:39:34 nuc2 otbr-agent[129]: [DEBG]-BBA-----: BackboneAgent: HandleBackboneRouterState: state=1, mBackboneRouterState=0
Jan 20 11:39:34 nuc2 otbr-agent[129]: 00:00:00.043 [I] Platform------: [netif] Host netif is down
Jan 20 11:39:34 nuc2 rsyslogd: rsyslogd's groupid changed to 101
Jan 20 11:39:34 nuc2 rsyslogd: rsyslogd's userid changed to 101
Jan 20 11:39:34 nuc2 rsyslogd:  [origin software="rsyslogd" swVersion="8.32.0" x-pid="97" x-info="http://www.rsyslog.com"] start
Jan 20 11:39:35 nuc2 otbr-agent[129]: [INFO]-MDNS----: Avahi group (@0x562842df7450) is established
Jan 20 11:39:35 nuc2 otbr-agent[129]: [INFO]-BA------: Result of publish meshcop service OpenThread BorderRouter #5444._meshcop._udp.local: OK
```