### PR TITLE
[border-agent] add `_meshcop-e` service for ePSKc mode

### DIFF
--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -149,6 +149,10 @@ private:
     std::string GetServiceInstanceNameWithExtAddr(const std::string &aServiceInstanceName) const;
     std::string GetAlternativeServiceInstanceName() const;
 
+    static void HandleEpskcStateChanged(void *aContext);
+    void        PublishEpskcService(void);
+    void        UnpublishEpskcService(void);
+
     otbr::Ncp::ControllerOpenThread &mNcp;
     Mdns::Publisher                 &mPublisher;
     bool                             mIsEnabled;


### PR DESCRIPTION
Meshcop-e service is published when receiving DNS query for PTR records and BA is in the "ba ephemeralkey" active mode with the same instance name with Meshcop service and different UDP port number for the DTLS connection using ePSKc.
Test:
1. Active ePSKc mode using "ba ephemeralkey" commands, verified Meshcop-e package and service
2. DTLS connection could successfully set using ePSKc mode with Candidate Commissioner.
3. DTLS connection using ePSKc by inputing wrong ePSK in Candidate Commissioner, Meshcop-e service has been unpublished and no negative impacted with Meshcop service.
4. Meshcop-e service unpublished after timeout.