### PR TITLE
[continuous-integration] fix the path for uploading artifacts when BR test fails

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -173,15 +173,15 @@ jobs:
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e OTBR_COVERAGE"
         echo "CI_ENV=${CI_ENV}"
-        (cd third_party/openthread/repo && sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r *.log *.json *.pcap && false))
+        (cd third_party/openthread/repo && sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r ot_testing/* && false))
     - uses: actions/upload-artifact@v4
       if: ${{ failure() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       with:
         name: thread-1-3-backbone-results
         path: |
-          third_party/openthread/repo/*.pcap
-          third_party/openthread/repo/*.json
-          third_party/openthread/repo/*.log
+          third_party/openthread/repo/ot_testing/*.pcap
+          third_party/openthread/repo/ot_testing/*.json
+          third_party/openthread/repo/ot_testing/*.log
     - name: Codecov
       if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
The OTBR testing artifacts used to be at `third_party/openthread/repo/` but they are now at `third_party/openthread/repo/ot_testing/`