### PR TITLE
[utils] update SuccessOrExit for error tracking

### DIFF
--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -72,13 +72,14 @@
  *  @param[in] aStatus  A scalar status to be evaluated against zero (0).
  *
  */
-#define SuccessOrExit(aStatus) \
-    do                         \
-    {                          \
-        if ((aStatus) != 0)    \
-        {                      \
-            goto exit;         \
-        }                      \
+#define SuccessOrExit(aStatus, ...) \
+    do                              \
+    {                               \
+        if ((aStatus) != 0)         \
+        {                           \
+            __VA_ARGS__;            \
+            goto exit;              \
+        }                           \
     } while (false)
 
 /**
@@ -89,14 +90,14 @@
  * @param[in] aMessage  A message (text string) to print on failure.
  *
  */
-#define SuccessOrDie(aStatus, aMessage)                                      \
-    do                                                                       \
-    {                                                                        \
-        if ((aStatus) != 0)                                                  \
-        {                                                                    \
-            otbrLogEmerg("FAILED %s:%d - %s", __FILE__, __LINE__, aMessage); \
-            exit(-1);                                                        \
-        }                                                                    \
+#define SuccessOrDie(aStatus, aMessage)                                                   \
+    do                                                                                    \
+    {                                                                                     \
+        if ((aStatus) != 0)                                                               \
+        {                                                                                 \
+            otbrLogEmerg("FAILED %s:%d - %d: %s", __FILE__, __LINE__, aStatus, aMessage); \
+            exit(-1);                                                                     \
+        }                                                                                 \
     } while (false)
 
 /**

--- a/tests/scripts/openwrt
+++ b/tests/scripts/openwrt
@@ -43,7 +43,7 @@ readonly CONTAINER_NAME
 
 do_prepare()
 {
-    docker create --name "${CONTAINER_NAME}" --rm -v openwrt-bin:/home/build/openwrt/bin -it openwrt/sdk
+    docker create --name "${CONTAINER_NAME}" --rm -v openwrt-bin:/home/build/openwrt/bin -it openwrt/sdk:22.03.3
     docker cp . "${CONTAINER_NAME}":/home/build/ot-br-posix
     echo 'src-link openthread /home/build/ot-br-posix/etc/openwrt' >feeds.conf
 


### PR DESCRIPTION
This commit updates the `SuccessOrExit` macro to accept an action before goto "exit". It allows us to add a log when error happens. For example, we can write:

```
SuccessOrExit((error = writeDatasetToSettings()), otbrLogErr("Failed to write dataset to settings"));
```

So that we know exactly which step a method fails at.

------

This commit also prints the error/status code for macro `SuccessOrDie`.