### PR TITLE
[trel] use `otTrelSetEnabled` instead of `otTrelEnable`/`otTrelDisable`

### DIFF
--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -259,14 +259,7 @@ otError ControllerOpenThread::ApplyFeatureFlagList(const FeatureFlagList &aFeatu
     }
 
 #if OTBR_ENABLE_TREL
-    if (aFeatureFlagList.enable_trel())
-    {
-        otTrelEnable(mInstance);
-    }
-    else
-    {
-        otTrelDisable(mInstance);
-    }
+    otTrelSetEnabled(mInstance, aFeatureFlagList.enable_trel());
 #endif
 
     return error;


### PR DESCRIPTION
This PR uses otTrelSetEnabled api instead of the deprecated otTrelEnable/otTrelDisable apis.

Related to https://github.com/openthread/openthread/pull/8731