### PR TITLE
[github-actions] update the build directory for otbr-agent

### DIFF
--- a/.github/workflows/ncp_mode.yml
+++ b/.github/workflows/ncp_mode.yml
@@ -60,8 +60,8 @@ jobs:
       run: tests/scripts/bootstrap.sh
     - name: Build
       run: |
-        script/test build
+        OTBR_BUILD_DIR="./build/temp" script/cmake-build -DCMAKE_BUILD_TYPE=Debug -DOT_THREAD_VERSION=1.3 -DOTBR_DBUS=ON -DOTBR_FEATURE_FLAGS=ON -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_WEB=ON -DOTBR_UNSECURE_JOIN=ON -DOTBR_TREL=ON
     - name: Run
-      run: OTBR_VERBOSE=1 script/test ncp_mode
+      run: OTBR_VERBOSE=1 OTBR_TOP_BUILDDIR="./build/temp" script/test ncp_mode
     - name: Codecov
       uses: codecov/codecov-action@v4

--- a/script/test
+++ b/script/test
@@ -62,7 +62,7 @@ readonly OTBR_REST
 OTBR_OPTIONS="${OTBR_OPTIONS-}"
 readonly OTBR_OPTIONS
 
-OTBR_TOP_BUILDDIR="${BUILD_DIR}/otbr"
+OTBR_TOP_BUILDDIR="${OTBR_TOP_BUILDDIR:-${BUILD_DIR}/otbr}"
 readonly OTBR_TOP_BUILDDIR
 
 #######################################


### PR DESCRIPTION
This PR updates the build directory of otbr-agent in ncp_mode CI tests to a different path. This allows us to build a docker image from the same repo later. Currently if we build otbr-agent in default path and then we build a docker image, it will find existing cmake cache and report an error. 

Building docker image is to test border routing features of NCP in simulation environmrnt.