### PR TITLE
[ncp] fix a compilation issue in `ncp_spinel.cpp`

### DIFF
--- a/src/ncp/ncp_spinel.cpp
+++ b/src/ncp/ncp_spinel.cpp
@@ -69,7 +69,7 @@ void NcpSpinel::GetDeviceRole(GetDeviceRoleHandler aHandler)
 {
     otError      error = OT_ERROR_NONE;
     spinel_tid_t tid   = GetNextTid();
-    va_list      args;
+    va_list      args  = {};
 
     error = mSpinelDriver->SendCommand(SPINEL_CMD_PROP_VALUE_GET, SPINEL_PROP_NET_ROLE, tid, nullptr, args);
     if (error != OT_ERROR_NONE)


### PR DESCRIPTION
Fix an issue in `ncp_spinel.cpp` related to a dummy va_list variable being uninitialized. It causes problems with certain architectures and compiler flags, and initializing it using va_start doesn't work since it's not in a variadic function.