### PR TITLE
[version] introduce thread version 1.4

### DIFF
--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -60,10 +60,10 @@
 namespace otbr {
 namespace Ncp {
 
-static const uint16_t kThreadVersion11  = 2; ///< Thread Version 1.1
-static const uint16_t kThreadVersion12  = 3; ///< Thread Version 1.2
-static const uint16_t kThreadVersion13  = 4; ///< Thread Version 1.3
-static const uint16_t kThreadVersion131 = 5; ///< Thread Version 1.3.1
+static const uint16_t kThreadVersion11 = 2; ///< Thread Version 1.1
+static const uint16_t kThreadVersion12 = 3; ///< Thread Version 1.2
+static const uint16_t kThreadVersion13 = 4; ///< Thread Version 1.3
+static const uint16_t kThreadVersion14 = 5; ///< Thread Version 1.4
 
 ControllerOpenThread::ControllerOpenThread(const char                      *aInterfaceName,
                                            const std::vector<const char *> &aRadioUrls,
@@ -388,8 +388,8 @@ const char *ControllerOpenThread::GetThreadVersion(void)
     case kThreadVersion13:
         version = "1.3.0";
         break;
-    case kThreadVersion131:
-        version = "1.3.1";
+    case kThreadVersion14:
+        version = "1.4";
         break;
     default:
         otbrLogEmerg("Unexpected thread version %hu", otThreadGetVersion());


### PR DESCRIPTION
Update constants to reflect the new version number `"1.4"` (previously `"1.3.1"`).