### PR TITLE
[rest] add query parsing

### DIFF
--- a/src/rest/parser.cpp
+++ b/src/rest/parser.cpp
@@ -100,9 +100,10 @@ int Parser::OnMessageComplete(http_parser *parser)
     if (urlParser.field_set & (1 << UF_QUERY))
     {
         uint16_t offset = urlParser.field_data[UF_QUERY].off;
-        uint16_t end = offset + urlParser.field_data[UF_QUERY].len;
+        uint16_t end    = offset + urlParser.field_data[UF_QUERY].len;
 
-        while(offset < end) {
+        while (offset < end)
+        {
             std::string::size_type next = state->mUrl.find('&', offset);
             if (next == std::string::npos)
             {

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -80,8 +80,25 @@ public:
     void Process(const char *aBuf, size_t aLength);
 
 private:
+    class State {
+    public:
+        Request    *mRequest;
+        std::string mUrl;
+        std::string mNextHeaderField;
+    };
+
+    static int OnUrl(http_parser *parser, const char *at, size_t len);
+    static int OnBody(http_parser *parser, const char *at, size_t len);
+    static int OnMessageComplete(http_parser *parser);
+    static int OnMessageBegin(http_parser *parser);
+    static int OnHeaderComplete(http_parser *parser);
+    static int OnHandlerData(http_parser *, const char *, size_t);
+    static int OnHeaderField(http_parser *parser, const char *at, size_t len);
+    static int OnHeaderData(http_parser *parser, const char *at, size_t len);
+
     http_parser          mParser;
     http_parser_settings mSettings;
+    State                mState;
 };
 
 } // namespace rest

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -80,7 +80,8 @@ public:
     void Process(const char *aBuf, size_t aLength);
 
 private:
-    struct State {
+    struct State
+    {
         Request    *mRequest;
         std::string mUrl;
         std::string mNextHeaderField;

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -80,8 +80,7 @@ public:
     void Process(const char *aBuf, size_t aLength);
 
 private:
-    class State {
-    public:
+    struct State {
         Request    *mRequest;
         std::string mUrl;
         std::string mNextHeaderField;

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -91,9 +91,9 @@ std::string Request::GetHeaderValue(const std::string aHeaderField) const
 
 std::string Request::GetQueryValue(const std::string aQueryName) const
 {
-    auto it = mHeaders.find(aQueryName);
+    auto it = mQueryParameters.find(aQueryName);
 
-    return (it == mHeaders.end()) ? "" : it->second;
+    return (it == mQueryParameters.end()) ? "" : it->second;
 }
 
 void Request::SetReadComplete(void)

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -37,9 +37,9 @@ Request::Request(void)
 {
 }
 
-void Request::SetUrl(const char *aString, size_t aLength)
+void Request::SetUrlPath(std::string aPath)
 {
-    mUrl += std::string(aString, aLength);
+    mUrlPath = aPath;
 }
 
 void Request::SetBody(const char *aString, size_t aLength)
@@ -57,14 +57,14 @@ void Request::SetMethod(int32_t aMethod)
     mMethod = aMethod;
 }
 
-void Request::SetNextHeaderField(const char *aString, size_t aLength)
+void Request::AddHeaderField(std::string aField, std::string aValue)
 {
-    mNextHeaderField = StringUtils::ToLowercase(std::string(aString, aLength));
+    mHeaders[aField] = aValue;
 }
 
-void Request::SetHeaderValue(const char *aString, size_t aLength)
+void Request::AddQueryField(std::string aField, std::string aValue)
 {
-    mHeaders[mNextHeaderField] = std::string(aString, aLength);
+    mQueryParameters[aField] = aValue;
 }
 
 HttpMethod Request::GetMethod() const
@@ -77,30 +77,21 @@ std::string Request::GetBody() const
     return mBody;
 }
 
-std::string Request::GetUrl(void) const
+std::string Request::GetUrlPath(void) const
 {
-    std::string url = mUrl;
-
-    size_t urlEnd = url.find("?");
-
-    if (urlEnd != std::string::npos)
-    {
-        url = url.substr(0, urlEnd);
-    }
-    while (!url.empty() && url[url.size() - 1] == '/')
-    {
-        url.pop_back();
-    }
-
-    VerifyOrExit(url.size() > 0, url = "/");
-
-exit:
-    return url;
+    return mUrlPath;
 }
 
 std::string Request::GetHeaderValue(const std::string aHeaderField) const
 {
     auto it = mHeaders.find(StringUtils::ToLowercase(aHeaderField));
+
+    return (it == mHeaders.end()) ? "" : it->second;
+}
+
+std::string Request::GetQueryValue(const std::string aQueryName) const
+{
+    auto it = mHeaders.find(aQueryName);
 
     return (it == mHeaders.end()) ? "" : it->second;
 }

--- a/src/rest/request.hpp
+++ b/src/rest/request.hpp
@@ -59,13 +59,12 @@ public:
     Request(void);
 
     /**
-     * This method sets the Url field of a request.
+     * This method sets the Url Path field of a request.
      *
-     * @param[in] aString  A pointer points to url string.
-     * @param[in] aLength  Length of the url string
+     * @param[in] aPath  The url path
      *
      */
-    void SetUrl(const char *aString, size_t aLength);
+    void SetUrlPath(std::string aPath);
 
     /**
      * This method sets the body field of a request.
@@ -95,20 +94,19 @@ public:
     /**
      * This method sets the next header field of a request.
      *
-     * @param[in] aString  A pointer points to body string.
-     * @param[in] aLength  Length of the body string
+     * @param[in] aField  The field name.
+     * @param[in] aValue  The value of the field.
      *
      */
-    void SetNextHeaderField(const char *aString, size_t aLength);
+    void AddHeaderField(std::string aField, std::string aValue);
 
     /**
-     * This method sets the header value of the previously set header of a request.
+     * This method adds a query field to the request.
      *
-     * @param[in] aString  A pointer points to body string.
-     * @param[in] aLength  Length of the body string
-     *
+     * @param[in] aField  The field name.
+     * @param[in] aValue  The value of the field.
      */
-    void SetHeaderValue(const char *aString, size_t aLength);
+    void AddQueryField(std::string aField, std::string aValue);
 
     /**
      * This method labels the request as complete which means it no longer need to be parsed one more time .
@@ -141,7 +139,7 @@ public:
      *
      * @returns A string contains the url of this request.
      */
-    std::string GetUrl(void) const;
+    std::string GetUrlPath(void) const;
 
     /**
      * This method returns the specified header field for this request.
@@ -150,6 +148,14 @@ public:
      * @returns A string contains the header value of this request.
      */
     std::string GetHeaderValue(const std::string aHeaderField) const;
+
+    /**
+     * This method returns the specified query for this request.
+     *
+     * @param aQueryName  A query name.
+     * @return A string containing the value of the query or an empty string if the query could not be found.
+     */
+    std::string GetQueryValue(const std::string aQueryName) const;
 
     /**
      * This method indicates whether this request is parsed completely.
@@ -161,10 +167,10 @@ public:
 private:
     int32_t                            mMethod;
     size_t                             mContentLength;
-    std::string                        mUrl;
+    std::string                        mUrlPath;
     std::string                        mBody;
-    std::string                        mNextHeaderField;
     std::map<std::string, std::string> mHeaders;
+    std::map<std::string, std::string> mQueryParameters;
     bool                               mComplete;
 };
 

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -151,7 +151,7 @@ void Resource::Init(void)
 
 void Resource::Handle(Request &aRequest, Response &aResponse) const
 {
-    std::string url = aRequest.GetUrl();
+    std::string url = aRequest.GetUrlPath();
     auto        it  = mResourceMap.find(url);
 
     if (it != mResourceMap.end())
@@ -167,7 +167,7 @@ void Resource::Handle(Request &aRequest, Response &aResponse) const
 
 void Resource::HandleCallback(Request &aRequest, Response &aResponse)
 {
-    std::string url = aRequest.GetUrl();
+    std::string url = aRequest.GetUrlPath();
     auto        it  = mResourceCallbackMap.find(url);
 
     if (it != mResourceCallbackMap.end())


### PR DESCRIPTION
This adds the capability to parse url query strings to the rest api.

It also contains a small refactoring of the parser and request class which moved state that is only required for parsing out of the request class. The only exception to this is the body field which is still built up in the request class.