### PR TITLE
[mdns] update 'TxtEntry'  to handle boolean attribute

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -343,10 +343,11 @@ void AppendVendorTxtEntries(const std::map<std::string, std::vector<uint8_t>> &a
 
         for (auto &addedEntry : aTxtList)
         {
-            if (addedEntry.mName == key)
+            if (addedEntry.mKey == key)
             {
-                addedEntry.mValue = value;
-                found             = true;
+                addedEntry.mValue              = value;
+                addedEntry.mIsBooleanAttribute = false;
+                found                          = true;
                 break;
             }
         }

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -70,31 +70,48 @@ class Publisher : private NonCopyable
 {
 public:
     /**
-     * This structure represents a name/value pair of the TXT record.
+     * This structure represents a key/value pair of the TXT record.
      *
      */
     struct TxtEntry
     {
-        std::string          mName;  ///< The name of the TXT entry.
-        std::vector<uint8_t> mValue; ///< The value of the TXT entry.
+        std::string          mKey;                ///< The key of the TXT entry.
+        std::vector<uint8_t> mValue;              ///< The value of the TXT entry. Can be empty.
+        bool                 mIsBooleanAttribute; ///< This entry is boolean attribute (encoded as `key` without `=`).
 
-        TxtEntry(const char *aName, const char *aValue)
-            : TxtEntry(aName, reinterpret_cast<const uint8_t *>(aValue), strlen(aValue))
+        TxtEntry(const char *aKey, const char *aValue)
+            : TxtEntry(aKey, reinterpret_cast<const uint8_t *>(aValue), strlen(aValue))
         {
         }
 
-        TxtEntry(const char *aName, const uint8_t *aValue, size_t aValueLength)
-            : TxtEntry(aName, strlen(aName), aValue, aValueLength)
+        TxtEntry(const char *aKey, const uint8_t *aValue, size_t aValueLength)
+            : TxtEntry(aKey, strlen(aKey), aValue, aValueLength)
         {
         }
 
-        TxtEntry(const char *aName, size_t aNameLength, const uint8_t *aValue, size_t aValueLength)
-            : mName(aName, aNameLength)
+        TxtEntry(const char *aKey, size_t aKeyLength, const uint8_t *aValue, size_t aValueLength)
+            : mKey(aKey, aKeyLength)
             , mValue(aValue, aValue + aValueLength)
+            , mIsBooleanAttribute(false)
         {
         }
 
-        bool operator==(const TxtEntry &aOther) const { return mName == aOther.mName && mValue == aOther.mValue; }
+        TxtEntry(const char *aKey)
+            : TxtEntry(aKey, strlen(aKey))
+        {
+        }
+
+        TxtEntry(const char *aKey, size_t aKeyLength)
+            : mKey(aKey, aKeyLength)
+            , mIsBooleanAttribute(true)
+        {
+        }
+
+        bool operator==(const TxtEntry &aOther) const
+        {
+            return (mKey == aOther.mKey) && (mValue == aOther.mValue) &&
+                   (mIsBooleanAttribute == aOther.mIsBooleanAttribute);
+        }
     };
 
     typedef std::vector<TxtEntry>    TxtList;
@@ -356,7 +373,7 @@ public:
      * See RFC 6763 for details: https://tools.ietf.org/html/rfc6763#section-6.
      *
      * @param[in]  aTxtList  A TXT entry list.
-     * @param[out] aTxtData  A TXT data buffer.
+     * @param[out] aTxtData  A TXT data buffer. Will be cleared.
      *
      * @retval OTBR_ERROR_NONE          Successfully write the TXT entry list.
      * @retval OTBR_ERROR_INVALID_ARGS  The @p aTxtList includes invalid TXT entry.

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -342,18 +342,10 @@ Mdns::Publisher::TxtList AdvertisingProxy::MakeTxtList(const otSrpServerService 
 {
     const uint8_t           *txtData;
     uint16_t                 txtDataLength = 0;
-    otDnsTxtEntryIterator    iterator;
-    otDnsTxtEntry            txtEntry;
     Mdns::Publisher::TxtList txtList;
 
     txtData = otSrpServerServiceGetTxtData(aSrpService, &txtDataLength);
-
-    otDnsInitTxtEntryIterator(&iterator, txtData, txtDataLength);
-
-    while (otDnsGetNextTxtEntry(&iterator, &txtEntry) == OT_ERROR_NONE)
-    {
-        txtList.emplace_back(txtEntry.mKey, txtEntry.mValue, txtEntry.mValueLength);
-    }
+    Mdns::Publisher::DecodeTxtData(txtList, txtData, txtDataLength);
 
     return txtList;
 }

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -495,7 +495,12 @@ void TrelDnssd::Peer::ReadExtAddrFromTxtData(void)
 
     for (const auto &txtEntry : txtEntries)
     {
-        if (StringUtils::EqualCaseInsensitive(txtEntry.mName, kTxtRecordExtAddressKey))
+        if (txtEntry.mIsBooleanAttribute)
+        {
+            continue;
+        }
+
+        if (StringUtils::EqualCaseInsensitive(txtEntry.mKey, kTxtRecordExtAddressKey))
         {
             VerifyOrExit(txtEntry.mValue.size() == sizeof(mExtAddr));
 

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -410,9 +410,64 @@ exit:
     return ret;
 }
 
+otbrError CheckTxtDataEncoderDecoder(void)
+{
+    otbrError                error = OTBR_ERROR_NONE;
+    Mdns::Publisher::TxtList txtList;
+    Mdns::Publisher::TxtList parsedTxtList;
+    std::vector<uint8_t>     txtData;
+
+    // Encode empty `TxtList`
+
+    SuccessOrExit(error = Mdns::Publisher::EncodeTxtData(txtList, txtData));
+    VerifyOrExit(txtData.size() == 1, error = OTBR_ERROR_PARSE);
+    VerifyOrExit(txtData[0] == 0, error = OTBR_ERROR_PARSE);
+
+    SuccessOrExit(error = Mdns::Publisher::DecodeTxtData(parsedTxtList, txtData.data(), txtData.size()));
+    VerifyOrExit(parsedTxtList.size() == 0, error = OTBR_ERROR_PARSE);
+
+    // TxtList with one bool attribute
+
+    txtList.clear();
+    txtList.emplace_back("b1");
+
+    SuccessOrExit(error = Mdns::Publisher::EncodeTxtData(txtList, txtData));
+    SuccessOrExit(error = Mdns::Publisher::DecodeTxtData(parsedTxtList, txtData.data(), txtData.size()));
+    VerifyOrExit(parsedTxtList == txtList, error = OTBR_ERROR_PARSE);
+
+    // TxtList with one one key/value
+
+    txtList.clear();
+    txtList.emplace_back("k1", "v1");
+
+    SuccessOrExit(error = Mdns::Publisher::EncodeTxtData(txtList, txtData));
+    SuccessOrExit(error = Mdns::Publisher::DecodeTxtData(parsedTxtList, txtData.data(), txtData.size()));
+    VerifyOrExit(parsedTxtList == txtList, error = OTBR_ERROR_PARSE);
+
+    // TxtList with multiple entries
+
+    txtList.clear();
+    txtList.emplace_back("k1", "v1");
+    txtList.emplace_back("b1");
+    txtList.emplace_back("b2");
+    txtList.emplace_back("k2", "valu2");
+
+    SuccessOrExit(error = Mdns::Publisher::EncodeTxtData(txtList, txtData));
+    SuccessOrExit(error = Mdns::Publisher::DecodeTxtData(parsedTxtList, txtData.data(), txtData.size()));
+    VerifyOrExit(parsedTxtList == txtList, error = OTBR_ERROR_PARSE);
+
+exit:
+    return error;
+}
+
 int main(int argc, char *argv[])
 {
     int ret = 0;
+
+    if (CheckTxtDataEncoderDecoder() != OTBR_ERROR_NONE)
+    {
+        return 1;
+    }
 
     if (argc < 2)
     {


### PR DESCRIPTION
This commit updates `TxtEntry`, `EncodeTxtData()`, and `DecodeTxtData()` to support boolean attributes, which are encoded as `key` string without the `=` character. It also ensures that `EncodeTxtData()` will generate valid TXT data (containing a single zero byte) when given an empty `TxtList`. Additionally, this commit updates `AdvertisingProxy::MakeTxtList()` to use `DecodeTxtData()`, and adds a test to validate the encoder and decoder behavior.