### PR TITLE
Dockerfile: EXPOSE REST API port 8080

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -111,3 +111,4 @@ RUN ([ "${DNS64}" = "0" ] || chmod 644 /etc/bind/named.conf.options) \
 ENTRYPOINT ["/app/etc/docker/docker_entrypoint.sh"]
 
 EXPOSE 80
+EXPOSE 8080:8080


### PR DESCRIPTION
As this is needed by the WebUI topology page which interacts with the OTBR REST agent on port 8080