### PR TITLE
[ncp] implement dbus server for NCP mode

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -260,6 +260,9 @@ private:
     void InitRcpMode(void);
     void DeinitRcpMode(void);
 
+    void InitNcpMode(void);
+    void DeinitNcpMode(void);
+
     std::string mInterfaceName;
 #if __linux__
     otbr::Utils::InfraLinkSelector mInfraLinkSelector;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -159,4 +159,46 @@ std::string MacAddress::ToString(void) const
     return std::string(strbuf);
 }
 
+otError OtbrErrorToOtError(otbrError aError)
+{
+    otError error;
+
+    switch (aError)
+    {
+    case OTBR_ERROR_NONE:
+        error = OT_ERROR_NONE;
+        break;
+
+    case OTBR_ERROR_NOT_FOUND:
+        error = OT_ERROR_NOT_FOUND;
+        break;
+
+    case OTBR_ERROR_PARSE:
+        error = OT_ERROR_PARSE;
+        break;
+
+    case OTBR_ERROR_NOT_IMPLEMENTED:
+        error = OT_ERROR_NOT_IMPLEMENTED;
+        break;
+
+    case OTBR_ERROR_INVALID_ARGS:
+        error = OT_ERROR_INVALID_ARGS;
+        break;
+
+    case OTBR_ERROR_DUPLICATED:
+        error = OT_ERROR_DUPLICATED;
+        break;
+
+    case OTBR_ERROR_INVALID_STATE:
+        error = OT_ERROR_INVALID_STATE;
+        break;
+
+    default:
+        error = OT_ERROR_FAILED;
+        break;
+    }
+
+    return error;
+}
+
 } // namespace otbr

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -42,6 +42,8 @@
 #include <string>
 #include <vector>
 
+#include <openthread/error.h>
+
 #include "common/byteswap.hpp"
 
 #ifndef IN6ADDR_ANY
@@ -468,6 +470,16 @@ struct MdnsTelemetryInfo
 static constexpr size_t kVendorOuiLength      = 3;
 static constexpr size_t kMaxVendorNameLength  = 24;
 static constexpr size_t kMaxProductNameLength = 24;
+
+/**
+ * This method converts a otbrError to a otError.
+ *
+ * @param[in]  aError  a otbrError code.
+ *
+ * @returns  a otError code.
+ *
+ */
+otError OtbrErrorToOtError(otbrError aError);
 
 } // namespace otbr
 

--- a/src/dbus/server/CMakeLists.txt
+++ b/src/dbus/server/CMakeLists.txt
@@ -37,7 +37,8 @@ add_custom_target(otbr-dbus-introspect-header ALL
 add_library(otbr-dbus-server STATIC
     dbus_agent.cpp
     dbus_object.cpp
-    dbus_thread_object.cpp
+    dbus_thread_object_ncp.cpp
+    dbus_thread_object_rcp.cpp
     error_helper.cpp
 )
 
@@ -55,7 +56,7 @@ target_link_libraries(otbr-dbus-server PUBLIC
 
 if(OTBR_DOC)
 add_custom_target(otbr-dbus-server-doc ALL
-    COMMAND gdbus-codegen --generate-docbook generated-docs ${CMAKE_CURRENT_SOURCE_DIR}/introspect.xml 
+    COMMAND gdbus-codegen --generate-docbook generated-docs ${CMAKE_CURRENT_SOURCE_DIR}/introspect.xml
     COMMAND xmlto html generated-docs-io.openthread.BorderRouter.xml
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     VERBATIM

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -46,9 +46,9 @@
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
 #include "dbus/server/dbus_object.hpp"
-#include "dbus/server/dbus_thread_object.hpp"
-
-#include "ncp/rcp_host.hpp"
+#include "dbus/server/dbus_thread_object_ncp.hpp"
+#include "dbus/server/dbus_thread_object_rcp.hpp"
+#include "ncp/thread_host.hpp"
 
 namespace otbr {
 namespace DBus {
@@ -59,10 +59,11 @@ public:
     /**
      * The constructor of dbus agent.
      *
-     * @param[in] aHost  A reference to the Thread controller.
+     * @param[in] aHost           A reference to the Thread host.
+     * @param[in] aPublisher      A reference to the MDNS publisher.
      *
      */
-    DBusAgent(otbr::Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    DBusAgent(otbr::Ncp::ThreadHost &aHost, Mdns::Publisher &aPublisher);
 
     /**
      * This method initializes the dbus agent.
@@ -85,11 +86,11 @@ private:
 
     static const struct timeval kPollTimeout;
 
-    std::string                       mInterfaceName;
-    std::unique_ptr<DBusThreadObject> mThreadObject;
-    UniqueDBusConnection              mConnection;
-    otbr::Ncp::RcpHost               &mHost;
-    Mdns::Publisher                  &mPublisher;
+    std::string                 mInterfaceName;
+    std::unique_ptr<DBusObject> mThreadObject;
+    UniqueDBusConnection        mConnection;
+    otbr::Ncp::ThreadHost      &mHost;
+    Mdns::Publisher            &mPublisher;
 
     /**
      * This map is used to track DBusWatch-es.

--- a/src/dbus/server/dbus_object.cpp
+++ b/src/dbus/server/dbus_object.cpp
@@ -51,6 +51,11 @@ DBusObject::DBusObject(DBusConnection *aConnection, const std::string &aObjectPa
 
 otbrError DBusObject::Init(void)
 {
+    return Initialize(/* aIsAsyncPropertyHandler */ false);
+}
+
+otbrError DBusObject::Initialize(bool aIsAsyncPropertyHandler)
+{
     otbrError            error = OTBR_ERROR_NONE;
     DBusObjectPathVTable vTable;
 
@@ -60,12 +65,21 @@ otbrError DBusObject::Init(void)
 
     VerifyOrExit(dbus_connection_register_object_path(mConnection, mObjectPath.c_str(), &vTable, this),
                  error = OTBR_ERROR_DBUS);
-    RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_GET_METHOD,
-                   std::bind(&DBusObject::GetPropertyMethodHandler, this, _1));
-    RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_SET_METHOD,
-                   std::bind(&DBusObject::SetPropertyMethodHandler, this, _1));
-    RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_GET_ALL_METHOD,
-                   std::bind(&DBusObject::GetAllPropertiesMethodHandler, this, _1));
+
+    if (aIsAsyncPropertyHandler)
+    {
+        RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_GET_METHOD,
+                       std::bind(&DBusObject::AsyncGetPropertyMethodHandler, this, _1));
+    }
+    else
+    {
+        RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_GET_METHOD,
+                       std::bind(&DBusObject::GetPropertyMethodHandler, this, _1));
+        RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_SET_METHOD,
+                       std::bind(&DBusObject::SetPropertyMethodHandler, this, _1));
+        RegisterMethod(DBUS_INTERFACE_PROPERTIES, DBUS_PROPERTY_GET_ALL_METHOD,
+                       std::bind(&DBusObject::GetAllPropertiesMethodHandler, this, _1));
+    }
 
 exit:
     return error;
@@ -96,6 +110,13 @@ void DBusObject::RegisterSetPropertyHandler(const std::string         &aInterfac
 
     assert(mSetPropertyHandlers.find(fullPath) == mSetPropertyHandlers.end());
     mSetPropertyHandlers.emplace(fullPath, aHandler);
+}
+
+void DBusObject::RegisterAsyncGetPropertyHandler(const std::string              &aInterfaceName,
+                                                 const std::string              &aPropertyName,
+                                                 const AsyncPropertyHandlerType &aHandler)
+{
+    mAsyncGetPropertyHandlers[aInterfaceName].emplace(aPropertyName, aHandler);
 }
 
 DBusHandlerResult DBusObject::sMessageHandler(DBusConnection *aConnection, DBusMessage *aMessage, void *aData)
@@ -250,6 +271,40 @@ exit:
     }
     aRequest.ReplyOtResult(error);
     return;
+}
+
+void DBusObject::AsyncGetPropertyMethodHandler(DBusRequest &aRequest)
+{
+    DBusMessageIter iter;
+    std::string     interfaceName;
+    otError         error = OT_ERROR_NONE;
+    std::string     propertyName;
+
+    VerifyOrExit(dbus_message_iter_init(aRequest.GetMessage(), &iter), error = OT_ERROR_FAILED);
+    SuccessOrExit(error = OtbrErrorToOtError(DBusMessageExtract(&iter, interfaceName)));
+    SuccessOrExit(error = OtbrErrorToOtError(DBusMessageExtract(&iter, propertyName)));
+
+    {
+        auto propertyIter = mAsyncGetPropertyHandlers.find(interfaceName);
+
+        otbrLogDebug("AsyncGetProperty %s.%s", interfaceName.c_str(), propertyName.c_str());
+        VerifyOrExit(propertyIter != mAsyncGetPropertyHandlers.end(), error = OT_ERROR_NOT_FOUND);
+        {
+            auto &interfaceHandlers = propertyIter->second;
+            auto  interfaceIter     = interfaceHandlers.find(propertyName);
+
+            VerifyOrExit(interfaceIter != interfaceHandlers.end(), error = OT_ERROR_NOT_FOUND);
+            (interfaceIter->second)(aRequest);
+        }
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("GetProperty %s.%s error:%s", interfaceName.c_str(), propertyName.c_str(),
+                       ConvertToDBusErrorName(error));
+        aRequest.ReplyOtResult(error);
+    }
 }
 
 DBusObject::~DBusObject(void)

--- a/src/dbus/server/dbus_thread_object_ncp.cpp
+++ b/src/dbus/server/dbus_thread_object_ncp.cpp
@@ -1,0 +1,99 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "dbus_thread_object_ncp.hpp"
+
+#include "common/api_strings.hpp"
+#include "common/byteswap.hpp"
+#include "common/code_utils.hpp"
+#include "dbus/common/constants.hpp"
+#include "dbus/server/dbus_agent.hpp"
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+namespace otbr {
+namespace DBus {
+
+DBusThreadObjectNcp::DBusThreadObjectNcp(DBusConnection     &aConnection,
+                                         const std::string  &aInterfaceName,
+                                         otbr::Ncp::NcpHost &aHost)
+    : DBusObject(&aConnection, OTBR_DBUS_OBJECT_PREFIX + aInterfaceName)
+    , mHost(aHost)
+{
+}
+
+otbrError DBusThreadObjectNcp::Init(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    SuccessOrExit(error = DBusObject::Initialize(true));
+
+    RegisterAsyncGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
+                                    std::bind(&DBusThreadObjectNcp::AsyncGetDeviceRoleHandler, this, _1));
+
+exit:
+    return error;
+}
+
+void DBusThreadObjectNcp::AsyncGetDeviceRoleHandler(DBusRequest &aRequest)
+{
+    mHost.GetDeviceRole([this, aRequest](otError aError, otDeviceRole aRole) mutable {
+        if (aError == OT_ERROR_NONE)
+        {
+            this->ReplyAsyncGetProperty(aRequest, GetDeviceRoleName(aRole));
+        }
+        else
+        {
+            aRequest.ReplyOtResult(aError);
+        }
+    });
+}
+
+void DBusThreadObjectNcp::ReplyAsyncGetProperty(DBusRequest &aRequest, const std::string &aContent)
+{
+    UniqueDBusMessage reply{dbus_message_new_method_return(aRequest.GetMessage())};
+    DBusMessageIter   replyIter;
+    otError           error = OT_ERROR_NONE;
+
+    dbus_message_iter_init_append(reply.get(), &replyIter);
+    SuccessOrExit(error = OtbrErrorToOtError(DBusMessageEncodeToVariant(&replyIter, aContent)));
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        dbus_connection_send(aRequest.GetConnection(), reply.get(), nullptr);
+    }
+    else
+    {
+        aRequest.ReplyOtResult(error);
+    }
+}
+
+} // namespace DBus
+} // namespace otbr

--- a/src/dbus/server/dbus_thread_object_ncp.hpp
+++ b/src/dbus/server/dbus_thread_object_ncp.hpp
@@ -1,0 +1,96 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file includes definitions for the d-bus object of Thread service when
+ * the co-processor is an NCP.
+ */
+
+#ifndef OTBR_DBUS_THREAD_OBJECT_NCP_HPP_
+#define OTBR_DBUS_THREAD_OBJECT_NCP_HPP_
+
+#include "openthread-br/config.h"
+
+#include <string>
+
+#include <openthread/link.h>
+
+#include "dbus/server/dbus_object.hpp"
+#include "mdns/mdns.hpp"
+#include "ncp/ncp_host.hpp"
+
+namespace otbr {
+namespace DBus {
+
+/**
+ * @addtogroup border-router-dbus-server
+ *
+ * @brief
+ *   This module includes the <a href="dbus-api.html">dbus server api</a>.
+ *
+ * @{
+ */
+
+class DBusThreadObjectNcp : public DBusObject
+{
+public:
+    /**
+     * This constructor of dbus thread object.
+     *
+     * @param[in] aConnection     The dbus connection.
+     * @param[in] aInterfaceName  The dbus interface name.
+     * @param[in] aHost           The Thread controller.
+     *
+     */
+    DBusThreadObjectNcp(DBusConnection &aConnection, const std::string &aInterfaceName, otbr::Ncp::NcpHost &aHost);
+
+    /**
+     * This method initializes the dbus thread object.
+     *
+     * @retval OTBR_ERROR_NONE  The initialization succeeded.
+     * @retval OTBR_ERROR_DBUS  The initialization failed due to dbus connection.
+     *
+     */
+    otbrError Init(void) override;
+
+private:
+    void AsyncGetDeviceRoleHandler(DBusRequest &aRequest);
+    void ReplyAsyncGetProperty(DBusRequest &aRequest, const std::string &aContent);
+
+    otbr::Ncp::NcpHost &mHost;
+};
+
+/**
+ * @}
+ */
+
+} // namespace DBus
+} // namespace otbr
+
+#endif // OTBR_DBUS_THREAD_OBJECT_NCP_HPP_

--- a/src/dbus/server/dbus_thread_object_rcp.hpp
+++ b/src/dbus/server/dbus_thread_object_rcp.hpp
@@ -31,8 +31,8 @@
  * This file includes definitions for the d-bus object of OpenThread service.
  */
 
-#ifndef OTBR_DBUS_THREAD_OBJECT_HPP_
-#define OTBR_DBUS_THREAD_OBJECT_HPP_
+#ifndef OTBR_DBUS_THREAD_OBJECT_RCP_HPP_
+#define OTBR_DBUS_THREAD_OBJECT_RCP_HPP_
 
 #include "openthread-br/config.h"
 
@@ -54,13 +54,9 @@ namespace DBus {
  *   This module includes the <a href="dbus-api.html">dbus server api</a>.
  *
  * @{
- * @}
- *
  */
 
-class DBusAgent;
-
-class DBusThreadObject : public DBusObject
+class DBusThreadObjectRcp : public DBusObject
 {
 public:
     /**
@@ -72,10 +68,10 @@ public:
      * @param[in] aPublisher      The Mdns::Publisher
      *
      */
-    DBusThreadObject(DBusConnection     *aConnection,
-                     const std::string  &aInterfaceName,
-                     otbr::Ncp::RcpHost *aHost,
-                     Mdns::Publisher    *aPublisher);
+    DBusThreadObjectRcp(DBusConnection     &aConnection,
+                        const std::string  &aInterfaceName,
+                        otbr::Ncp::RcpHost &aHost,
+                        Mdns::Publisher    *aPublisher);
 
     otbrError Init(void) override;
 
@@ -179,12 +175,16 @@ private:
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
     void ReplyEnergyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otEnergyScanResult> &aResult);
 
-    otbr::Ncp::RcpHost                                  *mHost;
+    otbr::Ncp::RcpHost                                  &mHost;
     std::unordered_map<std::string, PropertyHandlerType> mGetPropertyHandlers;
     otbr::Mdns::Publisher                               *mPublisher;
 };
 
+/**
+ * @}
+ */
+
 } // namespace DBus
 } // namespace otbr
 
-#endif // OTBR_DBUS_THREAD_OBJECT_HPP_
+#endif // OTBR_DBUS_THREAD_OBJECT_RCP_HPP_

--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -40,10 +40,11 @@
 namespace otbr {
 namespace Ncp {
 
-NcpHost::NcpHost(bool aDryRun)
+NcpHost::NcpHost(const char *aInterfaceName, bool aDryRun)
     : mSpinelDriver(*static_cast<ot::Spinel::SpinelDriver *>(otSysGetSpinelDriver()))
 {
     memset(&mConfig, 0, sizeof(mConfig));
+    mConfig.mInterfaceName = aInterfaceName;
     mConfig.mDryRun        = aDryRun;
     mConfig.mSpeedUpFactor = 1;
 }

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -49,10 +49,11 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]   aDryRun  TRUE to indicate dry-run mode. FALSE otherwise.
+     * @param[in]   aInterfaceName  A string of the NCP interface name.
+     * @param[in]   aDryRun         TRUE to indicate dry-run mode. FALSE otherwise.
      *
      */
-    NcpHost(bool aDryRun);
+    NcpHost(const char *aInterfaceName, bool aDryRun);
 
     /**
      * Destructor.
@@ -64,6 +65,7 @@ public:
     void            GetDeviceRole(const DeviceRoleHandler aHandler) override;
     CoprocessorType GetCoprocessorType(void) override { return OT_COPROCESSOR_NCP; }
     const char     *GetCoprocessorVersion(void) override;
+    const char     *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }
     void            Init(void) override;
     void            Deinit(void) override;
 

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -165,7 +165,7 @@ public:
      * @returns A pointer to the Thread network interface name string.
      *
      */
-    const char *GetInterfaceName(void) const { return mConfig.mInterfaceName; }
+    const char *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }
 
     static otbrLogLevel ConvertToOtbrLogLevel(otLogLevel aLogLevel);
 

--- a/src/ncp/thread_host.cpp
+++ b/src/ncp/thread_host.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
         break;
 
     case OT_COPROCESSOR_NCP:
-        host = MakeUnique<NcpHost>(aDryRun);
+        host = MakeUnique<NcpHost>(aInterfaceName, aDryRun);
         break;
 
     default:

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -100,6 +100,14 @@ public:
     virtual const char *GetCoprocessorVersion(void) = 0;
 
     /**
+     * This method returns the Thread network interface name.
+     *
+     * @returns A pointer to the Thread network interface name string.
+     *
+     */
+    virtual const char *GetInterfaceName(void) const = 0;
+
+    /**
      * Initializes the Thread controller.
      *
      */

--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -51,48 +51,6 @@
 
 namespace otbr {
 
-static otError OtbrErrorToOtError(otbrError aError)
-{
-    otError error;
-
-    switch (aError)
-    {
-    case OTBR_ERROR_NONE:
-        error = OT_ERROR_NONE;
-        break;
-
-    case OTBR_ERROR_NOT_FOUND:
-        error = OT_ERROR_NOT_FOUND;
-        break;
-
-    case OTBR_ERROR_PARSE:
-        error = OT_ERROR_PARSE;
-        break;
-
-    case OTBR_ERROR_NOT_IMPLEMENTED:
-        error = OT_ERROR_NOT_IMPLEMENTED;
-        break;
-
-    case OTBR_ERROR_INVALID_ARGS:
-        error = OT_ERROR_INVALID_ARGS;
-        break;
-
-    case OTBR_ERROR_DUPLICATED:
-        error = OT_ERROR_DUPLICATED;
-        break;
-
-    case OTBR_ERROR_INVALID_STATE:
-        error = OT_ERROR_INVALID_STATE;
-        break;
-
-    default:
-        error = OT_ERROR_FAILED;
-        break;
-    }
-
-    return error;
-}
-
 AdvertisingProxy::AdvertisingProxy(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
     : mHost(aHost)
     , mPublisher(aPublisher)

--- a/tests/scripts/expect/ncp_get_device_role.exp
+++ b/tests/scripts/expect/ncp_get_device_role.exp
@@ -28,15 +28,22 @@
 #
 set timeout 1
 
-# Spawn the otbr-agent with NCP in Dry Run mode
-spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -v -d7 --radio-version "spinel+hdlc+forkpty://$::env(EXP_OT_NCP_PATH)?forkpty-arg=$::env(EXP_LEADER_NODE_ID)"
+spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -v -d7 "spinel+hdlc+forkpty://$::env(EXP_OT_NCP_PATH)?forkpty-arg=$::env(EXP_LEADER_NODE_ID)"
 
-# Expect the NCP version
-expect -re {OPENTHREAD/[0-9a-z]{6,9}; SIMULATION} {
+set otbr_id $spawn_id
+sleep 1
+
+spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
+
+expect -re {NotImplemented} {
 } timeout {
     puts "timeout!"
     exit 1
 }
 
-# Wait for the spawned process to terminate
+expect eof
+
+# Shut down otbr-agent
+set spawn_id $otbr_id
+send "\x04"
 expect eof

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -218,6 +218,7 @@ main()
     export EXP_LEADER_NODE_ID="${LEADER_NODE_ID}"
     export EXP_OT_NCP_PATH="${ot_ncp}"
     otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_version.exp" || die "ncp expect script failed!"
+    otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_get_device_role.exp" || die "ncp expect script failed!"
 }
 
 main "$@"


### PR DESCRIPTION
This PR refactors the `DBusAgent` so that it can work under NCP mode.

The DBus server will provide different methods under RCP mode and NCP mode. Currently under NCP mode, only `GetDeviceRole` is provided.

This PR renames `DBusThreadObject` to `DBusThreadObjectRcp` and added a new class `DBusThreadObjectNcp` which will handle the DBus requests under NCP mode. This PR also implements `AsyncPropertyHandler` to handle GetProperty requests by calling async methods of `NcpHost`.

A test case is added to test `GetDeviceRole` under NCP.

This PR is also a breakdown of PR #2283.