### PR TITLE
[telemetry] add `peer_br_count` in InfraLinkInfo

### DIFF
--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -494,6 +494,8 @@ message TelemetryData {
     optional uint32 link_local_address_count = 5;
     optional uint32 unique_local_address_count = 6;
     optional uint32 global_unicast_address_count = 7;
+    // Indicates how many peer BRs (connected to the same Thread mesh network) are on the infra link.
+    optional uint32 peer_br_count = 8;
   }
 
   // Message to indicate the information of external routes in network data.

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -1429,12 +1429,8 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
 #endif // OTBR_ENABLE_TREL
 
 #if OTBR_ENABLE_BORDER_ROUTING
-        // InfraLinkInfo section.
         RetrieveInfraLinkInfo(*wpanBorderRouter->mutable_infra_link_info());
-
-        // ExternalRoutes section
         RetrieveExternalRouteInfo(*wpanBorderRouter->mutable_external_route_info());
-
 #endif
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -944,7 +944,44 @@ void ThreadHelper::DetachGracefullyCallback(void)
 
 #if OTBR_ENABLE_TELEMETRY_DATA_API
 #if OTBR_ENABLE_BORDER_ROUTING
-void ThreadHelper::RetrieveExternalRouteInfo(threadnetwork::TelemetryData::ExternalRoutes *aExternalRouteInfo)
+void ThreadHelper::RetrieveInfraLinkInfo(threadnetwork::TelemetryData::InfraLinkInfo &aInfraLinkInfo)
+{
+    {
+        otSysInfraNetIfAddressCounters addressCounters;
+        uint32_t                       ifrFlags = otSysGetInfraNetifFlags();
+
+        otSysCountInfraNetifAddresses(&addressCounters);
+
+        aInfraLinkInfo.set_name(otSysGetInfraNetifName());
+        aInfraLinkInfo.set_is_up((ifrFlags & IFF_UP) != 0);
+        aInfraLinkInfo.set_is_running((ifrFlags & IFF_RUNNING) != 0);
+        aInfraLinkInfo.set_is_multicast((ifrFlags & IFF_MULTICAST) != 0);
+        aInfraLinkInfo.set_link_local_address_count(addressCounters.mLinkLocalAddresses);
+        aInfraLinkInfo.set_unique_local_address_count(addressCounters.mUniqueLocalAddresses);
+        aInfraLinkInfo.set_global_unicast_address_count(addressCounters.mGlobalUnicastAddresses);
+    }
+
+    //---- peer_br_count
+    {
+        uint32_t                           count = 0;
+        otBorderRoutingPrefixTableIterator iterator;
+        otBorderRoutingRouterEntry         entry;
+
+        otBorderRoutingPrefixTableInitIterator(mInstance, &iterator);
+
+        while (otBorderRoutingGetNextRouterEntry(mInstance, &iterator, &entry) == OT_ERROR_NONE)
+        {
+            if (entry.mIsPeerBr)
+            {
+                count++;
+            }
+        }
+
+        aInfraLinkInfo.set_peer_br_count(count);
+    }
+}
+
+void ThreadHelper::RetrieveExternalRouteInfo(threadnetwork::TelemetryData::ExternalRoutes &aExternalRouteInfo)
 {
     bool      isDefaultRouteAdded = false;
     bool      isUlaRouteAdded     = false;
@@ -977,9 +1014,9 @@ void ThreadHelper::RetrieveExternalRouteInfo(threadnetwork::TelemetryData::Exter
         }
     }
 
-    aExternalRouteInfo->set_has_default_route_added(isDefaultRouteAdded);
-    aExternalRouteInfo->set_has_ula_route_added(isUlaRouteAdded);
-    aExternalRouteInfo->set_has_others_route_added(isOthersRouteAdded);
+    aExternalRouteInfo.set_has_default_route_added(isDefaultRouteAdded);
+    aExternalRouteInfo.set_has_ula_route_added(isUlaRouteAdded);
+    aExternalRouteInfo.set_has_others_route_added(isOthersRouteAdded);
 }
 #endif // OTBR_ENABLE_BORDER_ROUTING
 
@@ -1392,26 +1429,11 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
 #endif // OTBR_ENABLE_TREL
 
 #if OTBR_ENABLE_BORDER_ROUTING
-        // Begin of InfraLinkInfo section.
-        {
-            auto                           infraLinkInfo = wpanBorderRouter->mutable_infra_link_info();
-            otSysInfraNetIfAddressCounters addressCounters;
-            uint32_t                       ifrFlags = otSysGetInfraNetifFlags();
-
-            otSysCountInfraNetifAddresses(&addressCounters);
-
-            infraLinkInfo->set_name(otSysGetInfraNetifName());
-            infraLinkInfo->set_is_up((ifrFlags & IFF_UP) != 0);
-            infraLinkInfo->set_is_running((ifrFlags & IFF_RUNNING) != 0);
-            infraLinkInfo->set_is_multicast((ifrFlags & IFF_MULTICAST) != 0);
-            infraLinkInfo->set_link_local_address_count(addressCounters.mLinkLocalAddresses);
-            infraLinkInfo->set_unique_local_address_count(addressCounters.mUniqueLocalAddresses);
-            infraLinkInfo->set_global_unicast_address_count(addressCounters.mGlobalUnicastAddresses);
-        }
-        // End of InfraLinkInfo section.
+        // InfraLinkInfo section.
+        RetrieveInfraLinkInfo(*wpanBorderRouter->mutable_infra_link_info());
 
         // ExternalRoutes section
-        RetrieveExternalRouteInfo(wpanBorderRouter->mutable_external_route_info());
+        RetrieveExternalRouteInfo(*wpanBorderRouter->mutable_external_route_info());
 
 #endif
 

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -325,7 +325,8 @@ private:
 #endif
 #if OTBR_ENABLE_TELEMETRY_DATA_API
 #if OTBR_ENABLE_BORDER_ROUTING
-    void RetrieveExternalRouteInfo(threadnetwork::TelemetryData::ExternalRoutes *aExternalRouteInfo);
+    void RetrieveInfraLinkInfo(threadnetwork::TelemetryData::InfraLinkInfo &aInfraLinkInfo);
+    void RetrieveExternalRouteInfo(threadnetwork::TelemetryData::ExternalRoutes &aExternalRouteInfo);
 #endif
 #if OTBR_ENABLE_DHCP6_PD
     void RetrievePdInfo(threadnetwork::TelemetryData::WpanBorderRouter *aWpanBorderRouter);

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -313,6 +313,7 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_border_router().infra_link_info().link_local_address_count() == 0);
     TEST_ASSERT(telemetryData.wpan_border_router().infra_link_info().unique_local_address_count() == 0);
     TEST_ASSERT(telemetryData.wpan_border_router().infra_link_info().global_unicast_address_count() == 0);
+    TEST_ASSERT(telemetryData.wpan_border_router().infra_link_info().peer_br_count() == 0);
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_default_route_added() == false);
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_ula_route_added() == false);
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_others_route_added() == false);


### PR DESCRIPTION
- Add new field `peer_br_count` which is the total number of peer border routers on the same infra link
- Also move all InfraLinkInfo section into a new function `RetrieveInfraLinkInfo()`