### PR TITLE
[scripts] install `avahi-utils` in `script/bootstrap`

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -100,7 +100,7 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y libjsoncpp-dev
 
     # reference device
-    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils
+    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils avahi-utils
 
     # backbone-router
     without BACKBONE_ROUTER || sudo apt-get install --no-install-recommends -y libnetfilter-queue1 libnetfilter-queue-dev


### PR DESCRIPTION
This is used for leveraging `avahi-publish` tool in BR test cases like https://github.com/openthread/openthread/pull/9075.