### PR TITLE
[dbus] fix `introspect.xml` for `AddOnMeshPrefix()`

### DIFF
--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -167,21 +167,22 @@
             uint8[] prefix_bytes
             uint8 prefix_length
           }
+          uint16 rloc16
           byte preference
-          struct {
-            boolean preferred
-            boolean slaac
-            boolean dhcp
-            boolean configure
-            boolean default_route
-            boolean on_mesh
-            boolean stable
-          }
+          bool preferred
+          bool slaac
+          bool dhcp
+          bool configure
+          bool default_route
+          bool on_mesh
+          bool stable
+          bool nd_dns
+          bool dp
         }
       </literallayout>
     -->
     <method name="AddOnMeshPrefix">
-      <arg name="prefix" type="((ayy)y(bbbbbbb))"/>
+      <arg name="prefix" type="((ayy)qybbbbbbbbb)"/>
     </method>
 
     <!-- RemoveOnMeshPrefix: Remove an on-mesh prefix from the network.


### PR DESCRIPTION
Fix the error calling `AddOnMeshPrefix` https://github.com/openthread/ot-br-posix/issues/2079#issuecomment-1833488124. The interface in `introspect.xml` has been out-of-sync for.


Verification: adding a prefix.
```
$ sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.AddOnMeshPrefix --object-path /io/openthread/BorderRouter/wpan0 "(([0xfd,0x11,0x12,0x13,0x13,0x14,0x15,0x16], 64),0x5343, 0x01, false,false,false,false,false,false,false,false,false)"

()
```

```
> netdata show
Prefixes:
fd11:1213:1314:1516::/64 high d800
Routes:
Services:
44970 01 1f000500000e10 s d800
Contexts:
fd11:1213:1314:1516::/64 1 c
Commissioning:
12688 - - -
Done
```