### PR TITLE
[ncp] rename `ControllerOpenThread` to `RcpHost`

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -60,33 +60,33 @@ Application::Application(const std::string               &aInterfaceName,
 #else
     , mBackboneInterfaceName(aBackboneInterfaceNames.empty() ? "" : aBackboneInterfaceNames.front())
 #endif
-    , mNcp(mInterfaceName.c_str(), aRadioUrls, mBackboneInterfaceName, /* aDryRun */ false, aEnableAutoAttach)
+    , mHost(mInterfaceName.c_str(), aRadioUrls, mBackboneInterfaceName, /* aDryRun */ false, aEnableAutoAttach)
 #if OTBR_ENABLE_MDNS
     , mPublisher(Mdns::Publisher::Create([this](Mdns::Publisher::State aState) { this->HandleMdnsState(aState); }))
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
-    , mBorderAgent(mNcp, *mPublisher)
+    , mBorderAgent(mHost, *mPublisher)
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
-    , mBackboneAgent(mNcp, aInterfaceName, mBackboneInterfaceName)
+    , mBackboneAgent(mHost, aInterfaceName, mBackboneInterfaceName)
 #endif
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    , mAdvertisingProxy(mNcp, *mPublisher)
+    , mAdvertisingProxy(mHost, *mPublisher)
 #endif
 #if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    , mDiscoveryProxy(mNcp, *mPublisher)
+    , mDiscoveryProxy(mHost, *mPublisher)
 #endif
 #if OTBR_ENABLE_TREL
-    , mTrelDnssd(mNcp, *mPublisher)
+    , mTrelDnssd(mHost, *mPublisher)
 #endif
 #if OTBR_ENABLE_OPENWRT
-    , mUbusAgent(mNcp)
+    , mUbusAgent(mHost)
 #endif
 #if OTBR_ENABLE_REST_SERVER
-    , mRestWebServer(mNcp, aRestListenAddress, aRestListenPort)
+    , mRestWebServer(mHost, aRestListenAddress, aRestListenPort)
 #endif
 #if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
-    , mDBusAgent(mNcp, *mPublisher)
+    , mDBusAgent(mHost, *mPublisher)
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
     , mVendorServer(vendor::VendorServer::newInstance(*this))
@@ -98,7 +98,7 @@ Application::Application(const std::string               &aInterfaceName,
 
 void Application::Init(void)
 {
-    mNcp.Init();
+    mHost.Init();
 
 #if OTBR_ENABLE_MDNS
     mPublisher->Start();
@@ -150,7 +150,7 @@ void Application::Deinit(void)
     mPublisher->Stop();
 #endif
 
-    mNcp.Deinit();
+    mHost.Deinit();
 }
 
 otbrError Application::Run(void)

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -44,7 +44,7 @@
 #if OTBR_ENABLE_BORDER_AGENT
 #include "border_agent/border_agent.hpp"
 #endif
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 #if OTBR_ENABLE_BACKBONE_ROUTER
 #include "backbone_router/backbone_agent.hpp"
 #endif
@@ -132,7 +132,7 @@ public:
      *
      * @returns The OpenThread controller object.
      */
-    Ncp::ControllerOpenThread &GetNcp(void) { return mNcp; }
+    Ncp::RcpHost &GetNcp(void) { return mHost; }
 
 #if OTBR_ENABLE_MDNS
     /**
@@ -260,8 +260,8 @@ private:
 #if __linux__
     otbr::Utils::InfraLinkSelector mInfraLinkSelector;
 #endif
-    const char               *mBackboneInterfaceName;
-    Ncp::ControllerOpenThread mNcp;
+    const char  *mBackboneInterfaceName;
+    Ncp::RcpHost mHost;
 #if OTBR_ENABLE_MDNS
     std::unique_ptr<Mdns::Publisher> mPublisher;
 #endif

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -56,7 +56,7 @@
 #include "common/logging.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 static const char kDefaultInterfaceName[] = "wpan0";
 
@@ -176,17 +176,18 @@ static otbrLogLevel GetDefaultLogLevel(void)
 
 static void PrintRadioVersionAndExit(const std::vector<const char *> &aRadioUrls)
 {
-    otbr::Ncp::ControllerOpenThread ncpOpenThread{/* aInterfaceName */ "", aRadioUrls, /* aBackboneInterfaceName */ "",
-                                                  /* aDryRun */ true, /* aEnableAutoAttach */ false};
-    const char                     *radioVersion;
+    otbr::Ncp::RcpHost rcpHost{/* aInterfaceName */ "", aRadioUrls,
+                               /* aBackboneInterfaceName */ "",
+                               /* aDryRun */ true, /* aEnableAutoAttach */ false};
+    const char        *radioVersion;
 
-    ncpOpenThread.Init();
+    rcpHost.Init();
 
-    radioVersion = otPlatRadioGetVersionString(ncpOpenThread.GetInstance());
+    radioVersion = otPlatRadioGetVersionString(rcpHost.GetInstance());
     otbrLogNotice("Radio version: %s", radioVersion);
     printf("%s\n", radioVersion);
 
-    ncpOpenThread.Deinit();
+    rcpHost.Deinit();
 
     exit(EXIT_SUCCESS);
 }
@@ -279,7 +280,7 @@ static int realmain(int argc, char *argv[])
 
     otbrLogInit(argv[0], logLevel, verbose, syslogDisable);
     otbrLogNotice("Running %s", OTBR_PACKAGE_VERSION);
-    otbrLogNotice("Thread version: %s", otbr::Ncp::ControllerOpenThread::GetThreadVersion());
+    otbrLogNotice("Thread version: %s", otbr::Ncp::RcpHost::GetThreadVersion());
     otbrLogNotice("Thread interface: %s", interfaceName);
 
     if (backboneInterfaceNames.empty())

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -47,7 +47,7 @@
 #include "backbone_router/dua_routing_manager.hpp"
 #include "backbone_router/nd_proxy.hpp"
 #include "common/code_utils.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace BackboneRouter {
@@ -73,12 +73,10 @@ public:
     /**
      * This constructor intiializes the `BackboneAgent` instance.
      *
-     * @param[in] aNcp  The Thread instance.
+     * @param[in] aHost  The Thread controller instance.
      *
      */
-    BackboneAgent(otbr::Ncp::ControllerOpenThread &aNcp,
-                  std::string                      aInterfaceName,
-                  std::string                      aBackboneInterfaceName);
+    BackboneAgent(otbr::Ncp::RcpHost &aHost, std::string aInterfaceName, std::string aBackboneInterfaceName);
 
     /**
      * This method initializes the Backbone agent.
@@ -106,9 +104,9 @@ private:
 
     static const char *StateToString(otBackboneRouterState aState);
 
-    otbr::Ncp::ControllerOpenThread &mNcp;
-    otBackboneRouterState            mBackboneRouterState;
-    Ip6Prefix                        mDomainPrefix;
+    otbr::Ncp::RcpHost   &mHost;
+    otBackboneRouterState mBackboneRouterState;
+    Ip6Prefix             mDomainPrefix;
 #if OTBR_ENABLE_DUA_ROUTING
     NdProxyManager    mNdProxyManager;
     DuaRoutingManager mDuaRoutingManager;

--- a/src/backbone_router/dua_routing_manager.hpp
+++ b/src/backbone_router/dua_routing_manager.hpp
@@ -43,7 +43,7 @@
 #include <openthread/backbone_router_ftd.h>
 
 #include "common/code_utils.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 #include "utils/system_utils.hpp"
 
 namespace otbr {

--- a/src/backbone_router/nd_proxy.cpp
+++ b/src/backbone_router/nd_proxy.cpp
@@ -311,7 +311,7 @@ void NdProxyManager::SendNeighborAdvertisement(const Ip6Address &aTarget, const 
     otbrError                  error = OTBR_ERROR_NONE;
     otBackboneRouterNdProxyInfo aNdProxyInfo;
 
-    VerifyOrExit(otBackboneRouterGetNdProxyInfo(mNcp.GetInstance(), reinterpret_cast<const otIp6Address *>(&aTarget),
+    VerifyOrExit(otBackboneRouterGetNdProxyInfo(mHost.GetInstance(), reinterpret_cast<const otIp6Address *>(&aTarget),
                                                 &aNdProxyInfo) == OT_ERROR_NONE,
                  error = OTBR_ERROR_OPENTHREAD);
 

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -55,7 +55,7 @@
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace BackboneRouter {
@@ -80,8 +80,8 @@ public:
      * This constructor initializes a NdProxyManager instance.
      *
      */
-    explicit NdProxyManager(otbr::Ncp::ControllerOpenThread &aNcp, std::string aBackboneInterfaceName)
-        : mNcp(aNcp)
+    explicit NdProxyManager(otbr::Ncp::RcpHost &aHost, std::string aBackboneInterfaceName)
+        : mHost(aHost)
         , mBackboneInterfaceName(std::move(aBackboneInterfaceName))
         , mIcmp6RawSock(-1)
         , mUnicastNsQueueSock(-1)
@@ -153,16 +153,16 @@ private:
                                     void                *aContext);
     int HandleNetfilterQueue(struct nfq_q_handle *aNfQueueHandler, struct nfgenmsg *aNfMsg, struct nfq_data *aNfData);
 
-    otbr::Ncp::ControllerOpenThread &mNcp;
-    std::string                      mBackboneInterfaceName;
-    std::set<Ip6Address>             mNdProxySet;
-    uint32_t                         mBackboneIfIndex;
-    int                              mIcmp6RawSock;
-    int                              mUnicastNsQueueSock;
-    struct nfq_handle               *mNfqHandler;      ///< A pointer to an NFQUEUE handler.
-    struct nfq_q_handle             *mNfqQueueHandler; ///< A pointer to a newly created queue.
-    MacAddress                       mMacAddress;
-    Ip6Prefix                        mDomainPrefix;
+    otbr::Ncp::RcpHost  &mHost;
+    std::string          mBackboneInterfaceName;
+    std::set<Ip6Address> mNdProxySet;
+    uint32_t             mBackboneIfIndex;
+    int                  mIcmp6RawSock;
+    int                  mUnicastNsQueueSock;
+    struct nfq_handle   *mNfqHandler;      ///< A pointer to an NFQUEUE handler.
+    struct nfq_q_handle *mNfqQueueHandler; ///< A pointer to a newly created queue.
+    MacAddress           mMacAddress;
+    Ip6Prefix            mDomainPrefix;
 };
 
 /**

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -48,7 +48,7 @@
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "mdns/mdns.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 #include "sdp_proxy/advertising_proxy.hpp"
 #include "sdp_proxy/discovery_proxy.hpp"
 #include "trel_dnssd/trel_dnssd.hpp"
@@ -86,11 +86,11 @@ public:
     /**
      * The constructor to initialize the Thread border agent.
      *
-     * @param[in] aNcp  A reference to the NCP controller.
+     * @param[in] aHost       A reference to the Thread controller.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    BorderAgent(otbr::Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    BorderAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
 
     ~BorderAgent(void) = default;
 
@@ -153,9 +153,9 @@ private:
     void        PublishEpskcService(void);
     void        UnpublishEpskcService(void);
 
-    otbr::Ncp::ControllerOpenThread &mNcp;
-    Mdns::Publisher                 &mPublisher;
-    bool                             mIsEnabled;
+    otbr::Ncp::RcpHost &mHost;
+    Mdns::Publisher    &mPublisher;
+    bool                mIsEnabled;
 
 #if OTBR_ENABLE_DBUS_SERVER
     std::map<std::string, std::vector<uint8_t>> mMeshCopTxtUpdate;

--- a/src/common/mainloop_manager.hpp
+++ b/src/common/mainloop_manager.hpp
@@ -42,7 +42,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -44,9 +44,9 @@ namespace DBus {
 const struct timeval           DBusAgent::kPollTimeout = {0, 0};
 constexpr std::chrono::seconds DBusAgent::kDBusWaitAllowance;
 
-DBusAgent::DBusAgent(otbr::Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
-    : mInterfaceName(aNcp.GetInterfaceName())
-    , mNcp(aNcp)
+DBusAgent::DBusAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
+    : mInterfaceName(aHost.GetInterfaceName())
+    , mHost(aHost)
     , mPublisher(aPublisher)
 {
 }
@@ -66,7 +66,7 @@ void DBusAgent::Init(void)
     VerifyOrDie(mConnection != nullptr, "Failed to get DBus connection");
 
     mThreadObject =
-        std::unique_ptr<DBusThreadObject>(new DBusThreadObject(mConnection.get(), mInterfaceName, &mNcp, &mPublisher));
+        std::unique_ptr<DBusThreadObject>(new DBusThreadObject(mConnection.get(), mInterfaceName, &mHost, &mPublisher));
     error = mThreadObject->Init();
     VerifyOrDie(error == OTBR_ERROR_NONE, "Failed to initialize DBus Agent");
 }

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -48,7 +48,7 @@
 #include "dbus/server/dbus_object.hpp"
 #include "dbus/server/dbus_thread_object.hpp"
 
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace DBus {
@@ -59,10 +59,10 @@ public:
     /**
      * The constructor of dbus agent.
      *
-     * @param[in] aNcp  A reference to the NCP controller.
+     * @param[in] aHost  A reference to the Thread controller.
      *
      */
-    DBusAgent(otbr::Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    DBusAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
 
     /**
      * This method initializes the dbus agent.
@@ -88,7 +88,7 @@ private:
     std::string                       mInterfaceName;
     std::unique_ptr<DBusThreadObject> mThreadObject;
     UniqueDBusConnection              mConnection;
-    otbr::Ncp::ControllerOpenThread  &mNcp;
+    otbr::Ncp::RcpHost               &mHost;
     Mdns::Publisher                  &mPublisher;
 
     /**

--- a/src/dbus/server/dbus_thread_object.hpp
+++ b/src/dbus/server/dbus_thread_object.hpp
@@ -42,7 +42,7 @@
 
 #include "dbus/server/dbus_object.hpp"
 #include "mdns/mdns.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace DBus {
@@ -68,14 +68,14 @@ public:
      *
      * @param[in] aConnection     The dbus connection.
      * @param[in] aInterfaceName  The dbus interface name.
-     * @param[in] aNcp            The ncp controller
+     * @param[in] aHost           The Thread controller
      * @param[in] aPublisher      The Mdns::Publisher
      *
      */
-    DBusThreadObject(DBusConnection                  *aConnection,
-                     const std::string               &aInterfaceName,
-                     otbr::Ncp::ControllerOpenThread *aNcp,
-                     Mdns::Publisher                 *aPublisher);
+    DBusThreadObject(DBusConnection     *aConnection,
+                     const std::string  &aInterfaceName,
+                     otbr::Ncp::RcpHost *aHost,
+                     Mdns::Publisher    *aPublisher);
 
     otbrError Init(void) override;
 
@@ -178,7 +178,7 @@ private:
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
     void ReplyEnergyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otEnergyScanResult> &aResult);
 
-    otbr::Ncp::ControllerOpenThread                     *mNcp;
+    otbr::Ncp::RcpHost                                  *mHost;
     std::unordered_map<std::string, PropertyHandlerType> mGetPropertyHandlers;
     otbr::Mdns::Publisher                               *mPublisher;
 };

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -27,8 +27,8 @@
 #
 
 add_library(otbr-ncp
-    ncp_openthread.cpp
-    ncp_openthread.hpp
+    rcp_host.cpp
+    rcp_host.hpp
 )
 
 target_link_libraries(otbr-ncp PRIVATE

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -28,11 +28,11 @@
 
 /**
  * @file
- *   This file includes definitions for NCP service.
+ *   This file includes definitions of Thread Controller under RCP mode.
  */
 
-#ifndef OTBR_AGENT_NCP_OPENTHREAD_HPP_
-#define OTBR_AGENT_NCP_OPENTHREAD_HPP_
+#ifndef OTBR_AGENT_RCP_HOST_HPP_
+#define OTBR_AGENT_RCP_HOST_HPP_
 
 #include "openthread-br/config.h"
 
@@ -60,10 +60,10 @@ class FeatureFlagList;
 namespace Ncp {
 
 /**
- * This interface defines NCP Controller functionality.
+ * This interface defines OpenThread Controller under RCP mode.
  *
  */
-class ControllerOpenThread : public MainloopProcessor
+class RcpHost : public MainloopProcessor
 {
 public:
     using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;
@@ -78,11 +78,11 @@ public:
      * @param[in]   aEnableAutoAttach       Whether or not to automatically attach to the saved network.
      *
      */
-    ControllerOpenThread(const char                      *aInterfaceName,
-                         const std::vector<const char *> &aRadioUrls,
-                         const char                      *aBackboneInterfaceName,
-                         bool                             aDryRun,
-                         bool                             aEnableAutoAttach);
+    RcpHost(const char                      *aInterfaceName,
+            const std::vector<const char *> &aRadioUrls,
+            const char                      *aBackboneInterfaceName,
+            bool                             aDryRun,
+            bool                             aEnableAutoAttach);
 
     /**
      * This method initialize the NCP controller.
@@ -99,7 +99,7 @@ public:
     /**
      * Returns an OpenThread instance.
      *
-     * @retval Non-null OpenThread instance if `ControllerOpenThread::Init()` has been called.
+     * @retval Non-null OpenThread instance if `RcpHost::Init()` has been called.
      *         Otherwise, it's guaranteed to be `null`
      */
     otInstance *GetInstance(void) { return mInstance; }
@@ -191,12 +191,12 @@ public:
     }
 #endif
 
-    ~ControllerOpenThread(void) override;
+    ~RcpHost(void) override;
 
 private:
     static void HandleStateChanged(otChangedFlags aFlags, void *aContext)
     {
-        static_cast<ControllerOpenThread *>(aContext)->HandleStateChanged(aFlags);
+        static_cast<RcpHost *>(aContext)->HandleStateChanged(aFlags);
     }
     void HandleStateChanged(otChangedFlags aFlags);
 
@@ -237,4 +237,4 @@ private:
 } // namespace Ncp
 } // namespace otbr
 
-#endif // OTBR_AGENT_NCP_OPENTHREAD_HPP_
+#endif // OTBR_AGENT_RCP_HOST_HPP_

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -44,7 +44,7 @@
 #include <openthread/thread_ftd.h>
 
 #include "common/logging.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace ubus {
@@ -58,12 +58,12 @@ const static int PANID_LENGTH      = 10;
 const static int XPANID_LENGTH     = 64;
 const static int NETWORKKEY_LENGTH = 64;
 
-UbusServer::UbusServer(Ncp::ControllerOpenThread *aController, std::mutex *aMutex)
+UbusServer::UbusServer(Ncp::RcpHost *aHost, std::mutex *aMutex)
     : mIfFinishScan(false)
     , mContext(nullptr)
     , mSockPath(nullptr)
-    , mController(aController)
-    , mNcpThreadMutex(aMutex)
+    , mHost(aHost)
+    , mHostMutex(aMutex)
     , mSecond(0)
 {
     memset(&mNetworkdataBuf, 0, sizeof(mNetworkdataBuf));
@@ -78,9 +78,9 @@ UbusServer &UbusServer::GetInstance(void)
     return *sUbusServerInstance;
 }
 
-void UbusServer::Initialize(Ncp::ControllerOpenThread *aController, std::mutex *aMutex)
+void UbusServer::Initialize(Ncp::RcpHost *aHost, std::mutex *aMutex)
 {
-    sUbusServerInstance = new UbusServer(aController, aMutex);
+    sUbusServerInstance = new UbusServer(aHost, aMutex);
 }
 
 enum
@@ -229,11 +229,11 @@ void UbusServer::ProcessScan(void)
     uint32_t scanChannels = 0;
     uint16_t scanDuration = 0;
 
-    mNcpThreadMutex->lock();
-    SuccessOrExit(error = otLinkActiveScan(mController->GetInstance(), scanChannels, scanDuration,
+    mHostMutex->lock();
+    SuccessOrExit(error = otLinkActiveScan(mHost->GetInstance(), scanChannels, scanDuration,
                                            &UbusServer::HandleActiveScanResult, this));
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     return;
 }
 
@@ -679,8 +679,8 @@ int UbusServer::UbusLeaveHandlerDetail(struct ubus_context      *aContext,
     uint64_t eventNum;
     ssize_t  retval;
 
-    mNcpThreadMutex->lock();
-    otInstanceFactoryReset(mController->GetInstance());
+    mHostMutex->lock();
+    otInstanceFactoryReset(mHost->GetInstance());
 
     eventNum = 1;
     retval   = write(sUbusEfd, &eventNum, sizeof(uint64_t));
@@ -693,7 +693,7 @@ int UbusServer::UbusLeaveHandlerDetail(struct ubus_context      *aContext,
     blob_buf_init(&mBuf, 0);
 
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     AppendResult(error, aContext, aRequest);
     return 0;
 }
@@ -714,19 +714,19 @@ int UbusServer::UbusThreadHandler(struct ubus_context      *aContext,
 
     if (!strcmp(aAction, "start"))
     {
-        mNcpThreadMutex->lock();
-        SuccessOrExit(error = otIp6SetEnabled(mController->GetInstance(), true));
-        SuccessOrExit(error = otThreadSetEnabled(mController->GetInstance(), true));
+        mHostMutex->lock();
+        SuccessOrExit(error = otIp6SetEnabled(mHost->GetInstance(), true));
+        SuccessOrExit(error = otThreadSetEnabled(mHost->GetInstance(), true));
     }
     else if (!strcmp(aAction, "stop"))
     {
-        mNcpThreadMutex->lock();
-        SuccessOrExit(error = otThreadSetEnabled(mController->GetInstance(), false));
-        SuccessOrExit(error = otIp6SetEnabled(mController->GetInstance(), false));
+        mHostMutex->lock();
+        SuccessOrExit(error = otThreadSetEnabled(mHost->GetInstance(), false));
+        SuccessOrExit(error = otIp6SetEnabled(mHost->GetInstance(), false));
     }
 
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     AppendResult(error, aContext, aRequest);
     return 0;
 }
@@ -750,8 +750,8 @@ int UbusServer::UbusParentHandlerDetail(struct ubus_context      *aContext,
 
     blob_buf_init(&mBuf, 0);
 
-    mNcpThreadMutex->lock();
-    SuccessOrExit(error = otThreadGetParentInfo(mController->GetInstance(), &parentInfo));
+    mHostMutex->lock();
+    SuccessOrExit(error = otThreadGetParentInfo(mHost->GetInstance(), &parentInfo));
 
     jsonArray = blobmsg_open_array(&mBuf, "parent_list");
     jsonList  = blobmsg_open_table(&mBuf, "parent");
@@ -772,7 +772,7 @@ int UbusServer::UbusParentHandlerDetail(struct ubus_context      *aContext,
     blobmsg_close_array(&mBuf, jsonArray);
 
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     AppendResult(error, aContext, aRequest);
     return error;
 }
@@ -799,8 +799,8 @@ int UbusServer::UbusNeighborHandlerDetail(struct ubus_context      *aContext,
 
     sJsonUri = blobmsg_open_array(&mBuf, "neighbor_list");
 
-    mNcpThreadMutex->lock();
-    while (otThreadGetNextNeighborInfo(mController->GetInstance(), &iterator, &neighborInfo) == OT_ERROR_NONE)
+    mHostMutex->lock();
+    while (otThreadGetNextNeighborInfo(mHost->GetInstance(), &iterator, &neighborInfo) == OT_ERROR_NONE)
     {
         jsonList = blobmsg_open_table(&mBuf, nullptr);
 
@@ -847,7 +847,7 @@ int UbusServer::UbusNeighborHandlerDetail(struct ubus_context      *aContext,
 
     blobmsg_close_array(&mBuf, sJsonUri);
 
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
 
     AppendResult(error, aContext, aRequest);
     return 0;
@@ -870,7 +870,7 @@ int UbusServer::UbusMgmtset(struct ubus_context      *aContext,
     long                 value;
     int                  length = 0;
 
-    SuccessOrExit(error = otDatasetGetActive(mController->GetInstance(), &dataset));
+    SuccessOrExit(error = otDatasetGetActive(mHost->GetInstance(), &dataset));
 
     blobmsg_parse(mgmtsetPolicy, MGMTSET_MAX, tb, blob_data(aMsg), blob_len(aMsg));
     if (tb[NETWORKKEY] != nullptr)
@@ -919,12 +919,12 @@ int UbusServer::UbusMgmtset(struct ubus_context      *aContext,
         length = 0;
     }
     dataset.mActiveTimestamp.mSeconds++;
-    if (otCommissionerGetState(mController->GetInstance()) == OT_COMMISSIONER_STATE_DISABLED)
+    if (otCommissionerGetState(mHost->GetInstance()) == OT_COMMISSIONER_STATE_DISABLED)
     {
-        otCommissionerStop(mController->GetInstance());
+        otCommissionerStop(mHost->GetInstance());
     }
-    SuccessOrExit(error = otDatasetSendMgmtActiveSet(mController->GetInstance(), &dataset, tlvs,
-                                                     static_cast<uint8_t>(length), /* aCallback */ nullptr,
+    SuccessOrExit(error = otDatasetSendMgmtActiveSet(mHost->GetInstance(), &dataset, tlvs, static_cast<uint8_t>(length),
+                                                     /* aCallback */ nullptr,
                                                      /* aContext */ nullptr));
 exit:
     AppendResult(error, aContext, aRequest);
@@ -944,13 +944,13 @@ int UbusServer::UbusCommissioner(struct ubus_context      *aContext,
 
     otError error = OT_ERROR_NONE;
 
-    mNcpThreadMutex->lock();
+    mHostMutex->lock();
 
     if (!strcmp(aAction, "start"))
     {
-        if (otCommissionerGetState(mController->GetInstance()) == OT_COMMISSIONER_STATE_DISABLED)
+        if (otCommissionerGetState(mHost->GetInstance()) == OT_COMMISSIONER_STATE_DISABLED)
         {
-            error = otCommissionerStart(mController->GetInstance(), &UbusServer::HandleStateChanged,
+            error = otCommissionerStart(mHost->GetInstance(), &UbusServer::HandleStateChanged,
                                         &UbusServer::HandleJoinerEvent, this);
         }
     }
@@ -982,8 +982,8 @@ int UbusServer::UbusCommissioner(struct ubus_context      *aContext,
         }
 
         unsigned long timeout = kDefaultJoinerTimeout;
-        SuccessOrExit(
-            error = otCommissionerAddJoiner(mController->GetInstance(), addrPtr, pskd, static_cast<uint32_t>(timeout)));
+        SuccessOrExit(error =
+                          otCommissionerAddJoiner(mHost->GetInstance(), addrPtr, pskd, static_cast<uint32_t>(timeout)));
     }
     else if (!strcmp(aAction, "joinerremove"))
     {
@@ -1006,11 +1006,11 @@ int UbusServer::UbusCommissioner(struct ubus_context      *aContext,
             }
         }
 
-        SuccessOrExit(error = otCommissionerRemoveJoiner(mController->GetInstance(), addrPtr));
+        SuccessOrExit(error = otCommissionerRemoveJoiner(mHost->GetInstance(), addrPtr));
     }
 
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     blob_buf_init(&mBuf, 0);
     AppendResult(error, aContext, aRequest);
     return 0;
@@ -1087,31 +1087,31 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
 
     blob_buf_init(&mBuf, 0);
 
-    mNcpThreadMutex->lock();
+    mHostMutex->lock();
     if (!strcmp(aAction, "networkname"))
-        blobmsg_add_string(&mBuf, "NetworkName", otThreadGetNetworkName(mController->GetInstance()));
+        blobmsg_add_string(&mBuf, "NetworkName", otThreadGetNetworkName(mHost->GetInstance()));
     else if (!strcmp(aAction, "interfacename"))
     {
-        blobmsg_add_string(&mBuf, "InterfaceName", mController->GetInterfaceName());
+        blobmsg_add_string(&mBuf, "InterfaceName", mHost->GetInterfaceName());
     }
     else if (!strcmp(aAction, "state"))
     {
         char state[10];
-        GetState(mController->GetInstance(), state);
+        GetState(mHost->GetInstance(), state);
         blobmsg_add_string(&mBuf, "State", state);
     }
     else if (!strcmp(aAction, "channel"))
-        blobmsg_add_u32(&mBuf, "Channel", otLinkGetChannel(mController->GetInstance()));
+        blobmsg_add_u32(&mBuf, "Channel", otLinkGetChannel(mHost->GetInstance()));
     else if (!strcmp(aAction, "panid"))
     {
         char panIdString[PANID_LENGTH];
-        sprintf(panIdString, "0x%04x", otLinkGetPanId(mController->GetInstance()));
+        sprintf(panIdString, "0x%04x", otLinkGetPanId(mHost->GetInstance()));
         blobmsg_add_string(&mBuf, "PanId", panIdString);
     }
     else if (!strcmp(aAction, "rloc16"))
     {
         char rloc[PANID_LENGTH];
-        sprintf(rloc, "0x%04x", otThreadGetRloc16(mController->GetInstance()));
+        sprintf(rloc, "0x%04x", otThreadGetRloc16(mHost->GetInstance()));
         blobmsg_add_string(&mBuf, "rloc16", rloc);
     }
     else if (!strcmp(aAction, "networkkey"))
@@ -1119,7 +1119,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
         char         outputKey[NETWORKKEY_LENGTH] = "";
         otNetworkKey key;
 
-        otThreadGetNetworkKey(mController->GetInstance(), &key);
+        otThreadGetNetworkKey(mHost->GetInstance(), &key);
         OutputBytes(key.m8, OT_NETWORK_KEY_SIZE, outputKey);
         blobmsg_add_string(&mBuf, "Networkkey", outputKey);
     }
@@ -1128,15 +1128,14 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
         char   outputPskc[NETWORKKEY_LENGTH] = "";
         otPskc pskc;
 
-        otThreadGetPskc(mController->GetInstance(), &pskc);
+        otThreadGetPskc(mHost->GetInstance(), &pskc);
         OutputBytes(pskc.m8, OT_PSKC_MAX_SIZE, outputPskc);
         blobmsg_add_string(&mBuf, "pskc", outputPskc);
     }
     else if (!strcmp(aAction, "extpanid"))
     {
         char           outputExtPanId[XPANID_LENGTH] = "";
-        const uint8_t *extPanId =
-            reinterpret_cast<const uint8_t *>(otThreadGetExtendedPanId(mController->GetInstance()));
+        const uint8_t *extPanId = reinterpret_cast<const uint8_t *>(otThreadGetExtendedPanId(mHost->GetInstance()));
         OutputBytes(extPanId, OT_EXT_PAN_ID_SIZE, outputExtPanId);
         blobmsg_add_string(&mBuf, "ExtPanId", outputExtPanId);
     }
@@ -1147,7 +1146,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
 
         memset(&linkMode, 0, sizeof(otLinkModeConfig));
 
-        linkMode = otThreadGetLinkMode(mController->GetInstance());
+        linkMode = otThreadGetLinkMode(mHost->GetInstance());
 
         if (linkMode.mRxOnWhenIdle)
         {
@@ -1167,13 +1166,13 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
     }
     else if (!strcmp(aAction, "partitionid"))
     {
-        blobmsg_add_u32(&mBuf, "Partitionid", otThreadGetPartitionId(mController->GetInstance()));
+        blobmsg_add_u32(&mBuf, "Partitionid", otThreadGetPartitionId(mHost->GetInstance()));
     }
     else if (!strcmp(aAction, "leaderdata"))
     {
         otLeaderData leaderData;
 
-        SuccessOrExit(error = otThreadGetLeaderData(mController->GetInstance(), &leaderData));
+        SuccessOrExit(error = otThreadGetLeaderData(mHost->GetInstance(), &leaderData));
 
         sJsonUri = blobmsg_open_table(&mBuf, "leaderdata");
 
@@ -1205,7 +1204,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
             tlvTypes[count++] = static_cast<uint8_t>(OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE);
 
             sBufNum = 0;
-            otThreadSendDiagnosticGet(mController->GetInstance(), &address, tlvTypes, count,
+            otThreadSendDiagnosticGet(mHost->GetInstance(), &address, tlvTypes, count,
                                       &UbusServer::HandleDiagnosticGetResponse, this);
             mSecond = time(nullptr);
         }
@@ -1223,7 +1222,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
         blob_buf_init(&mBuf, 0);
 
         jsonArray = blobmsg_open_array(&mBuf, "joinerList");
-        while (otCommissionerGetNextJoinerInfo(mController->GetInstance(), &iterator, &joinerInfo) == OT_ERROR_NONE)
+        while (otCommissionerGetNextJoinerInfo(mHost->GetInstance(), &iterator, &joinerInfo) == OT_ERROR_NONE)
         {
             memset(eui64, 0, sizeof(eui64));
 
@@ -1258,7 +1257,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
     }
     else if (!strcmp(aAction, "macfilterstate"))
     {
-        otMacFilterAddressMode mode = otLinkFilterGetAddressMode(mController->GetInstance());
+        otMacFilterAddressMode mode = otLinkFilterGetAddressMode(mHost->GetInstance());
 
         blob_buf_init(&mBuf, 0);
 
@@ -1288,7 +1287,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
 
         sJsonUri = blobmsg_open_array(&mBuf, "addrlist");
 
-        while (otLinkFilterGetNextAddress(mController->GetInstance(), &iterator, &entry) == OT_ERROR_NONE)
+        while (otLinkFilterGetNextAddress(mHost->GetInstance(), &iterator, &entry) == OT_ERROR_NONE)
         {
             char extAddress[XPANID_LENGTH] = "";
             OutputBytes(entry.mExtAddress.m8, sizeof(entry.mExtAddress.m8), extAddress);
@@ -1304,7 +1303,7 @@ int UbusServer::UbusGetInformation(struct ubus_context      *aContext,
 
     AppendResult(error, aContext, aRequest);
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     return 0;
 }
 
@@ -1440,7 +1439,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
 
     blob_buf_init(&mBuf, 0);
 
-    mNcpThreadMutex->lock();
+    mHostMutex->lock();
     if (!strcmp(aAction, "networkname"))
     {
         struct blob_attr *tb[SET_NETWORK_MAX];
@@ -1449,7 +1448,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
         if (tb[SETNETWORK] != nullptr)
         {
             char *newName = blobmsg_get_string(tb[SETNETWORK]);
-            SuccessOrExit(error = otThreadSetNetworkName(mController->GetInstance(), newName));
+            SuccessOrExit(error = otThreadSetNetworkName(mHost->GetInstance(), newName));
         }
     }
     else if (!strcmp(aAction, "channel"))
@@ -1460,7 +1459,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
         if (tb[SETNETWORK] != nullptr)
         {
             uint32_t channel = blobmsg_get_u32(tb[SETNETWORK]);
-            SuccessOrExit(error = otLinkSetChannel(mController->GetInstance(), static_cast<uint8_t>(channel)));
+            SuccessOrExit(error = otLinkSetChannel(mHost->GetInstance(), static_cast<uint8_t>(channel)));
         }
     }
     else if (!strcmp(aAction, "panid"))
@@ -1473,7 +1472,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
             long  value;
             char *panid = blobmsg_get_string(tb[SETNETWORK]);
             SuccessOrExit(error = ParseLong(panid, value));
-            error = otLinkSetPanId(mController->GetInstance(), static_cast<otPanId>(value));
+            error = otLinkSetPanId(mHost->GetInstance(), static_cast<otPanId>(value));
         }
     }
     else if (!strcmp(aAction, "networkkey"))
@@ -1487,7 +1486,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
             char        *networkkey = blobmsg_get_string(tb[SETNETWORK]);
 
             VerifyOrExit(Hex2Bin(networkkey, key.m8, sizeof(key.m8)) == OT_NETWORK_KEY_SIZE, error = OT_ERROR_PARSE);
-            SuccessOrExit(error = otThreadSetNetworkKey(mController->GetInstance(), &key));
+            SuccessOrExit(error = otThreadSetNetworkKey(mHost->GetInstance(), &key));
         }
     }
     else if (!strcmp(aAction, "pskc"))
@@ -1501,7 +1500,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
 
             VerifyOrExit(Hex2Bin(blobmsg_get_string(tb[SETNETWORK]), pskc.m8, sizeof(pskc)) == OT_PSKC_MAX_SIZE,
                          error = OT_ERROR_PARSE);
-            SuccessOrExit(error = otThreadSetPskc(mController->GetInstance(), &pskc));
+            SuccessOrExit(error = otThreadSetPskc(mHost->GetInstance(), &pskc));
         }
     }
     else if (!strcmp(aAction, "extpanid"))
@@ -1514,7 +1513,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
             otExtendedPanId extPanId;
             char           *input = blobmsg_get_string(tb[SETNETWORK]);
             VerifyOrExit(Hex2Bin(input, extPanId.m8, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
-            error = otThreadSetExtendedPanId(mController->GetInstance(), &extPanId);
+            error = otThreadSetExtendedPanId(mHost->GetInstance(), &extPanId);
         }
     }
     else if (!strcmp(aAction, "mode"))
@@ -1547,7 +1546,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
                 }
             }
 
-            SuccessOrExit(error = otThreadSetLinkMode(mController->GetInstance(), linkMode));
+            SuccessOrExit(error = otThreadSetLinkMode(mHost->GetInstance(), linkMode));
         }
     }
     else if (!strcmp(aAction, "macfilteradd"))
@@ -1562,7 +1561,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
 
             VerifyOrExit(Hex2Bin(addr, extAddr.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE, error = OT_ERROR_PARSE);
 
-            error = otLinkFilterAddAddress(mController->GetInstance(), &extAddr);
+            error = otLinkFilterAddAddress(mHost->GetInstance(), &extAddr);
 
             VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
         }
@@ -1578,7 +1577,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
             char *addr = blobmsg_get_string(tb[SETNETWORK]);
             VerifyOrExit(Hex2Bin(addr, extAddr.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE, error = OT_ERROR_PARSE);
 
-            otLinkFilterRemoveAddress(mController->GetInstance(), &extAddr);
+            otLinkFilterRemoveAddress(mHost->GetInstance(), &extAddr);
         }
     }
     else if (!strcmp(aAction, "macfiltersetstate"))
@@ -1592,21 +1591,21 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
 
             if (strcmp(state, "disable") == 0)
             {
-                otLinkFilterSetAddressMode(mController->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
+                otLinkFilterSetAddressMode(mHost->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
             }
             else if (strcmp(state, "allowlist") == 0)
             {
-                otLinkFilterSetAddressMode(mController->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST);
+                otLinkFilterSetAddressMode(mHost->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST);
             }
             else if (strcmp(state, "denylist") == 0)
             {
-                otLinkFilterSetAddressMode(mController->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_DENYLIST);
+                otLinkFilterSetAddressMode(mHost->GetInstance(), OT_MAC_FILTER_ADDRESS_MODE_DENYLIST);
             }
         }
     }
     else if (!strcmp(aAction, "macfilterclear"))
     {
-        otLinkFilterClearAddresses(mController->GetInstance());
+        otLinkFilterClearAddresses(mHost->GetInstance());
     }
     else
     {
@@ -1614,7 +1613,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
     }
 
 exit:
-    mNcpThreadMutex->unlock();
+    mHostMutex->unlock();
     AppendResult(error, aContext, aRequest);
     return 0;
 }
@@ -1810,7 +1809,7 @@ void UBusAgent::Init(void)
 {
     otbr::ubus::sUbusEfd = eventfd(0, 0);
 
-    otbr::ubus::UbusServer::Initialize(&mNcp, &mThreadMutex);
+    otbr::ubus::UbusServer::Initialize(&mHost, &mThreadMutex);
 
     if (otbr::ubus::sUbusEfd == -1)
     {

--- a/src/openwrt/ubus/otubus.hpp
+++ b/src/openwrt/ubus/otubus.hpp
@@ -46,7 +46,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 extern "C" {
 #include <libubox/blobmsg_json.h>
@@ -58,7 +58,7 @@ extern "C" {
 
 namespace otbr {
 namespace Ncp {
-class ControllerOpenThread;
+class RcpHost;
 }
 
 namespace ubus {
@@ -77,10 +77,10 @@ public:
     /**
      * Constructor
      *
-     * @param[in] aController  A pointer to OpenThread Controller structure.
+     * @param[in] aHost  A pointer to OpenThread Controller structure.
      * @param[in] aMutex       A pointer to mutex.
      */
-    static void Initialize(Ncp::ControllerOpenThread *aController, std::mutex *aMutex);
+    static void Initialize(Ncp::RcpHost *aHost, std::mutex *aMutex);
 
     /**
      * This method return the instance of the global UbusServer.
@@ -787,14 +787,14 @@ public:
     void HandleDiagnosticGetResponse(otError aError, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
 private:
-    bool                       mIfFinishScan;
-    struct ubus_context       *mContext;
-    const char                *mSockPath;
-    struct blob_buf            mBuf;
-    struct blob_buf            mNetworkdataBuf;
-    Ncp::ControllerOpenThread *mController;
-    std::mutex                *mNcpThreadMutex;
-    time_t                     mSecond;
+    bool                 mIfFinishScan;
+    struct ubus_context *mContext;
+    const char          *mSockPath;
+    struct blob_buf      mBuf;
+    struct blob_buf      mNetworkdataBuf;
+    Ncp::RcpHost        *mHost;
+    std::mutex          *mHostMutex;
+    time_t               mSecond;
     enum
     {
         kDefaultJoinerTimeout = 120,
@@ -803,10 +803,10 @@ private:
     /**
      * Constructor
      *
-     * @param[in] aController  The pointer to OpenThread Controller structure.
-     * @param[in] aMutex       A pointer to mutex.
+     * @param[in] aHost    The pointer to OpenThread Controller structure.
+     * @param[in] aMutex   A pointer to mutex.
      */
-    UbusServer(Ncp::ControllerOpenThread *aController, std::mutex *aMutex);
+    UbusServer(Ncp::RcpHost *aHost, std::mutex *aMutex);
 
     /**
      * This method start scan.
@@ -1149,11 +1149,11 @@ public:
     /**
      * The constructor to initialize the UBus agent.
      *
-     * @param[in] aNcp  A reference to the NCP controller.
+     * @param[in] aHost  A reference to the Thread controller.
      *
      */
-    UBusAgent(otbr::Ncp::ControllerOpenThread &aNcp)
-        : mNcp(aNcp)
+    UBusAgent(otbr::Ncp::RcpHost &aHost)
+        : mHost(aHost)
         , mThreadMutex()
     {
     }
@@ -1170,8 +1170,8 @@ public:
 private:
     static void UbusServerRun(void) { otbr::ubus::UbusServer::GetInstance().InstallUbusObject(); }
 
-    otbr::Ncp::ControllerOpenThread &mNcp;
-    std::mutex                       mThreadMutex;
+    otbr::Ncp::RcpHost &mHost;
+    std::mutex          mThreadMutex;
 };
 } // namespace ubus
 } // namespace otbr

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -121,9 +121,9 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     return httpStatus;
 }
 
-Resource::Resource(ControllerOpenThread *aNcp)
+Resource::Resource(RcpHost *aHost)
     : mInstance(nullptr)
-    , mNcp(aNcp)
+    , mHost(aHost)
 {
     // Resource Handler
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::Diagnostic);
@@ -146,7 +146,7 @@ Resource::Resource(ControllerOpenThread *aNcp)
 
 void Resource::Init(void)
 {
-    mInstance = mNcp->GetThreadHelper()->GetInstance();
+    mInstance = mHost->GetThreadHelper()->GetInstance();
 }
 
 void Resource::Handle(Request &aRequest, Response &aResponse) const
@@ -262,9 +262,9 @@ void Resource::DeleteNodeInfo(Response &aResponse) const
     otbrError   error = OTBR_ERROR_NONE;
     std::string errorCode;
 
-    VerifyOrExit(mNcp->GetThreadHelper()->Detach() == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
+    VerifyOrExit(mHost->GetThreadHelper()->Detach() == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
     VerifyOrExit(otInstanceErasePersistentInfo(mInstance) == OT_ERROR_NONE, error = OTBR_ERROR_REST);
-    mNcp->Reset();
+    mHost->Reset();
 
 exit:
     if (error == OTBR_ERROR_NONE)

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -42,7 +42,7 @@
 #include <openthread/border_router.h>
 
 #include "common/api_strings.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 #include "openthread/dataset.h"
 #include "openthread/dataset_ftd.h"
 #include "rest/json.hpp"
@@ -50,7 +50,7 @@
 #include "rest/response.hpp"
 #include "utils/thread_helper.hpp"
 
-using otbr::Ncp::ControllerOpenThread;
+using otbr::Ncp::RcpHost;
 using std::chrono::steady_clock;
 
 namespace otbr {
@@ -66,10 +66,10 @@ public:
     /**
      * The constructor initializes the resource handler instance.
      *
-     * @param[in] aNcp  A pointer to the NCP controller.
+     * @param[in] aHost  A pointer to the Thread controller.
      *
      */
-    Resource(ControllerOpenThread *aNcp);
+    Resource(RcpHost *aHost);
 
     /**
      * This method initialize the Resource handler.
@@ -160,8 +160,8 @@ private:
                                           void                *aContext);
     void        DiagnosticResponseHandler(otError aError, const otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
-    otInstance           *mInstance;
-    ControllerOpenThread *mNcp;
+    otInstance *mInstance;
+    RcpHost    *mHost;
 
     std::unordered_map<std::string, ResourceHandler>         mResourceMap;
     std::unordered_map<std::string, ResourceCallbackHandler> mResourceCallbackMap;

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -47,8 +47,8 @@ namespace rest {
 // Maximum number of connection a server support at the same time.
 static const uint32_t kMaxServeNum = 500;
 
-RestWebServer::RestWebServer(ControllerOpenThread &aNcp, const std::string &aRestListenAddress, int aRestListenPort)
-    : mResource(Resource(&aNcp))
+RestWebServer::RestWebServer(RcpHost &aHost, const std::string &aRestListenAddress, int aRestListenPort)
+    : mResource(Resource(&aHost))
     , mListenFd(-1)
 {
     mAddress.sin6_family = AF_INET6;

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -43,7 +43,7 @@
 #include "common/mainloop.hpp"
 #include "rest/connection.hpp"
 
-using otbr::Ncp::ControllerOpenThread;
+using otbr::Ncp::RcpHost;
 using std::chrono::steady_clock;
 
 namespace otbr {
@@ -59,10 +59,10 @@ public:
     /**
      * The constructor to initialize a REST server.
      *
-     * @param[in] aNcp  A reference to the NCP controller.
+     * @param[in] aHost  A reference to the Thread controller.
      *
      */
-    RestWebServer(ControllerOpenThread &aNcp, const std::string &aRestListenAddress, int aRestListenPort);
+    RestWebServer(RcpHost &aHost, const std::string &aRestListenAddress, int aRestListenPort);
 
     /**
      * The destructor destroys the server instance.

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -93,12 +93,12 @@ static otError OtbrErrorToOtError(otbrError aError)
     return error;
 }
 
-AdvertisingProxy::AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
-    : mNcp(aNcp)
+AdvertisingProxy::AdvertisingProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
+    : mHost(aHost)
     , mPublisher(aPublisher)
     , mIsEnabled(false)
 {
-    mNcp.RegisterResetHandler(
+    mHost.RegisterResetHandler(
         [this]() { otSrpServerSetServiceUpdateHandler(GetInstance(), AdvertisingHandler, this); });
 }
 

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -45,7 +45,7 @@
 
 #include "common/code_utils.hpp"
 #include "mdns/mdns.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 
@@ -59,11 +59,11 @@ public:
     /**
      * This constructor initializes the Advertising Proxy object.
      *
-     * @param[in] aNcp        A reference to the NCP controller.
+     * @param[in] aHost       A reference to the NCP controller.
      * @param[in] aPublisher  A reference to the mDNS publisher.
      *
      */
-    explicit AdvertisingProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    explicit AdvertisingProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
 
     /**
      * This method enables/disables the Advertising Proxy.
@@ -126,10 +126,10 @@ private:
      */
     otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);
 
-    otInstance *GetInstance(void) { return mNcp.GetInstance(); }
+    otInstance *GetInstance(void) { return mHost.GetInstance(); }
 
     // A reference to the NCP controller, has no ownership.
-    Ncp::ControllerOpenThread &mNcp;
+    Ncp::RcpHost &mHost;
 
     // A reference to the mDNS publisher, has no ownership.
     Mdns::Publisher &mPublisher;

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -48,7 +48,7 @@
 
 #include "common/dns_utils.hpp"
 #include "mdns/mdns.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace Dnssd {
@@ -63,11 +63,11 @@ public:
     /**
      * This constructor initializes the Discovery Proxy instance.
      *
-     * @param[in] aNcp        A reference to the OpenThread Controller instance.
+     * @param[in] aHost       A reference to the OpenThread Controller instance.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    explicit DiscoveryProxy(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    explicit DiscoveryProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
 
     /**
      * This method enables/disables the Discovery Proxy.
@@ -112,10 +112,10 @@ private:
     void Stop(void);
     bool IsEnabled(void) const { return mIsEnabled; }
 
-    Ncp::ControllerOpenThread &mNcp;
-    Mdns::Publisher           &mMdnsPublisher;
-    bool                       mIsEnabled;
-    uint64_t                   mSubscriberId = 0;
+    Ncp::RcpHost    &mHost;
+    Mdns::Publisher &mMdnsPublisher;
+    bool             mIsEnabled;
+    uint64_t         mSubscriberId = 0;
 };
 
 } // namespace Dnssd

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -81,9 +81,9 @@ namespace otbr {
 
 namespace TrelDnssd {
 
-TrelDnssd::TrelDnssd(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher)
+TrelDnssd::TrelDnssd(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
     : mPublisher(aPublisher)
-    , mNcp(aNcp)
+    , mHost(aHost)
 {
     sTrelDnssd = this;
 }
@@ -229,7 +229,7 @@ exit:
 
 std::string TrelDnssd::GetTrelInstanceName(void)
 {
-    const otExtAddress *extaddr = otLinkGetExtendedAddress(mNcp.GetInstance());
+    const otExtAddress *extaddr = otLinkGetExtendedAddress(mHost.GetInstance());
     std::string         name;
     char                nameBuf[sizeof(otExtAddress) * 2 + 1];
 
@@ -331,7 +331,7 @@ void TrelDnssd::OnTrelServiceInstanceAdded(const Mdns::Publisher::DiscoveredInst
 
         VerifyOrExit(peer.mValid, otbrLogWarning("Peer %s is invalid", aInstanceInfo.mName.c_str()));
 
-        otPlatTrelHandleDiscoveredPeerInfo(mNcp.GetInstance(), &peerInfo);
+        otPlatTrelHandleDiscoveredPeerInfo(mHost.GetInstance(), &peerInfo);
 
         mPeers.emplace(instanceName, peer);
         CheckPeersNumLimit();
@@ -392,7 +392,7 @@ void TrelDnssd::NotifyRemovePeer(const Peer &aPeer)
     peerInfo.mTxtLength = aPeer.mTxtData.size();
     peerInfo.mSockAddr  = aPeer.mSockAddr;
 
-    otPlatTrelHandleDiscoveredPeerInfo(mNcp.GetInstance(), &peerInfo);
+    otPlatTrelHandleDiscoveredPeerInfo(mHost.GetInstance(), &peerInfo);
 }
 
 void TrelDnssd::RemoveAllPeers(void)

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -45,7 +45,7 @@
 
 #include "common/types.hpp"
 #include "mdns/mdns.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 
@@ -66,11 +66,11 @@ public:
     /**
      * This constructor initializes the TrelDnssd instance.
      *
-     * @param[in] aNcp        A reference to the OpenThread Controller instance.
+     * @param[in] aHost       A reference to the OpenThread Controller instance.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    explicit TrelDnssd(Ncp::ControllerOpenThread &aNcp, Mdns::Publisher &aPublisher);
+    explicit TrelDnssd(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
 
     /**
      * This method initializes the TrelDnssd instance.
@@ -176,15 +176,15 @@ private:
     void     RemoveAllPeers(void);
     uint16_t CountDuplicatePeers(const Peer &aPeer);
 
-    Mdns::Publisher           &mPublisher;
-    Ncp::ControllerOpenThread &mNcp;
-    TaskRunner                 mTaskRunner;
-    std::string                mTrelNetif;
-    uint32_t                   mTrelNetifIndex = 0;
-    uint64_t                   mSubscriberId   = 0;
-    RegisterInfo               mRegisterInfo;
-    PeerMap                    mPeers;
-    bool                       mMdnsPublisherReady = false;
+    Mdns::Publisher &mPublisher;
+    Ncp::RcpHost    &mHost;
+    TaskRunner       mTaskRunner;
+    std::string      mTrelNetif;
+    uint32_t         mTrelNetifIndex = 0;
+    uint64_t         mSubscriberId   = 0;
+    RegisterInfo     mRegisterInfo;
+    PeerMap          mPeers;
+    bool             mMdnsPublisherReady = false;
 };
 
 /**

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -68,7 +68,7 @@
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/tlv.hpp"
-#include "ncp/ncp_openthread.hpp"
+#include "ncp/rcp_host.hpp"
 
 namespace otbr {
 namespace agent {
@@ -227,9 +227,9 @@ void CopyMdnsResponseCounters(const MdnsResponseCounters &from, threadnetwork::T
 #endif // OTBR_ENABLE_TELEMETRY_DATA_API
 } // namespace
 
-ThreadHelper::ThreadHelper(otInstance *aInstance, otbr::Ncp::ControllerOpenThread *aNcp)
+ThreadHelper::ThreadHelper(otInstance *aInstance, otbr::Ncp::RcpHost *aHost)
     : mInstance(aInstance)
-    , mNcp(aNcp)
+    , mHost(aHost)
 {
 #if OTBR_ENABLE_TELEMETRY_DATA_API && (OTBR_ENABLE_NAT64 || OTBR_ENABLE_DHCP6_PD)
     otError error;
@@ -855,7 +855,7 @@ otError ThreadHelper::PermitUnsecureJoin(uint16_t aPort, uint32_t aSeconds)
 
         ++mUnsecurePortRefCounter[aPort];
 
-        mNcp->PostTimerTask(delay, [this, aPort]() {
+        mHost->PostTimerTask(delay, [this, aPort]() {
             assert(mUnsecurePortRefCounter.find(aPort) != mUnsecurePortRefCounter.end());
             assert(mUnsecurePortRefCounter[aPort] > 0);
 

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -56,7 +56,7 @@
 
 namespace otbr {
 namespace Ncp {
-class ControllerOpenThread;
+class RcpHost;
 }
 } // namespace otbr
 
@@ -81,10 +81,10 @@ public:
      * The constructor of a Thread helper.
      *
      * @param[in] aInstance  The Thread instance.
-     * @param[in] aNcp       The ncp controller.
+     * @param[in] aHost      The Thread controller.
      *
      */
-    ThreadHelper(otInstance *aInstance, otbr::Ncp::ControllerOpenThread *aNcp);
+    ThreadHelper(otInstance *aInstance, otbr::Ncp::RcpHost *aHost);
 
     /**
      * This method adds a callback for device role change.
@@ -304,7 +304,7 @@ private:
 
     otInstance *mInstance;
 
-    otbr::Ncp::ControllerOpenThread *mNcp;
+    otbr::Ncp::RcpHost *mHost;
 
     ScanHandler                     mScanHandler;
     std::vector<otActiveScanResult> mScanResults;


### PR DESCRIPTION
This PR does a few renaming for `ControllerOpenThread`:
1. Rename file `ncp_openthread.*` to `rcp_host.*`
2. Rename all the member variable `mNcp` to `mHost` and all the
parameters `aNcp` to `aHost`.
3. Rename the class `ControllerOpenThread` to `RcpHost`.

Currently the `ControllerOpenThread` actually works under RCP mode.
So the name `Ncp` is very confusing. `RcpHost` is used
in this PR so that we can later add `NcpHost`.

This PR is a subset of PR #2283 and only does some renaming.