### PR TITLE
[style] include missing header

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_APPLICATION_HPP_
 #define OTBR_AGENT_APPLICATION_HPP_
 
+#include "openthread-br/config.h"
+
 #include <atomic>
 #include <signal.h>
 #include <stdint.h>

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_VENDOR_HPP_
 #define OTBR_AGENT_VENDOR_HPP_
 
+#include "openthread-br/config.h"
+
 #include "ncp/ncp_openthread.hpp"
 
 namespace otbr {

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -34,6 +34,8 @@
 #ifndef BACKBONE_ROUTER_BACKBONE_AGENT_HPP_
 #define BACKBONE_ROUTER_BACKBONE_AGENT_HPP_
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_BACKBONE_ROUTER
 
 #include <openthread/backbone_router_ftd.h>

--- a/src/backbone_router/constants.hpp
+++ b/src/backbone_router/constants.hpp
@@ -34,6 +34,8 @@
 #ifndef BACKBONE_CONSTANTS_HPP_
 #define BACKBONE_CONSTANTS_HPP_
 
+#include "openthread-br/config.h"
+
 namespace otbr {
 namespace BackboneRouter {
 

--- a/src/backbone_router/dua_routing_manager.hpp
+++ b/src/backbone_router/dua_routing_manager.hpp
@@ -34,6 +34,8 @@
 #ifndef BACKBONE_ROUTER_DUA_ROUTING_MANAGER
 #define BACKBONE_ROUTER_DUA_ROUTING_MANAGER
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_DUA_ROUTING
 
 #include <set>

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -34,6 +34,8 @@
 #ifndef ND_PROXY_HPP_
 #define ND_PROXY_HPP_
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_DUA_ROUTING
 
 #ifdef __APPLE__

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_BORDER_AGENT_HPP_
 #define OTBR_AGENT_BORDER_AGENT_HPP_
 
+#include "openthread-br/config.h"
+
 #if !(OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO)
 #error "Border Agent feature requires at least one `OTBR_MDNS` implementation"
 #endif

--- a/src/common/api_strings.hpp
+++ b/src/common/api_strings.hpp
@@ -35,6 +35,8 @@
 #ifndef OTBR_COMMON_API_STRINGS_HPP_
 #define OTBR_COMMON_API_STRINGS_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string>
 
 #include <openthread/thread.h>

--- a/src/common/byteswap.hpp
+++ b/src/common/byteswap.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_COMMON_BYTESWAP_HPP_
 #define OTBR_COMMON_BYTESWAP_HPP_
 
+#include "openthread-br/config.h"
+
 #if __APPLE__
 #include <libkern/OSByteOrder.h>
 #define bswap_16 OSSwapInt16

--- a/src/common/callback.hpp
+++ b/src/common/callback.hpp
@@ -29,6 +29,8 @@
 #ifndef OTBR_COMMON_CALLBACK_HPP_
 #define OTBR_COMMON_CALLBACK_HPP_
 
+#include "openthread-br/config.h"
+
 #include <functional>
 #include <type_traits>
 

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -33,6 +33,8 @@
 #ifndef OTBR_COMMON_CODE_UTILS_HPP_
 #define OTBR_COMMON_CODE_UTILS_HPP_
 
+#include "openthread-br/config.h"
+
 #ifndef OTBR_LOG_TAG
 #define OTBR_LOG_TAG "UTILS"
 #endif

--- a/src/common/dns_utils.hpp
+++ b/src/common/dns_utils.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_COMMON_DNS_UTILS_HPP_
 #define OTBR_COMMON_DNS_UTILS_HPP_
 
+#include "openthread-br/config.h"
+
 #include "common/types.hpp"
 
 /**

--- a/src/dbus/client/client_error.hpp
+++ b/src/dbus/client/client_error.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_CLIENT_CLIENT_ERROR_HPP_
 #define OTBR_DBUS_CLIENT_CLIENT_ERROR_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string>
 
 #include <dbus/dbus.h>

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_THREAD_API_DBUS_HPP_
 #define OTBR_THREAD_API_DBUS_HPP_
 
+#include "openthread-br/config.h"
+
 #include <functional>
 
 #include <dbus/dbus.h>

--- a/src/dbus/common/dbus_message_dump.hpp
+++ b/src/dbus/common/dbus_message_dump.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_DBUS_MESSAGE_DUMP_HPP_
 #define OTBR_AGENT_DBUS_MESSAGE_DUMP_HPP_
 
+#include "openthread-br/config.h"
+
 #include <dbus/dbus.h>
 
 namespace otbr {

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -34,6 +34,8 @@
 #ifndef DBUS_MESSAGE_HELPER_HPP_
 #define DBUS_MESSAGE_HELPER_HPP_
 
+#include "openthread-br/config.h"
+
 #include <array>
 #include <string>
 #include <tuple>

--- a/src/dbus/common/dbus_resources.hpp
+++ b/src/dbus/common/dbus_resources.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_DBUS_RESOURCES_HPP_
 #define OTBR_DBUS_DBUS_RESOURCES_HPP_
 
+#include "openthread-br/config.h"
+
 #include <memory>
 #include <utility>
 

--- a/src/dbus/common/error.hpp
+++ b/src/dbus/common/error.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_COMMON_ERROR_HPP_
 #define OTBR_DBUS_COMMON_ERROR_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string>
 
 #include <dbus/dbus.h>

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_COMMON_TYPES_HPP_
 #define OTBR_DBUS_COMMON_TYPES_HPP_
 
+#include "openthread-br/config.h"
+
 #include "dbus/common/error.hpp"
 
 #include <stdint.h>

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_AGENT_HPP_
 #define OTBR_DBUS_AGENT_HPP_
 
+#include "openthread-br/config.h"
+
 #include <functional>
 #include <set>
 #include <string>

--- a/src/dbus/server/dbus_object.hpp
+++ b/src/dbus/server/dbus_object.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_DBUS_OBJECT_HPP_
 #define OTBR_DBUS_DBUS_OBJECT_HPP_
 
+#include "openthread-br/config.h"
+
 #ifndef OTBR_LOG_TAG
 #define OTBR_LOG_TAG "DBUS"
 #endif

--- a/src/dbus/server/dbus_request.hpp
+++ b/src/dbus/server/dbus_request.hpp
@@ -31,6 +31,11 @@
  * This file includes definitions for a d-bus request.
  */
 
+#ifndef DBUS_SERVER_DBUS_REQUEST_HPP_
+#define DBUS_SERVER_DBUS_REQUEST_HPP_
+
+#include "openthread-br/config.h"
+
 #ifndef OTBR_LOG_TAG
 #define OTBR_LOG_TAG "DBUS"
 #endif
@@ -218,3 +223,5 @@ private:
 
 } // namespace DBus
 } // namespace otbr
+
+#endif // DBUS_SERVER_DBUS_REQUEST_HPP_

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_THREAD_OBJECT_HPP_
 #define OTBR_DBUS_THREAD_OBJECT_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string>
 
 #include <openthread/link.h>

--- a/src/dbus/server/error_helper.hpp
+++ b/src/dbus/server/error_helper.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_SERVER_ERROR_HELPER_HPP_
 #define OTBR_DBUS_SERVER_ERROR_HELPER_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string>
 
 #include <dbus/dbus.h>

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_MDNS_HPP_
 #define OTBR_AGENT_MDNS_HPP_
 
+#include "openthread-br/config.h"
+
 #include <functional>
 #include <map>
 #include <memory>

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_MDNS_AVAHI_HPP_
 #define OTBR_AGENT_MDNS_AVAHI_HPP_
 
+#include "openthread-br/config.h"
+
 #include <memory>
 #include <set>
 #include <vector>

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_MDNS_MDNSSD_HPP_
 #define OTBR_AGENT_MDNS_MDNSSD_HPP_
 
+#include "openthread-br/config.h"
+
 #include <array>
 #include <map>
 #include <memory>

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_NCP_OPENTHREAD_HPP_
 #define OTBR_AGENT_NCP_OPENTHREAD_HPP_
 
+#include "openthread-br/config.h"
+
 #include <chrono>
 #include <memory>
 

--- a/src/rest/connection.hpp
+++ b/src/rest/connection.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_CONNECTION_HPP_
 #define OTBR_REST_CONNECTION_HPP_
 
+#include "openthread-br/config.h"
+
 #include <string.h>
 #include <unistd.h>
 

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_JSON_HPP_
 #define OTBR_REST_JSON_HPP_
 
+#include "openthread-br/config.h"
+
 #include "openthread/dataset.h"
 #include "openthread/link.h"
 #include "openthread/thread_ftd.h"

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_PARSER_HPP_
 #define OTBR_REST_PARSER_HPP_
 
+#include "openthread-br/config.h"
+
 #include <memory>
 
 #include "rest/types.hpp"

--- a/src/rest/request.hpp
+++ b/src/rest/request.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_REQUEST_HPP_
 #define OTBR_REST_REQUEST_HPP_
 
+#include "openthread-br/config.h"
+
 #include <map>
 #include <string>
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_RESOURCE_HPP_
 #define OTBR_REST_RESOURCE_HPP_
 
+#include "openthread-br/config.h"
+
 #include <unordered_map>
 
 #include <openthread/border_agent.h>

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_RESPONSE_HPP_
 #define OTBR_REST_RESPONSE_HPP_
 
+#include "openthread-br/config.h"
+
 #include <chrono>
 #include <map>
 #include <string>

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_REST_WEB_SERVER_HPP_
 #define OTBR_REST_REST_WEB_SERVER_HPP_
 
+#include "openthread-br/config.h"
+
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <sys/socket.h>

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_REST_TYPES_HPP_
 #define OTBR_REST_TYPES_HPP_
 
+#include "openthread-br/config.h"
+
 #include <chrono>
 #include <string>
 #include <vector>

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_SRP_ADVERTISING_PROXY_HPP_
 #define OTBR_SRP_ADVERTISING_PROXY_HPP_
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
 
 #include <stdint.h>

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_DISCOVERY_PROXY_HPP_
 #define OTBR_AGENT_DISCOVERY_PROXY_HPP_
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 
 #include <set>

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_TREL_DNSSD_HPP_
 #define OTBR_AGENT_TREL_DNSSD_HPP_
 
+#include "openthread-br/config.h"
+
 #if OTBR_ENABLE_TREL
 
 #include <assert.h>

--- a/src/utils/infra_link_selector.hpp
+++ b/src/utils/infra_link_selector.hpp
@@ -34,6 +34,8 @@
 #ifndef INFRA_LINK_SELECTOR_HPP_
 #define INFRA_LINK_SELECTOR_HPP_
 
+#include "openthread-br/config.h"
+
 #if __linux__
 
 #include <assert.h>

--- a/src/utils/system_utils.hpp
+++ b/src/utils/system_utils.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_UTILS_SYSTEM_UTILS_HPP_
 #define OTBR_UTILS_SYSTEM_UTILS_HPP_
 
+#include "openthread-br/config.h"
+
 namespace otbr {
 namespace SystemUtils {
 

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_THREAD_HELPER_HPP_
 #define OTBR_THREAD_HELPER_HPP_
 
+#include "openthread-br/config.h"
+
 #include <chrono>
 #include <functional>
 #include <map>


### PR DESCRIPTION
always include openthread-br/config.h so that OTBR_CONFIG_FILE will always take effect.