### PR TITLE
[controller] rename to ThreadController to ThreadHost

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -60,11 +60,11 @@ Application::Application(const std::string               &aInterfaceName,
 #else
     , mBackboneInterfaceName(aBackboneInterfaceNames.empty() ? "" : aBackboneInterfaceNames.front())
 #endif
-    , mHost(Ncp::ThreadController::Create(mInterfaceName.c_str(),
-                                          aRadioUrls,
-                                          mBackboneInterfaceName,
-                                          /* aDryRun */ false,
-                                          aEnableAutoAttach))
+    , mHost(Ncp::ThreadHost::Create(mInterfaceName.c_str(),
+                                    aRadioUrls,
+                                    mBackboneInterfaceName,
+                                    /* aDryRun */ false,
+                                    aEnableAutoAttach))
 #if OTBR_ENABLE_MDNS
     , mPublisher(Mdns::Publisher::Create([this](Mdns::Publisher::State aState) { this->HandleMdnsState(aState); }))
 #endif

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -132,7 +132,7 @@ public:
      *
      * @returns The OpenThread controller object.
      */
-    Ncp::ThreadController &GetHost(void) { return *mHost; }
+    Ncp::ThreadHost &GetHost(void) { return *mHost; }
 
 #if OTBR_ENABLE_MDNS
     /**
@@ -264,8 +264,8 @@ private:
 #if __linux__
     otbr::Utils::InfraLinkSelector mInfraLinkSelector;
 #endif
-    const char                            *mBackboneInterfaceName;
-    std::unique_ptr<Ncp::ThreadController> mHost;
+    const char                      *mBackboneInterfaceName;
+    std::unique_ptr<Ncp::ThreadHost> mHost;
 #if OTBR_ENABLE_MDNS
     std::unique_ptr<Mdns::Publisher> mPublisher;
 #endif

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -56,7 +56,7 @@
 #include "common/logging.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
-#include "ncp/thread_controller.hpp"
+#include "ncp/thread_host.hpp"
 
 static const char kDefaultInterfaceName[] = "wpan0";
 
@@ -176,10 +176,10 @@ static otbrLogLevel GetDefaultLogLevel(void)
 
 static void PrintRadioVersionAndExit(const std::vector<const char *> &aRadioUrls)
 {
-    auto host = std::unique_ptr<otbr::Ncp::ThreadController>(
-        otbr::Ncp::ThreadController::Create(/* aInterfaceName */ "", aRadioUrls,
-                                            /* aBackboneInterfaceName */ "",
-                                            /* aDryRun */ true, /* aEnableAutoAttach */ false));
+    auto host = std::unique_ptr<otbr::Ncp::ThreadHost>(
+        otbr::Ncp::ThreadHost::Create(/* aInterfaceName */ "", aRadioUrls,
+                                      /* aBackboneInterfaceName */ "",
+                                      /* aDryRun */ true, /* aEnableAutoAttach */ false));
     const char *coprocessorVersion;
 
     host->Init();

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -29,8 +29,8 @@
 add_library(otbr-ncp
     rcp_host.cpp
     rcp_host.hpp
-    thread_controller.cpp
-    thread_controller.hpp
+    thread_host.cpp
+    thread_host.hpp
 )
 
 target_link_libraries(otbr-ncp PRIVATE

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -49,7 +49,7 @@
 #include "common/mainloop.hpp"
 #include "common/task_runner.hpp"
 #include "common/types.hpp"
-#include "ncp/thread_controller.hpp"
+#include "ncp/thread_host.hpp"
 #include "utils/thread_helper.hpp"
 
 namespace otbr {
@@ -64,7 +64,7 @@ namespace Ncp {
  * This interface defines OpenThread Controller under RCP mode.
  *
  */
-class RcpHost : public MainloopProcessor, public ThreadController
+class RcpHost : public MainloopProcessor, public ThreadHost
 {
 public:
     using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;

--- a/src/ncp/thread_host.cpp
+++ b/src/ncp/thread_host.cpp
@@ -28,7 +28,7 @@
 
 #define OTBR_LOG_TAG "CTRLR"
 
-#include "thread_controller.hpp"
+#include "thread_host.hpp"
 
 #include <openthread/logging.h>
 #include <openthread/openthread-system.h>
@@ -40,16 +40,16 @@
 namespace otbr {
 namespace Ncp {
 
-std::unique_ptr<ThreadController> ThreadController::Create(const char                      *aInterfaceName,
-                                                           const std::vector<const char *> &aRadioUrls,
-                                                           const char                      *aBackboneInterfaceName,
-                                                           bool                             aDryRun,
-                                                           bool                             aEnableAutoAttach)
+std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *aInterfaceName,
+                                               const std::vector<const char *> &aRadioUrls,
+                                               const char                      *aBackboneInterfaceName,
+                                               bool                             aDryRun,
+                                               bool                             aEnableAutoAttach)
 {
-    CoprocessorType                   coprocessorType;
-    otPlatformCoprocessorUrls         urls;
-    std::unique_ptr<ThreadController> host;
-    otLogLevel                        level = ConvertToOtLogLevel(otbrLogGetLevel());
+    CoprocessorType             coprocessorType;
+    otPlatformCoprocessorUrls   urls;
+    std::unique_ptr<ThreadHost> host;
+    otLogLevel                  level = ConvertToOtLogLevel(otbrLogGetLevel());
 
     VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
 
@@ -76,7 +76,7 @@ std::unique_ptr<ThreadController> ThreadController::Create(const char           
     return host;
 }
 
-otLogLevel ThreadController::ConvertToOtLogLevel(otbrLogLevel aLevel)
+otLogLevel ThreadHost::ConvertToOtLogLevel(otbrLogLevel aLevel)
 {
     otLogLevel level;
 

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -31,8 +31,8 @@
  *   This file includes definitions of Thead Controller Interface.
  */
 
-#ifndef OTBR_AGENT_THREAD_CONTROLLER_HPP_
-#define OTBR_AGENT_THREAD_CONTROLLER_HPP_
+#ifndef OTBR_AGENT_THREAD_HOST_HPP_
+#define OTBR_AGENT_THREAD_HOST_HPP_
 
 #include <functional>
 #include <memory>
@@ -54,7 +54,7 @@ namespace Ncp {
  * The APIs are unified for both NCP and RCP cases.
  *
  */
-class ThreadController
+class ThreadHost
 {
 public:
     using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
@@ -73,11 +73,11 @@ public:
      * @returns Non-null OpenThread Controller instance.
      *
      */
-    static std::unique_ptr<ThreadController> Create(const char                      *aInterfaceName,
-                                                    const std::vector<const char *> &aRadioUrls,
-                                                    const char                      *aBackboneInterfaceName,
-                                                    bool                             aDryRun,
-                                                    bool                             aEnableAutoAttach);
+    static std::unique_ptr<ThreadHost> Create(const char                      *aInterfaceName,
+                                              const std::vector<const char *> &aRadioUrls,
+                                              const char                      *aBackboneInterfaceName,
+                                              bool                             aDryRun,
+                                              bool                             aEnableAutoAttach);
 
     /**
      * This method gets the device role and returns the role through the handler.
@@ -115,7 +115,7 @@ public:
      * The destructor.
      *
      */
-    virtual ~ThreadController(void) = default;
+    virtual ~ThreadHost(void) = default;
 
 protected:
     static otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel);
@@ -124,4 +124,4 @@ protected:
 } // namespace Ncp
 } // namespace otbr
 
-#endif // OTBR_AGENT_THREAD_CONTROLLER_HPP_
+#endif // OTBR_AGENT_THREAD_HOST_HPP_


### PR DESCRIPTION
This PR renames `ThreadController` to `ThreadHost`.

As discussed in #2329, since the implementation class are called
as `RcpHost` and `NcpHost`, the interface name should also be named
as 'Host'.