### PR TITLE
[mdns-mdnssd] fix access of freed `mHostsRef` in `Stop()`

### DIFF
--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -76,7 +76,7 @@ public:
     void      UnsubscribeHost(const std::string &aHostName) override;
     otbrError Start(void) override;
     bool      IsStarted(void) const override;
-    void      Stop(void) override;
+    void      Stop(void) override { Stop(kNormalStop); }
 
     // Implementation of MainloopProcessor.
 
@@ -102,6 +102,12 @@ protected:
 
 private:
     static constexpr uint32_t kDefaultTtl = 10;
+
+    enum StopMode : uint8_t
+    {
+        kNormalStop,
+        kStopOnServiceNotRunningError,
+    };
 
     class DnssdServiceRegistration : public ServiceRegistration
     {
@@ -156,6 +162,8 @@ private:
         std::map<DNSRecordRef, Ip6Address>       &GetRecordRefMap() { return mRecordRefMap; }
 
     private:
+        PublisherMDnsSd &GetPublisher(void) { return *static_cast<PublisherMDnsSd *>(mPublisher); }
+
         DNSServiceRef mServiceRef;
 
     public:
@@ -344,6 +352,8 @@ private:
 
     static std::string MakeRegType(const std::string &aType, SubTypeList aSubTypeList);
 
+    void Stop(StopMode aStopMode);
+    void DeallocateHostsRef(void);
     void HandleServiceRefDeallocating(const DNSServiceRef &aServiceRef);
 
     ServiceRegistration *FindServiceRegistration(const DNSServiceRef &aServiceRef);


### PR DESCRIPTION
This commit updates the `Stop()` method to behave differently based on a `StopMode` input. If called from `DNSServiceProcessResult()` call where we get a `kDNSServiceErr_ServiceNotRunning` error, we need to restart the `Publisher` and should immediately de-allocate all `ServiceRefs`, including `mHostsRef`. Otherwise, during a `kNormalStop`, we first clear the `m{Host/Service}Registrations` lists before de-allocating the `mHostsRef`. This ensures that `mHostsRef` and all its related child `DNSRecordRef`s remain valid when `DnssdHostRegistration` destructor is called, which accesses and uses them to update the published AAAA (IPv6 address) records.

----

- ~This PR currently contains the commit from https://github.com/openthread/ot-br-posix/pull/2012.~
- ~Please check and review the second commit on this PR. Thanks.~ 
- Should help address https://github.com/openthread/ot-br-posix/issues/2007
