### PR TITLE
[rest] initialize dataset

### DIFF
--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -659,7 +659,7 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
     struct NodeInfo          node;
     std::string              body;
     std::string              errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
-    otOperationalDataset     dataset;
+    otOperationalDataset     dataset   = {};
     otOperationalDatasetTlvs datasetTlvs;
     otOperationalDatasetTlvs datasetUpdateTlvs;
     int                      ret;


### PR DESCRIPTION
When there is already a dataset, and setting properties using the PUT method and an incomplete JSON dataset, some fields of the dataset variable might not be initialized. This leads to uninitialized data being used as active dataset.

Make sure we initialize the dataset variable. This makes sure that all components of the dataset are considered not set.