### PR TITLE
[discovery-proxy] remove `assert` checks on query name parse errors

### DIFF
--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -214,11 +214,9 @@ void DiscoveryProxy::OnServiceDiscovered(const std::string                      
         {
         case OT_DNSSD_QUERY_TYPE_BROWSE:
             splitError = SplitFullServiceName(queryName, serviceName, domain);
-            assert(splitError == OTBR_ERROR_NONE);
             break;
         case OT_DNSSD_QUERY_TYPE_RESOLVE:
             splitError = SplitFullServiceInstanceName(queryName, instanceName, serviceName, domain);
-            assert(splitError == OTBR_ERROR_NONE);
             break;
         default:
             splitError = OTBR_ERROR_NOT_FOUND;
@@ -226,6 +224,7 @@ void DiscoveryProxy::OnServiceDiscovered(const std::string                      
         }
         if (splitError != OTBR_ERROR_NONE)
         {
+            // Incoming service/instance was not what current query wanted to see, move on.
             continue;
         }
 
@@ -284,8 +283,13 @@ void DiscoveryProxy::OnHostDiscovered(const std::string                         
         {
             continue;
         }
+
         splitError = SplitFullHostName(queryName, hostName, domain);
-        assert(splitError == OTBR_ERROR_NONE);
+
+        if (splitError != OTBR_ERROR_NONE)
+        {
+            continue;
+        }
 
         if (DnsLabelsEqual(hostName, aHostName))
         {


### PR DESCRIPTION
Remove the `assert` checks on query name parse errors and instead skip over such entries. Query names are external input (received as DNS query message from other devices) and discovery proxy code should not assume that external input will follow the proper query name format.

---

- Suggested fix for https://github.com/openthread/ot-br-posix/issues/2207