### PR TITLE
[pretty] fix `script/clang-format`

### DIFF
--- a/script/clang-format
+++ b/script/clang-format
@@ -65,10 +65,10 @@ for arg; do
     esac
 done
 
-file=$arg
-
 [ $REPLACE != yes ] || {
-    [ -n "$(tail -c1 "$file")" ] && echo >>"$file"
+    for file in "$arg"; do
+        [ -n "$(tail -c1 "$file")" ] && echo >>"$file"
+    done
 }
 
 exit 0


### PR DESCRIPTION
`script/clang-format` is supposed to add an EOF newline for every file passed in as an argument. However, the script only processed the first file. This can cause `script/make-pretty check` to fail even after `script/make-pretty clang`.