### PR TITLE
[rest] return border agent ID

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -346,6 +346,7 @@ std::string Node2JsonString(const NodeInfo &aNode)
     cJSON      *node = cJSON_CreateObject();
     std::string ret;
 
+    cJSON_AddItemToObject(node, "BaId", Bytes2HexJson(aNode.mBaId, OT_BORDER_AGENT_ID_LENGTH));
     cJSON_AddItemToObject(node, "State", cJSON_CreateNumber(aNode.mRole));
     cJSON_AddItemToObject(node, "NumOfRouter", cJSON_CreateNumber(aNode.mNumOfRouter));
     cJSON_AddItemToObject(node, "RlocAddress", IpAddr2Json(aNode.mRlocAddress));

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -43,6 +43,20 @@ paths:
             application/json:
               schema:
                 type: object
+  /node/ba-id:
+    get:
+      tags:
+        - node
+      summary: Get the border agent ID
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: 16 byte border agent ID as hex string.
+                example: "AA897CA8A67F6E6DD6166133AD1562A5"
   /node/rloc:
     get:
       tags:

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -215,13 +215,13 @@ void Resource::ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) cons
 void Resource::GetNodeInfo(Response &aResponse) const
 {
     otbrError       error = OTBR_ERROR_NONE;
-    struct NodeInfo node;
+    struct NodeInfo node  = {};
     otRouterInfo    routerInfo;
     uint8_t         maxRouterId;
     std::string     body;
     std::string     errorCode;
 
-    VerifyOrExit(otThreadGetLeaderData(mInstance, &node.mLeaderData) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
+    (void)otThreadGetLeaderData(mInstance, &node.mLeaderData);
 
     node.mNumOfRouter = 0;
     maxRouterId       = otThreadGetMaxRouterId(mInstance);

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -37,6 +37,7 @@
 
 #define OT_REST_RESOURCE_PATH_DIAGNOSTICS "/diagnostics"
 #define OT_REST_RESOURCE_PATH_NODE "/node"
+#define OT_REST_RESOURCE_PATH_NODE_BAID "/node/ba-id"
 #define OT_REST_RESOURCE_PATH_NODE_RLOC "/node/rloc"
 #define OT_REST_RESOURCE_PATH_NODE_RLOC16 "/node/rloc16"
 #define OT_REST_RESOURCE_PATH_NODE_EXTADDRESS "/node/ext-address"
@@ -129,6 +130,7 @@ Resource::Resource(ControllerOpenThread *aNcp)
     // Resource Handler
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::Diagnostic);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE, &Resource::NodeInfo);
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_BAID, &Resource::BaId);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_STATE, &Resource::State);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_EXTADDRESS, &Resource::ExtendedAddr);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_NETWORKNAME, &Resource::NetworkName);
@@ -220,7 +222,9 @@ void Resource::GetNodeInfo(Response &aResponse) const
     uint8_t         maxRouterId;
     std::string     body;
     std::string     errorCode;
+    uint16_t        idLength = OT_BORDER_AGENT_ID_LENGTH;
 
+    VerifyOrExit(otBorderAgentGetId(mInstance, node.mBaId, &idLength) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
     (void)otThreadGetLeaderData(mInstance, &node.mLeaderData);
 
     node.mNumOfRouter = 0;
@@ -262,6 +266,45 @@ void Resource::NodeInfo(const Request &aRequest, Response &aResponse) const
     if (aRequest.GetMethod() == HttpMethod::kGet)
     {
         GetNodeInfo(aResponse);
+    }
+    else
+    {
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+    }
+}
+
+void Resource::GetDataBaId(Response &aResponse) const
+{
+    otbrError   error = OTBR_ERROR_NONE;
+    uint8_t     id[OT_BORDER_AGENT_ID_LENGTH];
+    uint16_t    idLength = OT_BORDER_AGENT_ID_LENGTH;
+    std::string body;
+    std::string errorCode;
+
+    VerifyOrExit(otBorderAgentGetId(mInstance, id, &idLength) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
+
+    body = Json::Bytes2HexJsonString(id, idLength);
+    aResponse.SetBody(body);
+
+exit:
+    if (error == OTBR_ERROR_NONE)
+    {
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+        aResponse.SetResponsCode(errorCode);
+    }
+    else
+    {
+        ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+    }
+}
+
+void Resource::BaId(const Request &aRequest, Response &aResponse) const
+{
+    std::string errorCode;
+
+    if (aRequest.GetMethod() == HttpMethod::kGet)
+    {
+        GetDataBaId(aResponse);
     }
     else
     {

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -36,6 +36,7 @@
 
 #include <unordered_map>
 
+#include <openthread/border_agent.h>
 #include <openthread/border_router.h>
 
 #include "ncp/ncp_openthread.hpp"
@@ -117,6 +118,7 @@ private:
     typedef void (Resource::*ResourceHandler)(const Request &aRequest, Response &aResponse) const;
     typedef void (Resource::*ResourceCallbackHandler)(const Request &aRequest, Response &aResponse);
     void NodeInfo(const Request &aRequest, Response &aResponse) const;
+    void BaId(const Request &aRequest, Response &aResponse) const;
     void ExtendedAddr(const Request &aRequest, Response &aResponse) const;
     void State(const Request &aRequest, Response &aResponse) const;
     void NetworkName(const Request &aRequest, Response &aResponse) const;
@@ -132,6 +134,7 @@ private:
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
     void GetNodeInfo(Response &aResponse) const;
+    void GetDataBaId(Response &aResponse) const;
     void GetDataExtendedAddr(Response &aResponse) const;
     void GetDataState(Response &aResponse) const;
     void GetDataNetworkName(Response &aResponse) const;

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -38,6 +38,8 @@
 #include <string>
 #include <vector>
 
+#include <openthread/border_agent.h>
+
 #include "openthread/netdiag.h"
 
 #define OT_REST_ACCEPT_HEADER "Accept"
@@ -96,6 +98,7 @@ enum class ConnectionState : std::uint8_t
 };
 struct NodeInfo
 {
+    uint8_t        mBaId[OT_BORDER_AGENT_ID_LENGTH];
     uint32_t       mRole;
     uint32_t       mNumOfRouter;
     uint16_t       mRloc16;


### PR DESCRIPTION
Add BaId to the node JSON object and add a dedicated endpoint
/node/ba-id to retrive the border agent ID.

Also return node information even when the border router is
detached.