### PR TITLE
[rest] support erasing all persistent info

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -43,6 +43,15 @@ paths:
             application/json:
               schema:
                 type: object
+    delete:
+      tags:
+        - node
+      summary: Erase all persistent information, essentially factory reset the Border Router.
+      responses:
+        "200":
+          description: Successful operation
+        "409":
+          description: Thread interface is in wrong state.
   /node/ba-id:
     get:
       tags:

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -137,6 +137,7 @@ private:
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
     void GetNodeInfo(Response &aResponse) const;
+    void DeleteNodeInfo(Response &aResponse) const;
     void GetDataBaId(Response &aResponse) const;
     void GetDataExtendedAddr(Response &aResponse) const;
     void GetDataState(Response &aResponse) const;

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -34,7 +34,7 @@
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "GET, OPTIONS, PUT"
+#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "DELETE, GET, OPTIONS, PUT"
 #define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {


### PR DESCRIPTION
Add REST API to support erasing all persistent information, effectively factory resetting the OTBR. The implementation follows the semantic of the D-Bus API and automatically disables the Thread network.

After erasing all persistent information the dataset is cleared too. So this allows to build a new Thread network with subsequent use of the PUT method to the /node/dataset/active endpoint.