### PR TITLE
[web] show pskc on the "status" web page

### DIFF
--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -383,6 +383,9 @@ std::string WpanService::HandleStatusRequest()
     VerifyOrExit((rval = client.Execute("partitionid")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
     networkInfo["Network:PartitionID"] = rval;
 
+    VerifyOrExit((rval = client.Execute("pskc")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
+    networkInfo["Network:PSKc"] = rval;
+
     {
         static const char kMeshLocalPrefixLocator[]       = "Mesh Local Prefix: ";
         static const char kMeshLocalAddressTokenLocator[] = "0:ff:fe00:";


### PR DESCRIPTION
Displaying PSKC on a web page is more convenient for users to obtain value as a credential for the commissioner to join the network.