### PR TITLE
[build] add `openthread-radio-spinel` to lib dependencies

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(otbr-agent PRIVATE
     openthread-cli-ftd
     openthread-ftd
     openthread-spinel-rcp
+    openthread-radio-spinel
     openthread-hdlc
     otbr-sdp-proxy
     otbr-ncp


### PR DESCRIPTION
OpenThread has moved the file `radio_spinel.cpp` to the new lib `openthread-radio-spinel` in https://github.com/openthread/openthread/pull/9530. This commit adds the lib `openthread-radio-spinel` to lib dependencies to avoid build errors.