### PR TITLE
[bbr] add a flag to enable BBR on init

### DIFF
--- a/src/backbone_router/backbone_agent.cpp
+++ b/src/backbone_router/backbone_agent.cpp
@@ -71,7 +71,9 @@ void BackboneAgent::Init(void)
     mNdProxyManager.Init();
 #endif
 
+#if OTBR_ENABLE_BACKBONE_ROUTER_ON_INIT
     otBackboneRouterSetEnabled(mNcp.GetInstance(), /* aEnabled */ true);
+#endif
 }
 
 void BackboneAgent::HandleThreadStateChanged(otChangedFlags aFlags)

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -36,6 +36,10 @@
 
 #include "openthread-br/config.h"
 
+#ifndef OTBR_ENABLE_BACKBONE_ROUTER_ON_INIT
+#define OTBR_ENABLE_BACKBONE_ROUTER_ON_INIT OTBR_ENABLE_BACKBONE_ROUTER
+#endif
+
 #if OTBR_ENABLE_BACKBONE_ROUTER
 
 #include <openthread/backbone_router_ftd.h>


### PR DESCRIPTION
Flag `OTBR_ENABLE_BACKBONE_ROUTER_ON_INIT` is created for enabling BBR on init. It's set to OTBR_ENABLE_BACKBONE_ROUTER by default and this works when infra link is statically configured. If infra link is dynamically configured then this flag should be set to 0, the component that sets infra link should enable/disable BBR feature with the otBackboneRouterSetEnabled API.