### PR TITLE
[logging] add command line arg to disable syslog

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -70,6 +70,7 @@ enum
     OTBR_OPT_HELP                    = 'h',
     OTBR_OPT_INTERFACE_NAME          = 'I',
     OTBR_OPT_VERBOSE                 = 'v',
+    OTBR_OPT_SYSLOG_DISABLE          = 's',
     OTBR_OPT_VERSION                 = 'V',
     OTBR_OPT_SHORTMAX                = 128,
     OTBR_OPT_RADIO_VERSION,
@@ -90,6 +91,7 @@ static const struct option kOptions[] = {
     {"help", no_argument, nullptr, OTBR_OPT_HELP},
     {"thread-ifname", required_argument, nullptr, OTBR_OPT_INTERFACE_NAME},
     {"verbose", no_argument, nullptr, OTBR_OPT_VERBOSE},
+    {"syslog-disable", no_argument, nullptr, OTBR_OPT_SYSLOG_DISABLE},
     {"version", no_argument, nullptr, OTBR_OPT_VERSION},
     {"radio-version", no_argument, nullptr, OTBR_OPT_RADIO_VERSION},
     {"auto-attach", optional_argument, nullptr, OTBR_OPT_AUTO_ATTACH},
@@ -136,9 +138,10 @@ static std::vector<char *> AppendAutoAttachDisableArg(int argc, char *argv[])
 static void PrintHelp(const char *aProgramName)
 {
     fprintf(stderr,
-            "Usage: %s [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] [--auto-attach[=0/1]] RADIO_URL "
-            "[RADIO_URL]\n"
-            "    --auto-attach defaults to 1\n",
+            "Usage: %s [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] [-s] [--auto-attach[=0/1]] "
+            "RADIO_URL [RADIO_URL]\n"
+            "    --auto-attach defaults to 1\n"
+            "    -s disables syslog and prints to standard out\n",
             aProgramName);
     fprintf(stderr, "%s", otSysGetRadioUrlHelpString());
 }
@@ -195,6 +198,7 @@ static int realmain(int argc, char *argv[])
     int                       ret               = EXIT_SUCCESS;
     const char               *interfaceName     = kDefaultInterfaceName;
     bool                      verbose           = false;
+    bool                      syslogDisable     = false;
     bool                      printRadioVersion = false;
     bool                      enableAutoAttach  = true;
     const char               *restListenAddress = "";
@@ -205,7 +209,7 @@ static int realmain(int argc, char *argv[])
 
     std::set_new_handler(OnAllocateFailed);
 
-    while ((opt = getopt_long(argc, argv, "B:d:hI:Vv", kOptions, nullptr)) != -1)
+    while ((opt = getopt_long(argc, argv, "B:d:hI:Vvs", kOptions, nullptr)) != -1)
     {
         switch (opt)
         {
@@ -226,6 +230,10 @@ static int realmain(int argc, char *argv[])
 
         case OTBR_OPT_VERBOSE:
             verbose = true;
+            break;
+
+        case OTBR_OPT_SYSLOG_DISABLE:
+            syslogDisable = true;
             break;
 
         case OTBR_OPT_VERSION:
@@ -269,7 +277,7 @@ static int realmain(int argc, char *argv[])
         }
     }
 
-    otbrLogInit(argv[0], logLevel, verbose);
+    otbrLogInit(argv[0], logLevel, verbose, syslogDisable);
     otbrLogNotice("Running %s", OTBR_PACKAGE_VERSION);
     otbrLogNotice("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
     otbrLogNotice("Thread interface: %s", interfaceName);

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -78,20 +78,21 @@ void otbrLogSetLevel(otbrLogLevel aLevel);
 /**
  * Control log to syslog.
  *
- * @param[in] enable  True to log to/via syslog.
+ * @param[in] aEnabled  True to enable logging to/via syslog.
  *
  */
-void otbrLogEnableSyslog(bool aEnabled);
+void otbrLogSyslogSetEnabled(bool aEnabled);
 
 /**
  * This function initialize the logging service.
  *
- * @param[in] aProgramName  The name of this runnable program.
- * @param[in] aLevel        Log level of the logger.
- * @param[in] aPrintStderr  Whether to log to stderr.
+ * @param[in] aProgramName    The name of this runnable program.
+ * @param[in] aLevel          Log level of the logger.
+ * @param[in] aPrintStderr    Whether to log to stderr.
+ * @param[in] aSyslogDisable  Whether to disable logging to syslog.
  *
  */
-void otbrLogInit(const char *aProgramName, otbrLogLevel aLevel, bool aPrintStderr);
+void otbrLogInit(const char *aProgramName, otbrLogLevel aLevel, bool aPrintStderr, bool aSyslogDisable);
 
 /**
  * This function log at level @p aLevel.

--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         }
     }
 
-    otbrLogInit(argv[0], logLevel, true);
+    otbrLogInit(argv[0], logLevel, true, false);
     otbrLogInfo("Running %s", OTBR_PACKAGE_VERSION);
 
     if (interfaceName == nullptr)

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    otbrLogInit("otbr-mdns", OTBR_LOG_DEBUG, true);
+    otbrLogInit("otbr-mdns", OTBR_LOG_DEBUG, true, false);
     // allow quitting elegantly
     signal(SIGTERM, RecoverSignal);
     switch (argv[1][0])

--- a/tests/mdns/test_subscribe.cpp
+++ b/tests/mdns/test_subscribe.cpp
@@ -130,7 +130,7 @@ Ip6Address         sAddr4;
 
 void SetUp(void)
 {
-    otbrLogInit("test-mdns-subscriber", OTBR_LOG_INFO, true);
+    otbrLogInit("test-mdns-subscriber", OTBR_LOG_INFO, true, false);
     SuccessOrDie(Ip6Address::FromString("2002::1", sAddr1), "");
     SuccessOrDie(Ip6Address::FromString("2002::2", sAddr2), "");
     SuccessOrDie(Ip6Address::FromString("2002::3", sAddr3), "");

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -43,7 +43,7 @@ TEST(Logging, TestLoggingHigherLevel)
     char ident[20];
 
     snprintf(ident, sizeof(ident), "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO, true);
+    otbrLogInit(ident, OTBR_LOG_INFO, true, false);
     otbrLog(OTBR_LOG_DEBUG, OTBR_LOG_TAG, "cool-higher");
     otbrLogDeinit();
     sleep(0);
@@ -58,7 +58,7 @@ TEST(Logging, TestLoggingEqualLevel)
     char ident[20];
 
     snprintf(ident, sizeof(ident), "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO, true);
+    otbrLogInit(ident, OTBR_LOG_INFO, true, false);
     otbrLog(OTBR_LOG_INFO, OTBR_LOG_TAG, "cool-equal");
     otbrLogDeinit();
     sleep(0);
@@ -69,13 +69,29 @@ TEST(Logging, TestLoggingEqualLevel)
     CHECK(0 == system(cmd));
 }
 
+TEST(Logging, TestLoggingEqualLevelNoSyslog)
+{
+    char ident[20];
+
+    snprintf(ident, sizeof(ident), "otbr-test-%ld", clock());
+    otbrLogInit(ident, OTBR_LOG_INFO, true, true);
+    otbrLog(OTBR_LOG_INFO, OTBR_LOG_TAG, "cool-equal");
+    otbrLogDeinit();
+    sleep(0);
+
+    char cmd[128];
+    snprintf(cmd, sizeof(cmd), "grep '%s.*cool-equal' /var/log/syslog", ident);
+    printf("CMD = %s\n", cmd);
+    CHECK(0 != system(cmd));
+}
+
 TEST(Logging, TestLoggingLowerLevel)
 {
     char ident[20];
     char cmd[128];
 
     snprintf(ident, sizeof(ident), "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO, true);
+    otbrLogInit(ident, OTBR_LOG_INFO, true, false);
     otbrLog(OTBR_LOG_WARNING, OTBR_LOG_TAG, "cool-lower");
     otbrLogDeinit();
     sleep(0);
@@ -90,7 +106,7 @@ TEST(Logging, TestLoggingDump)
     char cmd[128];
 
     snprintf(ident, sizeof(ident), "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_DEBUG, true);
+    otbrLogInit(ident, OTBR_LOG_DEBUG, true, false);
     const char s[] = "one super long string with lots of text";
     otbrDump(OTBR_LOG_INFO, "Test", "foobar", s, sizeof(s));
     otbrLogDeinit();


### PR DESCRIPTION
Adds an optional flag to otbr-agent to allow disabling of logging to syslog.

Current behavior has logs sent to both standard output as well as the file indicated by syslog. With this flag enabled, logs would only be sent to standard output.