### PR TITLE
[mdns] change `PublishService()` to get encoded TXT data as input

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -368,7 +368,11 @@ void BorderAgent::PublishMeshCopService(void)
     const otExtAddress      *extAddr     = otLinkGetExtendedAddress(instance);
     const char              *networkName = otThreadGetNetworkName(instance);
     Mdns::Publisher::TxtList txtList{{"rv", "1"}};
+    Mdns::Publisher::TxtData txtData;
     int                      port;
+    otbrError                error;
+
+    OTBR_UNUSED_VARIABLE(error);
 
     otbrLogInfo("Publish meshcop service %s.%s.local.", mServiceInstanceName.c_str(), kBorderAgentServiceType);
 
@@ -434,8 +438,11 @@ void BorderAgent::PublishMeshCopService(void)
         port = kBorderAgentServiceDummyPort;
     }
 
+    error = Mdns::Publisher::EncodeTxtData(txtList, txtData);
+    assert(error == OTBR_ERROR_NONE);
+
     mPublisher->PublishService(/* aHostName */ "", mServiceInstanceName, kBorderAgentServiceType,
-                               Mdns::Publisher::SubTypeList{}, port, txtList, [this](otbrError aError) {
+                               Mdns::Publisher::SubTypeList{}, port, txtData, [this](otbrError aError) {
                                    if (aError == OTBR_ERROR_ABORTED)
                                    {
                                        // OTBR_ERROR_ABORTED is thrown when an ongoing service registration is

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -92,7 +92,7 @@ protected:
                                  const std::string &aType,
                                  const SubTypeList &aSubTypeList,
                                  uint16_t           aPort,
-                                 const TxtList     &aTxtList,
+                                 const TxtData     &aTxtData,
                                  ResultCallback   &&aCallback) override;
     otbrError PublishHostImpl(const std::string             &aName,
                               const std::vector<Ip6Address> &aAddresses,
@@ -115,7 +115,7 @@ private:
                                  const std::string &aType,
                                  const SubTypeList &aSubTypeList,
                                  uint16_t           aPort,
-                                 const TxtList     &aTxtList,
+                                 const TxtData     &aTxtData,
                                  ResultCallback   &&aCallback,
                                  AvahiEntryGroup   *aEntryGroup,
                                  PublisherAvahi    *aPublisher)
@@ -124,7 +124,7 @@ private:
                                   aType,
                                   aSubTypeList,
                                   aPort,
-                                  aTxtList,
+                                  aTxtData,
                                   std::move(aCallback),
                                   aPublisher)
             , mEntryGroup(aEntryGroup)
@@ -340,7 +340,7 @@ private:
     void        HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
     void        CallHostOrServiceCallback(AvahiEntryGroup *aGroup, otbrError aError);
 
-    static otbrError TxtListToAvahiStringList(const TxtList    &aTxtList,
+    static otbrError TxtDataToAvahiStringList(const TxtData    &aTxtData,
                                               AvahiStringList  *aBuffer,
                                               size_t            aBufferSize,
                                               AvahiStringList *&aHead);

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -89,7 +89,7 @@ protected:
                                  const std::string &aType,
                                  const SubTypeList &aSubTypeList,
                                  uint16_t           aPort,
-                                 const TxtList     &aTxtList,
+                                 const TxtData     &aTxtData,
                                  ResultCallback   &&aCallback) override;
     otbrError PublishHostImpl(const std::string             &aName,
                               const std::vector<Ip6Address> &aAddress,
@@ -111,7 +111,7 @@ private:
                                  const std::string &aType,
                                  const SubTypeList &aSubTypeList,
                                  uint16_t           aPort,
-                                 const TxtList     &aTxtList,
+                                 const TxtData     &aTxtData,
                                  ResultCallback   &&aCallback,
                                  DNSServiceRef      aServiceRef,
                                  PublisherMDnsSd   *aPublisher)
@@ -120,7 +120,7 @@ private:
                                   aType,
                                   aSubTypeList,
                                   aPort,
-                                  aTxtList,
+                                  aTxtData,
                                   std::move(aCallback),
                                   aPublisher)
             , mServiceRef(aServiceRef)

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -265,12 +265,12 @@ otbrError AdvertisingProxy::PublishHostAndItsServices(const otSrpServerHost *aHo
 
         if (!hostDeleted && !otSrpServerServiceIsDeleted(service))
         {
-            Mdns::Publisher::TxtList     txtList     = MakeTxtList(service);
+            Mdns::Publisher::TxtData     txtData     = MakeTxtData(service);
             Mdns::Publisher::SubTypeList subTypeList = MakeSubTypeList(service);
 
             otbrLogDebug("Publish SRP service '%s'", fullServiceName.c_str());
             mPublisher.PublishService(
-                hostName, serviceName, serviceType, subTypeList, otSrpServerServiceGetPort(service), txtList,
+                hostName, serviceName, serviceType, subTypeList, otSrpServerServiceGetPort(service), txtData,
                 [this, hasUpdate, updateId, fullServiceName](otbrError aError) {
                     otbrLogResult(aError, "Handle publish SRP service '%s'", fullServiceName.c_str());
                     if (hasUpdate)
@@ -338,16 +338,14 @@ exit:
     return error;
 }
 
-Mdns::Publisher::TxtList AdvertisingProxy::MakeTxtList(const otSrpServerService *aSrpService)
+Mdns::Publisher::TxtData AdvertisingProxy::MakeTxtData(const otSrpServerService *aSrpService)
 {
-    const uint8_t           *txtData;
-    uint16_t                 txtDataLength = 0;
-    Mdns::Publisher::TxtList txtList;
+    const uint8_t *data;
+    uint16_t       length = 0;
 
-    txtData = otSrpServerServiceGetTxtData(aSrpService, &txtDataLength);
-    Mdns::Publisher::DecodeTxtData(txtList, txtData, txtDataLength);
+    data = otSrpServerServiceGetTxtData(aSrpService, &length);
 
-    return txtList;
+    return Mdns::Publisher::TxtData(data, data + length);
 }
 
 Mdns::Publisher::SubTypeList AdvertisingProxy::MakeSubTypeList(const otSrpServerService *aSrpService)

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -100,7 +100,7 @@ private:
                                    void                      *aContext);
     void        AdvertisingHandler(otSrpServerServiceUpdateId aId, const otSrpServerHost *aHost, uint32_t aTimeout);
 
-    static Mdns::Publisher::TxtList     MakeTxtList(const otSrpServerService *aSrpService);
+    static Mdns::Publisher::TxtData     MakeTxtData(const otSrpServerService *aSrpService);
     static Mdns::Publisher::SubTypeList MakeSubTypeList(const otSrpServerService *aSrpService);
     void                                OnMdnsPublishResult(otSrpServerServiceUpdateId aUpdateId, otbrError aError);
 

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -249,7 +249,7 @@ void TrelDnssd::PublishTrelService(void)
 
     mRegisterInfo.mInstanceName = GetTrelInstanceName();
     mPublisher.PublishService(/* aHostName */ "", mRegisterInfo.mInstanceName, kTrelServiceName,
-                              Mdns::Publisher::SubTypeList{}, mRegisterInfo.mPort, mRegisterInfo.mTxtEntries,
+                              Mdns::Publisher::SubTypeList{}, mRegisterInfo.mPort, mRegisterInfo.mTxtData,
                               [](otbrError aError) { HandlePublishTrelServiceError(aError); });
 }
 
@@ -461,18 +461,11 @@ uint16_t TrelDnssd::CountDuplicatePeers(const TrelDnssd::Peer &aPeer)
 
 void TrelDnssd::RegisterInfo::Assign(uint16_t aPort, const uint8_t *aTxtData, uint8_t aTxtLength)
 {
-    otbrError error;
-
-    OTBR_UNUSED_VARIABLE(error);
-
     assert(!IsPublished());
     assert(aPort > 0);
 
     mPort = aPort;
-    mTxtEntries.clear();
-
-    error = Mdns::Publisher::DecodeTxtData(mTxtEntries, aTxtData, aTxtLength);
-    assert(error == OTBR_ERROR_NONE);
+    mTxtData.assign(aTxtData, aTxtData + aTxtLength);
 }
 
 void TrelDnssd::RegisterInfo::Clear(void)
@@ -480,7 +473,7 @@ void TrelDnssd::RegisterInfo::Clear(void)
     assert(!IsPublished());
 
     mPort = 0;
-    mTxtEntries.clear();
+    mTxtData.clear();
 }
 
 const char TrelDnssd::Peer::kTxtRecordExtAddressKey[] = "xa";

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -120,9 +120,9 @@ private:
 
     struct RegisterInfo
     {
-        uint16_t                               mPort = 0;
-        std::vector<Mdns::Publisher::TxtEntry> mTxtEntries;
-        std::string                            mInstanceName;
+        uint16_t                 mPort = 0;
+        Mdns::Publisher::TxtData mTxtData;
+        std::string              mInstanceName;
 
         bool IsValid(void) const { return mPort > 0; }
         bool IsPublished(void) const { return !mInstanceName.empty(); }

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -96,14 +96,17 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
     VerifyOrDie(aContext == &sContext, "unexpected context");
     if (aState == Mdns::Publisher::State::kReady)
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
+
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishHost(hostName, {Ip6Address(hostAddr)},
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
-            hostName, "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            hostName, "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the service"); });
     }
 }
@@ -123,18 +126,21 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
     VerifyOrDie(aContext == &sContext, "unexpected context");
     if (aState == Mdns::Publisher::State::kReady)
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
+
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishHost(hostName1, {Ip6Address(hostAddr)},
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
-            hostName1, "MultipleService11", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            hostName1, "MultipleService11", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the first service"); });
 
         sContext.mPublisher->PublishService(
-            hostName1, "MultipleService12", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            hostName1, "MultipleService12", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second service"); });
 
         sContext.mPublisher->PublishHost(hostName2, {Ip6Address(hostAddr)}, [](otbrError aError) {
@@ -142,11 +148,11 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
         });
 
         sContext.mPublisher->PublishService(
-            hostName2, "MultipleService21", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            hostName2, "MultipleService21", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the first service"); });
 
         sContext.mPublisher->PublishService(
-            hostName2, "MultipleService22", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            hostName2, "MultipleService22", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second service"); });
     }
 }
@@ -157,14 +163,17 @@ void PublishSingleService(void *aContext, Mdns::Publisher::State aState)
 
     uint8_t                  xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t                  extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    Mdns::Publisher::TxtData txtData;
     Mdns::Publisher::TxtList txtList{
         {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
+
+    Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
         sContext.mPublisher->PublishService(
-            "", "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            "", "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "SingleService._meshcop._udp."); });
     }
 }
@@ -175,13 +184,16 @@ void PublishSingleServiceWithEmptyName(void *aContext, Mdns::Publisher::State aS
 
     uint8_t                  xpanid[kSizeExtPanId] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
     uint8_t                  extAddr[kSizeExtAddr] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
+    Mdns::Publisher::TxtData txtData;
     Mdns::Publisher::TxtList txtList{
         {"nn", "cool"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
+
+    Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
-        sContext.mPublisher->PublishService("", "", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+        sContext.mPublisher->PublishService("", "", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
                                             [](otbrError aError) { SuccessOrDie(aError, "(empty)._meshcop._udp."); });
     }
 }
@@ -196,21 +208,27 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool1"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
 
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
+
         sContext.mPublisher->PublishService(
-            "", "MultipleService1", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            "", "MultipleService1", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "MultipleService1._meshcop._udp."); });
     }
 
     if (aState == Mdns::Publisher::State::kReady)
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool2"}, {"xp", xpanid, sizeof(xpanid)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
 
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
+
         sContext.mPublisher->PublishService(
-            "", "MultipleService2", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            "", "MultipleService2", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "MultipleService2._meshcop._udp."); });
     }
 }
@@ -226,28 +244,38 @@ void PublishUpdateServices(void *aContext)
     assert(aContext == &sContext);
     if (!sContext.mUpdate)
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{
             {"nn", "cool"}, {"xp", xpanidOld, sizeof(xpanidOld)}, {"tv", "1.1.1"}, {"xa", extAddr, sizeof(extAddr)}};
 
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
+
         sContext.mPublisher->PublishService(
-            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { otbrLogResult(aError, "UpdateService._meshcop._udp"); });
     }
     else
     {
+        Mdns::Publisher::TxtData txtData;
         Mdns::Publisher::TxtList txtList{{"nn", "coolcool"},
                                          {"xp", xpanidNew, sizeof(xpanidNew)},
                                          {"tv", "1.1.1"},
                                          {"xa", extAddr, sizeof(extAddr)}};
 
+        Mdns::Publisher::EncodeTxtData(txtList, txtData);
+
         sContext.mPublisher->PublishService(
-            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtList,
+            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "UpdateService._meshcop._udp"); });
     }
 }
 
 void PublishServiceSubTypes(void *aContext)
 {
+    Mdns::Publisher::TxtData txtData;
+
+    txtData.push_back(0);
+
     OT_UNUSED_VARIABLE(aContext);
 
     assert(aContext == &sContext);
@@ -257,7 +285,7 @@ void PublishServiceSubTypes(void *aContext)
     subTypeList.back() = "_SUBTYPE3";
 
     sContext.mPublisher->PublishService(
-        "", "ServiceWithSubTypes", "_meshcop._udp.", subTypeList, 12345, Mdns::Publisher::TxtList{},
+        "", "ServiceWithSubTypes", "_meshcop._udp.", subTypeList, 12345, txtData,
         [](otbrError aError) { SuccessOrDie(aError, "ServiceWithSubTypes._meshcop._udp."); });
 }
 


### PR DESCRIPTION
This commit updates `Mdns::Publisher::PublishService()` to take encoded TXT data as its input, harmonizing the `Publish` API with the `Subscribe` API, which also uses encoded TXT data. This makes it easier to use with advertising proxy and TREL, avoiding the extra step of decoding already encoded TXT data to call `PublishService()`.

---

- ~This PR currently contains the commit from PR https://github.com/openthread/ot-br-posix/pull/1992.~ 
- ~Please check/review the second commit only.~