### PR TITLE
[github-actions] deprecate the configuration OT_POSIX_CONFIG_RCP_BUS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,8 +44,6 @@ jobs:
 
   docker-check:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     env:
       OTBR_COVERAGE: 1
       VERBOSE: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,10 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        rcp_bus: ["UART", "SPI"]
     env:
-      OT_POSIX_CONFIG_RCP_BUS: ${{matrix.rcp_bus}}
       OTBR_COVERAGE: 1
       VERBOSE: 1
     steps:

--- a/tests/scripts/check-docker
+++ b/tests/scripts/check-docker
@@ -29,9 +29,6 @@
 
 set -euxo pipefail
 
-OT_POSIX_CONFIG_RCP_BUS=${OT_POSIX_CONFIG_RCP_BUS:-UART}
-readonly OT_POSIX_CONFIG_RCP_BUS
-
 on_exit()
 {
     local status=$?
@@ -56,15 +53,12 @@ main()
 {
     sudo modprobe ip6table_filter
     docker build -t otbr \
-        --build-arg OTBR_OPTIONS=-DOT_POSIX_CONFIG_RCP_BUS="${OT_POSIX_CONFIG_RCP_BUS}" \
+        --build-arg OTBR_OPTIONS=-DOPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE=1 \
         --build-arg BACKBONE_ROUTER=0 \
         -f etc/docker/Dockerfile .
 
     # SPI simulation is not available yet, so just verify the binary runs
-    if [[ ${OT_POSIX_CONFIG_RCP_BUS} == SPI ]]; then
-        docker run --rm -t --entrypoint otbr-agent otbr -h | grep 'spi://'
-        return 0
-    fi
+    docker run --rm -t --entrypoint otbr-agent otbr -h | grep 'spi://'
 
     local -r SOCAT_OUTPUT=/tmp/ot-socat
     socat -d -d pty,raw,echo=0 pty,raw,echo=0 2>&1 | tee $SOCAT_OUTPUT &

--- a/tests/scripts/check-docker
+++ b/tests/scripts/check-docker
@@ -53,7 +53,7 @@ main()
 {
     sudo modprobe ip6table_filter
     docker build -t otbr \
-        --build-arg OTBR_OPTIONS=-DOPENTHREAD_POSIX_CONFIG_SPINEL_SPI_INTERFACE_ENABLE=1 \
+        --build-arg OTBR_OPTIONS=-DOT_POSIX_RCP_SPI_BUS=ON \
         --build-arg BACKBONE_ROUTER=0 \
         -f etc/docker/Dockerfile .
 


### PR DESCRIPTION
OpenThread has deprecated the configuration `OT_POSIX_CONFIG_RCP_BUS`. It causes build issues in https://github.com/openthread/ot-br-posix/issues/2060. This commit updates the github action test scripts to avoid using the configuration `OT_POSIX_CONFIG_RCP_BUS`. This commit also updates OpenThread to the lates to avoid the github action test issues.