### PR TITLE
[logging] use program name for log id

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -58,7 +58,6 @@
 #include "common/types.hpp"
 #include "ncp/ncp_openthread.hpp"
 
-static const char kSyslogIdent[]          = "otbr-agent";
 static const char kDefaultInterfaceName[] = "wpan0";
 
 // Port number used by Rest server.
@@ -268,7 +267,7 @@ static int realmain(int argc, char *argv[])
         }
     }
 
-    otbrLogInit(kSyslogIdent, logLevel, verbose);
+    otbrLogInit(argv[0], logLevel, verbose);
     otbrLogNotice("Running %s", OTBR_PACKAGE_VERSION);
     otbrLogNotice("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
     otbrLogNotice("Thread interface: %s", interfaceName);

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -78,12 +78,17 @@ void otbrLogSetLevel(otbrLogLevel aLevel)
 }
 
 /** Initialize logging */
-void otbrLogInit(const char *aIdent, otbrLogLevel aLevel, bool aPrintStderr)
+void otbrLogInit(const char *aProgramName, otbrLogLevel aLevel, bool aPrintStderr)
 {
-    assert(aIdent);
+    const char *ident;
+
+    assert(aProgramName != nullptr);
     assert(aLevel >= OTBR_LOG_EMERG && aLevel <= OTBR_LOG_DEBUG);
 
-    openlog(aIdent, (LOG_CONS | LOG_PID) | (aPrintStderr ? LOG_PERROR : 0), OTBR_SYSLOG_FACILITY_ID);
+    ident = strrchr(aProgramName, '/');
+    ident = (ident != nullptr) ? ident + 1 : aProgramName;
+
+    openlog(ident, (LOG_CONS | LOG_PID) | (aPrintStderr ? LOG_PERROR : 0), OTBR_SYSLOG_FACILITY_ID);
     sLevel        = aLevel;
     sDefaultLevel = sLevel;
 }

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -86,12 +86,12 @@ void otbrLogEnableSyslog(bool aEnabled);
 /**
  * This function initialize the logging service.
  *
- * @param[in] aIdent        Identity of the logger.
+ * @param[in] aProgramName  The name of this runnable program.
  * @param[in] aLevel        Log level of the logger.
  * @param[in] aPrintStderr  Whether to log to stderr.
  *
  */
-void otbrLogInit(const char *aIdent, otbrLogLevel aLevel, bool aPrintStderr);
+void otbrLogInit(const char *aProgramName, otbrLogLevel aLevel, bool aPrintStderr);
 
 /**
  * This function log at level @p aLevel.

--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -46,7 +46,6 @@
 #include "common/logging.hpp"
 #include "web/web-service/web_server.hpp"
 
-static const char kSyslogIdent[]          = "otbr-web";
 static const char kDefaultInterfaceName[] = "wpan0";
 static const char kDefaultListenAddr[]    = "::";
 
@@ -112,7 +111,7 @@ int main(int argc, char **argv)
         }
     }
 
-    otbrLogInit(kSyslogIdent, logLevel, true);
+    otbrLogInit(argv[0], logLevel, true);
     otbrLogInfo("Running %s", OTBR_PACKAGE_VERSION);
 
     if (interfaceName == nullptr)


### PR DESCRIPTION
On Android, we use the "ot-daemon" name for the runnable program
and want the syslog id be updated to "ot-daemon" as well. Instead of
hard coding the syslog id, this commit derive the id from the program
name so it works for both linux and Android.

For example, logs on Android will be like:
```
ot-daemon[2152867]: [NOTE]-AGENT---: Running 0.3.0-090e5b55-dirty
ot-daemon[2152867]: [NOTE]-AGENT---: Thread version: 1.3.0
ot-daemon[2152867]: [NOTE]-AGENT---: Thread interface: wpan0
```