### PR TITLE
[controller] update the usage of otPlatformConfig

### DIFF
--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -84,7 +84,7 @@ RcpHost::RcpHost(const char                      *aInterfaceName,
 
     for (const char *url : aRadioUrls)
     {
-        mConfig.mRadioUrls[mConfig.mRadioUrlNum++] = url;
+        mConfig.mCoprocessorUrls.mUrls[mConfig.mCoprocessorUrls.mNum++] = url;
     }
     mConfig.mSpeedUpFactor = 1;
 }


### PR DESCRIPTION
This PR updates the usage of `otPlatformConfig` as the definition is changed in openthread/openthread#10344.

This PR also bumps [third_party/openthread/repo](https://github.com/openthread/openthread) from d6eb56c to cdeb02b 