### PR TITLE
[docker] add environment variable for HTTP server

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -87,6 +87,7 @@ parse_args "$@"
 [ -n "$BACKBONE_INTERFACE" ] || BACKBONE_INTERFACE="eth0"
 [ -n "$NAT64_PREFIX" ] || NAT64_PREFIX="64:ff9b::/96"
 [ -n "$DEBUG_LEVEL" ] || DEBUG_LEVEL="7"
+[ -n "$HTTP_PORT" ] || HTTP_PORT=80
 
 echo "RADIO_URL:" $RADIO_URL
 echo "TREL_URL:" "$TREL_URL"
@@ -104,7 +105,7 @@ BIND_CONF_OPTIONS=/etc/bind/named.conf.options
 sed -i "s/$INFRA_IF_NAME/$BACKBONE_INTERFACE/" /etc/sysctl.d/60-otbr-accept-ra.conf
 
 echo "OTBR_AGENT_OPTS=\"-I $TUN_INTERFACE_NAME -B $BACKBONE_INTERFACE -d${DEBUG_LEVEL} $RADIO_URL $TREL_URL\"" >/etc/default/otbr-agent
-echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d${DEBUG_LEVEL} -p 80\"" >/etc/default/otbr-web
+echo "OTBR_WEB_OPTS=\"-I $TUN_INTERFACE_NAME -d${DEBUG_LEVEL} -p $HTTP_PORT\"" >/etc/default/otbr-web
 
 /app/script/server
 

--- a/tests/scripts/check-docker
+++ b/tests/scripts/check-docker
@@ -77,9 +77,11 @@ main()
     # shellcheck disable=SC2094
     ot-rcp 1 >"$DEVICE_PTY" <"$DEVICE_PTY" &
 
-    OTBR_DOCKER_PID=$(docker run -d \
-        --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1" \
-        --privileged -p 8080:80 --dns=127.0.0.1 --volume "$DOCKER_PTY":/dev/ttyUSB0 otbr --backbone-interface eth0)
+    OTBR_DOCKER_PID=$(
+        docker run -d -e HTTP_PORT=10080 \
+            --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1" \
+            --privileged -p 8080:10080 --dns=127.0.0.1 --volume "$DOCKER_PTY":/dev/ttyUSB0 otbr --backbone-interface eth0
+    )
     readonly OTBR_DOCKER_PID
     sleep 10
     sudo lsof -i :8080


### PR DESCRIPTION
This commit adds an environment variable to specify the otbr-web port in docker, so that it can avoid port conflict with other services in host network mode.