### PR TITLE
[host] add network properties class

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -610,7 +610,7 @@ exit:
 
 bool BorderAgent::IsThreadStarted(void) const
 {
-    otDeviceRole role = otThreadGetDeviceRole(mHost.GetInstance());
+    otDeviceRole role = mHost.GetDeviceRole();
 
     return role == OT_DEVICE_ROLE_CHILD || role == OT_DEVICE_ROLE_ROUTER || role == OT_DEVICE_ROLE_LEADER;
 }

--- a/src/dbus/server/dbus_thread_object_ncp.cpp
+++ b/src/dbus/server/dbus_thread_object_ncp.cpp
@@ -63,16 +63,9 @@ exit:
 
 void DBusThreadObjectNcp::AsyncGetDeviceRoleHandler(DBusRequest &aRequest)
 {
-    mHost.GetDeviceRole([this, aRequest](otError aError, otDeviceRole aRole) mutable {
-        if (aError == OT_ERROR_NONE)
-        {
-            this->ReplyAsyncGetProperty(aRequest, GetDeviceRoleName(aRole));
-        }
-        else
-        {
-            aRequest.ReplyOtResult(aError);
-        }
-    });
+    otDeviceRole role = mHost.GetDeviceRole();
+
+    ReplyAsyncGetProperty(aRequest, GetDeviceRoleName(role));
 }
 
 void DBusThreadObjectNcp::ReplyAsyncGetProperty(DBusRequest &aRequest, const std::string &aContent)

--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -40,6 +40,25 @@
 namespace otbr {
 namespace Ncp {
 
+// =============================== NcpNetworkProperties ===============================
+
+NcpNetworkProperties::NcpNetworkProperties(void)
+    : mDeviceRole(OT_DEVICE_ROLE_DISABLED)
+{
+}
+
+otDeviceRole NcpNetworkProperties::GetDeviceRole(void) const
+{
+    return mDeviceRole;
+}
+
+void NcpNetworkProperties::SetDeviceRole(otDeviceRole aRole)
+{
+    mDeviceRole = aRole;
+}
+
+// ===================================== NcpHost ======================================
+
 NcpHost::NcpHost(const char *aInterfaceName, bool aDryRun)
     : mSpinelDriver(*static_cast<ot::Spinel::SpinelDriver *>(otSysGetSpinelDriver()))
 {
@@ -57,18 +76,13 @@ const char *NcpHost::GetCoprocessorVersion(void)
 void NcpHost::Init(void)
 {
     otSysInit(&mConfig);
-    mNcpSpinel.Init(mSpinelDriver);
+    mNcpSpinel.Init(mSpinelDriver, *this);
 }
 
 void NcpHost::Deinit(void)
 {
     mNcpSpinel.Deinit();
     otSysDeinit();
-}
-
-void NcpHost::GetDeviceRole(DeviceRoleHandler aHandler)
-{
-    mNcpSpinel.GetDeviceRole(aHandler);
 }
 
 void NcpHost::Process(const MainloopContext &aMainloop)

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -44,7 +44,30 @@
 namespace otbr {
 namespace Ncp {
 
-class NcpHost : public MainloopProcessor, public ThreadHost
+/**
+ * This class implements the NetworkProperties under NCP mode.
+ *
+ */
+class NcpNetworkProperties : virtual public NetworkProperties, public PropsObserver
+{
+public:
+    /**
+     * Constructor
+     *
+     */
+    explicit NcpNetworkProperties(void);
+
+    // NetworkProperties methods
+    otDeviceRole GetDeviceRole(void) const override;
+
+private:
+    // PropsObserver methods
+    void SetDeviceRole(otDeviceRole aRole) override;
+
+    otDeviceRole mDeviceRole;
+};
+
+class NcpHost : public MainloopProcessor, public ThreadHost, public NcpNetworkProperties
 {
 public:
     /**
@@ -63,7 +86,6 @@ public:
     ~NcpHost(void) override = default;
 
     // ThreadHost methods
-    void            GetDeviceRole(const DeviceRoleHandler aHandler) override;
     CoprocessorType GetCoprocessorType(void) override { return OT_COPROCESSOR_NCP; }
     const char     *GetCoprocessorVersion(void) override;
     const char     *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -50,14 +50,34 @@ namespace otbr {
 namespace Ncp {
 
 /**
+ * This interface is an observer to subscribe the network properties from NCP.
+ *
+ */
+class PropsObserver
+{
+public:
+    /**
+     * Updates the device role.
+     *
+     * @param[in] aRole  The device role.
+     *
+     */
+    virtual void SetDeviceRole(otDeviceRole aRole) = 0;
+
+    /**
+     * The destructor.
+     *
+     */
+    virtual ~PropsObserver(void) = default;
+};
+
+/**
  * The class provides methods for controlling the Thread stack on the network co-processor (NCP).
  *
  */
 class NcpSpinel
 {
 public:
-    using GetDeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
-
     /**
      * Constructor.
      *
@@ -68,9 +88,10 @@ public:
      * Do the initialization.
      *
      * @param[in]  aSpinelDriver   A reference to the SpinelDriver instance that this object depends.
+     * @param[in]  aObserver       A reference to the Network properties observer.
      *
      */
-    void Init(ot::Spinel::SpinelDriver &aSpinelDriver);
+    void Init(ot::Spinel::SpinelDriver &aSpinelDriver, PropsObserver &aObserver);
 
     /**
      * Do the de-initialization.
@@ -83,17 +104,6 @@ public:
      *
      */
     const char *GetCoprocessorVersion(void) { return mSpinelDriver->GetVersion(); }
-
-    /**
-     * This method gets the device role and return the role through the handler.
-     *
-     * If this method is called again before the handler is called, the previous handler will be
-     * overridden and there will be only one call to the latest handler.
-     *
-     * @param[in]  aHandler   A handler to return the role.
-     *
-     */
-    void GetDeviceRole(GetDeviceRoleHandler aHandler);
 
 private:
     using FailureHandler = std::function<void(otError)>;
@@ -133,10 +143,9 @@ private:
     spinel_tid_t              mCmdNextTid;                ///< Next available transaction id.
     spinel_prop_key_t         mWaitingKeyTable[kMaxTids]; ///< The property keys of ongoing transactions.
 
-    otDeviceRole         mDeviceRole;
-    GetDeviceRoleHandler mGetDeviceRoleHandler;
-
     TaskRunner mTaskRunner;
+
+    PropsObserver *mPropsObserver;
 };
 
 } // namespace Ncp

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -61,10 +61,33 @@ class FeatureFlagList;
 namespace Ncp {
 
 /**
+ * This class implements the NetworkProperties for architectures where OT APIs are directly accessible.
+ *
+ */
+class OtNetworkProperties : virtual public NetworkProperties
+{
+public:
+    /**
+     * Constructor.
+     *
+     */
+    explicit OtNetworkProperties(void);
+
+    // NetworkProperties methods
+    otDeviceRole GetDeviceRole(void) const override;
+
+    // Set the otInstance
+    void SetInstance(otInstance *aInstance);
+
+private:
+    otInstance *mInstance;
+};
+
+/**
  * This interface defines OpenThread Controller under RCP mode.
  *
  */
-class RcpHost : public MainloopProcessor, public ThreadHost
+class RcpHost : public MainloopProcessor, public ThreadHost, public OtNetworkProperties
 {
 public:
     using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;
@@ -194,9 +217,6 @@ public:
 
     ~RcpHost(void) override;
 
-    // Thread Control virtual methods
-    void GetDeviceRole(const DeviceRoleHandler aHandler) override;
-
     CoprocessorType GetCoprocessorType(void) override
     {
         return OT_COPROCESSOR_RCP;
@@ -240,6 +260,7 @@ private:
     TaskRunner                                 mTaskRunner;
     std::vector<ThreadStateChangedCallback>    mThreadStateChangedCallbacks;
     bool                                       mEnableAutoAttach = false;
+
 #if OTBR_ENABLE_FEATURE_FLAGS
     // The applied FeatureFlagList in ApplyFeatureFlagList call, used for debugging purpose.
     std::string mAppliedFeatureFlagListBytes;

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -48,13 +48,36 @@ namespace otbr {
 namespace Ncp {
 
 /**
+ * This interface provides access to some Thread network properties in a sync way.
+ *
+ * The APIs are unified for both NCP and RCP cases.
+ */
+class NetworkProperties
+{
+public:
+    /**
+     * Returns the device role.
+     *
+     * @returns the device role.
+     *
+     */
+    virtual otDeviceRole GetDeviceRole(void) const = 0;
+
+    /**
+     * The destructor.
+     *
+     */
+    virtual ~NetworkProperties(void) = default;
+};
+
+/**
  * This class is an interface which provides a set of async APIs to control the
  * Thread network.
  *
  * The APIs are unified for both NCP and RCP cases.
  *
  */
-class ThreadHost
+class ThreadHost : virtual public NetworkProperties
 {
 public:
     using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
@@ -78,14 +101,6 @@ public:
                                               const char                      *aBackboneInterfaceName,
                                               bool                             aDryRun,
                                               bool                             aEnableAutoAttach);
-
-    /**
-     * This method gets the device role and returns the role through the handler.
-     *
-     * @param[in] aHandler  A handler to return the role.
-     *
-     */
-    virtual void GetDeviceRole(DeviceRoleHandler aHandler) = 0;
 
     /**
      * Returns the co-processor type.

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -248,7 +248,7 @@ void ThreadHelper::StateChangedCallback(otChangedFlags aFlags)
 {
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {
-        otDeviceRole role = otThreadGetDeviceRole(mInstance);
+        otDeviceRole role = mHost->GetDeviceRole();
 
         for (const auto &handler : mDeviceRoleHandlers)
         {
@@ -670,7 +670,7 @@ otError ThreadHelper::TryResumeNetwork(void)
 {
     otError error = OT_ERROR_NONE;
 
-    if (otLinkGetPanId(mInstance) != UINT16_MAX && otThreadGetDeviceRole(mInstance) == OT_DEVICE_ROLE_DISABLED)
+    if (otLinkGetPanId(mInstance) != UINT16_MAX && mHost->GetDeviceRole() == OT_DEVICE_ROLE_DISABLED)
     {
         if (!otIp6IsEnabled(mInstance))
         {
@@ -708,7 +708,7 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, At
     otOperationalDatasetTlvs datasetTlvs;
     otOperationalDataset     dataset;
     otOperationalDataset     emptyDataset{};
-    otDeviceRole             role = otThreadGetDeviceRole(mInstance);
+    otDeviceRole             role = mHost->GetDeviceRole();
     Tlv                     *tlv;
     uint64_t                 pendingTimestamp = 0;
     timespec                 currentTime;
@@ -1094,7 +1094,7 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
     auto wpanStats = telemetryData.mutable_wpan_stats();
 
     {
-        otDeviceRole     role  = otThreadGetDeviceRole(mInstance);
+        otDeviceRole     role  = mHost->GetDeviceRole();
         otLinkModeConfig otCfg = otThreadGetLinkMode(mInstance);
 
         wpanStats->set_node_type(TelemetryNodeTypeFromRoleAndLinkMode(role, otCfg));


### PR DESCRIPTION
This PR adds a new interface `NetworkProperties` to provide a unified, synchronized way to access network properties for both NCP and RCP.

* For RCP, the property getters are implemented by OT APIs with an OT instance.
* For NCP, the property getters are implemented by the replica of the data that comes from NCP.

This is important for adding NCP support because in some cases the network properties are required by some functionality and we don't want to make an asynchronous call simply to get the property. As one example, in AdvertisingProxy, we need to the MeshLocal Prefix to check if an address is mesh local address. Currently this is done by OT API, which is not available under NCP mode. However, the information is contained in the active dataset and NCP will always notify the host about the change. With `NetworkProperties`, we can always get these properties in a synchronized way.

This PR also replaces a few usage of `otThreadGetDeviceRole` by `NetworkProperties`. In this way we will gradually remove the direct usage of OT APIs and mInstance in ot-br-posix modules. In this way we can develop for both NCP&RCP more easily. 