### PR TITLE
[mdns] Limit to v4 or v6 only when resolving with avahi resolver

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1079,7 +1079,7 @@ void PublisherAvahi::ServiceSubscription::Resolve(uint32_t           aInterfaceI
 
     resolver = avahi_service_resolver_new(
         mPublisherAvahi->mClient, aInterfaceIndex, aProtocol, aInstanceName.c_str(), aType.c_str(),
-        /* domain */ nullptr, AVAHI_PROTO_UNSPEC, static_cast<AvahiLookupFlags>(0), HandleResolveResult, this);
+        /* domain */ nullptr, aProtocol, static_cast<AvahiLookupFlags>(0), HandleResolveResult, this);
     if (resolver != nullptr)
     {
         AddServiceResolver(aInstanceName, resolver);


### PR DESCRIPTION
We have set supported proto to `AVAHI_PROTO_UNSPEC` (both v4 and v6) for avahi resolver to align with browse operation: https://github.com/openthread/ot-br-posix/pull/1783/files#r1149101582

However our mdns implementation does only support v6: https://github.com/openthread/ot-br-posix/blob/main/src/mdns/mdns_avahi.cpp#L1154

When a service contains both A record and AAAA records avahi resolver only returns the v4 address and we will not get the v6 address thus service could not be resolved.

The issue is not seen if service is published by avahi daemon, as it by default publishes AAAA (IPv6) records over IPv4, but not A (IPv4) records over IPv6.

In this PR updated the supported protocol to be same as the protocol used in the resolver query. For example, look for A record with v4 query and look for AAAA record with v6 query.
