### PR TITLE
[mdns] publish 'id' as Extended MAC Address

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -127,3 +127,8 @@ option(OTBR_DNS_UPSTREAM_QUERY "Allow sending DNS queries to upstream" OFF)
 if (OTBR_DNS_UPSTREAM_QUERY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_DNS_UPSTREAM_QUERY=1)
 endif()
+
+option(OTBR_PUBLISH_MESHCOP_ID_AS_EXT_ADDRESS "Publish the MeshCoP mDNS 'id' TXT entry as the Extended MAC Address, enable this feature only when 'id' is not set via dbus API" OFF)
+if (OTBR_PUBLISH_MESHCOP_ID_AS_EXT_ADDRESS)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_PUBLISH_MESHCOP_ID_AS_EXT_ADDRESS=1)
+endif()

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -378,6 +378,19 @@ void BorderAgent::PublishMeshCopService(void)
     // "xa" stands for Extended MAC Address (64-bit) of the Thread Interface of the Border Agent.
     txtList.emplace_back("xa", extAddr->m8, sizeof(extAddr->m8));
 
+    // An unique ID is required for adding the Thread network credentials of this BR to Android
+    // or iOS system. Products can use the dbus "UpdateVendorMeshCopTxtEntries" method to set a
+    // vendor-specific ID, or otherwise, enable the feature here to set ID to Extended MAC Address
+    // by padding zeros at the tail.
+#if OTBR_ENABLE_PUBLISH_MESHCOP_ID_AS_EXT_ADDRESS
+    {
+        uint8_t id[16] = {0};
+
+        memcpy(id, extAddr->m8, sizeof(extAddr->m8));
+        txtList.emplace_back("id", id, sizeof(id));
+    }
+#endif
+
     state       = GetStateBitmap(*instance);
     stateUint32 = htobe32(state.ToUint32());
     txtList.emplace_back("sb", reinterpret_cast<uint8_t *>(&stateUint32), sizeof(stateUint32));


### PR DESCRIPTION
An unique ID is required for adding the Thread network credentials
of this BR to Android or iOS system. Products can use the dbus
"UpdateVendorMeshCopTxtEntries" method to set a vendor-specific ID,
or otherwise, enable the "OTBR_PUBLISH_ID_AS_EXT_ADDRESS" feature
to set ID to Extended MAC Address by padding zeros at the tail.