### PR TITLE
[cmake] fix cmake warnings

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -33,10 +33,6 @@ add_executable(otbr-agent
     vendor.hpp
 )
 
-target_link_libraries(openthread-radio-spinel INTERFACE
-    openthread-spinel-rcp
-)
-
 target_link_libraries(otbr-agent PRIVATE
     $<$<BOOL:${OTBR_BORDER_AGENT}>:otbr-border-agent>
     $<$<BOOL:${OTBR_BACKBONE_ROUTER}>:otbr-backbone-router>


### PR DESCRIPTION
This commit fixes the following warnings:

```bash
CMake Warning (dev) at src/agent/CMakeLists.txt:36
(target_link_libraries):
  Policy CMP0079 is not set: target_link_libraries allows use with
targets in
  other directories.  Run "cmake --help-policy CMP0079" for policy
details.
  Use the cmake_policy command to set the policy and suppress this
warning.

  Target

    openthread-radio-spinel

  is not created in this directory.  For compatibility with older
versions of
  CMake, link library

    openthread-spinel-rcp

  will be looked up in the directory in which the target was created
rather
  than in this calling directory.
This warning is for project developers.  Use -Wno-dev to suppress it.
```