### PR TITLE
Keep avahi resolver until service instance is removed for trel

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -258,9 +258,15 @@ public:
      *
      * @param[in] aType          The service type.
      * @param[in] aInstanceName  The service instance to subscribe, or empty to subscribe the service.
+     * @param[in] aKeepAlive     Whether the subscription should be kept alive to receive updates to the service
+     *                           instance. Note this only applies to avahi, as for avahi browse operation,
+     *                           instance updates will not trigger add/rm events.
+     *                           For dnssd browse operation, updates of instances will trigger add/rmv events.
      *
      */
-    virtual void SubscribeService(const std::string &aType, const std::string &aInstanceName) = 0;
+    virtual void SubscribeService(const std::string &aType,
+                                  const std::string &aInstanceName,
+                                  const bool         aKeepAlive) = 0;
 
     /**
      * This method unsubscribes a given service or service instance.

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -74,12 +74,12 @@ public:
     PublisherAvahi(StateCallback aStateCallback);
     ~PublisherAvahi(void) override;
 
-    void      UnpublishService(const std::string &aName, const std::string &aType, ResultCallback &&aCallback) override;
-    void      UnpublishHost(const std::string &aName, ResultCallback &&aCallback) override;
-    void      SubscribeService(const std::string &aType, const std::string &aInstanceName) override;
-    void      UnsubscribeService(const std::string &aType, const std::string &aInstanceName) override;
-    void      SubscribeHost(const std::string &aHostName) override;
-    void      UnsubscribeHost(const std::string &aHostName) override;
+    void UnpublishService(const std::string &aName, const std::string &aType, ResultCallback &&aCallback) override;
+    void UnpublishHost(const std::string &aName, ResultCallback &&aCallback) override;
+    void SubscribeService(const std::string &aType, const std::string &aInstanceName, const bool aKeepAlive) override;
+    void UnsubscribeService(const std::string &aType, const std::string &aInstanceName) override;
+    void SubscribeHost(const std::string &aHostName) override;
+    void UnsubscribeHost(const std::string &aHostName) override;
     otbrError Start(void) override;
     bool      IsStarted(void) const override;
     void      Stop(void) override;
@@ -168,11 +168,15 @@ private:
 
     struct ServiceSubscription : public Subscription
     {
-        explicit ServiceSubscription(PublisherAvahi &aPublisherAvahi, std::string aType, std::string aInstanceName)
+        explicit ServiceSubscription(PublisherAvahi &aPublisherAvahi,
+                                     std::string     aType,
+                                     std::string     aInstanceName,
+                                     bool            aKeepAlive)
             : Subscription(aPublisherAvahi)
             , mType(std::move(aType))
             , mInstanceName(std::move(aInstanceName))
             , mServiceBrowser(nullptr)
+            , mKeepAlive(aKeepAlive)
         {
         }
 
@@ -237,6 +241,7 @@ private:
         std::string                      mInstanceName;
         AvahiServiceBrowser             *mServiceBrowser;
         std::set<AvahiServiceResolver *> mServiceResolvers;
+        bool                             mKeepAlive;
     };
 
     struct HostSubscription : public Subscription

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -688,8 +688,12 @@ std::string PublisherMDnsSd::MakeRegType(const std::string &aType, SubTypeList a
     return regType;
 }
 
-void PublisherMDnsSd::SubscribeService(const std::string &aType, const std::string &aInstanceName)
+void PublisherMDnsSd::SubscribeService(const std::string &aType,
+                                       const std::string &aInstanceName,
+                                       const bool         aKeepAlive)
 {
+    OTBR_UNUSED_VARIABLE(aKeepAlive);
+
     VerifyOrExit(mState == Publisher::State::kReady);
     mSubscribedServices.push_back(MakeUnique<ServiceSubscription>(*this, aType, aInstanceName));
 

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -67,11 +67,11 @@ public:
 
     void UnpublishService(const std::string &aName, const std::string &aType, ResultCallback &&aCallback) override;
 
-    void      UnpublishHost(const std::string &aName, ResultCallback &&aCallback) override;
-    void      SubscribeService(const std::string &aType, const std::string &aInstanceName) override;
-    void      UnsubscribeService(const std::string &aType, const std::string &aInstanceName) override;
-    void      SubscribeHost(const std::string &aHostName) override;
-    void      UnsubscribeHost(const std::string &aHostName) override;
+    void UnpublishHost(const std::string &aName, ResultCallback &&aCallback) override;
+    void SubscribeService(const std::string &aType, const std::string &aInstanceName, const bool aKeepAlive) override;
+    void UnsubscribeService(const std::string &aType, const std::string &aInstanceName) override;
+    void SubscribeHost(const std::string &aHostName) override;
+    void UnsubscribeHost(const std::string &aHostName) override;
     otbrError Start(void) override;
     bool      IsStarted(void) const override;
     void      Stop(void) override;

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -119,7 +119,7 @@ void DiscoveryProxy::OnDiscoveryProxySubscribe(const char *aFullName)
     {
         if (nameInfo.mHostName.empty())
         {
-            mMdnsPublisher.SubscribeService(nameInfo.mServiceName, nameInfo.mInstanceName);
+            mMdnsPublisher.SubscribeService(nameInfo.mServiceName, nameInfo.mInstanceName, false);
         }
         else
         {

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -118,7 +118,7 @@ void TrelDnssd::StartBrowse(void)
 
     if (IsReady())
     {
-        mPublisher.SubscribeService(kTrelServiceName, /* aInstanceName */ "");
+        mPublisher.SubscribeService(kTrelServiceName, /* aInstanceName */ "", true);
     }
 
 exit:
@@ -428,7 +428,7 @@ void TrelDnssd::OnBecomeReady(void)
 
         if (mSubscriberId > 0)
         {
-            mPublisher.SubscribeService(kTrelServiceName, /* aInstanceName */ "");
+            mPublisher.SubscribeService(kTrelServiceName, /* aInstanceName */ "", true);
         }
 
         if (mRegisterInfo.IsValid())


### PR DESCRIPTION
In the current avahi mdns design, after service browse we resolve the discovered instance once, when instance is resolved the resolver is removed.

Trel uses dnssd browse to discover peers, when a discovered peer changes ipv6 address, trel would not know the change and still try to send packets to the old address.

This PR lets trel service subscription to keep the avahi service resolver until the instance is removed, so any updates to the instance will be noticed.

A followup to this PR is to add test in openthread.


