### PR TITLE
[controller] allows polymorphism of the controller

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -33,6 +33,10 @@ add_executable(otbr-agent
     vendor.hpp
 )
 
+target_link_libraries(openthread-radio-spinel INTERFACE
+    openthread-spinel-rcp
+)
+
 target_link_libraries(otbr-agent PRIVATE
     $<$<BOOL:${OTBR_BORDER_AGENT}>:otbr-border-agent>
     $<$<BOOL:${OTBR_BACKBONE_ROUTER}>:otbr-backbone-router>

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -60,6 +60,11 @@ Application::Application(const std::string               &aInterfaceName,
 #else
     , mBackboneInterfaceName(aBackboneInterfaceNames.empty() ? "" : aBackboneInterfaceNames.front())
 #endif
+    , mHost(Ncp::ThreadController::Create(mInterfaceName.c_str(),
+                                          aRadioUrls,
+                                          mBackboneInterfaceName,
+                                          /* aDryRun */ false,
+                                          aEnableAutoAttach))
 #if OTBR_ENABLE_MDNS
     , mPublisher(Mdns::Publisher::Create([this](Mdns::Publisher::State aState) { this->HandleMdnsState(aState); }))
 #endif
@@ -67,91 +72,28 @@ Application::Application(const std::string               &aInterfaceName,
     , mVendorServer(vendor::VendorServer::newInstance(*this))
 #endif
 {
-    mHost = MakeUnique<Ncp::RcpHost>(mInterfaceName.c_str(), aRadioUrls, mBackboneInterfaceName,
-                                     /* aDryRun */ false, aEnableAutoAttach);
-
-#if OTBR_ENABLE_BORDER_AGENT
-    mBorderAgent = MakeUnique<BorderAgent>(*mHost, *mPublisher);
-#endif
-#if OTBR_ENABLE_BACKBONE_ROUTER
-    mBackboneAgent = MakeUnique<BackboneRouter::BackboneAgent>(*mHost, aInterfaceName, mBackboneInterfaceName);
-#endif
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    mAdvertisingProxy = MakeUnique<AdvertisingProxy>(*mHost, *mPublisher);
-#endif
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    mDiscoveryProxy = MakeUnique<Dnssd::DiscoveryProxy>(*mHost, *mPublisher);
-#endif
-#if OTBR_ENABLE_TREL
-    mTrelDnssd = MakeUnique<TrelDnssd::TrelDnssd>(*mHost, *mPublisher);
-#endif
-#if OTBR_ENABLE_OPENWRT
-    mUbusAgent = MakeUnique<ubus::UBusAgent>(*mHost);
-#endif
-#if OTBR_ENABLE_REST_SERVER
-    mRestWebServer = MakeUnique<rest::RestWebServer>(*mHost, aRestListenAddress, aRestListenPort);
-#endif
-#if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
-    mDBusAgent = MakeUnique<DBus::DBusAgent>(*mHost, *mPublisher);
-#endif
-
-    OT_UNUSED_VARIABLE(aRestListenAddress);
-    OT_UNUSED_VARIABLE(aRestListenPort);
+    if (mHost->GetCoprocessorType() == OT_COPROCESSOR_RCP)
+    {
+        CreateRcpMode(aRestListenAddress, aRestListenPort);
+    }
 }
 
 void Application::Init(void)
 {
     mHost->Init();
 
-#if OTBR_ENABLE_MDNS
-    mPublisher->Start();
-#endif
-#if OTBR_ENABLE_BORDER_AGENT
-// This is for delaying publishing the MeshCoP service until the correct
-// vendor name and OUI etc. are correctly set by BorderAgent::SetMeshCopServiceValues()
-#if OTBR_STOP_BORDER_AGENT_ON_INIT
-    mBorderAgent->SetEnabled(false);
-#else
-    mBorderAgent->SetEnabled(true);
-#endif
-#endif
-#if OTBR_ENABLE_BACKBONE_ROUTER
-    mBackboneAgent->Init();
-#endif
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    mAdvertisingProxy->SetEnabled(true);
-#endif
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    mDiscoveryProxy->SetEnabled(true);
-#endif
-#if OTBR_ENABLE_OPENWRT
-    mUbusAgent->Init();
-#endif
-#if OTBR_ENABLE_REST_SERVER
-    mRestWebServer->Init();
-#endif
-#if OTBR_ENABLE_DBUS_SERVER
-    mDBusAgent->Init();
-#endif
-#if OTBR_ENABLE_VENDOR_SERVER
-    mVendorServer->Init();
-#endif
+    if (mHost->GetCoprocessorType() == OT_COPROCESSOR_RCP)
+    {
+        InitRcpMode();
+    }
 }
 
 void Application::Deinit(void)
 {
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    mAdvertisingProxy->SetEnabled(false);
-#endif
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    mDiscoveryProxy->SetEnabled(false);
-#endif
-#if OTBR_ENABLE_BORDER_AGENT
-    mBorderAgent->SetEnabled(false);
-#endif
-#if OTBR_ENABLE_MDNS
-    mPublisher->Stop();
-#endif
+    if (mHost->GetCoprocessorType() == OT_COPROCESSOR_RCP)
+    {
+        DeinitRcpMode();
+    }
 
     mHost->Deinit();
 }
@@ -253,6 +195,91 @@ void Application::HandleSignal(int aSignal)
 {
     sShouldTerminate = true;
     signal(aSignal, SIG_DFL);
+}
+
+void Application::CreateRcpMode(const std::string &aRestListenAddress, int aRestListenPort)
+{
+    otbr::Ncp::RcpHost &rcpHost = static_cast<otbr::Ncp::RcpHost &>(*mHost);
+#if OTBR_ENABLE_BORDER_AGENT
+    mBorderAgent = MakeUnique<BorderAgent>(rcpHost, *mPublisher);
+#endif
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    mBackboneAgent = MakeUnique<BackboneRouter::BackboneAgent>(rcpHost, mInterfaceName, mBackboneInterfaceName);
+#endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mAdvertisingProxy = MakeUnique<AdvertisingProxy>(rcpHost, *mPublisher);
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mDiscoveryProxy = MakeUnique<Dnssd::DiscoveryProxy>(rcpHost, *mPublisher);
+#endif
+#if OTBR_ENABLE_TREL
+    mTrelDnssd = MakeUnique<TrelDnssd::TrelDnssd>(rcpHost, *mPublisher);
+#endif
+#if OTBR_ENABLE_OPENWRT
+    mUbusAgent = MakeUnique<ubus::UBusAgent>(rcpHost);
+#endif
+#if OTBR_ENABLE_REST_SERVER
+    mRestWebServer = MakeUnique<rest::RestWebServer>(rcpHost, aRestListenAddress, aRestListenPort);
+#endif
+#if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
+    mDBusAgent = MakeUnique<DBus::DBusAgent>(rcpHost, *mPublisher);
+#endif
+
+    OT_UNUSED_VARIABLE(aRestListenAddress);
+    OT_UNUSED_VARIABLE(aRestListenPort);
+}
+
+void Application::InitRcpMode(void)
+{
+#if OTBR_ENABLE_MDNS
+    mPublisher->Start();
+#endif
+#if OTBR_ENABLE_BORDER_AGENT
+// This is for delaying publishing the MeshCoP service until the correct
+// vendor name and OUI etc. are correctly set by BorderAgent::SetMeshCopServiceValues()
+#if OTBR_STOP_BORDER_AGENT_ON_INIT
+    mBorderAgent->SetEnabled(false);
+#else
+    mBorderAgent->SetEnabled(true);
+#endif
+#endif
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    mBackboneAgent->Init();
+#endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mAdvertisingProxy->SetEnabled(true);
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mDiscoveryProxy->SetEnabled(true);
+#endif
+#if OTBR_ENABLE_OPENWRT
+    mUbusAgent->Init();
+#endif
+#if OTBR_ENABLE_REST_SERVER
+    mRestWebServer->Init();
+#endif
+#if OTBR_ENABLE_DBUS_SERVER
+    mDBusAgent->Init();
+#endif
+#if OTBR_ENABLE_VENDOR_SERVER
+    mVendorServer->Init();
+#endif
+}
+
+void Application::DeinitRcpMode(void)
+{
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mAdvertisingProxy->SetEnabled(false);
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mDiscoveryProxy->SetEnabled(false);
+#endif
+#if OTBR_ENABLE_BORDER_AGENT
+    mBorderAgent->SetEnabled(false);
+#endif
+#if OTBR_ENABLE_MDNS
+    mPublisher->Stop();
+#endif
 }
 
 } // namespace otbr

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -132,7 +132,7 @@ public:
      *
      * @returns The OpenThread controller object.
      */
-    Ncp::RcpHost &GetNcp(void) { return *mHost; }
+    Ncp::ThreadController &GetHost(void) { return *mHost; }
 
 #if OTBR_ENABLE_MDNS
     /**
@@ -256,12 +256,16 @@ private:
 
     static void HandleSignal(int aSignal);
 
+    void CreateRcpMode(const std::string &aRestListenAddress, int aRestListenPort);
+    void InitRcpMode(void);
+    void DeinitRcpMode(void);
+
     std::string mInterfaceName;
 #if __linux__
     otbr::Utils::InfraLinkSelector mInfraLinkSelector;
 #endif
-    const char                   *mBackboneInterfaceName;
-    std::unique_ptr<Ncp::RcpHost> mHost;
+    const char                            *mBackboneInterfaceName;
+    std::unique_ptr<Ncp::ThreadController> mHost;
 #if OTBR_ENABLE_MDNS
     std::unique_ptr<Mdns::Publisher> mPublisher;
 #endif

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -56,7 +56,7 @@
 #include "common/logging.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
-#include "ncp/rcp_host.hpp"
+#include "ncp/thread_controller.hpp"
 
 static const char kDefaultInterfaceName[] = "wpan0";
 
@@ -176,18 +176,19 @@ static otbrLogLevel GetDefaultLogLevel(void)
 
 static void PrintRadioVersionAndExit(const std::vector<const char *> &aRadioUrls)
 {
-    otbr::Ncp::RcpHost rcpHost{/* aInterfaceName */ "", aRadioUrls,
-                               /* aBackboneInterfaceName */ "",
-                               /* aDryRun */ true, /* aEnableAutoAttach */ false};
-    const char        *radioVersion;
+    auto host = std::unique_ptr<otbr::Ncp::ThreadController>(
+        otbr::Ncp::ThreadController::Create(/* aInterfaceName */ "", aRadioUrls,
+                                            /* aBackboneInterfaceName */ "",
+                                            /* aDryRun */ true, /* aEnableAutoAttach */ false));
+    const char *coprocessorVersion;
 
-    rcpHost.Init();
+    host->Init();
 
-    radioVersion = otPlatRadioGetVersionString(rcpHost.GetInstance());
-    otbrLogNotice("Radio version: %s", radioVersion);
-    printf("%s\n", radioVersion);
+    coprocessorVersion = host->GetCoprocessorVersion();
+    otbrLogNotice("Co-processor version: %s", coprocessorVersion);
+    printf("%s\n", coprocessorVersion);
 
-    rcpHost.Deinit();
+    host->Deinit();
 
     exit(EXIT_SUCCESS);
 }

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -143,6 +143,19 @@
     } while (false)
 
 /**
+ * This macro prints the message and terminates the program.
+ *
+ * @param[in] aMessage    A message (text string) to print.
+ *
+ */
+#define DieNow(aMessage)                                                 \
+    do                                                                   \
+    {                                                                    \
+        otbrLogEmerg("FAILED %s:%d - %s", __FILE__, __LINE__, aMessage); \
+        exit(-1);                                                        \
+    } while (false)
+
+/**
  *  This unconditionally executes @a ... and branches to the local
  *  label 'exit'.
  *

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -29,6 +29,8 @@
 add_library(otbr-ncp
     rcp_host.cpp
     rcp_host.hpp
+    thread_controller.cpp
+    thread_controller.hpp
 )
 
 target_link_libraries(otbr-ncp PRIVATE

--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -164,36 +164,6 @@ otbrLogLevel ConvertProtoToOtbrLogLevel(ProtoLogLevel aProtoLogLevel)
 }
 #endif
 
-otLogLevel RcpHost::ConvertToOtLogLevel(otbrLogLevel aLevel)
-{
-    otLogLevel level;
-
-    switch (aLevel)
-    {
-    case OTBR_LOG_EMERG:
-    case OTBR_LOG_ALERT:
-    case OTBR_LOG_CRIT:
-        level = OT_LOG_LEVEL_CRIT;
-        break;
-    case OTBR_LOG_ERR:
-    case OTBR_LOG_WARNING:
-        level = OT_LOG_LEVEL_WARN;
-        break;
-    case OTBR_LOG_NOTICE:
-        level = OT_LOG_LEVEL_NOTE;
-        break;
-    case OTBR_LOG_INFO:
-        level = OT_LOG_LEVEL_INFO;
-        break;
-    case OTBR_LOG_DEBUG:
-    default:
-        level = OT_LOG_LEVEL_DEBG;
-        break;
-    }
-
-    return level;
-}
-
 otError RcpHost::SetOtbrAndOtLogLevel(otbrLogLevel aLevel)
 {
     otError error = OT_ERROR_NONE;

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -86,16 +86,16 @@ public:
             bool                             aEnableAutoAttach);
 
     /**
-     * This method initialize the NCP controller.
+     * This method initialize the Thread controller.
      *
      */
-    void Init(void);
+    void Init(void) override;
 
     /**
-     * This method deinitialize the NCP controller.
+     * This method deinitialize the Thread controller.
      *
      */
-    void Deinit(void);
+    void Deinit(void) override;
 
     /**
      * Returns an OpenThread instance.
@@ -194,8 +194,18 @@ public:
 
     ~RcpHost(void) override;
 
-    // Thread Control APIs
+    // Thread Control virtual methods
     void GetDeviceRole(const DeviceRoleHandler aHandler) override;
+
+    CoprocessorType GetCoprocessorType(void) override
+    {
+        return OT_COPROCESSOR_RCP;
+    }
+
+    const char *GetCoprocessorVersion(void) override
+    {
+        return otPlatRadioGetVersionString(mInstance);
+    }
 
 private:
     static void HandleStateChanged(otChangedFlags aFlags, void *aContext)
@@ -219,8 +229,6 @@ private:
 
     bool IsAutoAttachEnabled(void);
     void DisableAutoAttach(void);
-
-    static otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel);
 
     otError SetOtbrAndOtLogLevel(otbrLogLevel aLevel);
 

--- a/src/ncp/thread_controller.cpp
+++ b/src/ncp/thread_controller.cpp
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "CTRLR"
+
+#include "thread_controller.hpp"
+
+#include <openthread/logging.h>
+#include <openthread/openthread-system.h>
+
+#include "lib/spinel/coprocessor_type.h"
+
+#include "rcp_host.hpp"
+
+namespace otbr {
+namespace Ncp {
+
+std::unique_ptr<ThreadController> ThreadController::Create(const char                      *aInterfaceName,
+                                                           const std::vector<const char *> &aRadioUrls,
+                                                           const char                      *aBackboneInterfaceName,
+                                                           bool                             aDryRun,
+                                                           bool                             aEnableAutoAttach)
+{
+    CoprocessorType                   coprocessorType;
+    otPlatformCoprocessorUrls         urls;
+    std::unique_ptr<ThreadController> host;
+    otLogLevel                        level = ConvertToOtLogLevel(otbrLogGetLevel());
+
+    VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
+
+    urls.mNum = 0;
+    for (const char *url : aRadioUrls)
+    {
+        urls.mUrls[urls.mNum++] = url;
+    }
+
+    VerifyOrDie(otLoggingSetLevel(level) == OT_ERROR_NONE, "Failed to set OT log Level!");
+
+    coprocessorType = otSysInitCoprocessor(&urls);
+
+    if (coprocessorType == OT_COPROCESSOR_RCP)
+    {
+        host = MakeUnique<RcpHost>(aInterfaceName, aRadioUrls, aBackboneInterfaceName, aDryRun, aEnableAutoAttach);
+    }
+    else
+    {
+        // TODO: add NCP type
+        DieNow("Unknown coprocessor type!");
+    }
+
+    return host;
+}
+
+otLogLevel ThreadController::ConvertToOtLogLevel(otbrLogLevel aLevel)
+{
+    otLogLevel level;
+
+    switch (aLevel)
+    {
+    case OTBR_LOG_EMERG:
+    case OTBR_LOG_ALERT:
+    case OTBR_LOG_CRIT:
+        level = OT_LOG_LEVEL_CRIT;
+        break;
+    case OTBR_LOG_ERR:
+    case OTBR_LOG_WARNING:
+        level = OT_LOG_LEVEL_WARN;
+        break;
+    case OTBR_LOG_NOTICE:
+        level = OT_LOG_LEVEL_NOTE;
+        break;
+    case OTBR_LOG_INFO:
+        level = OT_LOG_LEVEL_INFO;
+        break;
+    case OTBR_LOG_DEBUG:
+    default:
+        level = OT_LOG_LEVEL_DEBG;
+        break;
+    }
+
+    return level;
+}
+
+} // namespace Ncp
+} // namespace otbr

--- a/src/ncp/thread_controller.hpp
+++ b/src/ncp/thread_controller.hpp
@@ -35,6 +35,7 @@
 #define OTBR_AGENT_THREAD_CONTROLLER_HPP_
 
 #include <functional>
+#include <memory>
 
 #include <openthread/error.h>
 #include <openthread/thread.h>
@@ -59,12 +60,65 @@ public:
     using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
 
     /**
+     * Create a Thread Controller Instance.
+     *
+     * This is a factory method that will decide which implementation class will be created.
+     *
+     * @param[in]   aInterfaceName          A string of the Thread interface name.
+     * @param[in]   aRadioUrls              The radio URLs (can be IEEE802.15.4 or TREL radio).
+     * @param[in]   aBackboneInterfaceName  The Backbone network interface name.
+     * @param[in]   aDryRun                 TRUE to indicate dry-run mode. FALSE otherwise.
+     * @param[in]   aEnableAutoAttach       Whether or not to automatically attach to the saved network.
+     *
+     * @returns Non-null OpenThread Controller instance.
+     *
+     */
+    static std::unique_ptr<ThreadController> Create(const char                      *aInterfaceName,
+                                                    const std::vector<const char *> &aRadioUrls,
+                                                    const char                      *aBackboneInterfaceName,
+                                                    bool                             aDryRun,
+                                                    bool                             aEnableAutoAttach);
+
+    /**
      * This method gets the device role and returns the role through the handler.
      *
      * @param[in] aHandler  A handler to return the role.
      *
      */
     virtual void GetDeviceRole(DeviceRoleHandler aHandler) = 0;
+
+    /**
+     * Returns the co-processor type.
+     *
+     */
+    virtual CoprocessorType GetCoprocessorType(void) = 0;
+
+    /**
+     * Returns the co-processor version string.
+     *
+     */
+    virtual const char *GetCoprocessorVersion(void) = 0;
+
+    /**
+     * Initializes the Thread controller.
+     *
+     */
+    virtual void Init(void) = 0;
+
+    /**
+     * Deinitializes the Thread controller.
+     *
+     */
+    virtual void Deinit(void) = 0;
+
+    /**
+     * The destructor.
+     *
+     */
+    virtual ~ThreadController(void) = default;
+
+protected:
+    static otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel);
 };
 
 } // namespace Ncp


### PR DESCRIPTION
This PR is also a breakdown of #2283 

This PR adds a factory method `CreateInstance` to provide polymorphism
for the `ThreadController`. This PR moves the construction and initialization
of the components to RCP specific methods and only contructs these
modules when the Co-processor is an RCP.

