### PR TITLE
[mdns] all `On{Item}Resolved()` callbacks to use value parameters

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -81,14 +81,14 @@ void Publisher::PublishHost(const std::string             &aName,
     }
 }
 
-void Publisher::OnServiceResolveFailed(const std::string &aType, const std::string &aInstanceName, int32_t aErrorCode)
+void Publisher::OnServiceResolveFailed(std::string aType, std::string aInstanceName, int32_t aErrorCode)
 {
     UpdateMdnsResponseCounters(mTelemetryInfo.mServiceResolutions, DnsErrorToOtbrError(aErrorCode));
     UpdateServiceInstanceResolutionEmaLatency(aInstanceName, aType, DnsErrorToOtbrError(aErrorCode));
     OnServiceResolveFailedImpl(aType, aInstanceName, aErrorCode);
 }
 
-void Publisher::OnHostResolveFailed(const std::string &aHostName, int32_t aErrorCode)
+void Publisher::OnHostResolveFailed(std::string aHostName, int32_t aErrorCode)
 {
     UpdateMdnsResponseCounters(mTelemetryInfo.mHostResolutions, DnsErrorToOtbrError(aErrorCode));
     UpdateHostResolutionEmaLatency(aHostName, DnsErrorToOtbrError(aErrorCode));
@@ -175,7 +175,7 @@ uint64_t Publisher::AddSubscriptionCallbacks(Publisher::DiscoveredServiceInstanc
     return subscriberId;
 }
 
-void Publisher::OnServiceResolved(std::string aType, const DiscoveredInstanceInfo &aInstanceInfo)
+void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aInstanceInfo)
 {
     std::vector<uint64_t> subscriberIds;
 
@@ -216,7 +216,7 @@ void Publisher::OnServiceResolved(std::string aType, const DiscoveredInstanceInf
     }
 }
 
-void Publisher::OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType, const std::string &aInstanceName)
+void Publisher::OnServiceRemoved(uint32_t aNetifIndex, std::string aType, std::string aInstanceName)
 {
     DiscoveredInstanceInfo instanceInfo;
 
@@ -229,7 +229,7 @@ void Publisher::OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType,
     OnServiceResolved(aType, instanceInfo);
 }
 
-void Publisher::OnHostResolved(const std::string &aHostName, const Publisher::DiscoveredHostInfo &aHostInfo)
+void Publisher::OnHostResolved(std::string aHostName, Publisher::DiscoveredHostInfo aHostInfo)
 {
     otbrLogInfo("Host %s is resolved successfully: host %s addresses %zu ttl %u", aHostName.c_str(),
                 aHostInfo.mHostName.c_str(), aHostInfo.mAddresses.size(), aHostInfo.mTtl);

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -512,11 +512,12 @@ protected:
     void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
     void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
-    void                 OnServiceResolved(std::string aType, const DiscoveredInstanceInfo &aInstanceInfo);
-    void OnServiceResolveFailed(const std::string &aType, const std::string &aInstanceName, int32_t aErrorCode);
-    void OnServiceRemoved(uint32_t aNetifIndex, const std::string &aType, const std::string &aInstanceName);
-    void OnHostResolved(const std::string &aHostName, const DiscoveredHostInfo &aHostInfo);
-    void OnHostResolveFailed(const std::string &aHostName, int32_t aErrorCode);
+
+    void OnServiceResolved(std::string aType, DiscoveredInstanceInfo aInstanceInfo);
+    void OnServiceResolveFailed(std::string aType, std::string aInstanceName, int32_t aErrorCode);
+    void OnServiceRemoved(uint32_t aNetifIndex, std::string aType, std::string aInstanceName);
+    void OnHostResolved(std::string aHostName, DiscoveredHostInfo aHostInfo);
+    void OnHostResolveFailed(std::string aHostName, int32_t aErrorCode);
 
     // Handles the cases that there is already a registration for the same service.
     // If the returned callback is completed, current registration should be considered


### PR DESCRIPTION
This commit updates all base class `Publisher::On{Item}Resolved()` callbacks to use value parameters instead of `const` reference. This change ensures that the objects passed to these callbacks will not be freed until the callbacks have completed and prevent any potential problem. In particular user may unsubscribe (invoke `UnsubscribeService()` or `UnsubscribeHost()`) from the callback.

----

This is follow up https://github.com/openthread/ot-br-posix/pull/1910.
