### PR TITLE
[docker] accelerate building an OTBR docker image by cache

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -63,9 +63,6 @@ ENV DOCKER 1
 
 RUN env
 
-COPY . /app
-WORKDIR /app
-
 # Required during build or run
 ENV OTBR_DOCKER_REQS sudo python3
 
@@ -88,10 +85,16 @@ ENV OTBR_NORELEASE_DEPS \
 RUN apt-get update \
   && apt-get install --no-install-recommends -y $OTBR_DOCKER_REQS $OTBR_DOCKER_DEPS \
   && ([ "${OT_BACKBONE_CI}" != "1" ] || apt-get install --no-install-recommends -y $OTBR_OT_BACKBONE_CI_DEPS) \
-  && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
-  && ./script/bootstrap \
-  && ./script/setup \
-  && ([ "${DNS64}" = "0" ] || chmod 644 /etc/bind/named.conf.options) \
+  && ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+
+COPY ./script /app/script
+WORKDIR /app
+
+RUN ./script/bootstrap
+COPY . .
+RUN ./script/setup
+
+RUN ([ "${DNS64}" = "0" ] || chmod 644 /etc/bind/named.conf.options) \
   && ([ "${OT_BACKBONE_CI}" = "1" ] || ( \
     mv ./script /tmp \
     && mv ./etc /tmp \


### PR DESCRIPTION
This PR changes the order of the steps for building the OTBR docker image. In this way we can leverage more on the docker build cache and save time when building an image. 

When we want to build an image after only modifying C++ code, we won't need to rerun the bootstrap step.

Local runs comparison:
- Before:
  - Build without cache: 7m32.835s
  - Build with cache: 6m40.570s
- After:
  - Build without cache: 6m32.783s
  - Build with cache: 2m13.498s