### PR TITLE
[mdns-avahi] allow `UnsubscribeService/Host()` to remove non-present entries

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1047,7 +1047,7 @@ void PublisherAvahi::UnsubscribeService(const std::string &aType, const std::str
                           return aService->mType == aType && aService->mInstanceName == aInstanceName;
                       });
 
-    assert(it != mSubscribedServices.end());
+    VerifyOrExit(it != mSubscribedServices.end());
 
     {
         std::unique_ptr<ServiceSubscription> service = std::move(*it);
@@ -1106,7 +1106,7 @@ void PublisherAvahi::UnsubscribeHost(const std::string &aHostName)
         mSubscribedHosts.begin(), mSubscribedHosts.end(),
         [&aHostName](const std::unique_ptr<HostSubscription> &aHost) { return aHost->mHostName == aHostName; });
 
-    assert(it != mSubscribedHosts.end());
+    VerifyOrExit(it != mSubscribedHosts.end());
 
     {
         std::unique_ptr<HostSubscription> host = std::move(*it);


### PR DESCRIPTION
This commit adds a similar change to #2206 but for Avahi example. It updates `UnsubscribeService/Host()` to allow them to be called with service or host name that may not be present in the list. This situation may happen if duplicate queries are received for the same names.