### PR TITLE
[mdns-mdnssd] ensure allocated `DnssdHostRegistration` is freed

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -560,10 +560,10 @@ otbrError PublisherMDnsSd::PublishHostImpl(const std::string             &aName,
                                            const std::vector<Ip6Address> &aAddresses,
                                            ResultCallback               &&aCallback)
 {
-    otbrError              ret   = OTBR_ERROR_NONE;
-    int                    error = 0;
-    std::string            fullName;
-    DnssdHostRegistration *registration;
+    otbrError                              ret   = OTBR_ERROR_NONE;
+    int                                    error = 0;
+    std::string                            fullName;
+    std::unique_ptr<DnssdHostRegistration> registration;
 
     VerifyOrExit(mState == Publisher::State::kReady, ret = OTBR_ERROR_INVALID_STATE);
 
@@ -579,7 +579,7 @@ otbrError PublisherMDnsSd::PublishHostImpl(const std::string             &aName,
         otbrLogDebug("Created new DNSServiceRef for hosts: %p", mHostsRef);
     }
 
-    registration = new DnssdHostRegistration(aName, aAddresses, std::move(aCallback), mHostsRef, this);
+    registration.reset(new DnssdHostRegistration(aName, aAddresses, std::move(aCallback), mHostsRef, this));
 
     otbrLogInfo("Registering new host %s", aName.c_str());
     for (const auto &address : aAddresses)
@@ -593,7 +593,7 @@ otbrError PublisherMDnsSd::PublishHostImpl(const std::string             &aName,
         registration->GetRecordRefMap()[recordRef] = address;
     }
 
-    AddHostRegistration(std::unique_ptr<DnssdHostRegistration>(registration));
+    AddHostRegistration(std::move(registration));
 
 exit:
     if (error != kDNSServiceErr_NoError || ret != OTBR_ERROR_NONE)


### PR DESCRIPTION
This commit changes the `PublisherMDnsSd::PublishHostImpl` so that the allocated `DnssdHostRegistration` instance is tracked as a `std::unique_ptr`. This  ensures that the allocated instance is correctly freed if any steps after the allocation fail before we get to `AddHostRegistration()`.