### PR TITLE
[tests] enhance expect test framework for ncp_mode

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -1,0 +1,103 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+proc wait_for {command success {failure {[\r\n]FAILURE_NOT_EXPECTED[\r\n]}}} {
+    set timeout 1
+    for {set i 0} {$i < 40} {incr i} {
+        if {$command != ""} {
+            send "$command\n"
+        }
+
+        expect {
+            -re $success {
+                return 0
+            }
+            -re $failure {
+                fail "Failed due to '$failure' found"
+            }
+            timeout {
+                # Do nothing
+            }
+        }
+    }
+    fail "Failed due to '$success' not found"
+}
+
+proc expect_line {line} {
+    set timeout 10
+    expect -re "\[\r\n \]($line)(?=\[\r\n>\])"
+    return $expect_out(1,string)
+}
+
+# type: The type of the node.
+#   Possible values:
+#   1. cli: The cli app. ot-cli-ftd or ot-cli-mtd
+#   2. otbr: The otbr-agent.
+#
+# sim_app: The path of the simulation app to start the node.
+#   If type is 'cli', sim_app is the path of the cli app.
+#   If type is 'otbr', sim_app is the path of the coprocessor. It could be 'ot-rcp', 'ot-ncp-ftd'
+#     or 'ot-ncp-mtd'.
+proc spawn_node {id type sim_app} {
+    global spawn_id
+    global spawn_ids
+    global argv0
+
+    send_user "\n# ${id} ${type} ${sim_app}\n"
+
+    switch -regexp ${type} {
+        cli {
+            spawn $sim_app $id
+            send "factoryreset\n"
+            wait_for "state" "disabled"
+            expect_line "Done"
+            send "routerselectionjitter 1\n"
+            expect_line "Done"
+
+            expect_after {
+                timeout { fail "Timed out" }
+            }
+        }
+        otbr {
+            spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -d7 "spinel+hdlc+forkpty://${sim_app}?forkpty-arg=${id}"
+        }
+    }
+
+    set spawn_ids($id) $spawn_id
+
+    return $spawn_id
+}
+
+proc switch_node {id} {
+    global spawn_ids
+    global spawn_id
+
+    send_user "\n# ${id}\n"
+    set spawn_id $spawn_ids($id)
+}

--- a/tests/scripts/expect/ncp_get_device_role.exp
+++ b/tests/scripts/expect/ncp_get_device_role.exp
@@ -26,24 +26,21 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-set timeout 1
+source "tests/scripts/expect/_common.exp"
 
-spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -v -d7 "spinel+hdlc+forkpty://$::env(EXP_OT_NCP_PATH)?forkpty-arg=$::env(EXP_LEADER_NODE_ID)"
+spawn_node 1 otbr $::env(EXP_OT_NCP_PATH)
 
-set otbr_id $spawn_id
 sleep 1
 
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-
 expect -re {disabled} {
 } timeout {
     puts "timeout!"
     exit 1
 }
-
 expect eof
 
 # Shut down otbr-agent
-set spawn_id $otbr_id
+switch_node 1
 send "\x04"
 expect eof

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -40,6 +40,9 @@ readonly EXPECT_SCRIPT_DIR
 #---------------------------------------
 # Configurations
 #---------------------------------------
+OT_CLI="${OT_CLI:-ot-cli-ftd}"
+readonly OT_CLI
+
 OT_NCP="${OT_NCP:-ot-ncp-ftd}"
 readonly OT_NCP
 
@@ -125,7 +128,8 @@ readonly TUN_NAME
 #----------------------------------------
 build_ot_simulation()
 {
-    "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation -DOT_APP_CLI=OFF -DOT_MTD=OFF
+    "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation -DOT_MTD=OFF
+    ot_cli=$(find "${ABS_TOP_OT_BUILDDIR}" -name "${OT_CLI}")
     ot_ncp=$(find "${ABS_TOP_OT_BUILDDIR}" -name "${OT_NCP}")
 }
 
@@ -216,9 +220,15 @@ main()
     export EXP_OTBR_AGENT_PATH="${OTBR_AGENT_PATH}"
     export EXP_TUN_NAME="${TUN_NAME}"
     export EXP_LEADER_NODE_ID="${LEADER_NODE_ID}"
+    export EXP_OT_CLI_PATH="${ot_cli}"
     export EXP_OT_NCP_PATH="${ot_ncp}"
-    otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_version.exp" || die "ncp expect script failed!"
-    otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_get_device_role.exp" || die "ncp expect script failed!"
+
+    if [[ $# != 0 ]]; then
+        otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/$1" || die "ncp expect script failed!"
+    else
+        otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_version.exp" || die "ncp expect script failed!"
+        otbr_exec_expect_script "${EXPECT_SCRIPT_DIR}/ncp_get_device_role.exp" || die "ncp expect script failed!"
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
This PR enhances the expect test framework for testing NCP mode:
1. Add util methods to simplify the tests
2. Allow the bash script to run specific test for easier local testing
3. Build ot-cli node and allow create CLI node in the tests