### PR TITLE
Add reserved fields in thread telemetry

### DIFF
--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -304,6 +304,9 @@ message TelemetryData {
 
     // The number of other responses
     optional uint32 other_count = 6;
+
+    // TODO: Remove reserved fields, use upstream_dns metrics in DnsServerResponseCounters.
+    reserved 7 to 9;
   }
 
   enum SrpServerState {


### PR DESCRIPTION
Three upstream DNS metrics were added in wrong Counters in proto file. Add reserved field to avoid misusing.