### PR TITLE
[mdns] keep avahi service resolver until instance is removed

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1140,7 +1140,6 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
     avahi_address_snprint(addrBuf, sizeof(addrBuf), aAddress);
     otbrLogInfo("Resolve service reply: address %s", addrBuf);
 
-    RemoveServiceResolver(aServiceResolver);
     VerifyOrExit(aHostName != nullptr, avahiError = AVAHI_ERR_INVALID_HOST_NAME);
 
     instanceInfo.mNetifIndex = static_cast<uint32_t>(aInterfaceIndex);
@@ -1176,6 +1175,10 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
 exit:
     if (resolved)
     {
+        if (instanceInfo.mRemoved)
+        {
+            RemoveServiceResolver(aServiceResolver);
+        }
         // NOTE: This `ServiceSubscrption` object may be freed in `OnServiceResolved`.
         mPublisherAvahi->OnServiceResolved(mType, instanceInfo);
     }

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1189,7 +1189,7 @@ exit:
     }
 }
 
-void PublisherAvahi::ServiceSubscription::AddServiceResolver(std::string           aInstanceName,
+void PublisherAvahi::ServiceSubscription::AddServiceResolver(const std::string    &aInstanceName,
                                                              AvahiServiceResolver *aServiceResolver)
 {
     assert(aServiceResolver != nullptr);
@@ -1198,9 +1198,10 @@ void PublisherAvahi::ServiceSubscription::AddServiceResolver(std::string        
     otbrLogDebug("Added service resolver for instance %s", aInstanceName.c_str());
 }
 
-void PublisherAvahi::ServiceSubscription::RemoveServiceResolver(std::string aInstanceName)
+void PublisherAvahi::ServiceSubscription::RemoveServiceResolver(const std::string &aInstanceName)
 {
     int numResolvers = 0;
+
     VerifyOrExit(mServiceResolvers.find(aInstanceName) != mServiceResolvers.end());
 
     numResolvers = mServiceResolvers[aInstanceName].size();

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -997,12 +997,16 @@ void PublisherAvahi::ServiceSubscription::Browse(void)
 
 void PublisherAvahi::ServiceSubscription::Release(void)
 {
-    for (AvahiServiceResolver *resolver : mServiceResolvers)
-    {
-        avahi_service_resolver_free(resolver);
-    }
+    std::vector<std::string> instanceNames;
 
-    mServiceResolvers.clear();
+    for (const auto &resolvers : mServiceResolvers)
+    {
+        instanceNames.push_back(resolvers.first);
+    }
+    for (const auto &name : instanceNames)
+    {
+        RemoveServiceResolver(name);
+    }
 
     if (mServiceBrowser != nullptr)
     {
@@ -1050,6 +1054,7 @@ void PublisherAvahi::ServiceSubscription::HandleBrowseResult(AvahiServiceBrowser
         break;
     case AVAHI_BROWSER_REMOVE:
         mPublisherAvahi->OnServiceRemoved(static_cast<uint32_t>(aInterfaceIndex), aType, aName);
+        RemoveServiceResolver(aName);
         break;
     case AVAHI_BROWSER_CACHE_EXHAUSTED:
     case AVAHI_BROWSER_ALL_FOR_NOW:
@@ -1077,7 +1082,7 @@ void PublisherAvahi::ServiceSubscription::Resolve(uint32_t           aInterfaceI
         /* domain */ nullptr, AVAHI_PROTO_INET6, static_cast<AvahiLookupFlags>(0), HandleResolveResult, this);
     if (resolver != nullptr)
     {
-        AddServiceResolver(resolver);
+        AddServiceResolver(aInstanceName, resolver);
     }
     else
     {
@@ -1175,10 +1180,6 @@ void PublisherAvahi::ServiceSubscription::HandleResolveResult(AvahiServiceResolv
 exit:
     if (resolved)
     {
-        if (instanceInfo.mRemoved)
-        {
-            RemoveServiceResolver(aServiceResolver);
-        }
         // NOTE: This `ServiceSubscrption` object may be freed in `OnServiceResolved`.
         mPublisherAvahi->OnServiceResolved(mType, instanceInfo);
     }
@@ -1188,19 +1189,32 @@ exit:
     }
 }
 
-void PublisherAvahi::ServiceSubscription::AddServiceResolver(AvahiServiceResolver *aServiceResolver)
+void PublisherAvahi::ServiceSubscription::AddServiceResolver(std::string           aInstanceName,
+                                                             AvahiServiceResolver *aServiceResolver)
 {
     assert(aServiceResolver != nullptr);
-    mServiceResolvers.insert(aServiceResolver);
+    mServiceResolvers[aInstanceName].insert(aServiceResolver);
+
+    otbrLogDebug("Added service resolver for instance %s", aInstanceName.c_str());
 }
 
-void PublisherAvahi::ServiceSubscription::RemoveServiceResolver(AvahiServiceResolver *aServiceResolver)
+void PublisherAvahi::ServiceSubscription::RemoveServiceResolver(std::string aInstanceName)
 {
-    assert(aServiceResolver != nullptr);
-    assert(mServiceResolvers.find(aServiceResolver) != mServiceResolvers.end());
+    int numResolvers = 0;
+    VerifyOrExit(mServiceResolvers.find(aInstanceName) != mServiceResolvers.end());
 
-    avahi_service_resolver_free(aServiceResolver);
-    mServiceResolvers.erase(aServiceResolver);
+    numResolvers = mServiceResolvers[aInstanceName].size();
+
+    for (auto resolver : mServiceResolvers[aInstanceName])
+    {
+        avahi_service_resolver_free(resolver);
+    }
+
+    mServiceResolvers.erase(aInstanceName);
+
+exit:
+    otbrLogDebug("Removed %d service resolver for instance %s", numResolvers, aInstanceName.c_str());
+    return;
 }
 
 void PublisherAvahi::HostSubscription::Release(void)

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1079,7 +1079,7 @@ void PublisherAvahi::ServiceSubscription::Resolve(uint32_t           aInterfaceI
 
     resolver = avahi_service_resolver_new(
         mPublisherAvahi->mClient, aInterfaceIndex, aProtocol, aInstanceName.c_str(), aType.c_str(),
-        /* domain */ nullptr, AVAHI_PROTO_INET6, static_cast<AvahiLookupFlags>(0), HandleResolveResult, this);
+        /* domain */ nullptr, AVAHI_PROTO_UNSPEC, static_cast<AvahiLookupFlags>(0), HandleResolveResult, this);
     if (resolver != nullptr)
     {
         AddServiceResolver(aInstanceName, resolver);

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -184,8 +184,8 @@ private:
                      AvahiProtocol      aProtocol,
                      const std::string &aInstanceName,
                      const std::string &aType);
-        void AddServiceResolver(std::string, AvahiServiceResolver *aServiceResolver);
-        void RemoveServiceResolver(std::string aInstanceName);
+        void AddServiceResolver(const std::string &aInstanceName, AvahiServiceResolver *aServiceResolver);
+        void RemoveServiceResolver(const std::string &aInstanceName);
 
         static void HandleBrowseResult(AvahiServiceBrowser   *aServiceBrowser,
                                        AvahiIfIndex           aInterfaceIndex,

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -184,8 +184,8 @@ private:
                      AvahiProtocol      aProtocol,
                      const std::string &aInstanceName,
                      const std::string &aType);
-        void AddServiceResolver(AvahiServiceResolver *aServiceResolver);
-        void RemoveServiceResolver(AvahiServiceResolver *aServiceResolver);
+        void AddServiceResolver(std::string, AvahiServiceResolver *aServiceResolver);
+        void RemoveServiceResolver(std::string aInstanceName);
 
         static void HandleBrowseResult(AvahiServiceBrowser   *aServiceBrowser,
                                        AvahiIfIndex           aInterfaceIndex,
@@ -233,10 +233,12 @@ private:
                                  AvahiStringList       *aTxt,
                                  AvahiLookupResultFlags aFlags);
 
-        std::string                      mType;
-        std::string                      mInstanceName;
-        AvahiServiceBrowser             *mServiceBrowser;
-        std::set<AvahiServiceResolver *> mServiceResolvers;
+        std::string          mType;
+        std::string          mInstanceName;
+        AvahiServiceBrowser *mServiceBrowser;
+
+        using ServiceResolversMap = std::map<std::string, std::set<AvahiServiceResolver *>>;
+        ServiceResolversMap mServiceResolvers;
     };
 
     struct HostSubscription : public Subscription


### PR DESCRIPTION
There is a difference between avahi and dns-sd browse operation. An update in a discovered instance doesn't trigger any avahi browse events, while for dns-sd rmv/add events are triggered.

In the current avahi mdns design, after service browse we resolve the discovered instance once, when instance is resolved the resolver is removed.

Trel uses dnssd browse to discover peers, when a discovered peer changes ipv6 address, trel would not know the change and still try to send packets to the old address.

This PR changes the avahi mdns to keep service resolver until the instance is removed, so any updates to the instance will be noticed.

A followup to this PR is to add test in openthread.