### PR TITLE
[mdns-avahi] handle potential unknown Avahi states gracefully

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -570,10 +570,6 @@ void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupSt
     case AVAHI_ENTRY_GROUP_UNCOMMITED:
     case AVAHI_ENTRY_GROUP_REGISTERING:
         break;
-
-    default:
-        assert(false);
-        break;
     }
 }
 
@@ -695,10 +691,6 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
 
     case AVAHI_CLIENT_CONNECTING:
         otbrLogInfo("Avahi client is connecting to the server");
-        break;
-
-    default:
-        assert(false);
         break;
     }
 }


### PR DESCRIPTION
This change avoids `assert(false)` on `AvahiEntryGroupState` and `AvahiClientState` `switch` statements. This prevents potential crashes if Avahi introduces new states in future versions.