### PR TITLE
[mdns] publish a service using the default hostname as the instance name

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -189,7 +189,8 @@ public:
      *                          provided, this service resides on local host and it is the implementation
      *                          to provide specific host name. Otherwise, the caller MUST publish the host
      *                          with method PublishHost.
-     * @param[in] aName         The name of this service.
+     * @param[in] aName         The name of this service. If an empty string is provided, the service's name will be the
+     *                          same as the platform's hostname.
      * @param[in] aType         The type of this service.
      * @param[in] aSubTypeList  A list of service subtypes.
      * @param[in] aPort         The port number of this service.
@@ -412,6 +413,7 @@ protected:
         }
     };
 
+    // TODO: We may need a registration ID to fetch the information of a registration.
     class ServiceRegistration : public Registration
     {
     public:

--- a/tests/mdns/test-single-empty-service-name
+++ b/tests/mdns/test-single-empty-service-name
@@ -1,5 +1,6 @@
+#!/bin/bash
 #
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2023, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,64 +27,24 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(otbr-test-mdns
-    main.cpp
-)
+#
+# This script tests publishing single service.
+#
 
-target_link_libraries(otbr-test-mdns PRIVATE
-    otbr-config
-    otbr-mdns
-)
+# shellcheck source=tests/mdns/test_init
+. "$(dirname "$0")/test_init"
 
-add_test(
-    NAME mdns-single
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single
-)
+main()
+{
+    start_publisher se
 
-add_test(
-    NAME mdns-multiple
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple
-)
+    HOST_NAME="$(hostname -s)"
 
-add_test(
-    NAME mdns-update
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-update
-)
+    if [[ ${OTBR_MDNS} == 'mDNSResponder' ]]; then
+        dns_sd_check "${HOST_NAME}" _meshcop._udp 'nn=cool xp=ABCDEFGH tv=1.1.1 xa=ABCDEFGH'
+    else
+        avahi_check "${HOST_NAME}"';_meshcop._udp;.\+"xa=ABCDEFGH.\+"tv=1\.1\.1.\+"xp=ABCDEFGH.\+"nn=cool"'
+    fi
+}
 
-add_test(
-    NAME mdns-stop
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-stop
-)
-
-add_test(
-    NAME mdns-single-custom-host
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single-custom-host
-)
-
-add_test(
-    NAME mdns-multiple-custom-hosts
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-multiple-custom-hosts
-)
-
-add_test(
-    NAME mdns-service-subtypes
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-service-subtypes
-)
-
-add_test(
-    NAME mdns-single-empty-service-name
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test-single-empty-service-name
-)
-
-set_tests_properties(
-    mdns-single
-    mdns-multiple
-    mdns-update
-    mdns-stop
-    mdns-single-custom-host
-    mdns-multiple-custom-hosts
-    mdns-service-subtypes
-    mdns-single-empty-service-name
-    PROPERTIES
-        ENVIRONMENT "OTBR_MDNS=${OTBR_MDNS};OTBR_TEST_MDNS=$<TARGET_FILE:otbr-test-mdns>"
-)
+main "$@"


### PR DESCRIPTION
This PR has 2 enhancements for mDNS publisher which may be useful for supporting SRPL.

- Fix a potential bug: A service subscription callback may modify the container `mDiscoveredCallbacks`. This can invalidate an iterator and results in a crash.
- Supports publishing a service using the hostname as the service instance name.