### PR TITLE
[feature-flag] add a feature flag to control link metrics manager

### DIFF
--- a/src/ncp/ncp_openthread.cpp
+++ b/src/ncp/ncp_openthread.cpp
@@ -38,6 +38,7 @@
 #include <openthread/border_routing.h>
 #include <openthread/dataset.h>
 #include <openthread/dnssd_server.h>
+#include <openthread/link_metrics.h>
 #include <openthread/logging.h>
 #include <openthread/nat64.h>
 #include <openthread/srp_server.h>
@@ -284,6 +285,9 @@ otError ControllerOpenThread::ApplyFeatureFlagList(const FeatureFlagList &aFeatu
 #endif
 #if OTBR_ENABLE_DHCP6_PD
     otBorderRoutingDhcp6PdSetEnabled(mInstance, aFeatureFlagList.enable_dhcp6_pd());
+#endif
+#if OTBR_ENABLE_LINK_METRICS_TELEMETRY
+    otLinkMetricsManagerSetEnabled(mInstance, aFeatureFlagList.enable_link_metrics_manager());
 #endif
 
     return error;

--- a/src/proto/feature_flag.proto
+++ b/src/proto/feature_flag.proto
@@ -64,4 +64,6 @@ message FeatureFlagList {
   optional bool enable_dns_upstream_query = 5 [default = false];
   // Whether to enable prefix delegation.
   optional bool enable_dhcp6_pd = 6 [default = false];
+  // Whether to enable link metrics manager.
+  optional bool enable_link_metrics_manager = 7 [default = false];
 }


### PR DESCRIPTION
The PR adds a feature flag to control the link metrics manager.