### PR TITLE
[mdns] report the network interface index for discovered host info

### DIFF
--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -143,9 +143,10 @@ public:
      */
     struct DiscoveredHostInfo
     {
-        std::string mHostName;  ///< Full host name.
-        AddressList mAddresses; ///< IP6 addresses.
-        uint32_t    mTtl = 0;   ///< Host TTL.
+        std::string mHostName;       ///< Full host name.
+        AddressList mAddresses;      ///< IP6 addresses.
+        uint32_t    mNetifIndex = 0; ///< Network interface.
+        uint32_t    mTtl        = 0; ///< Host TTL.
     };
 
     /**

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1408,7 +1408,6 @@ void PublisherAvahi::HostSubscription::HandleResolveResult(AvahiRecordBrowser   
                                                            AvahiLookupResultFlags aFlags)
 {
     OTBR_UNUSED_VARIABLE(aRecordBrowser);
-    OTBR_UNUSED_VARIABLE(aInterfaceIndex);
     OTBR_UNUSED_VARIABLE(aProtocol);
     OTBR_UNUSED_VARIABLE(aEvent);
     OTBR_UNUSED_VARIABLE(aClazz);
@@ -1437,6 +1436,7 @@ void PublisherAvahi::HostSubscription::HandleResolveResult(AvahiRecordBrowser   
 
     mHostInfo.mHostName = std::string(aName) + ".";
     mHostInfo.mAddresses.push_back(std::move(address));
+    mHostInfo.mNetifIndex = static_cast<uint32_t>(aInterfaceIndex);
     // TODO: Use a more proper TTL
     mHostInfo.mTtl = kDefaultTtl;
     resolved       = true;

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -1168,7 +1168,6 @@ void PublisherMDnsSd::HostSubscription::HandleResolveResult(DNSServiceRef       
                                                             uint32_t               aTtl)
 {
     OTBR_UNUSED_VARIABLE(aServiceRef);
-    OTBR_UNUSED_VARIABLE(aInterfaceIndex);
 
     Ip6Address address;
 
@@ -1185,7 +1184,8 @@ void PublisherMDnsSd::HostSubscription::HandleResolveResult(DNSServiceRef       
 
     mHostInfo.mHostName = aHostName;
     mHostInfo.mAddresses.push_back(address);
-    mHostInfo.mTtl = aTtl;
+    mHostInfo.mNetifIndex = aInterfaceIndex;
+    mHostInfo.mTtl        = aTtl;
 
     otbrLogInfo("DNSServiceGetAddrInfo reply: address=%s, ttl=%" PRIu32, address.ToString().c_str(), aTtl);
 


### PR DESCRIPTION
This commit updates the `Mdns::Publisher::DiscoveredHostInfo` struct to include the `mNetifIndex` field, which provides the network interface index for a discovered host. This information is already provided by the `DiscoveredInstanceInfo` struct for a discovered service instance.

Both Avahi and MDNSResponder implementations are updated to provide the `mNetifIndex` field.