### PR TITLE
[telemetry] add `peer_br_count` in WpanTopoFull

### DIFF
--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -115,6 +115,8 @@ message TelemetryData {
     optional uint32 neighbor_table_size = 15;
     optional int32 instant_rssi = 16;
     optional uint64 extended_pan_id = 17;
+    // Indicates the number peer BR in Thread mesh network (from network data)
+    optional uint32 peer_br_count = 18;
   }
 
   message TopoEntry {

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -1234,6 +1234,9 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
 
         extPanIdVal = ConvertOpenThreadUint64(extPanId->m8);
         wpanTopoFull->set_extended_pan_id(extPanIdVal);
+#if OTBR_ENABLE_BORDER_ROUTING
+        wpanTopoFull->set_peer_br_count(otBorderRoutingCountPeerBrs(mInstance, /*minAge=*/nullptr));
+#endif
         // End of WpanTopoFull section.
 
         // Begin of TopoEntry section.

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -289,6 +289,7 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_topo_full().network_data().size() > 0);
     TEST_ASSERT(telemetryData.wpan_topo_full().partition_id() > 0);
     TEST_ASSERT(telemetryData.wpan_topo_full().extended_pan_id() > 0);
+    TEST_ASSERT(telemetryData.wpan_topo_full().peer_br_count() == 0);
     TEST_ASSERT(telemetryData.topo_entries_size() == 1);
     TEST_ASSERT(telemetryData.topo_entries(0).rloc16() < 0xffff);
     TEST_ASSERT(telemetryData.wpan_border_router().border_routing_counters().rs_tx_failure() == 0);


### PR DESCRIPTION
`peer_br_count` is the number of border routers retrieved from network data.