### PR TITLE
[advertising-proxy] let Advertising Proxy not fail early on errors

### DIFF
--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -90,6 +90,9 @@ private:
         otSrpServerServiceUpdateId mId;                // The ID of the SRP service update transaction.
         std::string                mHostName;          // The host name.
         uint32_t                   mCallbackCount = 0; // The number of callbacks which we are waiting for.
+        std::set<otbrError>        mResults;           // The results of advertisements on mDNS.
+
+        otError GetResult(void) const;
     };
 
     static void AdvertisingHandler(otSrpServerServiceUpdateId aId,


### PR DESCRIPTION
This PR lets the Advertising Proxy report the result to SRP server only after doing all publish/unpublish work. This may be needed by SRP Replication (SRPL) which may have transient `kAborted` errors. 

Here's the logic how Advertising Proxy summarizes all sub-results into a single result:
- If all error codes are the same, return the that error code.
- If there's only one type of error code besides `OTBR_ERROR_NONE`, return the error code. 
- In all other cases, return `OT_ERROR_FAILED`.