### PR TITLE
[tests] fix expect test

### DIFF
--- a/.github/workflows/ncp_mode.yml
+++ b/.github/workflows/ncp_mode.yml
@@ -62,6 +62,6 @@ jobs:
       run: |
         script/test build
     - name: Run
-      run: OTBR_VERBOSE=${RUNNER_DEBUG:-0} script/test ncp_mode
+      run: OTBR_VERBOSE=1 script/test ncp_mode
     - name: Codecov
       uses: codecov/codecov-action@v4

--- a/tests/scripts/expect/ncp_version.exp
+++ b/tests/scripts/expect/ncp_version.exp
@@ -6,7 +6,7 @@ set timeout 1
 spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -v -d7 --radio-version "spinel+hdlc+forkpty://$::env(EXP_OT_NCP_PATH)?forkpty-arg=$::env(EXP_LEADER_NODE_ID)"
 
 # Expect the NCP version
-expect -re {OPENTHREAD/[0-9a-z]{9}; SIMULATION} {
+expect -re {OPENTHREAD/[0-9a-z]{6,9}; SIMULATION} {
 } timeout {
     puts "timeout!"
     exit 1

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -160,8 +160,6 @@ test_setup()
 
 test_teardown()
 {
-    exit_message="Test teardown"
-
     # Capture the exit code so we can return it below
     EXIT_CODE=$?
     readonly EXIT_CODE
@@ -176,6 +174,7 @@ test_teardown()
     sudo rm -rf "${BUILD_DIR}" || true
     sudo rm -rf "${ABS_TOP_OT_BUILDDIR}" || true
 
+    exit_message="Test teardown"
     echo "EXIT ${EXIT_CODE}: MESSAGE: ${exit_message}"
     exit ${EXIT_CODE}
 }
@@ -218,7 +217,7 @@ main()
     export EXP_TUN_NAME="${TUN_NAME}"
     export EXP_LEADER_NODE_ID="${LEADER_NODE_ID}"
     export EXP_OT_NCP_PATH="${ot_ncp}"
-    otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_version.exp"
+    otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_version.exp" || die "ncp expect script failed!"
 }
 
 main "$@"


### PR DESCRIPTION
This PR fixes the expect test. Currently even the expect script fails, the exit_code is still 0 in `test_teardown`. And the CI won't fail.