### PR TITLE
[dbus] fix null attach handler issue

### DIFF
--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -537,7 +537,11 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, At
     uint64_t                 pendingTimestamp = 0;
     timespec                 currentTime;
 
-    assert(aHandler != nullptr);
+    if (aHandler == nullptr)
+    {
+        otbrLogWarning("Attach Handler is nullptr");
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
     VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = OT_ERROR_BUSY);
 
     VerifyOrExit(aDatasetTlvs.size() <= sizeof(datasetTlvs.mTlvs), error = OT_ERROR_INVALID_ARGS);
@@ -642,7 +646,13 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult)
 
     LogOpenThreadResult("MgmtSetResponseHandler()", aResult);
 
-    assert(mAttachHandler != nullptr);
+    if (mAttachHandler == nullptr)
+    {
+        otbrLogWarning("mAttachHandler is nullptr");
+        mAttachDelayMs            = 0;
+        mAttachPendingDatasetTlvs = {};
+        ExitNow();
+    }
 
     switch (aResult)
     {
@@ -667,6 +677,9 @@ void ThreadHelper::MgmtSetResponseHandler(otError aResult)
     {
         handler(aResult, 0);
     }
+
+exit:
+    return;
 }
 
 #if OTBR_ENABLE_UNSECURE_JOIN

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -294,6 +294,8 @@ private:
 
     std::map<uint16_t, size_t> mUnsecurePortRefCounter;
 
+    bool mWaitingMgmtSetResponse =
+        false; // During waiting for mgmt set response, calls to AttachHandler by StateChangedCallback will be ignored
     int64_t       mAttachDelayMs = 0;
     AttachHandler mAttachHandler;
     ResultHandler mJoinerHandler;


### PR DESCRIPTION
Recently we got a crash issue on `otbr-agent`. From the coredump, it's a caused by a `bad_function_call` exception:
```
#4  0x00478f22 in std::__1::__throw_bad_function_call () at prebuilt/toolchain/armv7a/usr/bin/../include/c++/v1/functional:1441
#5  0x00492834 in otbr::agent::ThreadHelper::MgmtSetResponseHandler (this=<optimized out>, aResult=OT_ERROR_NONE) at ot-br-posix/src/utils/thread_helper.cpp:670
#6  0x004a9238 in ot::MeshCoP::DatasetManager::HandleMgmtSetResponse (this=0x53bfdc <ot::gInstanceRaw+134420>, aMessage=<optimized out>, aMessageInfo=<optimized out>, aError=<optimized out>) at openthread/src/core/meshcop/dataset_manager.cpp:358
#7  0x0049c3a2 in ot::Coap::CoapBase::ProcessReceivedResponse (this=0x0, aMessage=..., aMessageInfo=...) at openthread/src/core/coap/coap.cpp:1252
#8  0x004b6ae8 in ot::Ip6::Udp::HandleMessage (this=0x0, aMessage=..., aMessageInfo=...) at openthread/src/core/net/udp6.cpp:500
#9  0x004b0f9e in ot::Ip6::Ip6::HandlePayload (this=0x53b330 <ot::gInstanceRaw+131176>, aIp6Header=..., aMessage=..., aMessageInfo=..., aIpProto=17 '\021', aMessageOwnership=<optimized out>) at openthread/src/core/net/ip6.cpp:972
#10 0x004b0724 in ot::Ip6::Ip6::HandleDatagram (this=0x53b330 <ot::gInstanceRaw+131176>, aMessage=..., aNetif=<optimized out>, aLinkMessageInfo=<optimized out>, aFromHost=<optimized out>) at openthread/src/core/net/ip6.cpp:1227
#11 0x004affd8 in ot::Ip6::Ip6::HandleSendQueue (this=<optimized out>) at openthread/src/core/net/ip6.cpp:545
#12 ot::Ip6::Ip6::HandleSendQueue (aTasklet=...) at openthread/src/core/net/ip6.cpp:535
#13 0x0049fd4c in ot::Tasklet::RunTask (this=0x0) at openthread/src/core/common/tasklet.hpp:146
#14 ot::Tasklet::Scheduler::ProcessQueuedTasklets (this=<optimized out>) at openthread/src/core/common/tasklet.cpp:93
#15 0x0048ebf2 in otbr::Ncp::ControllerOpenThread::Process (this=0x7ea6a9d0, aMainloop=...) at ot-br-posix/src/ncp/ncp_openthread.cpp:235
#16 0x0047c24c in otbr::MainloopManager::Process (this=0x51b048 <otbr::MainloopManager::GetInstance()::sMainloopManager>, aMainloop=...) at ot-br-posix/src/common/mainloop_manager.cpp:57
#17 0x0047835a in otbr::Application::Run (this=<optimized out>) at ot-br-posix/src/agent/application.cpp:160
#18 0x00478c4a in realmain (argc=7, argv=<optimized out>) at ot-br-posix/src/agent/main.cpp:277
#19 main (argc=7, argv=<optimized out>) at ot-br-posix/src/agent/main.cpp:316
```

The `mAttachHandler` is called when it has no target (nullptr). The `assert` didn't work because `NDEBUG` is defined in our builds.

The `mAttachHandler` becomes `nullptr` in this way:
* `AttachAllNodesTo` was called and `mAttachHandler` was set.
* `AttachAllNodesTo` called `otDatasetSendMgmtPendingSet`. A message was sent and the process is waiting for the response.
* However the sending of the message failed. The attach is still going on.
* The device state changed and `StateChangedCallback` is called. Thus `mAttachHandler` was called and it's removed.
* However, after that, the previous response was received and the callback for `otDatasetSendMgmtPendingSet` was called. Thus `mAttachHandler` was called again. Since NDEBUG is enabled in cast build, the assert doesn't do anything. Then we have the bad function call error.

---

So this PR changes `assert` to if condition and a warning log.
