### PR TITLE
[telemetry] add upstream dns query state

### DIFF
--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -320,6 +320,12 @@ message TelemetryData {
     SRP_SERVER_ADDRESS_MODE_STATE_ANYCAST = 2;
   }
 
+  enum UpstreamDnsQueryState {
+    UPSTREAMDNS_QUERY_STATE_UNSPECIFIED = 0;
+    UPSTREAMDNS_QUERY_STATE_ENABLED = 1;
+    UPSTREAMDNS_QUERY_STATE_DISABLED = 2;
+  }
+
   message SrpServerInfo {
     // The state of the SRP server
     optional SrpServerState state = 1;
@@ -402,6 +408,9 @@ message TelemetryData {
 
     // The number of DNS queries resolved at the local SRP server
     optional uint32 resolved_by_local_srp_count = 2;
+
+    // The state of upstream DNS query
+    optional UpstreamDnsQueryState upstream_dns_query_state = 3;
   }
 
   message MdnsResponseCounters {

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -1345,13 +1345,19 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
             dnsServerResponseCounters->set_name_error_count(otDnssdCounters.mNameErrorResponse);
             dnsServerResponseCounters->set_not_implemented_count(otDnssdCounters.mNotImplementedResponse);
             dnsServerResponseCounters->set_other_count(otDnssdCounters.mOtherResponse);
-
-            dnsServer->set_resolved_by_local_srp_count(otDnssdCounters.mResolvedBySrp);
-
             // The counters of queries, responses, failures handled by upstream DNS server.
             dnsServerResponseCounters->set_upstream_dns_queries(otDnssdCounters.mUpstreamDnsCounters.mQueries);
             dnsServerResponseCounters->set_upstream_dns_responses(otDnssdCounters.mUpstreamDnsCounters.mResponses);
             dnsServerResponseCounters->set_upstream_dns_failures(otDnssdCounters.mUpstreamDnsCounters.mFailures);
+
+            dnsServer->set_resolved_by_local_srp_count(otDnssdCounters.mResolvedBySrp);
+
+#if OTBR_ENABLE_DNS_UPSTREAM_QUERY
+            dnsServer->set_upstream_dns_query_state(
+                otDnssdUpstreamQueryIsEnabled(mInstance)
+                    ? threadnetwork::TelemetryData::UPSTREAMDNS_QUERY_STATE_ENABLED
+                    : threadnetwork::TelemetryData::UPSTREAMDNS_QUERY_STATE_DISABLED);
+#endif // OTBR_ENABLE_DNS_UPSTREAM_QUERY
         }
         // End of DnsServerInfo section.
 #endif // OTBR_ENABLE_DNSSD_DISCOVERY_PROXY


### PR DESCRIPTION
Add upstream query state 
Need to use both upstream query state and srp server state to indicate the upstream server state
- SRP Server Disabled
- SRP Server Enabled, Upstream DNS forwarding disabled
- SRP Server Enabled, Upstream DNS forwarding enabled.
