### PR TITLE
[utils] add mNcp to VendorServer

### DIFF
--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -50,13 +50,19 @@ public:
      * @param[in] aNcp  A reference to the NCP controller.
      *
      */
-    VendorServer(otbr::Ncp::ControllerOpenThread &aNcp);
+    VendorServer(otbr::Ncp::ControllerOpenThread &aNcp)
+        : mNcp(aNcp)
+    {
+    }
 
     /**
      * This method initializes the vendor server.
      *
      */
     void Init(void);
+
+private:
+    otbr::Ncp::ControllerOpenThread &mNcp;
 };
 } // namespace vendor
 } // namespace otbr


### PR DESCRIPTION
BinderServer on Android will need to retrieve the `mNcp` object from the VendorServer.

See [aosp/2648679](https://android-review.git.corp.google.com/c/platform/external/ot-br-posix/+) for BinderServer implementation