### PR TITLE
[mdns] pass copy of `mType` for `OnServiceResolved`

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -175,7 +175,7 @@ uint64_t Publisher::AddSubscriptionCallbacks(Publisher::DiscoveredServiceInstanc
     return subscriberId;
 }
 
-void Publisher::OnServiceResolved(const std::string aType, const DiscoveredInstanceInfo &aInstanceInfo)
+void Publisher::OnServiceResolved(std::string aType, const DiscoveredInstanceInfo &aInstanceInfo)
 {
     std::vector<uint64_t> subscriberIds;
 

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -175,7 +175,7 @@ uint64_t Publisher::AddSubscriptionCallbacks(Publisher::DiscoveredServiceInstanc
     return subscriberId;
 }
 
-void Publisher::OnServiceResolved(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo)
+void Publisher::OnServiceResolved(const std::string aType, const DiscoveredInstanceInfo &aInstanceInfo)
 {
     std::vector<uint64_t> subscriberIds;
 

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -512,7 +512,7 @@ protected:
     void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
     void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
-    void                 OnServiceResolved(const std::string &aType, const DiscoveredInstanceInfo &aInstanceInfo);
+    void                 OnServiceResolved(const std::string aType, const DiscoveredInstanceInfo &aInstanceInfo);
     void OnServiceResolveFailed(const std::string &aType, const std::string &aInstanceName, int32_t aErrorCode);
     void OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType, const std::string &aInstanceName);
     void OnHostResolved(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo);

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -512,7 +512,7 @@ protected:
     void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
     void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
-    void                 OnServiceResolved(const std::string aType, const DiscoveredInstanceInfo &aInstanceInfo);
+    void                 OnServiceResolved(std::string aType, const DiscoveredInstanceInfo &aInstanceInfo);
     void OnServiceResolveFailed(const std::string &aType, const std::string &aInstanceName, int32_t aErrorCode);
     void OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType, const std::string &aInstanceName);
     void OnHostResolved(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo);


### PR DESCRIPTION
https://github.com/openthread/ot-br-posix/blob/main/src/mdns/mdns_avahi.cpp#L1261
`PublisherAvahi::ServiceResolver::HandleResolveHostResult` passes the reference of `ServiceResolver::mType` to `OnServiceResolved()` function which calls each registered service discovery callback on the resolved service. The ServiceResolver may be removed by a callback, when there are more callbacks called afterwards, there will be a crash as the `mType` is gone.


