### PR TITLE
[tests] fix service type names used in `mdns/main` tests

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -211,7 +211,7 @@ public:
      *                          with method PublishHost.
      * @param[in] aName         The name of this service. If an empty string is provided, the service's name will be the
      *                          same as the platform's hostname.
-     * @param[in] aType         The type of this service.
+     * @param[in] aType         The type of this service, e.g., "_srv._udp" (MUST NOT end with dot).
      * @param[in] aSubTypeList  A list of service subtypes.
      * @param[in] aPort         The port number of this service.
      * @param[in] aTxtData      The encoded TXT data for this service.
@@ -234,7 +234,7 @@ public:
      * This method un-publishes a service.
      *
      * @param[in] aName      The name of this service.
-     * @param[in] aType      The type of this service.
+     * @param[in] aType      The type of this service, e.g., "_srv._udp" (MUST NOT end with dot).
      * @param[in] aCallback  The callback for receiving the publishing result.
      *
      */
@@ -260,7 +260,7 @@ public:
     /**
      * This method un-publishes a host.
      *
-     * @param[in] aName      A host name.
+     * @param[in] aName      A host name (MUST not end with dot).
      * @param[in] aCallback  The callback for receiving the publishing result.
      *
      */
@@ -276,7 +276,7 @@ public:
      * @note Discovery Proxy implementation guarantees no duplicate subscriptions for the same service or service
      * instance.
      *
-     * @param[in] aType          The service type.
+     * @param[in] aType          The service type, e.g., "_srv._udp" (MUST NOT end with dot).
      * @param[in] aInstanceName  The service instance to subscribe, or empty to subscribe the service.
      *
      */
@@ -290,7 +290,7 @@ public:
      *
      * @note Discovery Proxy implementation guarantees no redundant unsubscription for a service or service instance.
      *
-     * @param[in] aType          The service type.
+     * @param[in] aType          The service type, e.g., "_srv._udp" (MUST NOT end with dot).
      * @param[in] aInstanceName  The service instance to unsubscribe, or empty to unsubscribe the service.
      *
      */

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -934,12 +934,11 @@ void PublisherMDnsSd::ServiceInstanceResolution::Resolve(void)
 {
     assert(mServiceRef == nullptr);
 
-    mSubscription->mMDnsSd->mServiceInstanceResolutionBeginTime[std::make_pair(mInstanceName, mTypeEndWithDot)] =
-        Clock::now();
+    mSubscription->mMDnsSd->mServiceInstanceResolutionBeginTime[std::make_pair(mInstanceName, mType)] = Clock::now();
 
-    otbrLogInfo("DNSServiceResolve %s %s inf %u", mInstanceName.c_str(), mTypeEndWithDot.c_str(), mNetifIndex);
+    otbrLogInfo("DNSServiceResolve %s %s inf %u", mInstanceName.c_str(), mType.c_str(), mNetifIndex);
     DNSServiceResolve(&mServiceRef, /* flags */ kDNSServiceFlagsTimeout, mNetifIndex, mInstanceName.c_str(),
-                      mTypeEndWithDot.c_str(), mDomain.c_str(), HandleResolveResult, this);
+                      mType.c_str(), mDomain.c_str(), HandleResolveResult, this);
 }
 
 void PublisherMDnsSd::ServiceInstanceResolution::HandleResolveResult(DNSServiceRef        aServiceRef,

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -191,7 +191,7 @@ private:
             : ServiceRef()
             , mSubscription(&aSubscription)
             , mInstanceName(std::move(aInstanceName))
-            , mTypeEndWithDot(std::move(aType))
+            , mType(std::move(aType))
             , mDomain(std::move(aDomain))
             , mNetifIndex(aNetifIndex)
         {
@@ -238,7 +238,7 @@ private:
 
         ServiceSubscription   *mSubscription;
         std::string            mInstanceName;
-        std::string            mTypeEndWithDot;
+        std::string            mType;
         std::string            mDomain;
         uint32_t               mNetifIndex;
         DiscoveredInstanceInfo mInstanceInfo;

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -106,7 +106,7 @@ void PublishSingleServiceWithCustomHost(void *aContext, Mdns::Publisher::State a
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
-            hostName, "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            hostName, "SingleService", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the service"); });
     }
 }
@@ -136,11 +136,11 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
                                          [](otbrError aError) { SuccessOrDie(aError, "cannot publish the host"); });
 
         sContext.mPublisher->PublishService(
-            hostName1, "MultipleService11", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            hostName1, "MultipleService11", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the first service"); });
 
         sContext.mPublisher->PublishService(
-            hostName1, "MultipleService12", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            hostName1, "MultipleService12", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second service"); });
 
         sContext.mPublisher->PublishHost(hostName2, {Ip6Address(hostAddr)}, [](otbrError aError) {
@@ -148,11 +148,11 @@ void PublishMultipleServicesWithCustomHost(void *aContext, Mdns::Publisher::Stat
         });
 
         sContext.mPublisher->PublishService(
-            hostName2, "MultipleService21", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            hostName2, "MultipleService21", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the first service"); });
 
         sContext.mPublisher->PublishService(
-            hostName2, "MultipleService22", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            hostName2, "MultipleService22", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "cannot publish the second service"); });
     }
 }
@@ -173,8 +173,8 @@ void PublishSingleService(void *aContext, Mdns::Publisher::State aState)
     if (aState == Mdns::Publisher::State::kReady)
     {
         sContext.mPublisher->PublishService(
-            "", "SingleService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
-            [](otbrError aError) { SuccessOrDie(aError, "SingleService._meshcop._udp."); });
+            "", "SingleService", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            [](otbrError aError) { SuccessOrDie(aError, "SingleService._meshcop._udp"); });
     }
 }
 
@@ -193,8 +193,8 @@ void PublishSingleServiceWithEmptyName(void *aContext, Mdns::Publisher::State aS
     assert(aContext == &sContext);
     if (aState == Mdns::Publisher::State::kReady)
     {
-        sContext.mPublisher->PublishService("", "", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
-                                            [](otbrError aError) { SuccessOrDie(aError, "(empty)._meshcop._udp."); });
+        sContext.mPublisher->PublishService("", "", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+                                            [](otbrError aError) { SuccessOrDie(aError, "(empty)._meshcop._udp"); });
     }
 }
 
@@ -215,8 +215,8 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishService(
-            "", "MultipleService1", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
-            [](otbrError aError) { SuccessOrDie(aError, "MultipleService1._meshcop._udp."); });
+            "", "MultipleService1", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            [](otbrError aError) { SuccessOrDie(aError, "MultipleService1._meshcop._udp"); });
     }
 
     if (aState == Mdns::Publisher::State::kReady)
@@ -228,8 +228,8 @@ void PublishMultipleServices(void *aContext, Mdns::Publisher::State aState)
         Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishService(
-            "", "MultipleService2", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
-            [](otbrError aError) { SuccessOrDie(aError, "MultipleService2._meshcop._udp."); });
+            "", "MultipleService2", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            [](otbrError aError) { SuccessOrDie(aError, "MultipleService2._meshcop._udp"); });
     }
 }
 
@@ -251,7 +251,7 @@ void PublishUpdateServices(void *aContext)
         Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishService(
-            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            "", "UpdateService", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { otbrLogResult(aError, "UpdateService._meshcop._udp"); });
     }
     else
@@ -265,7 +265,7 @@ void PublishUpdateServices(void *aContext)
         Mdns::Publisher::EncodeTxtData(txtList, txtData);
 
         sContext.mPublisher->PublishService(
-            "", "UpdateService", "_meshcop._udp.", Mdns::Publisher::SubTypeList{}, 12345, txtData,
+            "", "UpdateService", "_meshcop._udp", Mdns::Publisher::SubTypeList{}, 12345, txtData,
             [](otbrError aError) { SuccessOrDie(aError, "UpdateService._meshcop._udp"); });
     }
 }
@@ -285,8 +285,8 @@ void PublishServiceSubTypes(void *aContext)
     subTypeList.back() = "_SUBTYPE3";
 
     sContext.mPublisher->PublishService(
-        "", "ServiceWithSubTypes", "_meshcop._udp.", subTypeList, 12345, txtData,
-        [](otbrError aError) { SuccessOrDie(aError, "ServiceWithSubTypes._meshcop._udp."); });
+        "", "ServiceWithSubTypes", "_meshcop._udp", subTypeList, 12345, txtData,
+        [](otbrError aError) { SuccessOrDie(aError, "ServiceWithSubTypes._meshcop._udp"); });
 }
 
 otbrError TestSingleServiceWithCustomHost(void)


### PR DESCRIPTION
This commit updates the test to use "_meshcop._udp" as the service type (removing ending `.` char) as the service type should not end with dot character.

It also updates the documentation of `Mdns::Publisher` methods to indicate that the service type strings must not end with dot character.