### PR TITLE
[mdns-mdnssd] simplify service and host registrations

### DIFF
--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -112,63 +112,50 @@ private:
     class DnssdServiceRegistration : public ServiceRegistration
     {
     public:
-        DnssdServiceRegistration(const std::string &aHostName,
-                                 const std::string &aName,
-                                 const std::string &aType,
-                                 const SubTypeList &aSubTypeList,
-                                 uint16_t           aPort,
-                                 const TxtData     &aTxtData,
-                                 ResultCallback   &&aCallback,
-                                 DNSServiceRef      aServiceRef,
-                                 PublisherMDnsSd   *aPublisher)
-            : ServiceRegistration(aHostName,
-                                  aName,
-                                  aType,
-                                  aSubTypeList,
-                                  aPort,
-                                  aTxtData,
-                                  std::move(aCallback),
-                                  aPublisher)
-            , mServiceRef(aServiceRef)
-        {
-        }
+        using ServiceRegistration::ServiceRegistration; // Inherit base constructor
 
-        ~DnssdServiceRegistration(void) override;
-        const DNSServiceRef &GetServiceRef() const { return mServiceRef; }
-        PublisherMDnsSd     &GetPublisher(void) { return *static_cast<PublisherMDnsSd *>(mPublisher); }
+        ~DnssdServiceRegistration(void) override { Unregister(); }
+
+        void      Update(MainloopContext &aMainloop) const;
+        void      Process(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;
+        otbrError Register(void);
 
     private:
-        DNSServiceRef mServiceRef;
+        void             Unregister(void);
+        PublisherMDnsSd &GetPublisher(void) { return *static_cast<PublisherMDnsSd *>(mPublisher); }
+        void             HandleRegisterResult(DNSServiceFlags aFlags, DNSServiceErrorType aError);
+        static void      HandleRegisterResult(DNSServiceRef       aServiceRef,
+                                              DNSServiceFlags     aFlags,
+                                              DNSServiceErrorType aError,
+                                              const char         *aName,
+                                              const char         *aType,
+                                              const char         *aDomain,
+                                              void               *aContext);
+
+        DNSServiceRef mServiceRef = nullptr;
     };
 
     class DnssdHostRegistration : public HostRegistration
     {
     public:
-        DnssdHostRegistration(const std::string &aName,
-                              const AddressList &aAddresses,
-                              ResultCallback   &&aCallback,
-                              DNSServiceRef      aServiceRef,
-                              Publisher         *aPublisher)
-            : HostRegistration(aName, aAddresses, std::move(aCallback), aPublisher)
-            , mServiceRef(aServiceRef)
-            , mRecordRefMap()
-            , mCallbackCount(aAddresses.size())
-        {
-        }
+        using HostRegistration::HostRegistration; // Inherit base class constructor
 
-        ~DnssdHostRegistration(void) override;
-        const DNSServiceRef                      &GetServiceRef() const { return mServiceRef; }
-        const std::map<DNSRecordRef, Ip6Address> &GetRecordRefMap() const { return mRecordRefMap; }
-        std::map<DNSRecordRef, Ip6Address>       &GetRecordRefMap() { return mRecordRefMap; }
+        ~DnssdHostRegistration(void) override { Unregister(); }
+
+        otbrError Register(void);
 
     private:
+        void             Unregister(void);
         PublisherMDnsSd &GetPublisher(void) { return *static_cast<PublisherMDnsSd *>(mPublisher); }
+        void             HandleRegisterResult(DNSRecordRef aRecordRef, DNSServiceErrorType aError);
+        static void      HandleRegisterResult(DNSServiceRef       aServiceRef,
+                                              DNSRecordRef        aRecordRef,
+                                              DNSServiceFlags     aFlags,
+                                              DNSServiceErrorType aErrorCode,
+                                              void               *aContext);
 
-        DNSServiceRef mServiceRef;
-
-    public:
-        std::map<DNSRecordRef, Ip6Address> mRecordRefMap;
-        uint32_t                           mCallbackCount;
+        std::vector<DNSRecordRef> mAddrRecordRefs;
+        std::vector<bool>         mAddrRegistered;
     };
 
     struct ServiceRef : private ::NonCopyable
@@ -327,37 +314,12 @@ private:
     using ServiceSubscriptionList = std::vector<std::unique_ptr<ServiceSubscription>>;
     using HostSubscriptionList    = std::vector<std::unique_ptr<HostSubscription>>;
 
-    static void HandleServiceRegisterResult(DNSServiceRef         aService,
-                                            const DNSServiceFlags aFlags,
-                                            DNSServiceErrorType   aError,
-                                            const char           *aName,
-                                            const char           *aType,
-                                            const char           *aDomain,
-                                            void                 *aContext);
-    void        HandleServiceRegisterResult(DNSServiceRef         aService,
-                                            const DNSServiceFlags aFlags,
-                                            DNSServiceErrorType   aError,
-                                            const char           *aName,
-                                            const char           *aType,
-                                            const char           *aDomain);
-    static void HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
-                                         DNSRecordRef        aHostRecord,
-                                         DNSServiceFlags     aFlags,
-                                         DNSServiceErrorType aErrorCode,
-                                         void               *aContext);
-    void        HandleRegisterHostResult(DNSServiceRef       aHostsConnection,
-                                         DNSRecordRef        aHostRecord,
-                                         DNSServiceFlags     aFlags,
-                                         DNSServiceErrorType aErrorCode);
-
     static std::string MakeRegType(const std::string &aType, SubTypeList aSubTypeList);
 
-    void Stop(StopMode aStopMode);
-    void DeallocateHostsRef(void);
-    void HandleServiceRefDeallocating(const DNSServiceRef &aServiceRef);
-
-    ServiceRegistration *FindServiceRegistration(const DNSServiceRef &aServiceRef);
-    HostRegistration    *FindHostRegistration(const DNSServiceRef &aServiceRef, const DNSRecordRef &aRecordRef);
+    void                Stop(StopMode aStopMode);
+    DNSServiceErrorType CreateSharedHostsRef(void);
+    void                DeallocateHostsRef(void);
+    void                HandleServiceRefDeallocating(const DNSServiceRef &aServiceRef);
 
     DNSServiceRef mHostsRef;
     State         mState;


### PR DESCRIPTION
This commit updates and enhances the `Mdns::PublisherMDnsSd` class, which implements the `Mdns::Publisher` interface using MDNSResponder as its underlying DNS-SD provider.

The following changes are made related to service registration:

- Registration simplified: The `PublishServiceImpl()` method is updated to allocate a `DnssdServiceRegistration` object first and add it to the list of registrations before asking it to register itself. This simplifies the code path for invoking the `ResultCallback` on success or failure (one path to handle all cases) and also makes it clear that the `DNSServiceRef` object is owned and managed by the `DnssdServiceRegistration` instance.

- The `HandleRegisterResult` callback passed to the MDNSResponder `DNSServiceRegister()` function is now defined and handled by the `DnssdServiceRegistration` class instead of by the `PublisherMDnsSd` class. This simplifies the code, as we no longer need to iterate through the full list of `Registration` objects to find the one corresponding to a related `mServiceRef`. It also fits well with the notion of the `mServiceRef` being owned by a corresponding `DnssdServiceRegistration` object (the destructor will call the `DNSServiceRefDeallocate()` function to deallocate the `mServiceRef`, which will stop the MDNSResponder from invoking the callback).

This commit also makes similar changes to the `PublishHostImpl()` and `DnssdHostRegistration methods, but there are some additional changes specific to host registration:

- The `DnssdHostRegistration` class now tracks whether each host IPv6 address is registered or not.

- The `DnssdHostRegistration` destructor is also changed so that it will always remove all outstanding `DNSRecordRef` objects for all host IPv6 addresses. This updates and fixes the existing behavior where the records were removed only if `IsCompleted()` returned `true`, which requires all addresses to be registered, and could lead to some of the address records not being removed if the host registration was replaced or deleted quickly after its registration.