### PR TITLE
[github-actions] fix macOS workflow error due to protobuf library

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -60,7 +60,7 @@ jobs:
         rm -f /usr/local/bin/python3-config
         rm -f /usr/local/bin/python3.11-config
         brew update
-        brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf pkg-config
+        brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf@3 pkg-config
     - name: Build
       run: |
         OTBR_OPTIONS='-DOTBR_BORDER_AGENT=OFF -DOTBR_MDNS=OFF -DOT_FIREWALL=OFF -DOTBR_DBUS=OFF' ./script/test build

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -60,8 +60,7 @@ jobs:
         rm -f /usr/local/bin/python3-config
         rm -f /usr/local/bin/python3.11-config
         brew update
-        brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf@3 pkg-config
-        echo '/usr/local/opt/protobuf@3/bin'>> $GITHUB_PATH
+        brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf@21 pkg-config
     - name: Build
       run: |
         OTBR_OPTIONS='-DOTBR_BORDER_AGENT=OFF -DOTBR_MDNS=OFF -DOT_FIREWALL=OFF -DOTBR_DBUS=OFF' ./script/test build

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -61,6 +61,7 @@ jobs:
         rm -f /usr/local/bin/python3.11-config
         brew update
         brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf@3 pkg-config
+        echo '/usr/local/opt/protobuf@3/bin'>> $GITHUB_PATH
     - name: Build
       run: |
         OTBR_OPTIONS='-DOTBR_BORDER_AGENT=OFF -DOTBR_MDNS=OFF -DOT_FIREWALL=OFF -DOTBR_DBUS=OFF' ./script/test build

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Config protobuf version for Mac, see .github/workflows/macOS.yml
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(Protobuf_PREFIX_PATH
+        "/usr/local/opt/protobuf@3/include"            
+        "/usr/local/opt/protobuf@3/lib"             
+        "/usr/local/opt/protobuf@3/bin" )
+    list(APPEND CMAKE_PREFIX_PATH "${Protobuf_PREFIX_PATH}")
+endif()
 find_package(Protobuf REQUIRED)
 
 # Set up the output path.

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Config protobuf version for Mac, see .github/workflows/macOS.yml
+# Config brew protobuf version for Mac, see .github/workflows/macOS.yml
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(Protobuf_PREFIX_PATH
-        "/usr/local/opt/protobuf@3/include"            
-        "/usr/local/opt/protobuf@3/lib"             
-        "/usr/local/opt/protobuf@3/bin" )
+        "/usr/local/opt/protobuf@21/include"            
+        "/usr/local/opt/protobuf@21/lib"             
+        "/usr/local/opt/protobuf@21/bin")
     list(APPEND CMAKE_PREFIX_PATH "${Protobuf_PREFIX_PATH}")
 endif()
 find_package(Protobuf REQUIRED)


### PR DESCRIPTION
Fix Mac compile issue for latest brew protobuf library. Detail error log:

static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and newer.");
^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
