### PR TITLE
[telemetry] refine telemetry calculation function's `aPublisher` type

### DIFF
--- a/src/dbus/server/dbus_thread_object.cpp
+++ b/src/dbus/server/dbus_thread_object.cpp
@@ -1412,7 +1412,7 @@ otError DBusThreadObject::GetTelemetryDataHandler(DBusMessageIter &aIter)
     threadnetwork::TelemetryData telemetryData;
     auto                         threadHelper = mNcp->GetThreadHelper();
 
-    VerifyOrExit(threadHelper->RetrieveTelemetryData(*mPublisher, telemetryData) == OT_ERROR_NONE);
+    VerifyOrExit(threadHelper->RetrieveTelemetryData(mPublisher, telemetryData) == OT_ERROR_NONE);
 
     {
         const std::string    telemetryDataBytes = telemetryData.SerializeAsString();

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -888,7 +888,7 @@ void ThreadHelper::DetachGracefullyCallback(void)
 }
 
 #if OTBR_ENABLE_TELEMETRY_DATA_API
-otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher &aPublisher, threadnetwork::TelemetryData &telemetryData)
+otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadnetwork::TelemetryData &telemetryData)
 {
     otError error = OT_ERROR_NONE;
 
@@ -1260,9 +1260,10 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher &aPublisher, threadn
 #endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 
         // Start of MdnsInfo section.
+        if (aPublisher != NULL)
         {
             auto                     mdns     = wpanBorderRouter->mutable_mdns();
-            const MdnsTelemetryInfo &mdnsInfo = aPublisher.GetMdnsTelemetryInfo();
+            const MdnsTelemetryInfo &mdnsInfo = aPublisher->GetMdnsTelemetryInfo();
 
             CopyMdnsResponseCounters(mdnsInfo.mHostRegistrations, mdns->mutable_host_registration_responses());
             CopyMdnsResponseCounters(mdnsInfo.mServiceRegistrations, mdns->mutable_service_registration_responses());

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -1260,7 +1260,7 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
 #endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 
         // Start of MdnsInfo section.
-        if (aPublisher != NULL)
+        if (aPublisher != nullptr)
         {
             auto                     mdns     = wpanBorderRouter->mutable_mdns();
             const MdnsTelemetryInfo &mdnsInfo = aPublisher->GetMdnsTelemetryInfo();

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -260,12 +260,12 @@ public:
     /**
      * This method populates the telemetry data and returns the error code if error happens.
      *
-     * @param[in] aPublisher     The Mdns::Publisher
+     * @param[in] aPublisher     The Mdns::Publisher to populate MDNS telemetry if it is not NULL.
      * @param[in] telemetryData  The telemetry data to be populated.
      *
      * @returns The error code if error happens during the population of the telemetry data.
      */
-    otError RetrieveTelemetryData(Mdns::Publisher &aPublisher, threadnetwork::TelemetryData &telemetryData);
+    otError RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadnetwork::TelemetryData &telemetryData);
 #endif // OTBR_ENABLE_TELEMETRY_DATA_API
 
     /**

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -260,7 +260,7 @@ public:
     /**
      * This method populates the telemetry data and returns the error code if error happens.
      *
-     * @param[in] aPublisher     The Mdns::Publisher to populate MDNS telemetry if it is not NULL.
+     * @param[in] aPublisher     The Mdns::Publisher to provide MDNS telemetry if it is not NULL.
      * @param[in] telemetryData  The telemetry data to be populated.
      *
      * @returns The error code if error happens during the population of the telemetry data.

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -260,7 +260,7 @@ public:
     /**
      * This method populates the telemetry data and returns the error code if error happens.
      *
-     * @param[in] aPublisher     The Mdns::Publisher to provide MDNS telemetry if it is not NULL.
+     * @param[in] aPublisher     The Mdns::Publisher to provide MDNS telemetry if it is not `nullptr`.
      * @param[in] telemetryData  The telemetry data to be populated.
      *
      * @returns The error code if error happens during the population of the telemetry data.


### PR DESCRIPTION
Change aPublisher to pointer type. If it is not NULL, populate the MDNS telemetry; otherwise do not populate MDNS telemetry. This helps to reduce thread_helper's dependency issue on border_agent aPublisher.
