### PR TITLE
[meshcop] support runtime custom vendor and product name

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -104,7 +104,13 @@ void Application::Init(void)
     mPublisher->Start();
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
+// This is for delaying publishing the MeshCoP service until the correct
+// vendor name and OUI etc. are correctly set by BorderAgent::SetMeshCopServiceValues()
+#if OTBR_STOP_BORDER_AGENT_ON_INIT
+    mBorderAgent.SetEnabled(false);
+#else
     mBorderAgent.SetEnabled(true);
+#endif
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mBackboneAgent.Init();

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -414,6 +414,10 @@ struct MdnsTelemetryInfo
     uint32_t mServiceResolutionEmaLatency;   ///< The EMA latency of service resolutions in milliseconds
 };
 
+static constexpr size_t kVendorOuiLength      = 3;
+static constexpr size_t kMaxVendorNameLength  = 24;
+static constexpr size_t kMaxProductNameLength = 24;
+
 } // namespace otbr
 
 #endif // OTBR_COMMON_TYPES_HPP_


### PR DESCRIPTION
Existing implementation will publish the _meshcop._udp service
immediately when the program is started, even when there is no
provisioned Thread network. This works as expected as the Thread spec
defines.
    
The problem is that for non-Android linux platforms, the vendor,
product name are customized via build time flags but customization needs
to be runtime for Android because all Android device shares the same
Thread stack in the mainline module.
    
To support Android, we make updates to allow delaying the advertisement
of _meshcop._udp service after the customized vendor/product name has
been provided via the new "OTBR_STOP_BORDER_AGENT_ON_INIT" build flag
and the "BorderAgent::SetMeshcopServiceValues()" method.
    
Check https://android-review.git.corp.google.com/c/platform/packages/modules/Connectivity/+/2993930
for how this change is integrated with Android.
