### PR TITLE
[pretty] fix `script/clang-format`

### DIFF
--- a/script/clang-format
+++ b/script/clang-format
@@ -57,18 +57,23 @@ clang-format "$@" || die
 
 # ensure EOF newline
 REPLACE=no
+FILES=()
 for arg; do
     case $arg in
         -i)
             REPLACE=yes
             ;;
+        -*) ;;
+        *)
+            FILES+=("$arg")
+            ;;
     esac
 done
 
-file=$arg
-
 [ $REPLACE != yes ] || {
-    [ -n "$(tail -c1 "$file")" ] && echo >>"$file"
+    for file in "${FILES[@]}"; do
+        [ -n "$(tail -c1 "$file")" ] && echo >>"$file"
+    done
 }
 
 exit 0


### PR DESCRIPTION
`script/clang-format` is supposed to add an EOF newline for every file passed in as an argument. However, the script only processed the first file. This can cause `script/make-pretty check` to fail even after `script/make-pretty clang`.