### PR TITLE
[telemetry] fix and refactor the PD processing

### DIFF
--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -302,9 +302,16 @@ private:
 
     void ActiveDatasetChangedCallback(void);
 
-#if OTBR_ENABLE_TELEMETRY_DATA_API && OTBR_ENABLE_BORDER_ROUTING
-    void RetrieveExternalRouteInfo(threadnetwork::TelemetryData_ExternalRoutes *aExternalRouteInfo);
+#if OTBR_ENABLE_TELEMETRY_DATA_API
+#if OTBR_ENABLE_BORDER_ROUTING
+    void RetrieveExternalRouteInfo(threadnetwork::TelemetryData::ExternalRoutes *aExternalRouteInfo);
 #endif
+#if OTBR_ENABLE_DHCP6_PD
+    void RetrievePdInfo(threadnetwork::TelemetryData::WpanBorderRouter *aWpanBorderRouter);
+    void RetrieveHashedPdPrefix(std::string *aHashedPdPrefix);
+    void RetrievePdProcessedRaInfo(threadnetwork::TelemetryData::PdProcessedRaInfo *aPdProcessedRaInfo);
+#endif
+#endif // OTBR_ENABLE_TELEMETRY_DATA_API
 
     otInstance *mInstance;
 

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -323,7 +323,12 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
                 threadnetwork::TelemetryData::NAT64_STATE_NOT_RUNNING);
 #endif
 #if OTBR_ENABLE_DHCP6_PD
-    TEST_ASSERT(!telemetryData.wpan_border_router().hashed_pd_prefix().empty());
+    TEST_ASSERT(telemetryData.wpan_border_router().dhcp6_pd_state() ==
+                threadnetwork::TelemetryData::DHCP6_PD_STATE_DISABLED);
+    TEST_ASSERT(telemetryData.wpan_border_router().hashed_pd_prefix().empty());
+    TEST_ASSERT(telemetryData.wpan_border_router().pd_processed_ra_info().num_platform_ra_received() == 0);
+    TEST_ASSERT(telemetryData.wpan_border_router().pd_processed_ra_info().num_platform_pio_processed() == 0);
+    TEST_ASSERT(telemetryData.wpan_border_router().pd_processed_ra_info().last_platform_ra_msec() == 0);
 #endif
     TEST_ASSERT(telemetryData.wpan_rcp().rcp_interface_statistics().transferred_frames_count() > 0);
     TEST_ASSERT(telemetryData.coex_metrics().count_tx_request() > 0);


### PR DESCRIPTION
This PR refactors the telemetry code processing PD info to achieve two goals:
- Handle the error when calling OT API. Previously the issue was ignored which may cause uploading wrong data.
- Introduce helper methods for processing PD info.
- Fix the D-BUS unit test and check more fields.