### PR TITLE
[mbedtls] stop checking configuration explicitly

### DIFF
--- a/third_party/openthread/mbedtls-config.h
+++ b/third_party/openthread/mbedtls-config.h
@@ -103,6 +103,10 @@
 
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
-#include "mbedtls/check_config.h"
+#include "mbedtls/version.h"
+#if (MBEDTLS_VERSION_NUMBER < 0x03000000)
+    // Configuration sanity check. Done automatically in Mbed TLS >= 3.0.
+    #include "mbedtls/check_config.h"
+#endif
 
 #endif // OTBR_MBEDTLS_CONFIG_H_


### PR DESCRIPTION
This commit removes configuration sanity check for MbedTLS versions higher or equal to 3.0.0.

This is a follow-up after https://github.com/openthread/openthread/pull/10263 and needed to migrate to Mbed TLS 3.6.0.