### PR TITLE
[rest] explicitly set Connection header to close

### DIFF
--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -36,6 +36,7 @@
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET"
+#define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {
 namespace rest {
@@ -52,6 +53,7 @@ Response::Response(void)
     mHeaders["Access-Control-Allow-Origin"]  = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_ORIGIN;
     mHeaders["Access-Control-Allow-Methods"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD;
     mHeaders["Access-Control-Allow-Headers"] = OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS;
+    mHeaders["Connection"]                   = OT_REST_RESPONSE_CONNECTION;
 }
 
 void Response::SetComplete()


### PR DESCRIPTION
By default, HTTP 1.1 connections should stay open after a transaction. However, that is not how the current REST server implementation behaves: After each transaction the HTTP connection is being closed by the server.

Set the Connection header to "close" to tell the client about this behavior.