### PR TITLE
update channel mask in ThreadHelper attach

### DIFF
--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -391,6 +391,7 @@ void ThreadHelper::Attach(const std::string          &aNetworkName,
 
     channel = RandomChannelFromChannelMask(channelMask);
     SuccessOrExit(otLinkSetChannel(mInstance, channel));
+    SuccessOrExit(otLinkSetSupportedChannelMask(mInstance,channelMask));
 
     SuccessOrExit(error = otThreadSetPskc(mInstance, &pskc));
 


### PR DESCRIPTION
when using ThreadHelper::Attach, the active dataset is not updated with the network credentials. It remains with default channel mask