### PR TITLE
[openwrt] load D3.js over webserver protocol

### DIFF
--- a/src/openwrt/view/admin_thread/thread_view.htm
+++ b/src/openwrt/view/admin_thread/thread_view.htm
@@ -116,7 +116,7 @@
 </div>
 <%+footer%>
 
-<script src='http://d3js.org/d3.v4.min.js'></script>
+<script src='//d3js.org/d3.v4.min.js'></script>
 <script type="text/javascript" src="/luci-static/resources/handle_error.js"></script>
 <script type="text/javascript">//<![CDATA[
 	handle_error(GetURLParameter('error'));


### PR DESCRIPTION
This delegates the decision to use HTTPS or HTTP to the browser, so if the OpenWrt web server is using HTTPS, there will be no mixed content error preventing D3.js from loading.