### PR TITLE
[utils] generic vendor server

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(otbr-agent
     application.cpp
     main.cpp
     uris.hpp
+    vendor.hpp
 )
 
 target_link_libraries(otbr-agent PRIVATE

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -77,7 +77,7 @@ Application::Application(const std::string               &aInterfaceName,
     , mDBusAgent(mNcp, mBorderAgent.GetPublisher())
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
-    , mVendorServer(mNcp)
+    , mVendorServer(vendor::VendorServer::newInstance(mNcp))
 #endif
 {
     OTBR_UNUSED_VARIABLE(aRestListenAddress);
@@ -104,7 +104,7 @@ void Application::Init(void)
     mDBusAgent.Init();
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
-    mVendorServer.Init();
+    mVendorServer->Init();
 #endif
 }
 

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -76,8 +76,8 @@ Application::Application(const std::string               &aInterfaceName,
 #if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
     , mDBusAgent(mNcp, mBorderAgent.GetPublisher())
 #endif
-#if OTBR_ENABLE_ANDROID_OTDAEMON_SERVER
-    , mOtDaemonServer(ndk::SharedRefBase::make<Android::OtDaemonServer>())
+#if OTBR_ENABLE_VENDOR_SERVER
+    , mVendorServer(mNcp)
 #endif
 {
     OTBR_UNUSED_VARIABLE(aRestListenAddress);
@@ -103,8 +103,8 @@ void Application::Init(void)
 #if OTBR_ENABLE_DBUS_SERVER
     mDBusAgent.Init();
 #endif
-#if OTBR_ENABLE_ANDROID_OTDAEMON_SERVER
-    mOtDaemonServer->InitOrDie(&mNcp);
+#if OTBR_ENABLE_VENDOR_SERVER
+    mVendorServer.Init();
 #endif
 }
 

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -147,7 +147,7 @@ private:
     DBus::DBusAgent mDBusAgent;
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
-    vendor::VendorServer mVendorServer;
+    std::shared_ptr<vendor::VendorServer> mVendorServer;
 #endif
 
     static std::atomic_bool sShouldTerminate;

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -57,8 +57,8 @@
 #if OTBR_ENABLE_OPENWRT
 #include "openwrt/ubus/otubus.hpp"
 #endif
-#if OTBR_ENABLE_ANDROID_OTDAEMON_SERVER
-#include "android/otdaemon_server.hpp"
+#if OTBR_ENABLE_VENDOR_SERVER
+#include "agent/vendor.hpp"
 #endif
 #include "utils/infra_link_selector.hpp"
 
@@ -146,8 +146,8 @@ private:
 #if OTBR_ENABLE_DBUS_SERVER
     DBus::DBusAgent mDBusAgent;
 #endif
-#if OTBR_ENABLE_ANDROID_OTDAEMON_SERVER
-    std::shared_ptr<Android::OtDaemonServer> mOtDaemonServer;
+#if OTBR_ENABLE_VENDOR_SERVER
+    vendor::VendorServer mVendorServer;
 #endif
 
     static std::atomic_bool sShouldTerminate;

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions of the vendor server. The implementation of the
+ *   vendor server should be implemented by users.
+ */
+#ifndef OTBR_AGENT_VENDOR_HPP_
+#define OTBR_AGENT_VENDOR_HPP_
+
+#include "openthread-br/config.h"
+
+#include "ncp/ncp_openthread.hpp"
+
+namespace otbr {
+namespace vendor {
+
+class VendorServer
+{
+public:
+    /**
+     * The constructor of vendor server.
+     *
+     * @param[in] aNcp  A reference to the NCP controller.
+     *
+     */
+    VendorServer(otbr::Ncp::ControllerOpenThread &aNcp)
+        : mNcp(aNcp)
+    {
+    }
+
+    /**
+     * This method initializes the vendor server.
+     *
+     */
+    void Init(void);
+
+private:
+    otbr::Ncp::ControllerOpenThread &mNcp;
+};
+} // namespace vendor
+} // namespace otbr
+#endif // OTBR_AGENT_VENDOR_HPP_

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -41,29 +41,34 @@
 namespace otbr {
 namespace vendor {
 
+/**
+ * An interface for customized behavior depending on OpenThread API and state.
+ */
 class VendorServer
 {
 public:
-    /**
-     * The constructor of vendor server.
-     *
-     * @param[in] aNcp  A reference to the NCP controller.
-     *
-     */
-    VendorServer(otbr::Ncp::ControllerOpenThread &aNcp)
-        : mNcp(aNcp)
-    {
-    }
+    virtual ~VendorServer(void) = default;
 
     /**
-     * This method initializes the vendor server.
+     * Creates a new instance of VendorServer.
      *
+     * Custom vendor servers should implement this method to return an object of the derived class.
+     *
+     * @param[in]  aNcp  The OpenThread controller object.
+     *
+     * @returns  New derived VendorServer instance.
      */
-    void Init(void);
+    static std::shared_ptr<VendorServer> newInstance(otbr::Ncp::ControllerOpenThread &aNcp);
 
-private:
-    otbr::Ncp::ControllerOpenThread &mNcp;
+    /**
+     * Initializes the vendor server.
+     *
+     * This will be called by `Application::Init()` after OpenThread instance and other built-in
+     * servers have been created and initialized.
+     */
+    virtual void Init(void) = 0;
 };
+
 } // namespace vendor
 } // namespace otbr
 #endif // OTBR_AGENT_VENDOR_HPP_

--- a/src/ncp/ncp_openthread.hpp
+++ b/src/ncp/ncp_openthread.hpp
@@ -97,16 +97,12 @@ public:
     void Deinit(void);
 
     /**
-     * This method get mInstance pointer.
+     * Returns an OpenThread instance.
      *
-     * @retval The pointer of mInstance.
-     *
+     * @retval Non-null OpenThread instance if `ControllerOpenThread::Init()` has been called.
+     *         Otherwise, it's guaranteed to be `null`
      */
-    otInstance *GetInstance(void)
-    {
-        assert(mInstance != nullptr);
-        return mInstance;
-    }
+    otInstance *GetInstance(void) { return mInstance; }
 
     /**
      * This method gets the thread functionality helper.


### PR DESCRIPTION
This PR include two commits:
1. reverts https://github.com/openthread/ot-br-posix/pull/1967 as it breaks community use cases
2. Make VendorServer more generic to be used by multiple vendors. See https://github.com/openthread/ot-br-posix/pull/1967#issuecomment-1702407419

------

Prefer merging this PR as separate commits