### PR TITLE
[dbus] fix `u_int16_t` typo

### DIFF
--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -715,7 +715,7 @@ struct TrelInfo
     };
 
     bool               mEnabled;      ///< Whether TREL is enabled.
-    uint16_t          mNumTrelPeers; ///< The number of TREL peers.
+    uint16_t           mNumTrelPeers; ///< The number of TREL peers.
     TrelPacketCounters mTrelCounters; ///< The TREL counters.
 };
 

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -715,7 +715,7 @@ struct TrelInfo
     };
 
     bool               mEnabled;      ///< Whether TREL is enabled.
-    u_int16_t          mNumTrelPeers; ///< The number of TREL peers.
+    uint16_t          mNumTrelPeers; ///< The number of TREL peers.
     TrelPacketCounters mTrelCounters; ///< The TREL counters.
 };
 


### PR DESCRIPTION
There are no other `u_int16_t` occurrences in the entire repository, and this is indeed undefined.