### PR TITLE
[docker] cleanup `/tmp`

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -107,6 +107,7 @@ RUN ([ "${DNS64}" = "0" ] || chmod 644 /etc/bind/named.conf.options) \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $OTBR_BUILD_DEPS  \
     && ([ "${RELEASE}" = 1 ] ||  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false "$OTBR_NORELEASE_DEPS";) \
     && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
   ))
 
 ENTRYPOINT ["/app/etc/docker/docker_entrypoint.sh"]


### PR DESCRIPTION
This saves ~28MB by clearing out `/tmp`

```shell
root@4f33863bee35:/tmp# ll
total 2936
drwxrwxrwt  1 root root    4096 Sep  1 21:20 ./
drwxr-xr-x  1 root root    4096 Sep  1 21:52 ../
drwxr-xr-x 12 root root    4096 Sep  1 21:18 mDNSResponder-1790.80.10/
-rw-r--r--  1 root root 2989629 Sep  1 21:18 mDNSResponder-1790.80.10.tar.gz
drwxr-xr-x  3 root root    4096 Sep  1 21:20 npm-2233-869f1b4a/
root@4f33863bee35:/tmp# du -sh . --block-size=M
28M     .

```