### PR TITLE
[border-agent] decouple `BorderAgent` class from irrelevant responsibilities 

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -63,4 +63,10 @@ jobs:
         brew reinstall boost cmake cpputest dbus jsoncpp ninja protobuf@21 pkg-config
     - name: Build
       run: |
-        OTBR_OPTIONS='-DOTBR_BORDER_AGENT=OFF -DOTBR_MDNS=OFF -DOT_FIREWALL=OFF -DOTBR_DBUS=OFF' ./script/test build
+        OTBR_OPTIONS="-DOTBR_BORDER_AGENT=OFF \
+                      -DOTBR_MDNS=OFF \
+                      -DOTBR_ADVERTISING_PROXY=OFF \
+                      -DOTBR_DISCOVERY_PROXY=OFF \
+                      -DOTBR_TREL=OFF \
+                      -DOT_FIREWALL=OFF \
+                      -DOTBR_DBUS=OFF" ./script/test build

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -134,6 +134,18 @@ public:
      */
     Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }
 
+#if OTBR_ENABLE_MDNS
+    /**
+     * Get the Publisher object the application is using.
+     *
+     * @returns The Publisher object.
+     */
+    Mdns::Publisher &GetPublisher(void)
+    {
+        return *mPublisher;
+    }
+#endif
+
 #if OTBR_ENABLE_BORDER_AGENT
     /**
      * Get the border agent the application is using.
@@ -155,6 +167,42 @@ public:
     BackboneRouter::BackboneAgent &GetBackboneAgent(void)
     {
         return mBackboneAgent;
+    }
+#endif
+
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    /**
+     * Get the advertising proxy the application is using.
+     *
+     * @returns The advertising proxy.
+     */
+    AdvertisingProxy &GetAdvertisingProxy(void)
+    {
+        return mAdvertisingProxy;
+    }
+#endif
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    /**
+     * Get the discovery proxy the application is using.
+     *
+     * @returns The discovery proxy.
+     */
+    Dnssd::DiscoveryProxy &GetDiscoveryProxy(void)
+    {
+        return mDiscoveryProxy;
+    }
+#endif
+
+#if OTBR_ENABLE_TREL
+    /**
+     * Get the TrelDnssd object the application is using.
+     *
+     * @returns The TrelDnssd.
+     */
+    TrelDnssd::TrelDnssd &GetTrelDnssd(void)
+    {
+        return mTrelDnssd;
     }
 #endif
 
@@ -194,6 +242,14 @@ public:
     }
 #endif
 
+    /**
+     * This method handles mDNS publisher's state changes.
+     *
+     * @param[in] aState  The state of mDNS publisher.
+     *
+     */
+    void HandleMdnsState(Mdns::Publisher::State aState);
+
 private:
     // Default poll timeout.
     static const struct timeval kPollTimeout;
@@ -206,11 +262,23 @@ private:
 #endif
     const char               *mBackboneInterfaceName;
     Ncp::ControllerOpenThread mNcp;
+#if OTBR_ENABLE_MDNS
+    std::unique_ptr<Mdns::Publisher> mPublisher;
+#endif
 #if OTBR_ENABLE_BORDER_AGENT
     BorderAgent mBorderAgent;
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     BackboneRouter::BackboneAgent mBackboneAgent;
+#endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    AdvertisingProxy mAdvertisingProxy;
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    Dnssd::DiscoveryProxy mDiscoveryProxy;
+#endif
+#if OTBR_ENABLE_TREL
+    TrelDnssd::TrelDnssd mTrelDnssd;
 #endif
 #if OTBR_ENABLE_OPENWRT
     ubus::UBusAgent mUbusAgent;

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -87,36 +87,33 @@ public:
      * The constructor to initialize the Thread border agent.
      *
      * @param[in] aNcp  A reference to the NCP controller.
+     * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp);
+    BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
 
-    ~BorderAgent(void);
-
-    /**
-     * This method initialize border agent service.
-     *
-     */
-    void Init(void);
+    ~BorderAgent(void) = default;
 
     /**
-     * This method de-initializes border agent service.
+     * This method enables/disables the Border Agent.
+     *
+     * @param[in] aIsEnabled  Whether to enable the Border Agent.
      *
      */
-    void Deinit(void);
+    void SetEnabled(bool aIsEnabled);
 
     /**
-     * This method returns the Publisher the border agent is using.
+     * This method handles mDNS publisher's state changes.
      *
-     * @returns  A reference to the mPublisher.
+     * @param[in] aState  The state of mDNS publisher.
      *
      */
-    Mdns::Publisher &GetPublisher() { return *mPublisher; }
+    void HandleMdnsState(Mdns::Publisher::State aState);
 
 private:
     void Start(void);
     void Stop(void);
-    void HandleMdnsState(Mdns::Publisher::State aState);
+    bool IsEnabled(void) const { return mIsEnabled; }
     void PublishMeshCopService(void);
     void UpdateMeshCopService(void);
     void UnpublishMeshCopService(void);
@@ -131,20 +128,11 @@ private:
     std::string GetAlternativeServiceInstanceName() const;
 
     otbr::Ncp::ControllerOpenThread &mNcp;
-    Mdns::Publisher                 *mPublisher;
+    Mdns::Publisher                 &mPublisher;
+    bool                             mIsEnabled;
 
 #if OTBR_ENABLE_DBUS_SERVER
     std::map<std::string, std::vector<uint8_t>> mMeshCopTxtUpdate;
-#endif
-
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    AdvertisingProxy mAdvertisingProxy;
-#endif
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    Dnssd::DiscoveryProxy mDiscoveryProxy;
-#endif
-#if OTBR_ENABLE_TREL
-    TrelDnssd::TrelDnssd mTrelDnssd;
 #endif
 
     std::string mServiceInstanceName;

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -35,6 +35,8 @@
 
 #include "mdns/mdns.hpp"
 
+#if OTBR_ENABLE_MDNS
+
 #include <assert.h>
 
 #include <algorithm>
@@ -779,3 +781,5 @@ void Publisher::RemoveAddress(AddressList &aAddressList, const Ip6Address &aAddr
 
 } // namespace Mdns
 } // namespace otbr
+
+#endif // OTBR_ENABLE_MDNS

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -36,6 +36,10 @@
 
 #include "openthread-br/config.h"
 
+#ifndef OTBR_ENABLE_MDNS
+#define OTBR_ENABLE_MDNS (OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD)
+#endif
+
 #include <functional>
 #include <list>
 #include <map>

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -66,25 +66,26 @@ public:
     explicit AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
 
     /**
-     * This method starts the Advertising Proxy.
+     * This method enables/disables the Advertising Proxy.
      *
-     * @retval OTBR_ERROR_NONE  Successfully started the Advertising Proxy.
-     * @retval ...              Failed to start the Advertising Proxy.
-     *
-     */
-    otbrError Start(void);
-
-    /**
-     * This method stops the Advertising Proxy.
+     * @param[in] aIsEnabled  Whether to enable the Advertising Proxy.
      *
      */
-    void Stop();
+    void SetEnabled(bool aIsEnabled);
 
     /**
      * This method publishes all registered hosts and services.
      *
      */
     void PublishAllHostsAndServices(void);
+
+    /**
+     * This method handles mDNS publisher's state changes.
+     *
+     * @param[in] aState  The state of mDNS publisher.
+     *
+     */
+    void HandleMdnsState(Mdns::Publisher::State aState);
 
 private:
     struct OutstandingUpdate
@@ -105,6 +106,10 @@ private:
     void                                OnMdnsPublishResult(otSrpServerServiceUpdateId aUpdateId, otbrError aError);
 
     std::vector<Ip6Address> GetEligibleAddresses(const otIp6Address *aHostAddresses, uint8_t aHostAddressNum);
+
+    void Start(void);
+    void Stop(void);
+    bool IsEnabled(void) const { return mIsEnabled; }
 
     /**
      * This method publishes a specified host and its services.
@@ -128,6 +133,8 @@ private:
 
     // A reference to the mDNS publisher, has no ownership.
     Mdns::Publisher &mPublisher;
+
+    bool mIsEnabled;
 
     // A vector that tracks outstanding updates.
     std::vector<OutstandingUpdate> mOutstandingUpdates;

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -61,11 +61,28 @@ static inline bool DnsLabelsEqual(const std::string &aLabel1, const std::string 
 DiscoveryProxy::DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
     : mNcp(aNcp)
     , mMdnsPublisher(aPublisher)
+    , mIsEnabled(false)
 {
     mNcp.RegisterResetHandler([this]() {
         otDnssdQuerySetCallbacks(mNcp.GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
                                  &DiscoveryProxy::OnDiscoveryProxyUnsubscribe, this);
     });
+}
+
+void DiscoveryProxy::SetEnabled(bool aIsEnabled)
+{
+    VerifyOrExit(IsEnabled() != aIsEnabled);
+    mIsEnabled = aIsEnabled;
+    if (mIsEnabled)
+    {
+        Start();
+    }
+    else
+    {
+        Stop();
+    }
+exit:
+    return;
 }
 
 void DiscoveryProxy::Start(void)

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -70,16 +70,26 @@ public:
     explicit DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
 
     /**
-     * This method starts the Discovery Proxy.
+     * This method enables/disables the Discovery Proxy.
+     *
+     * @param[in] aIsEnabled  Whether to enable the Discovery Proxy.
      *
      */
-    void Start(void);
+    void SetEnabled(bool aIsEnabled);
 
     /**
-     * This method stops the Discovery Proxy.
+     * This method handles mDNS publisher's state changes.
+     *
+     * @param[in] aState  The state of mDNS publisher.
      *
      */
-    void Stop(void);
+    void HandleMdnsState(Mdns::Publisher::State aState)
+    {
+        VerifyOrExit(IsEnabled());
+        OTBR_UNUSED_VARIABLE(aState);
+    exit:
+        return;
+    }
 
 private:
     enum : uint32_t
@@ -98,8 +108,13 @@ private:
     void OnHostDiscovered(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aHostInfo);
     static uint32_t CapTtl(uint32_t aTtl);
 
+    void Start(void);
+    void Stop(void);
+    bool IsEnabled(void) const { return mIsEnabled; }
+
     Ncp::ControllerOpenThread &mNcp;
     Mdns::Publisher           &mMdnsPublisher;
+    bool                       mIsEnabled;
     uint64_t                   mSubscriberId = 0;
 };
 

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -188,9 +188,10 @@ exit:
     return;
 }
 
-void TrelDnssd::OnMdnsPublisherReady(void)
+void TrelDnssd::HandleMdnsState(Mdns::Publisher::State aState)
 {
     VerifyOrExit(IsInitialized());
+    VerifyOrExit(aState == Mdns::Publisher::State::kReady);
 
     otbrLogDebug("mDNS Publisher is Ready");
     mMdnsPublisherReady = true;

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -109,10 +109,12 @@ public:
     void UnregisterService(void);
 
     /**
-     * This method notifies that mDNS Publisher is ready.
+     * This method handles mDNS publisher's state changes.
+     *
+     * @param[in] aState  The state of mDNS publisher.
      *
      */
-    void OnMdnsPublisherReady(void);
+    void HandleMdnsState(Mdns::Publisher::State aState);
 
 private:
     static constexpr size_t   kPeerCacheSize             = 256;


### PR DESCRIPTION
`BorderAgent` class currently contains mDNS Publisher, Advertising Proxy, Discovery Proxy and TrelDnssd. Actually these contained components should be controlled by `Application` instead of `BorderAgent`. Then these components can be fetched by vendor server from `Application`. This PR also unifies the public methods of these components a bit.