### PR TITLE
[controller] replace reference of controller with pointer

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -93,24 +93,23 @@ public:
      *
      * @param[in] aInterfaceName         Name of the Thread network interface.
      * @param[in] aBackboneInterfaceName Name of the backbone network interface.
-     * @param[in] aRadioUrls             The radio URLs (can be IEEE802.15.4 or TREL radio).
-     * @param[in] aEnableAutoAttach      Whether or not to automatically attach to the saved network.
      * @param[in] aRestListenAddress     Network address to listen on.
      * @param[in] aRestListenPort        Network port to listen on.
      *
      */
     explicit Application(const std::string               &aInterfaceName,
                          const std::vector<const char *> &aBackboneInterfaceNames,
-                         const std::vector<const char *> &aRadioUrls,
-                         bool                             aEnableAutoAttach,
                          const std::string               &aRestListenAddress,
                          int                              aRestListenPort);
 
     /**
      * This method initializes the Application instance.
      *
+     * @param[in] aRadioUrls             The radio URLs (can be IEEE802.15.4 or TREL radio).
+     * @param[in] aEnableAutoAttach      Whether or not to automatically attach to the saved network.
+     *
      */
-    void Init(void);
+    void Init(const std::vector<const char *> &aRadioUrls, bool aEnableAutoAttach);
 
     /**
      * This method de-initializes the Application instance.
@@ -126,13 +125,6 @@ public:
      *
      */
     otbrError Run(void);
-
-    /**
-     * Get the OpenThread controller object the application is using.
-     *
-     * @returns The OpenThread controller object.
-     */
-    Ncp::RcpHost &GetNcp(void) { return mHost; }
 
 #if OTBR_ENABLE_MDNS
     /**
@@ -260,8 +252,8 @@ private:
 #if __linux__
     otbr::Utils::InfraLinkSelector mInfraLinkSelector;
 #endif
-    const char  *mBackboneInterfaceName;
-    Ncp::RcpHost mHost;
+    const char   *mBackboneInterfaceName;
+    Ncp::RcpHost *mHost;
 #if OTBR_ENABLE_MDNS
     std::unique_ptr<Mdns::Publisher> mPublisher;
 #endif

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -301,11 +301,10 @@ static int realmain(int argc, char *argv[])
     }
 
     {
-        otbr::Application app(interfaceName, backboneInterfaceNames, radioUrls, enableAutoAttach, restListenAddress,
-                              restListenPort);
+        otbr::Application app(interfaceName, backboneInterfaceNames, restListenAddress, restListenPort);
 
         gApp = &app;
-        app.Init();
+        app.Init(radioUrls, enableAutoAttach);
 
         ret = app.Run();
 

--- a/src/backbone_router/backbone_agent.hpp
+++ b/src/backbone_router/backbone_agent.hpp
@@ -73,16 +73,22 @@ public:
     /**
      * This constructor intiializes the `BackboneAgent` instance.
      *
-     * @param[in] aHost  The Thread controller instance.
-     *
      */
-    BackboneAgent(otbr::Ncp::RcpHost &aHost, std::string aInterfaceName, std::string aBackboneInterfaceName);
+    BackboneAgent(std::string aInterfaceName, std::string aBackboneInterfaceName);
 
     /**
      * This method initializes the Backbone agent.
      *
+     * @param[in] aHost  A pointer to the Thread controller instance.
+     *
      */
-    void Init(void);
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Backbone agent.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
 private:
     void        OnBecomePrimary(void);
@@ -104,7 +110,7 @@ private:
 
     static const char *StateToString(otBackboneRouterState aState);
 
-    otbr::Ncp::RcpHost   &mHost;
+    otbr::Ncp::RcpHost   *mHost;
     otBackboneRouterState mBackboneRouterState;
     Ip6Prefix             mDomainPrefix;
 #if OTBR_ENABLE_DUA_ROUTING

--- a/src/backbone_router/nd_proxy.cpp
+++ b/src/backbone_router/nd_proxy.cpp
@@ -111,8 +111,10 @@ exit:
     otbrLogResult(error, "NdProxyManager: %s", __FUNCTION__);
 }
 
-void NdProxyManager::Init(void)
+void NdProxyManager::Init(Ncp::RcpHost *aHost)
 {
+    mHost = aHost;
+
     mBackboneIfIndex = if_nametoindex(mBackboneInterfaceName.c_str());
     VerifyOrDie(mBackboneIfIndex > 0, "if_nametoindex failed");
 }
@@ -311,7 +313,7 @@ void NdProxyManager::SendNeighborAdvertisement(const Ip6Address &aTarget, const 
     otbrError                  error = OTBR_ERROR_NONE;
     otBackboneRouterNdProxyInfo aNdProxyInfo;
 
-    VerifyOrExit(otBackboneRouterGetNdProxyInfo(mHost.GetInstance(), reinterpret_cast<const otIp6Address *>(&aTarget),
+    VerifyOrExit(otBackboneRouterGetNdProxyInfo(mHost->GetInstance(), reinterpret_cast<const otIp6Address *>(&aTarget),
                                                 &aNdProxyInfo) == OT_ERROR_NONE,
                  error = OTBR_ERROR_OPENTHREAD);
 

--- a/src/backbone_router/nd_proxy.hpp
+++ b/src/backbone_router/nd_proxy.hpp
@@ -80,8 +80,8 @@ public:
      * This constructor initializes a NdProxyManager instance.
      *
      */
-    explicit NdProxyManager(otbr::Ncp::RcpHost &aHost, std::string aBackboneInterfaceName)
-        : mHost(aHost)
+    explicit NdProxyManager(std::string aBackboneInterfaceName)
+        : mHost(nullptr)
         , mBackboneInterfaceName(std::move(aBackboneInterfaceName))
         , mIcmp6RawSock(-1)
         , mUnicastNsQueueSock(-1)
@@ -93,8 +93,16 @@ public:
     /**
      * This method initializes a ND Proxy manager instance.
      *
+     * @param[in] aHost  A pointer to the Thread controller instance.
+     *
      */
-    void Init(void);
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the ND Proxy manager instance.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     /**
      * This method enables the ND Proxy manager.
@@ -153,7 +161,7 @@ private:
                                     void                *aContext);
     int HandleNetfilterQueue(struct nfq_q_handle *aNfQueueHandler, struct nfgenmsg *aNfMsg, struct nfq_data *aNfData);
 
-    otbr::Ncp::RcpHost  &mHost;
+    otbr::Ncp::RcpHost  *mHost;
     std::string          mBackboneInterfaceName;
     std::set<Ip6Address> mNdProxySet;
     uint32_t             mBackboneIfIndex;

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -86,13 +86,26 @@ public:
     /**
      * The constructor to initialize the Thread border agent.
      *
-     * @param[in] aHost       A reference to the Thread controller.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    BorderAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    BorderAgent(Mdns::Publisher &aPublisher);
 
     ~BorderAgent(void) = default;
+
+    /**
+     * Initialize the Border Agent.
+     *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
+     */
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Thread border agent.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     /**
      * Overrides MeshCoP service (i.e. _meshcop._udp) instance name, product name, vendor name and vendor OUI.
@@ -153,7 +166,7 @@ private:
     void        PublishEpskcService(void);
     void        UnpublishEpskcService(void);
 
-    otbr::Ncp::RcpHost &mHost;
+    otbr::Ncp::RcpHost *mHost;
     Mdns::Publisher    &mPublisher;
     bool                mIsEnabled;
 

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -44,16 +44,18 @@ namespace DBus {
 const struct timeval           DBusAgent::kPollTimeout = {0, 0};
 constexpr std::chrono::seconds DBusAgent::kDBusWaitAllowance;
 
-DBusAgent::DBusAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
-    : mInterfaceName(aHost.GetInterfaceName())
-    , mHost(aHost)
+DBusAgent::DBusAgent(Mdns::Publisher &aPublisher)
+    : mHost(nullptr)
     , mPublisher(aPublisher)
 {
 }
 
-void DBusAgent::Init(void)
+void DBusAgent::Init(Ncp::RcpHost *aHost)
 {
     otbrError error = OTBR_ERROR_NONE;
+
+    mHost          = aHost;
+    mInterfaceName = mHost->GetInterfaceName();
 
     auto connection_deadline = Clock::now() + kDBusWaitAllowance;
 
@@ -66,7 +68,7 @@ void DBusAgent::Init(void)
     VerifyOrDie(mConnection != nullptr, "Failed to get DBus connection");
 
     mThreadObject =
-        std::unique_ptr<DBusThreadObject>(new DBusThreadObject(mConnection.get(), mInterfaceName, &mHost, &mPublisher));
+        std::unique_ptr<DBusThreadObject>(new DBusThreadObject(mConnection.get(), mInterfaceName, mHost, &mPublisher));
     error = mThreadObject->Init();
     VerifyOrDie(error == OTBR_ERROR_NONE, "Failed to initialize DBus Agent");
 }

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -59,16 +59,22 @@ public:
     /**
      * The constructor of dbus agent.
      *
-     * @param[in] aHost  A reference to the Thread controller.
-     *
      */
-    DBusAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    DBusAgent(Mdns::Publisher &aPublisher);
 
     /**
      * This method initializes the dbus agent.
      *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
      */
-    void Init(void);
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the dbus agent.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
@@ -88,7 +94,7 @@ private:
     std::string                       mInterfaceName;
     std::unique_ptr<DBusThreadObject> mThreadObject;
     UniqueDBusConnection              mConnection;
-    otbr::Ncp::RcpHost               &mHost;
+    otbr::Ncp::RcpHost               *mHost;
     Mdns::Publisher                  &mPublisher;
 
     /**

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -1805,11 +1805,13 @@ exit:
     return rval;
 }
 
-void UBusAgent::Init(void)
+void UBusAgent::Init(Ncp::RcpHost *aHost)
 {
+    mHost = aHost;
+
     otbr::ubus::sUbusEfd = eventfd(0, 0);
 
-    otbr::ubus::UbusServer::Initialize(&mHost, &mThreadMutex);
+    otbr::ubus::UbusServer::Initialize(mHost, &mThreadMutex);
 
     if (otbr::ubus::sUbusEfd == -1)
     {

--- a/src/openwrt/ubus/otubus.hpp
+++ b/src/openwrt/ubus/otubus.hpp
@@ -1149,11 +1149,9 @@ public:
     /**
      * The constructor to initialize the UBus agent.
      *
-     * @param[in] aHost  A reference to the Thread controller.
-     *
      */
-    UBusAgent(otbr::Ncp::RcpHost &aHost)
-        : mHost(aHost)
+    UBusAgent()
+        : mHost(nullptr)
         , mThreadMutex()
     {
     }
@@ -1161,8 +1159,10 @@ public:
     /**
      * This method initializes the UBus agent.
      *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
      */
-    void Init(void);
+    void Init(Ncp::RcpHost *aHost);
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
@@ -1170,7 +1170,7 @@ public:
 private:
     static void UbusServerRun(void) { otbr::ubus::UbusServer::GetInstance().InstallUbusObject(); }
 
-    otbr::Ncp::RcpHost &mHost;
+    otbr::Ncp::RcpHost *mHost;
     std::mutex          mThreadMutex;
 };
 } // namespace ubus

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -121,9 +121,9 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     return httpStatus;
 }
 
-Resource::Resource(RcpHost *aHost)
+Resource::Resource(void)
     : mInstance(nullptr)
-    , mHost(aHost)
+    , mHost(nullptr)
 {
     // Resource Handler
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::Diagnostic);
@@ -144,8 +144,10 @@ Resource::Resource(RcpHost *aHost)
     mResourceCallbackMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::HandleDiagnosticCallback);
 }
 
-void Resource::Init(void)
+void Resource::Init(RcpHost *aHost)
 {
+    mHost = aHost;
+
     mInstance = mHost->GetThreadHelper()->GetInstance();
 }
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -66,17 +66,22 @@ public:
     /**
      * The constructor initializes the resource handler instance.
      *
-     * @param[in] aHost  A pointer to the Thread controller.
-     *
      */
-    Resource(RcpHost *aHost);
+    Resource(void);
 
     /**
      * This method initialize the Resource handler.
      *
+     * @param[in] aHost  A pointer to the Thread controller.
      *
      */
-    void Init(void);
+    void Init(RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Resource handler.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     /**
      * This method is the main entry of resource handler, which find corresponding handler according to request url

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -47,8 +47,8 @@ namespace rest {
 // Maximum number of connection a server support at the same time.
 static const uint32_t kMaxServeNum = 500;
 
-RestWebServer::RestWebServer(RcpHost &aHost, const std::string &aRestListenAddress, int aRestListenPort)
-    : mResource(Resource(&aHost))
+RestWebServer::RestWebServer(const std::string &aRestListenAddress, int aRestListenPort)
+    : mResource()
     , mListenFd(-1)
 {
     mAddress.sin6_family = AF_INET6;
@@ -71,10 +71,15 @@ RestWebServer::~RestWebServer(void)
     }
 }
 
-void RestWebServer::Init(void)
+void RestWebServer::Init(RcpHost *aHost)
 {
-    mResource.Init();
+    mResource.Init(aHost);
     InitializeListenFd();
+}
+
+void RestWebServer::Deinit(void)
+{
+    mResource.Deinit();
 }
 
 void RestWebServer::Update(MainloopContext &aMainloop)

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -59,10 +59,8 @@ public:
     /**
      * The constructor to initialize a REST server.
      *
-     * @param[in] aHost  A reference to the Thread controller.
-     *
      */
-    RestWebServer(RcpHost &aHost, const std::string &aRestListenAddress, int aRestListenPort);
+    RestWebServer(const std::string &aRestListenAddress, int aRestListenPort);
 
     /**
      * The destructor destroys the server instance.
@@ -73,8 +71,16 @@ public:
     /**
      * This method initializes the REST server.
      *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
      */
-    void Init(void);
+    void Init(RcpHost *aHost);
+
+    /**
+     * This method de-initializes the REST server.
+     *
+     */
+    void Deinit(void);
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -93,12 +93,17 @@ static otError OtbrErrorToOtError(otbrError aError)
     return error;
 }
 
-AdvertisingProxy::AdvertisingProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
-    : mHost(aHost)
+AdvertisingProxy::AdvertisingProxy(Mdns::Publisher &aPublisher)
+    : mHost(nullptr)
     , mPublisher(aPublisher)
     , mIsEnabled(false)
 {
-    mHost.RegisterResetHandler(
+}
+
+void AdvertisingProxy::Init(Ncp::RcpHost *aHost)
+{
+    mHost = aHost;
+    mHost->RegisterResetHandler(
         [this]() { otSrpServerSetServiceUpdateHandler(GetInstance(), AdvertisingHandler, this); });
 }
 

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -59,11 +59,24 @@ public:
     /**
      * This constructor initializes the Advertising Proxy object.
      *
-     * @param[in] aHost       A reference to the NCP controller.
      * @param[in] aPublisher  A reference to the mDNS publisher.
      *
      */
-    explicit AdvertisingProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    explicit AdvertisingProxy(Mdns::Publisher &aPublisher);
+
+    /**
+     * Initialize the Border Agent.
+     *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
+     */
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Border Agent.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     /**
      * This method enables/disables the Advertising Proxy.
@@ -126,10 +139,10 @@ private:
      */
     otbrError PublishHostAndItsServices(const otSrpServerHost *aHost, OutstandingUpdate *aUpdate);
 
-    otInstance *GetInstance(void) { return mHost.GetInstance(); }
+    otInstance *GetInstance(void) { return mHost->GetInstance(); }
 
     // A reference to the NCP controller, has no ownership.
-    Ncp::RcpHost &mHost;
+    Ncp::RcpHost *mHost;
 
     // A reference to the mDNS publisher, has no ownership.
     Mdns::Publisher &mPublisher;

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -58,13 +58,18 @@ static inline bool DnsLabelsEqual(const std::string &aLabel1, const std::string 
     return StringUtils::EqualCaseInsensitive(aLabel1, aLabel2);
 }
 
-DiscoveryProxy::DiscoveryProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
-    : mHost(aHost)
+DiscoveryProxy::DiscoveryProxy(Mdns::Publisher &aPublisher)
+    : mHost(nullptr)
     , mMdnsPublisher(aPublisher)
     , mIsEnabled(false)
 {
-    mHost.RegisterResetHandler([this]() {
-        otDnssdQuerySetCallbacks(mHost.GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
+}
+
+void DiscoveryProxy::Init(Ncp::RcpHost *aHost)
+{
+    mHost = aHost;
+    mHost->RegisterResetHandler([this]() {
+        otDnssdQuerySetCallbacks(mHost->GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
                                  &DiscoveryProxy::OnDiscoveryProxyUnsubscribe, this);
     });
 }
@@ -89,7 +94,7 @@ void DiscoveryProxy::Start(void)
 {
     assert(mSubscriberId == 0);
 
-    otDnssdQuerySetCallbacks(mHost.GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
+    otDnssdQuerySetCallbacks(mHost->GetInstance(), &DiscoveryProxy::OnDiscoveryProxySubscribe,
                              &DiscoveryProxy::OnDiscoveryProxyUnsubscribe, this);
 
     mSubscriberId = mMdnsPublisher.AddSubscriptionCallbacks(
@@ -109,7 +114,7 @@ void DiscoveryProxy::Start(void)
 
 void DiscoveryProxy::Stop(void)
 {
-    otDnssdQuerySetCallbacks(mHost.GetInstance(), nullptr, nullptr, nullptr);
+    otDnssdQuerySetCallbacks(mHost->GetInstance(), nullptr, nullptr, nullptr);
 
     if (mSubscriberId > 0)
     {
@@ -200,7 +205,7 @@ void DiscoveryProxy::OnServiceDiscovered(const std::string                      
     instanceInfo.mTxtData   = aInstanceInfo.mTxtData.data();
     instanceInfo.mTtl       = CapTtl(aInstanceInfo.mTtl);
 
-    while ((query = otDnssdGetNextQuery(mHost.GetInstance(), query)) != nullptr)
+    while ((query = otDnssdGetNextQuery(mHost->GetInstance(), query)) != nullptr)
     {
         std::string      instanceName;
         std::string      serviceName;
@@ -238,7 +243,7 @@ void DiscoveryProxy::OnServiceDiscovered(const std::string                      
             instanceInfo.mFullName = instanceFullName.c_str();
             instanceInfo.mHostName = translatedHostName.c_str();
 
-            otDnssdQueryHandleDiscoveredServiceInstance(mHost.GetInstance(), serviceFullName.c_str(), &instanceInfo);
+            otDnssdQueryHandleDiscoveredServiceInstance(mHost->GetInstance(), serviceFullName.c_str(), &instanceInfo);
         }
     }
 }
@@ -270,7 +275,7 @@ void DiscoveryProxy::OnHostDiscovered(const std::string                         
 
     hostInfo.mTtl = CapTtl(aHostInfo.mTtl);
 
-    while ((query = otDnssdGetNextQuery(mHost.GetInstance(), query)) != nullptr)
+    while ((query = otDnssdGetNextQuery(mHost->GetInstance(), query)) != nullptr)
     {
         std::string      hostName, domain;
         char             queryName[OT_DNS_MAX_NAME_SIZE];
@@ -295,7 +300,7 @@ void DiscoveryProxy::OnHostDiscovered(const std::string                         
         {
             std::string hostFullName = TranslateDomain(resolvedHostName, domain);
 
-            otDnssdQueryHandleDiscoveredHost(mHost.GetInstance(), hostFullName.c_str(), &hostInfo);
+            otDnssdQueryHandleDiscoveredHost(mHost->GetInstance(), hostFullName.c_str(), &hostInfo);
         }
     }
 }
@@ -321,7 +326,7 @@ int DiscoveryProxy::GetServiceSubscriptionCount(const DnsNameInfo &aNameInfo) co
     const otDnssdQuery *query = nullptr;
     int                 count = 0;
 
-    while ((query = otDnssdGetNextQuery(mHost.GetInstance(), query)) != nullptr)
+    while ((query = otDnssdGetNextQuery(mHost->GetInstance(), query)) != nullptr)
     {
         char        queryName[OT_DNS_MAX_NAME_SIZE];
         DnsNameInfo queryInfo;

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -63,11 +63,24 @@ public:
     /**
      * This constructor initializes the Discovery Proxy instance.
      *
-     * @param[in] aHost       A reference to the OpenThread Controller instance.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    explicit DiscoveryProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    explicit DiscoveryProxy(Mdns::Publisher &aPublisher);
+
+    /**
+     * Initialize the Border Agent.
+     *
+     * @param[in] aHost  A pointer to the Thread controller.
+     *
+     */
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Discovery Proxy.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
 
     /**
      * This method enables/disables the Discovery Proxy.
@@ -112,7 +125,7 @@ private:
     void Stop(void);
     bool IsEnabled(void) const { return mIsEnabled; }
 
-    Ncp::RcpHost    &mHost;
+    Ncp::RcpHost    *mHost;
     Mdns::Publisher &mMdnsPublisher;
     bool             mIsEnabled;
     uint64_t         mSubscriberId = 0;

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -66,19 +66,33 @@ public:
     /**
      * This constructor initializes the TrelDnssd instance.
      *
-     * @param[in] aHost       A reference to the OpenThread Controller instance.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      *
      */
-    explicit TrelDnssd(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    explicit TrelDnssd(Mdns::Publisher &aPublisher);
 
     /**
-     * This method initializes the TrelDnssd instance.
+     * This method Initializes the Trel Dnssd by setting the Thread Controller
+     * instance.
+     *
+     * @param[in] aHost  A pointer to the Thread Controller
+     *
+     */
+    void Init(Ncp::RcpHost *aHost);
+
+    /**
+     * This method de-initializes the Trel Dnssd.
+     *
+     */
+    void Deinit(void) { mHost = nullptr; }
+
+    /**
+     * This method initializes the Netif of the TrelDnssd instance.
      *
      * @param[in] aTrelNetif  The network interface for discovering TREL peers.
      *
      */
-    void Initialize(std::string aTrelNetif);
+    void InitializeNetif(std::string aTrelNetif);
 
     /**
      * This method starts browsing for TREL peers.
@@ -177,7 +191,7 @@ private:
     uint16_t CountDuplicatePeers(const Peer &aPeer);
 
     Mdns::Publisher &mPublisher;
-    Ncp::RcpHost    &mHost;
+    Ncp::RcpHost    *mHost;
     TaskRunner       mTaskRunner;
     std::string      mTrelNetif;
     uint32_t         mTrelNetifIndex = 0;


### PR DESCRIPTION
This PR changes the reference of `Ncp::HostRcp` inside all modules
to a pointer to `Ncp::HostRcp`. Instead of passing the reference of
`Ncp::HostRcp` to all modules in their contructors, this PR changes
it as passing a pointer in the `Init` of these modules.

This PR is also a subset of #2283. This change is required because:
Currently there is an instance of `Ncp::HostRcp` as a member of the
main class `Application`. Most modules inside `Application` have a
reference to the instance and the reference is passed to these modules
in their constructor (in `Application`'s initialization list).
However, in the NCP case, `Ncp::HostRcp` shouldn't be contructed at
all. So updating the reference to pointer allows `Application` to not
initialize these modules in NCP case and initialize a different `Host`.