### PR TITLE
[ncp] clear handlers and callbacks in `ControllerOpenThread::Deinit()`

### DIFF
--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -296,6 +296,9 @@ void ControllerOpenThread::Deinit(void)
 
     otSysDeinit();
     mInstance = nullptr;
+
+    mThreadStateChangedCallbacks.clear();
+    mResetHandlers.clear();
 }
 
 void ControllerOpenThread::HandleStateChanged(otChangedFlags aFlags)


### PR DESCRIPTION
This is to avoid having stale/undesired handlers when calling `ControllerOpenThread::Init()`.