### PR TITLE
[docker] perform a proper shutdown

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -65,6 +65,15 @@ function parse_args()
     done
 }
 
+function shutdown()
+{
+    echo "Shutting down"
+    /app/script/server shutdown
+    exit 0
+}
+
+trap shutdown TERM INT
+
 parse_args "$@"
 
 [ -n "$RADIO_URL" ] || RADIO_URL="spinel+hdlc+uart:///dev/ttyUSB0"
@@ -96,4 +105,5 @@ while [[ ! -f /var/log/syslog ]]; do
     sleep 1
 done
 
-tail -f /var/log/syslog
+tail -f /var/log/syslog &
+wait $!

--- a/script/server
+++ b/script/server
@@ -65,4 +65,33 @@ main()
     . "$AFTER_HOOK"
 }
 
-main
+shutdown()
+{
+    nat64_stop || echo 'Failed to start NAT64!'
+    dns64_stop || echo 'Failed to start DNS64!'
+    firewall_stop || echo 'Failed to start firewall'
+    if have systemctl; then
+        systemctl is-active rsyslog && sudo systemctl stop rsyslog || echo 'Failed to stop rsyslog!'
+        systemctl is-active dbus && sudo systemctl stop dbus || echo 'Failed to stop dbus!'
+        systemctl is-active avahi-daemon && sudo systemctl stop avahi-daemon || echo 'Failed to stop avahi!'
+        without WEB_GUI || systemctl is-active otbr-web && sudo systemctl stop otbr-web || echo 'Failed to stop otbr-web!'
+        systemctl is-active otbr-agent && sudo systemctl stop otbr-agent || echo 'Failed to stop otbr-agent!'
+    elif have service; then
+        sudo service rsyslog status && sudo service rsyslog stop || echo 'Failed to stop rsyslog!'
+        sudo service dbus status && sudo service dbus stop || echo 'Failed to stop dbus!'
+        # Tolerate the mdns failure as it is installed for only CI docker.
+        sudo service mdns status && sudo service mdns stop || echo "service mdns is not available!"
+        sudo service avahi-daemon status && sudo service avahi-daemon stop || echo 'Failed to stop avahi!'
+        sudo service otbr-agent status && sudo service otbr-agent stop || echo 'Failed to stop otbr-agent!'
+        without WEB_GUI || sudo service otbr-web status && sudo service otbr-web stop || echo 'Failed to stop otbr-web!'
+    else
+        echo 'Unable to find service manager. Try script/console to stop in console mode!'
+    fi
+}
+
+if [ "${1-}" == "shutdown" ]
+then
+    shutdown
+else
+    main
+fi

--- a/script/server
+++ b/script/server
@@ -67,9 +67,9 @@ startup()
 
 shutdown()
 {
-    nat64_stop || echo 'Failed to start NAT64!'
-    dns64_stop || echo 'Failed to start DNS64!'
-    firewall_stop || echo 'Failed to start firewall'
+    nat64_stop || echo 'Failed to stop NAT64!'
+    dns64_stop || echo 'Failed to stop DNS64!'
+    firewall_stop || echo 'Failed to stop firewall'
     if have systemctl; then
         systemctl is-active rsyslog && sudo systemctl stop rsyslog || echo 'Failed to stop rsyslog!'
         systemctl is-active dbus && sudo systemctl stop dbus || echo 'Failed to stop dbus!'

--- a/script/server
+++ b/script/server
@@ -79,7 +79,6 @@ shutdown()
     elif have service; then
         sudo service rsyslog status && sudo service rsyslog stop || echo 'Failed to stop rsyslog!'
         sudo service dbus status && sudo service dbus stop || echo 'Failed to stop dbus!'
-        # Tolerate the mdns failure as it is installed for only CI docker.
         sudo service mdns status && sudo service mdns stop || echo "service mdns is not available!"
         sudo service avahi-daemon status && sudo service avahi-daemon stop || echo 'Failed to stop avahi!'
         sudo service otbr-agent status && sudo service otbr-agent stop || echo 'Failed to stop otbr-agent!'

--- a/script/server
+++ b/script/server
@@ -90,7 +90,7 @@ shutdown()
 
 main()
 {
-    if [[ "${1-}" == "shutdown" ]]; then
+    if [[ ${1-} == "shutdown" ]]; then
         shift
         shutdown "$@"
     else

--- a/script/server
+++ b/script/server
@@ -36,7 +36,7 @@
 . script/_dns64
 . script/_firewall
 
-main()
+startup()
 {
     # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
@@ -88,9 +88,14 @@ shutdown()
     fi
 }
 
-if [ "${1-}" == "shutdown" ]
-then
-    shutdown
-else
-    main
-fi
+main()
+{
+    if [[ "${1-}" == "shutdown" ]]; then
+        shift
+        shutdown "$@"
+    else
+        startup "$@"
+    fi
+}
+
+main "$@"

--- a/tests/scripts/check-docker
+++ b/tests/scripts/check-docker
@@ -37,7 +37,15 @@ on_exit()
     local status=$?
 
     killall socat || true
+
     docker stop "${OTBR_DOCKER_PID}" || true
+    local -r CONTAINER_RET=$(docker inspect "${OTBR_DOCKER_PID}" --format='{{.State.ExitCode}}')
+    docker rm "${OTBR_DOCKER_PID}"
+
+    if [[ "${CONTAINER_RET}" != "0" ]]; then
+        echo 'Container did not shutdown properly'
+    fi
+
     killall ot-rcp || true
     killall socat || true
 
@@ -75,7 +83,7 @@ main()
     # shellcheck disable=SC2094
     ot-rcp 1 >"$DEVICE_PTY" <"$DEVICE_PTY" &
 
-    OTBR_DOCKER_PID=$(docker run --rm -d \
+    OTBR_DOCKER_PID=$(docker run -d \
         --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1" \
         --privileged -p 8080:80 --dns=127.0.0.1 --volume "$DOCKER_PTY":/dev/ttyUSB0 otbr --backbone-interface eth0)
     readonly OTBR_DOCKER_PID

--- a/tests/scripts/check-docker
+++ b/tests/scripts/check-docker
@@ -42,7 +42,7 @@ on_exit()
     local -r CONTAINER_RET=$(docker inspect "${OTBR_DOCKER_PID}" --format='{{.State.ExitCode}}')
     docker rm "${OTBR_DOCKER_PID}"
 
-    if [[ "${CONTAINER_RET}" != "0" ]]; then
+    if [[ ${CONTAINER_RET} != "0" ]]; then
         echo 'Container did not shutdown properly'
     fi
 


### PR DESCRIPTION
Catch the docker sigterm and handle a clean shutdown.

At least those advantages come to mind:

1. Allows for a faster shutdown (about 1.5s as seen in the example below) because we don't have to wait until docker times out (10s) and kills everything.

```
container-otbr-autostart-otbr-1   | Jan 21 14:28:04 nuc2 otbr-agent[93]: 00:00:15.619 [I] BorderRouter--: RouterAdvert: Added RIO for fd04:2240:0:20::/64 (lifetime=1800)
container-otbr-autostart-otbr-1   | Jan 21 14:28:04 nuc2 otbr-agent[93]: 00:00:15.619 [I] BorderRouter--: Sent Router Advertisement on infra netif 2
container-otbr-autostart-otbr-1   | Jan 21 14:28:04 nuc2 otbr-agent[93]: 00:00:15.619 [I] BorderRouter--: Start evaluating routing policy, scheduled in 16000 milliseconds
container-otbr-autostart-otbr-1   | Jan 21 14:28:04 nuc2 otbr-agent[93]: 00:00:15.619 [I] BorderRouter--: Received Router Advertisement from fe80:0:0:0:baae:edff:fe71:259d on infra netif 2
^CGracefully stopping... (press Ctrl+C again to force)
[+] Running 2/2
 ⠿ Container container-otbr-autostart-setup-1  Stopped                                                                                                                               0.0s
 ⠿ Container container-otbr-autostart-otbr-1   Stopped                                                                                                                               1.5s
``` 

2. If running the container with `--network host`, it won't leave iptables rules behind.