### PR TITLE
[rest] support deleting the dataset

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -239,6 +239,18 @@ paths:
           description: Invalid request body.
         "409":
           description: Writing active operational dataset rejected because Thread network is active.
+    delete:
+      tags:
+        - node
+      summary: Deletes the active operational dataset
+      description: |-
+        Deletes the the active operational dataset on the current node. Only allowed if the Thread node
+        is inactive.
+      responses:
+        "200":
+          description: Successfully deleted the active operational dataset.
+        "409":
+          description: Deleting active operational dataset rejected because Thread network is active.
   /node/dataset/pending:
     get:
       tags:
@@ -282,6 +294,15 @@ paths:
           description: Successfully created the pending operational dataset.
         "400":
           description: Invalid request body.
+    delete:
+      tags:
+        - node
+      summary: Deletes the pending operational dataset
+      description: |-
+        Deletes the the pending operational dataset on the current node.
+      responses:
+        "200":
+          description: Successfully deleted the active operational dataset.
 components:
   schemas:
     LeaderData:

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -147,6 +147,7 @@ private:
     void GetDataRloc(Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
+    void DeleteDataset(DatasetType aDatasetType, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -34,7 +34,7 @@
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, PUT"
+#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "DELETE, GET, OPTIONS, PUT"
 #define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {


### PR DESCRIPTION
Add REST API to support deleting the active or pending operational dataset. Deleting the active operational dataset requires the Thread network to be disabled (just like modifying the active operational dataset). Subsequent use of the PUT method allows to build entirly new datasets with values generated by the stack (through otDatasetCreateNewNetwork).