### PR TITLE
[mdns] add `PublishKey()` & `UnpublishKey()` methods

### DIFF
--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -402,11 +402,13 @@ struct MdnsTelemetryInfo
                   "kEmaFactorDenominator must be greater than kEmaFactorNumerator");
 
     MdnsResponseCounters mHostRegistrations;
+    MdnsResponseCounters mKeyRegistrations;
     MdnsResponseCounters mServiceRegistrations;
     MdnsResponseCounters mHostResolutions;
     MdnsResponseCounters mServiceResolutions;
 
     uint32_t mHostRegistrationEmaLatency;    ///< The EMA latency of host registrations in milliseconds
+    uint32_t mKeyRegistrationEmaLatency;     ///< The EMA latency of key registrations in milliseconds
     uint32_t mServiceRegistrationEmaLatency; ///< The EMA latency of service registrations in milliseconds
     uint32_t mHostResolutionEmaLatency;      ///< The EMA latency of host resolutions in milliseconds
     uint32_t mServiceResolutionEmaLatency;   ///< The EMA latency of service resolutions in milliseconds

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -79,6 +79,19 @@ void Publisher::PublishHost(const std::string &aName, const AddressList &aAddres
     }
 }
 
+void Publisher::PublishKey(const std::string &aName, const KeyData &aKeyData, ResultCallback &&aCallback)
+{
+    otbrError error;
+
+    mKeyRegistrationBeginTime[aName] = Clock::now();
+
+    error = PublishKeyImpl(aName, aKeyData, std::move(aCallback));
+    if (error != OTBR_ERROR_NONE)
+    {
+        UpdateMdnsResponseCounters(mTelemetryInfo.mKeyRegistrations, error);
+    }
+}
+
 void Publisher::OnServiceResolveFailed(std::string aType, std::string aInstanceName, int32_t aErrorCode)
 {
     UpdateMdnsResponseCounters(mTelemetryInfo.mServiceResolutions, DnsErrorToOtbrError(aErrorCode));
@@ -333,7 +346,7 @@ std::string Publisher::MakeFullServiceName(const std::string &aName, const std::
     return aName + "." + aType + ".local";
 }
 
-std::string Publisher::MakeFullHostName(const std::string &aName)
+std::string Publisher::MakeFullName(const std::string &aName)
 {
     return aName + ".local";
 }
@@ -365,6 +378,13 @@ exit:
 Publisher::ServiceRegistration *Publisher::FindServiceRegistration(const std::string &aName, const std::string &aType)
 {
     auto it = mServiceRegistrations.find(MakeFullServiceName(aName, aType));
+
+    return it != mServiceRegistrations.end() ? it->second.get() : nullptr;
+}
+
+Publisher::ServiceRegistration *Publisher::FindServiceRegistration(const std::string &aNameAndType)
+{
+    auto it = mServiceRegistrations.find(MakeFullName(aNameAndType));
 
     return it != mServiceRegistrations.end() ? it->second.get() : nullptr;
 }
@@ -479,6 +499,82 @@ Publisher::HostRegistration *Publisher::FindHostRegistration(const std::string &
     return it != mHostRegistrations.end() ? it->second.get() : nullptr;
 }
 
+Publisher::ResultCallback Publisher::HandleDuplicateKeyRegistration(const std::string &aName,
+                                                                    const KeyData     &aKeyData,
+                                                                    ResultCallback   &&aCallback)
+{
+    KeyRegistration *keyReg = FindKeyRegistration(aName);
+
+    VerifyOrExit(keyReg != nullptr);
+
+    if (keyReg->IsOutdated(aName, aKeyData))
+    {
+        otbrLogInfo("Removing existing key %s: outdated", aName.c_str());
+        RemoveKeyRegistration(keyReg->mName, OTBR_ERROR_ABORTED);
+    }
+    else if (keyReg->IsCompleted())
+    {
+        // Returns success if the same key has already been
+        // registered with exactly the same parameters.
+        std::move(aCallback)(OTBR_ERROR_NONE);
+    }
+    else
+    {
+        // If the same key is being registered with the same parameters,
+        // let's join the waiting queue for the result.
+        keyReg->mCallback = std::bind(
+            [](std::shared_ptr<ResultCallback> aExistingCallback, std::shared_ptr<ResultCallback> aNewCallback,
+               otbrError aError) {
+                std::move (*aExistingCallback)(aError);
+                std::move (*aNewCallback)(aError);
+            },
+            std::make_shared<ResultCallback>(std::move(keyReg->mCallback)),
+            std::make_shared<ResultCallback>(std::move(aCallback)), std::placeholders::_1);
+    }
+
+exit:
+    return std::move(aCallback);
+}
+
+void Publisher::AddKeyRegistration(KeyRegistrationPtr &&aKeyReg)
+{
+    mKeyRegistrations.emplace(MakeFullKeyName(aKeyReg->mName), std::move(aKeyReg));
+}
+
+void Publisher::RemoveKeyRegistration(const std::string &aName, otbrError aError)
+{
+    auto               it = mKeyRegistrations.find(MakeFullKeyName(aName));
+    KeyRegistrationPtr keyReg;
+
+    otbrLogInfo("Removing key %s", aName.c_str());
+    VerifyOrExit(it != mKeyRegistrations.end());
+
+    // Keep the KeyRegistration around before calling `Complete`
+    // to invoke the callback. This is for avoiding invalid access
+    // to the KeyRegistration when it's freed from the callback.
+    keyReg = std::move(it->second);
+    mKeyRegistrations.erase(it);
+    keyReg->Complete(aError);
+    otbrLogInfo("Removed key %s", aName.c_str());
+
+exit:
+    return;
+}
+
+Publisher::KeyRegistration *Publisher::FindKeyRegistration(const std::string &aName)
+{
+    auto it = mKeyRegistrations.find(MakeFullKeyName(aName));
+
+    return it != mKeyRegistrations.end() ? it->second.get() : nullptr;
+}
+
+Publisher::KeyRegistration *Publisher::FindKeyRegistration(const std::string &aName, const std::string &aType)
+{
+    auto it = mKeyRegistrations.find(MakeFullServiceName(aName, aType));
+
+    return it != mKeyRegistrations.end() ? it->second.get() : nullptr;
+}
+
 Publisher::Registration::~Registration(void)
 {
     TriggerCompleteCallback(OTBR_ERROR_ABORTED);
@@ -527,6 +623,26 @@ void Publisher::HostRegistration::OnComplete(otbrError aError)
     {
         mPublisher->UpdateMdnsResponseCounters(mPublisher->mTelemetryInfo.mHostRegistrations, aError);
         mPublisher->UpdateHostRegistrationEmaLatency(mName, aError);
+    }
+}
+
+bool Publisher::KeyRegistration::IsOutdated(const std::string &aName, const KeyData &aKeyData) const
+{
+    return !(mName == aName && mKeyData == aKeyData);
+}
+
+void Publisher::KeyRegistration::Complete(otbrError aError)
+{
+    OnComplete(aError);
+    Registration::TriggerCompleteCallback(aError);
+}
+
+void Publisher::KeyRegistration::OnComplete(otbrError aError)
+{
+    if (!IsCompleted())
+    {
+        mPublisher->UpdateMdnsResponseCounters(mPublisher->mTelemetryInfo.mKeyRegistrations, aError);
+        mPublisher->UpdateKeyRegistrationEmaLatency(mName, aError);
     }
 }
 
@@ -605,6 +721,18 @@ void Publisher::UpdateHostRegistrationEmaLatency(const std::string &aHostName, o
         uint32_t latency = std::chrono::duration_cast<Milliseconds>(Clock::now() - it->second).count();
         UpdateEmaLatency(mTelemetryInfo.mHostRegistrationEmaLatency, latency, aError);
         mHostRegistrationBeginTime.erase(it);
+    }
+}
+
+void Publisher::UpdateKeyRegistrationEmaLatency(const std::string &aKeyName, otbrError aError)
+{
+    auto it = mKeyRegistrationBeginTime.find(aKeyName);
+
+    if (it != mKeyRegistrationBeginTime.end())
+    {
+        uint32_t latency = std::chrono::duration_cast<Milliseconds>(Clock::now() - it->second).count();
+        UpdateEmaLatency(mTelemetryInfo.mKeyRegistrationEmaLatency, latency, aError);
+        mKeyRegistrationBeginTime.erase(it);
     }
 }
 

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -119,6 +119,7 @@ public:
     typedef std::vector<TxtEntry>    TxtList;
     typedef std::vector<std::string> SubTypeList;
     typedef std::vector<Ip6Address>  AddressList;
+    typedef std::vector<uint8_t>     KeyData;
 
     /**
      * This structure represents information of a discovered service instance.
@@ -273,6 +274,29 @@ public:
      *
      */
     virtual void UnpublishHost(const std::string &aName, ResultCallback &&aCallback) = 0;
+
+    /**
+     * This method publishes or updates a key record for a name.
+     *
+     * @param[in] aName       The name associated with key record (can be host name or service instance name).
+     * @param[in] aKeyData    The key data to publish.
+     * @param[in] aCallback   The callback for receiving the publishing result.`OTBR_ERROR_NONE` will be
+     *                        returned if the operation is successful and all other values indicate a
+     *                        failure. Specifically, `OTBR_ERROR_DUPLICATED` indicates that the name has
+     *                        already been published and the caller can re-publish with a new name if an
+     *                        alternative name is available/acceptable.
+     *
+     */
+    void PublishKey(const std::string &aName, const KeyData &aKeyData, ResultCallback &&aCallback);
+
+    /**
+     * This method un-publishes a key record
+     *
+     * @param[in] aName      The name associated with key record.
+     * @param[in] aCallback  The callback for receiving the publishing result.
+     *
+     */
+    virtual void UnpublishKey(const std::string &aName, ResultCallback &&aCallback) = 0;
 
     /**
      * This method subscribes a given service or service instance.
@@ -509,15 +533,43 @@ protected:
         void OnComplete(otbrError aError);
     };
 
+    class KeyRegistration : public Registration
+    {
+    public:
+        std::string mName;
+        KeyData     mKeyData;
+
+        KeyRegistration(std::string aName, KeyData aKeyData, ResultCallback &&aCallback, Publisher *aPublisher)
+            : Registration(std::move(aCallback), aPublisher)
+            , mName(std::move(aName))
+            , mKeyData(std::move(aKeyData))
+        {
+        }
+
+        ~KeyRegistration(void) { OnComplete(OTBR_ERROR_ABORTED); }
+
+        void Complete(otbrError aError);
+
+        // Tells whether this `KeyRegistration` object is outdated comparing to the given parameters.
+        bool IsOutdated(const std::string &aName, const KeyData &aKeyData) const;
+
+    private:
+        void OnComplete(otbrError aError);
+    };
+
     using ServiceRegistrationPtr = std::unique_ptr<ServiceRegistration>;
     using ServiceRegistrationMap = std::map<std::string, ServiceRegistrationPtr>;
     using HostRegistrationPtr    = std::unique_ptr<HostRegistration>;
     using HostRegistrationMap    = std::map<std::string, HostRegistrationPtr>;
+    using KeyRegistrationPtr     = std::unique_ptr<KeyRegistration>;
+    using KeyRegistrationMap     = std::map<std::string, KeyRegistrationPtr>;
 
     static SubTypeList SortSubTypeList(SubTypeList aSubTypeList);
     static AddressList SortAddressList(AddressList aAddressList);
+    static std::string MakeFullName(const std::string &aName);
     static std::string MakeFullServiceName(const std::string &aName, const std::string &aType);
-    static std::string MakeFullHostName(const std::string &aName);
+    static std::string MakeFullHostName(const std::string &aName) { return MakeFullName(aName); }
+    static std::string MakeFullKeyName(const std::string &aName) { return MakeFullName(aName); }
 
     virtual otbrError PublishServiceImpl(const std::string &aHostName,
                                          const std::string &aName,
@@ -531,6 +583,8 @@ protected:
                                       const AddressList &aAddresses,
                                       ResultCallback   &&aCallback) = 0;
 
+    virtual otbrError PublishKeyImpl(const std::string &aName, const KeyData &aKeyData, ResultCallback &&aCallback) = 0;
+
     virtual void OnServiceResolveFailedImpl(const std::string &aType,
                                             const std::string &aInstanceName,
                                             int32_t            aErrorCode) = 0;
@@ -542,6 +596,7 @@ protected:
     void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
     void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
+    ServiceRegistration *FindServiceRegistration(const std::string &aNameAndType);
 
     void OnServiceResolved(std::string aType, DiscoveredInstanceInfo aInstanceInfo);
     void OnServiceResolveFailed(std::string aType, std::string aInstanceName, int32_t aErrorCode);
@@ -564,9 +619,18 @@ protected:
                                                    const AddressList &aAddresses,
                                                    ResultCallback   &&aCallback);
 
+    ResultCallback HandleDuplicateKeyRegistration(const std::string &aName,
+                                                  const KeyData     &aKeyData,
+                                                  ResultCallback   &&aCallback);
+
     void              AddHostRegistration(HostRegistrationPtr &&aHostReg);
     void              RemoveHostRegistration(const std::string &aName, otbrError aError);
     HostRegistration *FindHostRegistration(const std::string &aName);
+
+    void             AddKeyRegistration(KeyRegistrationPtr &&aKeyReg);
+    void             RemoveKeyRegistration(const std::string &aName, otbrError aError);
+    KeyRegistration *FindKeyRegistration(const std::string &aName);
+    KeyRegistration *FindKeyRegistration(const std::string &aName, const std::string &aType);
 
     static void UpdateMdnsResponseCounters(MdnsResponseCounters &aCounters, otbrError aError);
     static void UpdateEmaLatency(uint32_t &aEmaLatency, uint32_t aLatency, otbrError aError);
@@ -575,6 +639,7 @@ protected:
                                              const std::string &aType,
                                              otbrError          aError);
     void UpdateHostRegistrationEmaLatency(const std::string &aHostName, otbrError aError);
+    void UpdateKeyRegistrationEmaLatency(const std::string &aKeyName, otbrError aError);
     void UpdateServiceInstanceResolutionEmaLatency(const std::string &aInstanceName,
                                                    const std::string &aType,
                                                    otbrError          aError);
@@ -585,6 +650,7 @@ protected:
 
     ServiceRegistrationMap mServiceRegistrations;
     HostRegistrationMap    mHostRegistrations;
+    KeyRegistrationMap     mKeyRegistrations;
 
     struct DiscoverCallback
     {
@@ -612,6 +678,8 @@ protected:
     std::map<std::pair<std::string, std::string>, Timepoint> mServiceRegistrationBeginTime;
     // host name -> the timepoint to begin host registration
     std::map<std::string, Timepoint> mHostRegistrationBeginTime;
+    // key name -> the timepoint to begin key registration
+    std::map<std::string, Timepoint> mKeyRegistrationBeginTime;
     // {instance name, service type} -> the timepoint to begin service resolution
     std::map<std::pair<std::string, std::string>, Timepoint> mServiceInstanceResolutionBeginTime;
     // host name -> the timepoint to begin host resolution

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -259,6 +259,7 @@ void PublisherMDnsSd::Stop(StopMode aStopMode)
 
     mServiceRegistrations.clear();
     mHostRegistrations.clear();
+    mKeyRegistrations.clear();
     DeallocateHostsRef();
 
     mSubscribedServices.clear();
@@ -444,11 +445,12 @@ exit:
 
 otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
 {
-    std::string         fullHostName;
-    std::string         regType            = MakeRegType(mType, mSubTypeList);
-    const char         *hostNameCString    = nullptr;
-    const char         *serviceNameCString = nullptr;
-    DNSServiceErrorType dnsError;
+    std::string           fullHostName;
+    std::string           regType            = MakeRegType(mType, mSubTypeList);
+    const char           *hostNameCString    = nullptr;
+    const char           *serviceNameCString = nullptr;
+    DnssdKeyRegistration *keyReg;
+    DNSServiceErrorType   dnsError;
 
     if (!mHostName.empty())
     {
@@ -459,6 +461,13 @@ otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
     if (!mName.empty())
     {
         serviceNameCString = mName.c_str();
+    }
+
+    keyReg = static_cast<DnssdKeyRegistration *>(GetPublisher().FindKeyRegistration(mName, mType));
+
+    if (keyReg != nullptr)
+    {
+        keyReg->Unregister();
     }
 
     otbrLogInfo("Registering service %s.%s", mName.c_str(), regType.c_str());
@@ -473,17 +482,44 @@ otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
         HandleRegisterResult(/* aFlags */ 0, dnsError);
     }
 
+    if (keyReg != nullptr)
+    {
+        keyReg->Register();
+    }
+
     return GetPublisher().DnsErrorToOtbrError(dnsError);
 }
 
 void PublisherMDnsSd::DnssdServiceRegistration::Unregister(void)
 {
-    if (mServiceRef != nullptr)
+    DnssdKeyRegistration *keyReg = mRelatedKeyReg;
+
+    VerifyOrExit(mServiceRef != nullptr);
+
+    // If we have a related key registration associated with this
+    // service registration, we first unregister it and after we
+    // deallocated the `mServiceRef` try to register it again
+    // (which will add it as an individual record not tied to a
+    // service registration). Note that the `keyReg->Unregister()`
+    // will clear the `mRelatedKeyReg` field, so we need to keep
+    // a local copy to it in `keyReg`.
+
+    if (keyReg != nullptr)
     {
-        GetPublisher().HandleServiceRefDeallocating(mServiceRef);
-        DNSServiceRefDeallocate(mServiceRef);
-        mServiceRef = nullptr;
+        keyReg->Unregister();
     }
+
+    GetPublisher().HandleServiceRefDeallocating(mServiceRef);
+    DNSServiceRefDeallocate(mServiceRef);
+    mServiceRef = nullptr;
+
+    if (keyReg != nullptr)
+    {
+        keyReg->Register();
+    }
+
+exit:
+    return;
 }
 
 void PublisherMDnsSd::DnssdServiceRegistration::HandleRegisterResult(DNSServiceRef       aServiceRef,
@@ -504,6 +540,11 @@ void PublisherMDnsSd::DnssdServiceRegistration::HandleRegisterResult(DNSServiceR
 
 void PublisherMDnsSd::DnssdServiceRegistration::HandleRegisterResult(DNSServiceFlags aFlags, DNSServiceErrorType aError)
 {
+    if (mRelatedKeyReg != nullptr)
+    {
+        mRelatedKeyReg->HandleRegisterResult(aError);
+    }
+
     if ((aError == kDNSServiceErr_NoError) && (aFlags & kDNSServiceFlagsAdd))
     {
         otbrLogInfo("Successfully registered service %s.%s", mName.c_str(), mType.c_str());
@@ -589,8 +630,8 @@ void PublisherMDnsSd::DnssdHostRegistration::HandleRegisterResult(DNSServiceRef 
                                                                   DNSServiceErrorType aError,
                                                                   void               *aContext)
 {
-    OT_UNUSED_VARIABLE(aServiceRef);
-    OT_UNUSED_VARIABLE(aFlags);
+    OTBR_UNUSED_VARIABLE(aServiceRef);
+    OTBR_UNUSED_VARIABLE(aFlags);
 
     static_cast<DnssdHostRegistration *>(aContext)->HandleRegisterResult(aRecordRef, aError);
 }
@@ -626,6 +667,119 @@ void PublisherMDnsSd::DnssdHostRegistration::HandleRegisterResult(DNSRecordRef a
             otbrLogInfo("Successfully registered all host %s addresses", mName.c_str());
             Complete(OTBR_ERROR_NONE);
         }
+    }
+}
+
+otbrError PublisherMDnsSd::DnssdKeyRegistration::Register(void)
+{
+    DNSServiceErrorType       dnsError = kDNSServiceErr_NoError;
+    DnssdServiceRegistration *serviceReg;
+
+    otbrLogInfo("Registering new key %s", mName.c_str());
+
+    serviceReg = static_cast<DnssdServiceRegistration *>(GetPublisher().FindServiceRegistration(mName));
+
+    if ((serviceReg != nullptr) && (serviceReg->mServiceRef != nullptr))
+    {
+        otbrLogInfo("Key %s is being registered as a record of an existing service registration", mName.c_str());
+
+        dnsError = DNSServiceAddRecord(serviceReg->mServiceRef, &mRecordRef, kDNSServiceFlagsUnique,
+                                       kDNSServiceType_KEY, mKeyData.size(), mKeyData.data(), /* ttl */ 0);
+
+        VerifyOrExit(dnsError == kDNSServiceErr_NoError);
+
+        mRelatedServiceReg         = serviceReg;
+        serviceReg->mRelatedKeyReg = this;
+
+        if (mRelatedServiceReg->IsCompleted())
+        {
+            HandleRegisterResult(kDNSServiceErr_NoError);
+        }
+
+        // If related service registration is not yet finished,
+        // we wait for service registration completion to signal
+        // key record registration as well.
+    }
+    else
+    {
+        otbrLogInfo("Key %s is being registered individually", mName.c_str());
+
+        dnsError = GetPublisher().CreateSharedHostsRef();
+        VerifyOrExit(dnsError == kDNSServiceErr_NoError);
+
+        dnsError = DNSServiceRegisterRecord(GetPublisher().mHostsRef, &mRecordRef, kDNSServiceFlagsUnique,
+                                            kDNSServiceInterfaceIndexAny, MakeFullKeyName(mName).c_str(),
+                                            kDNSServiceType_KEY, kDNSServiceClass_IN, mKeyData.size(), mKeyData.data(),
+                                            /* ttl */ 0, HandleRegisterResult, this);
+        VerifyOrExit(dnsError == kDNSServiceErr_NoError);
+    }
+
+exit:
+    if (dnsError != kDNSServiceErr_NoError)
+    {
+        HandleRegisterResult(dnsError);
+    }
+
+    return GetPublisher().DnsErrorToOtbrError(dnsError);
+}
+
+void PublisherMDnsSd::DnssdKeyRegistration::Unregister(void)
+{
+    DNSServiceErrorType dnsError;
+    DNSServiceRef       serviceRef;
+
+    VerifyOrExit(mRecordRef != nullptr);
+
+    if (mRelatedServiceReg != nullptr)
+    {
+        serviceRef = mRelatedServiceReg->mServiceRef;
+
+        mRelatedServiceReg->mRelatedKeyReg = nullptr;
+        mRelatedServiceReg                 = nullptr;
+
+        otbrLogInfo("Unregistering key %s (was registered as a record of a service)", mName.c_str());
+    }
+    else
+    {
+        serviceRef = GetPublisher().mHostsRef;
+
+        otbrLogInfo("Unregistering key %s (was registered individually)", mName.c_str());
+    }
+
+    VerifyOrExit(serviceRef != nullptr);
+
+    dnsError = DNSServiceRemoveRecord(serviceRef, mRecordRef, /* flags */ 0);
+
+    otbrLogInfo("Unregistered key %s: error:%s", mName.c_str(), DNSErrorToString(dnsError));
+
+exit:
+    return;
+}
+
+void PublisherMDnsSd::DnssdKeyRegistration::HandleRegisterResult(DNSServiceRef       aServiceRef,
+                                                                 DNSRecordRef        aRecordRef,
+                                                                 DNSServiceFlags     aFlags,
+                                                                 DNSServiceErrorType aError,
+                                                                 void               *aContext)
+{
+    OTBR_UNUSED_VARIABLE(aServiceRef);
+    OTBR_UNUSED_VARIABLE(aRecordRef);
+    OTBR_UNUSED_VARIABLE(aFlags);
+
+    static_cast<DnssdKeyRegistration *>(aContext)->HandleRegisterResult(aError);
+}
+
+void PublisherMDnsSd::DnssdKeyRegistration::HandleRegisterResult(DNSServiceErrorType aError)
+{
+    if (aError != kDNSServiceErr_NoError)
+    {
+        otbrLogErr("Failed to register key %s: %s", mName.c_str(), DNSErrorToString(aError));
+        GetPublisher().RemoveKeyRegistration(mName, DNSErrorToOtbrError(aError));
+    }
+    else
+    {
+        otbrLogInfo("Successfully registered key %s", mName.c_str());
+        Complete(OTBR_ERROR_NONE);
     }
 }
 
@@ -711,6 +865,41 @@ exit:
     // We may failed to unregister the host from underlying mDNS publishers, but
     // it usually means that the mDNS publisher is already not functioning. So it's
     // okay to return success directly since the service is not advertised anyway.
+    std::move(aCallback)(error);
+}
+
+otbrError PublisherMDnsSd::PublishKeyImpl(const std::string &aName, const KeyData &aKeyData, ResultCallback &&aCallback)
+{
+    otbrError             error = OTBR_ERROR_NONE;
+    DnssdKeyRegistration *keyReg;
+
+    if (mState != State::kReady)
+    {
+        error = OTBR_ERROR_INVALID_STATE;
+        std::move(aCallback)(error);
+        ExitNow();
+    }
+
+    aCallback = HandleDuplicateKeyRegistration(aName, aKeyData, std::move(aCallback));
+    VerifyOrExit(!aCallback.IsNull());
+
+    keyReg = new DnssdKeyRegistration(aName, aKeyData, std::move(aCallback), this);
+    AddKeyRegistration(std::unique_ptr<DnssdKeyRegistration>(keyReg));
+
+    error = keyReg->Register();
+
+exit:
+    return error;
+}
+
+void PublisherMDnsSd::UnpublishKey(const std::string &aName, ResultCallback &&aCallback)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mState == Publisher::State::kReady, error = OTBR_ERROR_INVALID_STATE);
+    RemoveKeyRegistration(aName, OTBR_ERROR_ABORTED);
+
+exit:
     std::move(aCallback)(error);
 }
 


### PR DESCRIPTION
This commit adds new methods in `Mdns::Publisher` to publish or unpublish a key record for a given (host or service instance) name. New methods are implemented for both MDNSResponder and Avahi sub-classes.

In the MDNSResponder implementation, if a key registration is for a service instance name matching a service registration,
`DNSServiceAddRecord()` is used to associate the new record with the service. Otherwise, `DNSServiceRegisterRecord()` is used to register the KEY record on its own. The implementation handles cases when related service and key registrations are updated or unregistered.

This commit also simplifies and updates the `test/mdns/main.cpp` tests, adding a common `Test()` function that takes a function pointer to run the test and handles all common boilerplate code, as well as adding a common callback to check the registration result. New test cases are also added to check key registration, registering keys on their own, and registering keys and services in different orders.

-----

- ~This PR contains the commit https://github.com/openthread/ot-br-posix/pull/2008~
- ~Please check and review the last commit on this PR. Thanks.~
