### PR TITLE
[script] use `/` instead of `.` in `sysctl.conf` to avoid issues when the infra if name contains `.`

### DIFF
--- a/script/_border_routing
+++ b/script/_border_routing
@@ -39,8 +39,8 @@ readonly SYSCTL_ACCEPT_RA_FILE
 accept_ra_install()
 {
     sudo tee $SYSCTL_ACCEPT_RA_FILE <<EOF
-net.ipv6.conf.${INFRA_IF_NAME}.accept_ra = 2
-net.ipv6.conf.${INFRA_IF_NAME}.accept_ra_rt_info_max_plen = 64
+net/ipv6/conf/${INFRA_IF_NAME}/accept_ra = 2
+net/ipv6/conf/${INFRA_IF_NAME}/accept_ra_rt_info_max_plen = 64
 EOF
 }
 


### PR DESCRIPTION
I have a setup which uses `eth0.10` (meaning vlan 10 on `eth0`) on the border router for daily use

When setting up brs, `net.ipv6.conf.${INFRA_IF_NAME}.accept_ra` converts to `net/ipv6/conf/eth0/10/accept_ra` making it failed to set the correct value for `accept_ra`

According to `SYSCTL(8)`, we can use `/` in case `.` is contained in the name of the component.

So using `/` instead of `.` is more robust in this case.