### PR TITLE
[utils] fix buffer overflow in `Pskc::SetSalt`

### DIFF
--- a/src/utils/pskc.cpp
+++ b/src/utils/pskc.cpp
@@ -41,15 +41,15 @@ namespace Psk {
 
 void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
 {
-    const char *saltPrefix      = "Thread";
-    int         cur             = 0;
-    int         ret             = kPskcStatus_Ok;
-    int         remainingSpace  = 0;
-    int         networkNameLen  = 0;
+    const char *saltPrefix     = "Thread";
+    int         cur            = 0;
+    int         ret            = kPskcStatus_Ok;
+    int         remainingSpace = 0;
+    int         networkNameLen = 0;
 
-    if(strlen(saltPrefix) + OT_EXTENDED_PAN_ID_LENGTH + strlen(aNetworkName) >= sizeof(mSalt)){
-      otbrLogWarning("Network name too long; will be truncated.");
-    }
+    if (strlen(saltPrefix) + OT_EXTENDED_PAN_ID_LENGTH + strlen(aNetworkName) >= sizeof(mSalt))
+    {
+        otbrLogWarning("Network name too long; will be truncated.");
 
     memset(mSalt, 0, sizeof(mSalt));
     memcpy(mSalt, saltPrefix, strlen(saltPrefix));

--- a/src/utils/pskc.cpp
+++ b/src/utils/pskc.cpp
@@ -61,7 +61,8 @@ void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
     VerifyOrExit(strlen(aNetworkName) > 0, ret = kPskcStatus_InvalidArgument);
 
     remainingSpace = sizeof(mSalt) - cur;
-    if (remainingSpace > 0) {
+    if (remainingSpace > 0)
+    {
         networkNameLen = std::min(static_cast<int>(strlen(aNetworkName)), remainingSpace);
         memcpy(mSalt + cur, aNetworkName, networkNameLen);
         cur += networkNameLen;

--- a/src/utils/pskc.cpp
+++ b/src/utils/pskc.cpp
@@ -49,7 +49,7 @@ void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
 
     if (strlen(saltPrefix) + OT_EXTENDED_PAN_ID_LENGTH + strlen(aNetworkName) >= sizeof(mSalt))
     {
-        otbrLogWarning("Network name too long; will be truncated."); 
+        otbrLogWarning("Network name too long; will be truncated.");
     }
 
     memset(mSalt, 0, sizeof(mSalt));

--- a/src/utils/pskc.cpp
+++ b/src/utils/pskc.cpp
@@ -49,7 +49,8 @@ void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
 
     if (strlen(saltPrefix) + OT_EXTENDED_PAN_ID_LENGTH + strlen(aNetworkName) >= sizeof(mSalt))
     {
-        otbrLogWarning("Network name too long; will be truncated.");
+        otbrLogWarning("Network name too long; will be truncated."); 
+    }
 
     memset(mSalt, 0, sizeof(mSalt));
     memcpy(mSalt, saltPrefix, strlen(saltPrefix));

--- a/src/utils/pskc.cpp
+++ b/src/utils/pskc.cpp
@@ -41,9 +41,15 @@ namespace Psk {
 
 void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
 {
-    const char *saltPrefix = "Thread";
-    int         cur        = 0;
-    int         ret        = kPskcStatus_Ok;
+    const char *saltPrefix      = "Thread";
+    int         cur             = 0;
+    int         ret             = kPskcStatus_Ok;
+    int         remainingSpace  = 0;
+    int         networkNameLen  = 0;
+
+    if(strlen(saltPrefix) + OT_EXTENDED_PAN_ID_LENGTH + strlen(aNetworkName) >= sizeof(mSalt)){
+      otbrLogWarning("Network name too long; will be truncated.");
+    }
 
     memset(mSalt, 0, sizeof(mSalt));
     memcpy(mSalt, saltPrefix, strlen(saltPrefix));
@@ -53,8 +59,13 @@ void Pskc::SetSalt(const uint8_t *aExtPanId, const char *aNetworkName)
     cur += OT_EXTENDED_PAN_ID_LENGTH;
 
     VerifyOrExit(strlen(aNetworkName) > 0, ret = kPskcStatus_InvalidArgument);
-    memcpy(mSalt + cur, aNetworkName, strlen(aNetworkName));
-    cur += strlen(aNetworkName);
+
+    remainingSpace = sizeof(mSalt) - cur;
+    if (remainingSpace > 0) {
+        networkNameLen = std::min(static_cast<int>(strlen(aNetworkName)), remainingSpace);
+        memcpy(mSalt + cur, aNetworkName, networkNameLen);
+        cur += networkNameLen;
+    }
 
     mSaltLen = static_cast<uint16_t>(cur);
 


### PR DESCRIPTION
This commit addresses a potential buffer overflow vulnerability in the `Pskc::SetSalt` method.

Root Issue:
The `Pskc::SetSalt` method copies data into `mSalt` without sufficiently checking that the combined length of the data being copied (`saltPrefix`, `aExtPanId`, `aNetworkName`) doesn't exceed the size of `mSalt`. This leads to a stack buffer overflow, which may cause stack corruption, resulting in undefined behavior and potential security risks.

Fix:
1. Added a check to ensure that the total length of data to be copied into `mSalt` doesn't exceed its size.
2. Added a warning log if the network name is too long and needs to be truncated.
3. Utilized `std::min` to copy only as much of the network name as can fit into the remaining space in `mSalt`.

This ensures that no buffer overflow occurs, thereby preventing stack corruption and potential security vulnerabilities.