### PR TITLE
[border-agent] update State Bitmap for ePSKc capability

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -108,6 +108,12 @@ if(OTBR_TREL)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TREL=1)
 endif()
 
+option(OTBR_EPSKC "Enable ePSKc Support" OFF)
+if (OTBR_EPSKC)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_EPSKC=1)
+else()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_EPSKC=0)
+endif()
 
 option(OTBR_WEB "Enable Web GUI" OFF)
 

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -111,6 +111,7 @@ struct StateBitmap
     uint32_t mAvailability : 2;
     uint32_t mBbrIsActive : 1;
     uint32_t mBbrIsPrimary : 1;
+    uint32_t mEpskcSupported : 1;
 
     StateBitmap(void)
         : mConnectionMode(0)
@@ -118,6 +119,7 @@ struct StateBitmap
         , mAvailability(0)
         , mBbrIsActive(0)
         , mBbrIsPrimary(0)
+        , mEpskcSupported(OTBR_ENABLE_EPSKC)
     {
     }
 
@@ -130,7 +132,7 @@ struct StateBitmap
         bitmap |= mAvailability << 5;
         bitmap |= mBbrIsActive << 7;
         bitmap |= mBbrIsPrimary << 8;
-
+        bitmap |= mEpskcSupported << 11;
         return bitmap;
     }
 };


### PR DESCRIPTION
A BA at all times set the ePSKc Support flag (bit 11) in the State Bitmap (sb) TXT record of its MeshCoP DNS-SD service to '1' if the OTBR_EPSKC_ENABLE = ON;

Test: mDNS package capture - sb value changes to "00 00 08 21" from original value "00 00 00 21"