### PR TITLE
[tests] fix the telemetry test for verifying the RLOC16

### DIFF
--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -285,12 +285,12 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_stats().phy_tx() > 0);
     TEST_ASSERT(telemetryData.wpan_stats().phy_rx() > 0);
     TEST_ASSERT(telemetryData.wpan_stats().ip_tx_success() > 0);
-    TEST_ASSERT(telemetryData.wpan_topo_full().rloc16() > 0);
+    TEST_ASSERT(telemetryData.wpan_topo_full().rloc16() < 0xffff);
     TEST_ASSERT(telemetryData.wpan_topo_full().network_data().size() > 0);
     TEST_ASSERT(telemetryData.wpan_topo_full().partition_id() > 0);
     TEST_ASSERT(telemetryData.wpan_topo_full().extended_pan_id() > 0);
     TEST_ASSERT(telemetryData.topo_entries_size() == 1);
-    TEST_ASSERT(telemetryData.topo_entries(0).rloc16() > 0);
+    TEST_ASSERT(telemetryData.topo_entries(0).rloc16() < 0xffff);
     TEST_ASSERT(telemetryData.wpan_border_router().border_routing_counters().rs_tx_failure() == 0);
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     TEST_ASSERT(telemetryData.wpan_border_router().srp_server().state() ==


### PR DESCRIPTION
Router ID is in range [0, MAX_ROUTER_ID] therefore zero is a valid RLOC16. The test case was wrongly checking if the RLOC16 is greater than zero.

An example failure: https://github.com/openthread/ot-br-posix/actions/runs/9361612569/job/25768930225?pr=2312.