### PR TITLE
[agent] add application integration for VendorServer instead of NCP

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -146,3 +146,8 @@ if (OTBR_DHCP6_PD)
 else()
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_DHCP6_PD=0)
 endif()
+
+option(OTBR_VENDOR_SERVER "Enable vendor server" OFF)
+if (OTBR_VENDOR_SERVER)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_VENDOR_SERVER=1)
+endif()

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -77,7 +77,7 @@ Application::Application(const std::string               &aInterfaceName,
     , mDBusAgent(mNcp, mBorderAgent.GetPublisher())
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
-    , mVendorServer(vendor::VendorServer::newInstance(mNcp))
+    , mVendorServer(vendor::VendorServer::newInstance(*this))
 #endif
 {
     OTBR_UNUSED_VARIABLE(aRestListenAddress);

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -164,7 +164,7 @@ public:
      *
      * @retval OpenThread UBus agent.
      */
-    ubus::UBusAgent mUbusAgent &GetUBusAgent(void)
+    ubus::UBusAgent &GetUBusAgent(void)
     {
         return mUBusAgent;
     }

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -140,7 +140,10 @@ public:
      *
      * @retval OpenThread border agent.
      */
-    BorderAgent &GetBorderAgent(void) { return mBorderAgent; }
+    BorderAgent &GetBorderAgent(void)
+    {
+        return mBorderAgent;
+    }
 #endif
 
 #if OTBR_ENABLE_BACKBONE_ROUTER
@@ -149,7 +152,10 @@ public:
      *
      * @retval OpenThread backbone agent.
      */
-    BackboneRouter::BackboneAgent &GetBackboneAgent(void) { return mBackboneAgent; }
+    BackboneRouter::BackboneAgent &GetBackboneAgent(void)
+    {
+        return mBackboneAgent;
+    }
 #endif
 
 #if OTBR_ENABLE_OPENWRT
@@ -158,7 +164,10 @@ public:
      *
      * @retval OpenThread UBus agent.
      */
-    ubus::UBusAgent mUbusAgent &GetUBusAgent(void) { return mUBusAgent; }
+    ubus::UBusAgent mUbusAgent &GetUBusAgent(void)
+    {
+        return mUBusAgent;
+    }
 #endif
 
 #if OTBR_ENABLE_REST_SERVER
@@ -167,7 +176,10 @@ public:
      *
      * @retval OpenThread rest web server.
      */
-    rest::RestWebServer &GetRestWebServer(void) { return mRestWebServer; }
+    rest::RestWebServer &GetRestWebServer(void)
+    {
+        return mRestWebServer;
+    }
 #endif
 
 #if OTBR_ENABLE_DBUS_SERVER
@@ -176,7 +188,10 @@ public:
      *
      * @retval OpenThread DBus agent.
      */
-    DBus::DBusAgent &GetDBusAgent(void) { return mDBusAgent; }
+    DBus::DBusAgent &GetDBusAgent(void)
+    {
+        return mDBusAgent;
+    }
 #endif
 
 private:

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -130,7 +130,7 @@ public:
     /**
      * Get the OpenThread controller object the application is using.
      *
-     * @returns OpenThread controller object.
+     * @returns The OpenThread controller object.
      */
     Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }
 
@@ -138,7 +138,7 @@ public:
     /**
      * Get the border agent the application is using.
      *
-     * @returns border agent.
+     * @returns The border agent.
      */
     BorderAgent &GetBorderAgent(void)
     {
@@ -150,7 +150,7 @@ public:
     /**
      * Get the backbone agent the application is using.
      *
-     * @returns backbone agent.
+     * @returns The backbone agent.
      */
     BackboneRouter::BackboneAgent &GetBackboneAgent(void)
     {
@@ -162,7 +162,7 @@ public:
     /**
      * Get the UBus agent the application is using.
      *
-     * @returns UBus agent.
+     * @returns The UBus agent.
      */
     ubus::UBusAgent &GetUBusAgent(void)
     {
@@ -174,7 +174,7 @@ public:
     /**
      * Get the rest web server the application is using.
      *
-     * @returns rest web server.
+     * @returns The rest web server.
      */
     rest::RestWebServer &GetRestWebServer(void)
     {
@@ -186,7 +186,7 @@ public:
     /**
      * Get the DBus agent the application is using.
      *
-     * @returns DBus agent.
+     * @returns The DBus agent.
      */
     DBus::DBusAgent &GetDBusAgent(void)
     {

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -166,7 +166,7 @@ public:
      */
     ubus::UBusAgent &GetUBusAgent(void)
     {
-        return mUBusAgent;
+        return mUbusAgent;
     }
 #endif
 

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -128,7 +128,7 @@ public:
     otbrError Run(void);
 
     /**
-     * Returns the OpenThread controller object the application is using.
+     * Get the OpenThread controller object the application is using.
      *
      * @returns OpenThread controller object.
      */
@@ -136,7 +136,7 @@ public:
 
 #if OTBR_ENABLE_BORDER_AGENT
     /**
-     * Returns the border agent the application is using.
+     * Get the border agent the application is using.
      *
      * @returns border agent.
      */
@@ -148,7 +148,7 @@ public:
 
 #if OTBR_ENABLE_BACKBONE_ROUTER
     /**
-     * Returns the backbone agent the application is using.
+     * Get the backbone agent the application is using.
      *
      * @returns backbone agent.
      */
@@ -160,7 +160,7 @@ public:
 
 #if OTBR_ENABLE_OPENWRT
     /**
-     * Returns the UBus agent the application is using.
+     * Get the UBus agent the application is using.
      *
      * @returns UBus agent.
      */
@@ -172,7 +172,7 @@ public:
 
 #if OTBR_ENABLE_REST_SERVER
     /**
-     * Returns the rest web server the application is using.
+     * Get the rest web server the application is using.
      *
      * @returns rest web server.
      */
@@ -184,7 +184,7 @@ public:
 
 #if OTBR_ENABLE_DBUS_SERVER
     /**
-     * Returns the DBus agent the application is using.
+     * Get the DBus agent the application is using.
      *
      * @returns DBus agent.
      */

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -130,15 +130,15 @@ public:
     /**
      * Returns the OpenThread controller object the application is using.
      *
-     * @retval OpenThread controller object.
+     * @returns OpenThread controller object.
      */
     Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }
 
 #if OTBR_ENABLE_BORDER_AGENT
     /**
-     * Returns the OpenThread border agent the application is using.
+     * Returns the border agent the application is using.
      *
-     * @retval OpenThread border agent.
+     * @returns border agent.
      */
     BorderAgent &GetBorderAgent(void)
     {
@@ -148,9 +148,9 @@ public:
 
 #if OTBR_ENABLE_BACKBONE_ROUTER
     /**
-     * Returns the OpenThread backbone agent the application is using.
+     * Returns the backbone agent the application is using.
      *
-     * @retval OpenThread backbone agent.
+     * @returns backbone agent.
      */
     BackboneRouter::BackboneAgent &GetBackboneAgent(void)
     {
@@ -160,9 +160,9 @@ public:
 
 #if OTBR_ENABLE_OPENWRT
     /**
-     * Returns the OpenThread UBus agent the application is using.
+     * Returns the UBus agent the application is using.
      *
-     * @retval OpenThread UBus agent.
+     * @returns UBus agent.
      */
     ubus::UBusAgent &GetUBusAgent(void)
     {
@@ -172,9 +172,9 @@ public:
 
 #if OTBR_ENABLE_REST_SERVER
     /**
-     * Returns the OpenThread rest web server the application is using.
+     * Returns the rest web server the application is using.
      *
-     * @retval OpenThread rest web server.
+     * @returns rest web server.
      */
     rest::RestWebServer &GetRestWebServer(void)
     {
@@ -184,9 +184,9 @@ public:
 
 #if OTBR_ENABLE_DBUS_SERVER
     /**
-     * Returns the OpenThread DBus agent the application is using.
+     * Returns the DBus agent the application is using.
      *
-     * @retval OpenThread DBus agent.
+     * @returns DBus agent.
      */
     DBus::DBusAgent &GetDBusAgent(void)
     {

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -64,6 +64,14 @@
 
 namespace otbr {
 
+#if OTBR_ENABLE_VENDOR_SERVER
+namespace vendor {
+
+class VendorServer;
+
+}
+#endif
+
 /**
  * @addtogroup border-router-agent
  *
@@ -118,6 +126,58 @@ public:
      *
      */
     otbrError Run(void);
+
+    /**
+     * Returns the OpenThread controller object the application is using.
+     *
+     * @retval OpenThread controller object.
+     */
+    Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }
+
+#if OTBR_ENABLE_BORDER_AGENT
+    /**
+     * Returns the OpenThread border agent the application is using.
+     *
+     * @retval OpenThread border agent.
+     */
+    BorderAgent &GetBorderAgent(void) { return mBorderAgent; }
+#endif
+
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    /**
+     * Returns the OpenThread backbone agent the application is using.
+     *
+     * @retval OpenThread backbone agent.
+     */
+    BackboneRouter::BackboneAgent &GetBackboneAgent(void) { return mBackboneAgent; }
+#endif
+
+#if OTBR_ENABLE_OPENWRT
+    /**
+     * Returns the OpenThread UBus agent the application is using.
+     *
+     * @retval OpenThread UBus agent.
+     */
+    ubus::UBusAgent mUbusAgent &GetUBusAgent(void) { return mUBusAgent; }
+#endif
+
+#if OTBR_ENABLE_REST_SERVER
+    /**
+     * Returns the OpenThread rest web server the application is using.
+     *
+     * @retval OpenThread rest web server.
+     */
+    rest::RestWebServer &GetRestWebServer(void) { return mRestWebServer; }
+#endif
+
+#if OTBR_ENABLE_DBUS_SERVER
+    /**
+     * Returns the OpenThread DBus agent the application is using.
+     *
+     * @retval OpenThread DBus agent.
+     */
+    DBus::DBusAgent &GetDBusAgent(void) { return mDBusAgent; }
+#endif
 
 private:
     // Default poll timeout.

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -57,11 +57,11 @@ public:
      *
      * Custom vendor servers should implement this method to return an object of the derived class.
      *
-     * @param[in]  application  The OTBR application.
+     * @param[in]  aApplication  The OTBR application.
      *
      * @returns  New derived VendorServer instance.
      */
-    static std::shared_ptr<VendorServer> newInstance(Application &application);
+    static std::shared_ptr<VendorServer> newInstance(Application &aApplication);
 
     /**
      * Initializes the vendor server.

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -36,9 +36,12 @@
 
 #include "openthread-br/config.h"
 
-#include "ncp/ncp_openthread.hpp"
+#include "agent/application.hpp"
 
 namespace otbr {
+
+class Application;
+
 namespace vendor {
 
 /**
@@ -54,11 +57,11 @@ public:
      *
      * Custom vendor servers should implement this method to return an object of the derived class.
      *
-     * @param[in]  aNcp  The OpenThread controller object.
+     * @param[in]  application  The OpenThread application.
      *
      * @returns  New derived VendorServer instance.
      */
-    static std::shared_ptr<VendorServer> newInstance(otbr::Ncp::ControllerOpenThread &aNcp);
+    static std::shared_ptr<VendorServer> newInstance(otbr::Application& application);
 
     /**
      * Initializes the vendor server.

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -61,7 +61,7 @@ public:
      *
      * @returns  New derived VendorServer instance.
      */
-    static std::shared_ptr<VendorServer> newInstance(otbr::Application& application);
+    static std::shared_ptr<VendorServer> newInstance(otbr::Application &application);
 
     /**
      * Initializes the vendor server.

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -57,7 +57,7 @@ public:
      *
      * Custom vendor servers should implement this method to return an object of the derived class.
      *
-     * @param[in]  application  The OpenThread application.
+     * @param[in]  application  The OTBR application.
      *
      * @returns  New derived VendorServer instance.
      */

--- a/src/agent/vendor.hpp
+++ b/src/agent/vendor.hpp
@@ -61,7 +61,7 @@ public:
      *
      * @returns  New derived VendorServer instance.
      */
-    static std::shared_ptr<VendorServer> newInstance(otbr::Application &application);
+    static std::shared_ptr<VendorServer> newInstance(Application &application);
 
     /**
      * Initializes the vendor server.


### PR DESCRIPTION
This allows VendorServer to visit application and all parts of application through Get API. This addresses the issues like: BorderAgent is not accessible from VendorServer.
