### PR TITLE
[docker] add ability to set debug-level

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -58,6 +58,11 @@ function parse_args()
                 shift
                 shift
                 ;;
+            --debug-level)
+                DEBUG_LEVEL=$2
+                shift
+                shift
+                ;;
             *)
                 shift
                 ;;
@@ -81,12 +86,14 @@ parse_args "$@"
 [ -n "$TUN_INTERFACE_NAME" ] || TUN_INTERFACE_NAME="wpan0"
 [ -n "$BACKBONE_INTERFACE" ] || BACKBONE_INTERFACE="eth0"
 [ -n "$NAT64_PREFIX" ] || NAT64_PREFIX="64:ff9b::/96"
+[ -n "$DEBUG_LEVEL" ] || DEBUG_LEVEL="7"
 
 echo "RADIO_URL:" $RADIO_URL
 echo "TREL_URL:" "$TREL_URL"
 echo "TUN_INTERFACE_NAME:" $TUN_INTERFACE_NAME
 echo "BACKBONE_INTERFACE: $BACKBONE_INTERFACE"
 echo "NAT64_PREFIX:" $NAT64_PREFIX
+echo "DEBUG_LEVEL:" $DEBUG_LEVEL
 
 NAT64_PREFIX=${NAT64_PREFIX/\//\\\/}
 TAYGA_CONF=/etc/tayga.conf
@@ -96,8 +103,8 @@ BIND_CONF_OPTIONS=/etc/bind/named.conf.options
 ! test -f $BIND_CONF_OPTIONS || sed -i "s/dns64.*$/dns64 $NAT64_PREFIX {};/" $BIND_CONF_OPTIONS
 sed -i "s/$INFRA_IF_NAME/$BACKBONE_INTERFACE/" /etc/sysctl.d/60-otbr-accept-ra.conf
 
-echo "OTBR_AGENT_OPTS=\"-I $TUN_INTERFACE_NAME -B $BACKBONE_INTERFACE -d7 $RADIO_URL $TREL_URL\"" >/etc/default/otbr-agent
-echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d7 -p 80\"" >/etc/default/otbr-web
+echo "OTBR_AGENT_OPTS=\"-I $TUN_INTERFACE_NAME -B $BACKBONE_INTERFACE -d${DEBUG_LEVEL} $RADIO_URL $TREL_URL\"" >/etc/default/otbr-agent
+echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d${DEBUG_LEVEL} -p 80\"" >/etc/default/otbr-web
 
 /app/script/server
 


### PR DESCRIPTION
Passing OTBR_OPTIONS=-DOT_LOG_LEVEL=INFO does not actually change the debug level as expected. Instead a -d command line option is required.

The current docker_entrypoint.sh file hard codes -d7 (Debug level) on the command line.

This PR changes the hard coded value to a ```--debug-level``` command line argument like the existing ```--radio_url```, ```--interface``` options.

This allows setting the debug level in the docker-compose file.

Closes #2323