### PR TITLE
[avahi] conditionalize Avahi Service Start and Installation (#2280)

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,6 +37,10 @@ NAT64_SERVICE="${NAT64_SERVICE:-openthread}"
 
 FIREWALL="${FIREWALL:-1}"
 
+OTBR_MDNS="${OTBR_MDNS:-mDNSResponder}"
+OT_BACKBONE_CI="${OT_BACKBONE_CI:-0}"
+REFERENCE_DEVICE="${REFERENCE_DEVICE:-0}"
+
 install_packages_apt()
 {
     sudo apt-get update
@@ -54,10 +58,18 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y rsyslog
 
     # For DBus server
-    sudo apt-get install --no-install-recommends -y libdbus-1-dev
+    sudo apt-get install --no-install-recommends -y dbus libdbus-1-dev
 
     # mDNS
-    sudo apt-get install --no-install-recommends -y libavahi-client3 libavahi-common-dev libavahi-client-dev avahi-daemon
+    sudo apt-get install --no-install-recommends -y libavahi-client3 libavahi-common-dev libavahi-client-dev
+
+    # Thread Certification tests require Avahi to publish records for tests. Since the
+    # same image is used for all tests this needs to be installed here. Additionally
+    # Avahi should be included for reference device builds.
+    if [[ ${OTBR_MDNS} == "avahi" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
+        sudo apt-get install --no-install-recommends -y avahi-daemon
+    fi
+
     (MDNS_RESPONDER_SOURCE_NAME=mDNSResponder-1790.80.10 \
         && MDNS_RESPONDER_PATCH_PATH=$(realpath "$(dirname "$0")"/../third_party/mDNSResponder) \
         && cd /tmp \

--- a/script/server
+++ b/script/server
@@ -36,6 +36,10 @@
 . script/_dns64
 . script/_firewall
 
+OTBR_MDNS="${OTBR_MDNS:-mDNSResponder}"
+OT_BACKBONE_CI="${OT_BACKBONE_CI:-0}"
+REFERENCE_DEVICE="${REFERENCE_DEVICE:-0}"
+
 startup()
 {
     # shellcheck source=/dev/null
@@ -47,7 +51,12 @@ startup()
     if have systemctl; then
         systemctl is-active rsyslog || sudo systemctl start rsyslog || die 'Failed to start rsyslog!'
         systemctl is-active dbus || sudo systemctl start dbus || die 'Failed to start dbus!'
-        systemctl is-active avahi-daemon || sudo systemctl start avahi-daemon || die 'Failed to start avahi!'
+        # Thread Certification tests require Avahi to publish records for tests. Since the
+        # same image is used for all tests Avahi needs to be started here and if
+        # building a reference device.
+        if [[ ${OTBR_MDNS} == "avahi" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
+            systemctl is-active avahi-daemon || sudo systemctl start avahi-daemon || die 'Failed to start avahi!'
+        fi
         without WEB_GUI || systemctl is-active otbr-web || sudo systemctl start otbr-web || die 'Failed to start otbr-web!'
         systemctl is-active otbr-agent || sudo systemctl start otbr-agent || die 'Failed to start otbr-agent!'
     elif have service; then
@@ -55,7 +64,12 @@ startup()
         sudo service dbus status || sudo service dbus start || die 'Failed to start dbus!'
         # Tolerate the mdns failure as it is installed for only CI docker.
         sudo service mdns status || sudo service mdns start || echo "service mdns is not available!"
-        sudo service avahi-daemon status || sudo service avahi-daemon start || die 'Failed to start avahi!'
+        # Thread Certification tests require Avahi to publish records for tests. Since the
+        # same image is used for all tests Avahi needs to be started here and if
+        # building a reference device.
+        if [[ ${OTBR_MDNS} == "avahi" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
+            sudo service avahi-daemon status || sudo service avahi-daemon start || die 'Failed to start avahi!'
+        fi
         sudo service otbr-agent status || sudo service otbr-agent start || die 'Failed to start otbr-agent!'
         without WEB_GUI || sudo service otbr-web status || sudo service otbr-web start || die 'Failed to start otbr-web!'
     else
@@ -73,14 +87,18 @@ shutdown()
     if have systemctl; then
         systemctl is-active rsyslog && sudo systemctl stop rsyslog || echo 'Failed to stop rsyslog!'
         systemctl is-active dbus && sudo systemctl stop dbus || echo 'Failed to stop dbus!'
-        systemctl is-active avahi-daemon && sudo systemctl stop avahi-daemon || echo 'Failed to stop avahi!'
+        if [[ ${OTBR_MDNS} == "avahi" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
+            systemctl is-active avahi-daemon && sudo systemctl stop avahi-daemon || echo 'Failed to stop avahi!'
+        fi
         without WEB_GUI || systemctl is-active otbr-web && sudo systemctl stop otbr-web || echo 'Failed to stop otbr-web!'
         systemctl is-active otbr-agent && sudo systemctl stop otbr-agent || echo 'Failed to stop otbr-agent!'
     elif have service; then
         sudo service rsyslog status && sudo service rsyslog stop || echo 'Failed to stop rsyslog!'
         sudo service dbus status && sudo service dbus stop || echo 'Failed to stop dbus!'
         sudo service mdns status && sudo service mdns stop || echo "service mdns is not available!"
-        sudo service avahi-daemon status && sudo service avahi-daemon stop || echo 'Failed to stop avahi!'
+        if [[ ${OTBR_MDNS} == "avahi" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
+            sudo service avahi-daemon status && sudo service avahi-daemon stop || echo 'Failed to stop avahi!'
+        fi
         sudo service otbr-agent status && sudo service otbr-agent stop || echo 'Failed to stop otbr-agent!'
         without WEB_GUI || sudo service otbr-web status && sudo service otbr-web stop || echo 'Failed to stop otbr-web!'
     else


### PR DESCRIPTION
Ensure the Avahi daemon is installed and started only when OTBR_MDNS == "avahi". This prevents multiple mDNS stacks from running especially in container environments.

I saw in the CONTRIBUTING documentation that CI checks should pass but I'm not sure how to get them to run in my fork.

Fixes #2280