### PR TITLE
[ncp] add posix netif for NCP

### DIFF
--- a/include/openthread-br/otbr-posix-config.h
+++ b/include/openthread-br/otbr-posix-config.h
@@ -1,0 +1,58 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file defines configs for otbr posix platform.
+ */
+
+#include "config.h"
+
+#ifdef __APPLE__
+
+/**
+ * Use built-in utun driver on mac OS
+ */
+#define OTBR_POSIX_CONFIG_MACOS_UTUN 1
+
+/**
+ * Use open-source tun driver on mac OS
+ */
+#define OTBR_POSIX_CONFIG_MACOS_TUN 2
+
+/**
+ * @def OTBR_POSIX_CONFIG_MACOS_TUN_OPTION
+ *
+ * This setting configures which tunnel driver to use.
+ *
+ */
+#ifndef OTBR_POSIX_CONFIG_MACOS_TUN_OPTION
+#define OTBR_POSIX_CONFIG_MACOS_TUN_OPTION OTBR_POSIX_CONFIG_MACOS_TUN
+#endif
+
+#endif // __APPLE__

--- a/script/test
+++ b/script/test
@@ -152,7 +152,7 @@ do_check()
 {
     (cd "${OTBR_TOP_BUILDDIR}" \
         && ninja && sudo ninja install \
-        && CTEST_OUTPUT_ON_FAILURE=1 ninja test)
+        && CTEST_OUTPUT_ON_FAILURE=1 sudo ninja test)
 }
 
 do_doxygen()

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 
+#include "types.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/types.hpp"
@@ -39,6 +40,11 @@ namespace otbr {
 Ip6Address::Ip6Address(const uint8_t (&aAddress)[16])
 {
     memcpy(m8, aAddress, sizeof(m8));
+}
+
+Ip6Address::Ip6Address(const otIp6Address &aAddress)
+{
+    memcpy(m8, aAddress.mFields.m8, sizeof(m8));
 }
 
 std::string Ip6Address::ToString() const

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include <openthread/error.h>
+#include <openthread/ip6.h>
 
 #include "common/byteswap.hpp"
 
@@ -142,6 +143,12 @@ public:
      *
      */
     Ip6Address(const uint8_t (&aAddress)[16]);
+
+    /**
+     * Constructor with an otIp6Address.
+     *
+     */
+    Ip6Address(const otIp6Address &aAddress);
 
     /**
      * Constructor with a string.

--- a/src/ncp/posix/CMakeLists.txt
+++ b/src/ncp/posix/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021, The OpenThread Authors.
+#  Copyright (c) 2024, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,22 +26,13 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_subdirectory(posix)
-
-add_library(otbr-ncp
-    ncp_host.cpp
-    ncp_host.hpp
-    ncp_spinel.cpp
-    ncp_spinel.hpp
-    rcp_host.cpp
-    rcp_host.hpp
-    thread_host.cpp
-    thread_host.hpp
+add_library(otbr-posix
+    netif.cpp
+    netif_linux.cpp
+    netif_unix.cpp
+    netif.hpp
 )
 
-target_link_libraries(otbr-ncp PRIVATE
+target_link_libraries(otbr-posix
     otbr-common
-    otbr-posix
-    $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
-    $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
 )

--- a/src/ncp/posix/netif.cpp
+++ b/src/ncp/posix/netif.cpp
@@ -1,0 +1,287 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <utility>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+namespace otbr {
+namespace Posix {
+
+Netif::Netif(const char *aInterfaceName)
+    : mInterfaceName(aInterfaceName)
+    , mTunFd(-1)
+    , mIpFd(-1)
+    , mNetlinkFd(-1)
+    , mNetlinkSequence(0)
+{
+    memset(mNetifName, 0, sizeof(mNetifName));
+}
+
+void Netif::Init(void)
+{
+    mIpFd = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, kSocketNonBlock);
+    VerifyOrDie(mIpFd >= 0, strerror(errno));
+
+    PlatConfigureNetLink();
+    PlatConfigureTunDevice();
+
+    mNetifIndex = if_nametoindex(mNetifName);
+    VerifyOrDie(mNetifIndex > 0, OTBR_ERROR_INVALID_STATE);
+
+    PlatInit();
+}
+
+void Netif::Deinit(void)
+{
+    if (mTunFd != -1)
+    {
+        close(mTunFd);
+        mTunFd = -1;
+    }
+
+    if (mIpFd != -1)
+    {
+        close(mIpFd);
+        mIpFd = -1;
+    }
+
+    if (mNetlinkFd != -1)
+    {
+        close(mNetlinkFd);
+        mNetlinkFd = -1;
+    }
+
+    mNetifIndex = 0;
+}
+
+void Netif::Process(const MainloopContext *aContext)
+{
+    VerifyOrExit(mNetifIndex > 0);
+
+    if (FD_ISSET(mTunFd, &aContext->mErrorFdSet))
+    {
+        close(mTunFd);
+        DieNow("Error on Tun Fd!");
+    }
+
+    if (FD_ISSET(mNetlinkFd, &aContext->mErrorFdSet))
+    {
+        close(mNetlinkFd);
+        DieNow("Error on Netlink Fd!");
+    }
+
+    if (FD_ISSET(mNetlinkFd, &aContext->mReadFdSet))
+    {
+        PlatProcessNetlinkEvent();
+    }
+
+exit:
+    return;
+}
+
+void Netif::UpdateFdSet(MainloopContext *aContext)
+{
+    VerifyOrExit(mNetifIndex > 0);
+
+    assert(aContext != nullptr);
+    assert(mTunFd >= 0);
+    assert(mNetlinkFd >= 0);
+    assert(mIpFd >= 0);
+
+    FD_SET(mTunFd, &aContext->mReadFdSet);
+    FD_SET(mTunFd, &aContext->mErrorFdSet);
+    FD_SET(mNetlinkFd, &aContext->mReadFdSet);
+    FD_SET(mNetlinkFd, &aContext->mErrorFdSet);
+
+    if (mTunFd > aContext->mMaxFd)
+    {
+        aContext->mMaxFd = mTunFd;
+    }
+
+    if (mNetlinkFd > aContext->mMaxFd)
+    {
+        aContext->mMaxFd = mNetlinkFd;
+    }
+
+exit:
+    return;
+}
+
+void Netif::UpdateIp6Addresses(const std::vector<otIp6AddressInfo> &aAddresses)
+{
+    mIp6AddressesUpdate.clear();
+    for (const otIp6AddressInfo &address : aAddresses)
+    {
+        mIp6AddressesUpdate.emplace_back(address);
+    }
+
+    // Remove stale addresses
+    for (const Ip6AddressInfo &address : mIp6Addresses)
+    {
+        if (std::find(mIp6AddressesUpdate.begin(), mIp6AddressesUpdate.end(), address) == mIp6AddressesUpdate.end())
+        {
+            otbrLogInfo("Remove address: %s", Ip6Address(address.mAddress).ToString().c_str());
+            ProcessAddressChange(address, false);
+        }
+    }
+
+    // Add new addresses
+    for (const Ip6AddressInfo &address : mIp6AddressesUpdate)
+    {
+        if (std::find(mIp6Addresses.begin(), mIp6Addresses.end(), address) == mIp6Addresses.end())
+        {
+            otbrLogInfo("Add address: %s", Ip6Address(address.mAddress).ToString().c_str());
+            ProcessAddressChange(address, true);
+        }
+    }
+
+    std::swap(mIp6Addresses, mIp6AddressesUpdate);
+}
+
+void Netif::UpdateIp6MulticastAddresses(const std::vector<otIp6Address> &aAddresses)
+{
+    // Remove stale addresses
+    for (const otIp6Address &address : mIp6MulticastAddresses)
+    {
+        auto condition = [&address](const otIp6Address &aAddr) {
+            return memcmp(&address, &aAddr, sizeof(otIp6Address)) == 0;
+        };
+
+        if (std::find_if(aAddresses.begin(), aAddresses.end(), condition) == aAddresses.end())
+        {
+            otbrLogInfo("Remove address: %s", Ip6Address(address).ToString().c_str());
+            UpdateMulticast(address, false);
+        }
+    }
+
+    // Add new addresses
+    for (const otIp6Address &address : aAddresses)
+    {
+        auto condition = [&address](const otIp6Address &aAddr) {
+            return memcmp(&address, &aAddr, sizeof(otIp6Address)) == 0;
+        };
+
+        if (std::find_if(mIp6MulticastAddresses.begin(), mIp6MulticastAddresses.end(), condition) ==
+            mIp6MulticastAddresses.end())
+        {
+            otbrLogInfo("Remove address: %s", Ip6Address(address).ToString().c_str());
+            UpdateMulticast(address, true);
+        }
+    }
+
+    mIp6MulticastAddresses.assign(aAddresses.begin(), aAddresses.end());
+}
+
+int Netif::SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption)
+{
+    int rval = 0;
+    int fd   = -1;
+
+#ifdef __APPLE__
+    VerifyOrExit((fd = socket(aDomain, aType, aProtocol)) != -1, perror("socket(SOCK_CLOEXEC)"));
+
+    VerifyOrExit((rval = fcntl(fd, F_GETFD, 0)) != -1, perror("fcntl(F_GETFD)"));
+    rval |= aBlockOption == kSocketNonBlock ? O_NONBLOCK | FD_CLOEXEC : FD_CLOEXEC;
+    VerifyOrExit((rval = fcntl(fd, F_SETFD, rval)) != -1, perror("fcntl(F_SETFD)"));
+#else
+    aType |= aBlockOption == kSocketNonBlock ? SOCK_CLOEXEC | SOCK_NONBLOCK : SOCK_CLOEXEC;
+    VerifyOrExit((fd = socket(aDomain, aType, aProtocol)) != -1, perror("socket(SOCK_CLOEXEC)"));
+#endif
+
+exit:
+    if (rval == -1)
+    {
+        VerifyOrDie(close(fd) == 0, strerror(errno));
+        fd = -1;
+    }
+
+    return fd;
+}
+
+void Netif::UpdateMulticast(const otIp6Address &aAddress, bool aIsAdded)
+{
+    struct ipv6_mreq mreq;
+    otbrError        error = OTBR_ERROR_NONE;
+    int              err;
+
+    VerifyOrExit(mIpFd >= 0);
+    memcpy(&mreq.ipv6mr_multiaddr, &aAddress, sizeof(mreq.ipv6mr_multiaddr));
+    mreq.ipv6mr_interface = mNetifIndex;
+
+    err = setsockopt(mIpFd, IPPROTO_IPV6, (aIsAdded ? IPV6_JOIN_GROUP : IPV6_LEAVE_GROUP), &mreq, sizeof(mreq));
+
+    if (err != 0)
+    {
+        otbrLogWarning("%s failure (%d)", aIsAdded ? "IPV6_JOIN_GROUP" : "IPV6_LEAVE_GROUP", errno);
+        error = OTBR_ERROR_ERRNO;
+        ExitNow();
+    }
+
+    otbrLogInfo("%s multicast address %s", aIsAdded ? "Added" : "Removed", Ip6Address(aAddress).ToString().c_str());
+
+exit:
+    SuccessOrDie(error, strerror(errno));
+}
+
+void Netif::ProcessAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+{
+    if (aAddressInfo.mAddress.mFields.m8[0] == 0xff)
+    {
+        UpdateMulticast(aAddressInfo.mAddress, aIsAdded);
+    }
+    else
+    {
+        PlatUpdateUnicast(aAddressInfo, aIsAdded);
+    }
+}
+
+bool Netif::CompareIp6Address(const otIp6Address &aObj1, const otIp6Address &aObj2)
+{
+    return memcmp(&aObj1, &aObj2, sizeof(otIp6Address)) == 0;
+}
+
+} // namespace Posix
+} // namespace otbr

--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -1,0 +1,173 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions of the posix Netif of otbr-agent.
+ */
+
+#ifndef OTBR_AGENT_POSIX_NETIF_HPP_
+#define OTBR_AGENT_POSIX_NETIF_HPP_
+
+#include <net/if.h>
+
+#include <list>
+#include <string.h>
+#include <string>
+#include <vector>
+
+#include <openthread/ip6.h>
+
+#include <openthread-br/otbr-posix-config.h>
+
+#include "common/mainloop.hpp"
+#include "ncp/ncp_spinel.hpp"
+
+namespace otbr {
+namespace Posix {
+
+class Netif
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param[in]  aInterfaceName  A string of the NCP interface name.
+     *
+     */
+    Netif(const char *aInterfaceName);
+
+    /**
+     * This method initializes the posix platform network interface.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method de-initializes the posix platform network interface.
+     *
+     */
+    void Deinit(void);
+
+    /**
+     * This method processes the posix platform network interface tasks.
+     *
+     * @param[in] aContext  A pointer to the mainloop context.
+     *
+     */
+    void Process(const MainloopContext *aContext);
+
+    /**
+     * This method updates the FD set of the mainloop with the FDs used in this module.
+     *
+     * @param[in] aContext  A pointer to the mainloop context.
+     *
+     */
+    void UpdateFdSet(MainloopContext *aContext);
+
+    /**
+     * This method updates the Ip6 addresses of the network interface.
+     *
+     * @param[in] aAddresses  The latest Ip6 addresses.
+     *
+     */
+    void UpdateIp6Addresses(const std::vector<otIp6AddressInfo> &aAddresses);
+
+    /**
+     * This method updates the Ip6 multicast addresses of the network interface.
+     *
+     * @param[in] aAddresses  The latest Ip6 multicast addresses.
+     *
+     */
+    void UpdateIp6MulticastAddresses(const std::vector<otIp6Address> &aAddresses);
+
+private:
+    static constexpr size_t kMaxIp6Size = 1280;
+
+    enum SocketBlockOption
+    {
+        kSocketBlock,
+        kSocketNonBlock,
+    };
+
+    struct Ip6AddressInfo
+    {
+        Ip6AddressInfo(const otIp6AddressInfo &aInfo)
+            : mPrefixLength(aInfo.mPrefixLength)
+            , mScope(aInfo.mScope)
+            , mPreferred(aInfo.mPreferred)
+            , mMeshLocal(aInfo.mMeshLocal)
+        {
+            memcpy(&mAddress, aInfo.mAddress, sizeof(otIp6Address));
+        }
+
+        otIp6Address mAddress;       ///< A pointer to the IPv6 address.
+        uint8_t      mPrefixLength;  ///< The prefix length of mAddress if it is a unicast address.
+        uint8_t      mScope : 4;     ///< The scope of this address.
+        bool         mPreferred : 1; ///< Whether this is a preferred address.
+        bool         mMeshLocal : 1; ///< Whether this is a mesh-local unicast/anycast address.
+
+        bool operator==(const Ip6AddressInfo &aOther) const
+        {
+            return memcmp(this, &aOther, sizeof(Ip6AddressInfo)) == 0;
+        }
+    };
+
+    static bool CompareIp6Address(const otIp6Address &aObj1, const otIp6Address &aObj2);
+
+    static int SocketWithCloseExec(int aDomain, int aType, int aProtocol, SocketBlockOption aBlockOption);
+
+    void PlatInit(void);
+    void PlatConfigureNetLink(void);
+    void PlatConfigureTunDevice(void);
+    void PlatUpdateUnicast(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
+    void PlatProcessNetlinkEvent(void);
+
+    void SetAddrGenModeToNone(void);
+    void ProcessAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
+    void UpdateMulticast(const otIp6Address &aAddress, bool aIsAdded);
+
+    const char *mInterfaceName;
+
+    int      mTunFd;           ///< Used to exchange IPv6 packets.
+    int      mIpFd;            ///< Used to manage IPv6 stack on Thread interface.
+    int      mNetlinkFd;       ///< Used to receive netlink events.
+    uint32_t mNetlinkSequence; ///< Netlink message sequence.
+
+    unsigned int mNetifIndex;
+    char         mNetifName[IFNAMSIZ];
+
+    std::list<Ip6AddressInfo> mIp6Addresses;
+    std::list<Ip6AddressInfo> mIp6AddressesUpdate;
+    std::vector<otIp6Address> mIp6MulticastAddresses;
+};
+
+} // namespace Posix
+} // namespace otbr
+
+#endif // OTBR_AGENT_POSIX_NETIF_HPP_

--- a/src/ncp/posix/netif_linux.cpp
+++ b/src/ncp/posix/netif_linux.cpp
@@ -1,0 +1,353 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __linux__
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include <openthread-br/otbr-posix-config.h>
+
+#include <assert.h>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <sys/ioctl.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+#ifndef OTBR_POSIX_TUN_DEVICE
+#define OTBR_POSIX_TUN_DEVICE "/dev/net/tun"
+#endif
+
+namespace otbr {
+namespace Posix {
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+static struct rtattr  *AddRtAttr(nlmsghdr *aHeader, uint32_t aMaxLen, uint8_t aType, const void *aData, uint8_t aLen)
+{
+    uint8_t len = RTA_LENGTH(aLen);
+    rtattr *rta;
+
+    assert(NLMSG_ALIGN(aHeader->nlmsg_len) + RTA_ALIGN(len) <= aMaxLen);
+    OTBR_UNUSED_VARIABLE(aMaxLen);
+
+    rta           = (rtattr *)((char *)(aHeader) + NLMSG_ALIGN((aHeader)->nlmsg_len));
+    rta->rta_type = aType;
+    rta->rta_len  = len;
+    if (aLen)
+    {
+        memcpy(RTA_DATA(rta), aData, aLen);
+    }
+    aHeader->nlmsg_len = NLMSG_ALIGN(aHeader->nlmsg_len) + RTA_ALIGN(len);
+
+    return rta;
+}
+
+void Netif::PlatUpdateUnicast(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+{
+    struct
+    {
+        nlmsghdr  nh;
+        ifaddrmsg ifa;
+        char      buf[512];
+    } req;
+
+    assert(mIpFd >= 0);
+    memset(&req, 0, sizeof(req));
+
+    req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifaddrmsg));
+    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | (aIsAdded ? (NLM_F_CREATE | NLM_F_EXCL) : 0);
+    req.nh.nlmsg_type  = aIsAdded ? RTM_NEWADDR : RTM_DELADDR;
+    req.nh.nlmsg_pid   = 0;
+    req.nh.nlmsg_seq   = ++mNetlinkSequence;
+
+    req.ifa.ifa_family    = AF_INET6;
+    req.ifa.ifa_prefixlen = aAddressInfo.mPrefixLength;
+    req.ifa.ifa_flags     = IFA_F_NODAD;
+    req.ifa.ifa_scope     = aAddressInfo.mScope;
+    req.ifa.ifa_index     = mNetifIndex;
+
+    AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, &aAddressInfo.mAddress, sizeof(aAddressInfo.mAddress));
+
+    if (!aAddressInfo.mPreferred || aAddressInfo.mMeshLocal)
+    {
+        ifa_cacheinfo cacheinfo;
+
+        memset(&cacheinfo, 0, sizeof(cacheinfo));
+        cacheinfo.ifa_valid = UINT32_MAX;
+
+        AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
+    }
+
+    if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1)
+    {
+        otbrLogInfo("Sent request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
+                    Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+    }
+    else
+    {
+        otbrLogWarning("Failed to send request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
+                       Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+    }
+}
+#pragma GCC diagnostic pop
+
+void Netif::SetAddrGenModeToNone(void)
+{
+    struct
+    {
+        nlmsghdr  nh;
+        ifinfomsg ifi;
+        char      buf[512];
+    } req;
+
+    const uint8_t mode = IN6_ADDR_GEN_MODE_NONE;
+
+    memset(&req, 0, sizeof(req));
+
+    req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifinfomsg));
+    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nh.nlmsg_type  = RTM_NEWLINK;
+    req.nh.nlmsg_pid   = 0;
+    req.nh.nlmsg_seq   = ++mNetlinkSequence;
+
+    req.ifi.ifi_index  = static_cast<int>(mNetifIndex);
+    req.ifi.ifi_change = 0xffffffff;
+    req.ifi.ifi_flags  = IFF_MULTICAST | IFF_NOARP;
+
+    {
+        rtattr *afSpec           = AddRtAttr(&req.nh, sizeof(req), IFLA_AF_SPEC, 0, 0);
+        rtattr *afInet6          = AddRtAttr(&req.nh, sizeof(req), AF_INET6, 0, 0);
+        rtattr *inet6AddrGenMode = AddRtAttr(&req.nh, sizeof(req), IFLA_INET6_ADDR_GEN_MODE, &mode, sizeof(mode));
+
+        afInet6->rta_len += inet6AddrGenMode->rta_len;
+        afSpec->rta_len += afInet6->rta_len;
+    }
+
+    if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1)
+    {
+        otbrLogInfo("Sent request#%u to set addr_gen_mode to %d", mNetlinkSequence, mode);
+    }
+    else
+    {
+        otbrLogWarning("Failed to send request#%u to set addr_gen_mode to %d", mNetlinkSequence, mode);
+    }
+}
+
+void Netif::PlatInit(void)
+{
+    SetAddrGenModeToNone();
+}
+
+#define ERR_RTA(errmsg, requestPayloadLength) \
+    ((rtattr *)((char *)(errmsg)) + NLMSG_ALIGN(sizeof(nlmsgerr)) + NLMSG_ALIGN(requestPayloadLength))
+
+// The format of NLMSG_ERROR is described below:
+//
+// ----------------------------------------------
+// | struct nlmsghdr - response header          |
+// ----------------------------------------------------------------
+// |    int error                               |                 |
+// ---------------------------------------------| struct nlmsgerr |
+// | struct nlmsghdr - original request header  |                 |
+// ----------------------------------------------------------------
+// | ** optionally (1) payload of the request   |
+// ----------------------------------------------
+// | ** optionally (2) extended ACK attrs       |
+// ----------------------------------------------
+//
+static void HandleNetlinkResponse(nlmsghdr *msg)
+{
+    const nlmsgerr *err;
+    const char     *errorMsg;
+    size_t          rtaLength;
+    size_t          requestPayloadLength = 0;
+    uint32_t        requestSeq           = 0;
+
+    if (msg->nlmsg_len < NLMSG_LENGTH(sizeof(nlmsgerr)))
+    {
+        otbrLogWarning("Truncated netlink reply of request#%u", requestSeq);
+        ExitNow();
+    }
+
+    err        = reinterpret_cast<const nlmsgerr *>(NLMSG_DATA(msg));
+    requestSeq = err->msg.nlmsg_seq;
+
+    if (err->error == 0)
+    {
+        otbrLogWarning("Succeeded to process request#%u", requestSeq);
+        ExitNow();
+    }
+
+    // For rtnetlink, `abs(err->error)` maps to values of `errno`.
+    // But this is not a requirement in RFC 3549.
+    errorMsg = strerror(abs(err->error));
+
+    // The payload of the request is omitted if NLM_F_CAPPED is set
+    if (!(msg->nlmsg_flags & NLM_F_CAPPED))
+    {
+        requestPayloadLength = NLMSG_PAYLOAD(&err->msg, 0);
+    }
+
+    rtaLength = NLMSG_PAYLOAD(msg, sizeof(nlmsgerr)) - requestPayloadLength;
+
+    for (rtattr *rta = ERR_RTA(err, requestPayloadLength); RTA_OK(rta, rtaLength); rta = RTA_NEXT(rta, rtaLength))
+    {
+        if (rta->rta_type == NLMSGERR_ATTR_MSG)
+        {
+            errorMsg = reinterpret_cast<const char *>(RTA_DATA(rta));
+            break;
+        }
+        else
+        {
+            otbrLogWarning("Ignoring netlink response attribute %d (request#%u)", rta->rta_type, requestSeq);
+        }
+    }
+
+    otbrLogWarning("Failed to process request#%u: %s", requestSeq, errorMsg);
+
+exit:
+    return;
+}
+
+void Netif::PlatConfigureNetLink(void)
+{
+    mNetlinkFd = SocketWithCloseExec(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE, kSocketNonBlock);
+    VerifyOrDie(mNetlinkFd >= 0, strerror(errno));
+
+#if defined(SOL_NETLINK)
+    {
+        int enable = 1;
+
+#if defined(NETLINK_EXT_ACK)
+        if (setsockopt(mNetlinkFd, SOL_NETLINK, NETLINK_EXT_ACK, &enable, sizeof(enable)) != 0)
+        {
+            otbrLogWarning("Failed to enable NETLINK_EXT_ACK: %s", strerror(errno));
+        }
+#endif
+#if defined(NETLINK_CAP_ACK)
+        if (setsockopt(mNetlinkFd, SOL_NETLINK, NETLINK_CAP_ACK, &enable, sizeof(enable)) != 0)
+        {
+            otbrLogWarning("Failed to enable NETLINK_CAP_ACK: %s", strerror(errno));
+        }
+#endif
+    }
+#endif
+
+    {
+        sockaddr_nl sa;
+
+        memset(&sa, 0, sizeof(sa));
+        sa.nl_family = AF_NETLINK;
+        sa.nl_groups = RTMGRP_LINK | RTMGRP_IPV6_IFADDR;
+        VerifyOrDie(bind(mNetlinkFd, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) == 0, strerror(errno));
+    }
+}
+
+void Netif::PlatConfigureTunDevice(void)
+{
+    ifreq ifr;
+
+    mTunFd = open(OTBR_POSIX_TUN_DEVICE, O_RDWR | O_CLOEXEC | O_NONBLOCK);
+    VerifyOrDie(mTunFd >= 0, strerror(errno));
+
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
+
+    if (mInterfaceName)
+    {
+        VerifyOrDie(strlen(mInterfaceName) < IFNAMSIZ, OTBR_ERROR_INVALID_ARGS);
+
+        strncpy(ifr.ifr_name, mInterfaceName, IFNAMSIZ);
+    }
+    else
+    {
+        strncpy(ifr.ifr_name, "wpan%d", IFNAMSIZ);
+    }
+
+    VerifyOrDie(ioctl(mTunFd, TUNSETIFF, static_cast<void *>(&ifr)) == 0, strerror(errno));
+
+    strncpy(mNetifName, ifr.ifr_name, sizeof(mNetifName));
+    otbrLogInfo("Netif name:%s", mNetifName);
+
+    VerifyOrDie(ioctl(mTunFd, TUNSETLINK, ARPHRD_NONE) == 0, strerror(errno));
+
+    ifr.ifr_mtu = static_cast<int>(kMaxIp6Size);
+    VerifyOrDie(ioctl(mIpFd, SIOCSIFMTU, static_cast<void *>(&ifr)) == 0, strerror(errno));
+}
+
+void Netif::PlatProcessNetlinkEvent(void)
+{
+    const size_t kMaxNetifEvent = 8192;
+    ssize_t      length;
+
+    union
+    {
+        nlmsghdr nlMsg;
+        char     buffer[kMaxNetifEvent];
+    } msgBuffer;
+
+    length = recv(mNetlinkFd, msgBuffer.buffer, sizeof(msgBuffer.buffer), 0);
+
+    // Ensures full netlink header is received
+    if (length < static_cast<ssize_t>(sizeof(nlmsghdr)))
+    {
+        otbrLogWarning("Unexpected netlink recv() result: %ld", static_cast<long>(length));
+        ExitNow();
+    }
+
+    for (nlmsghdr *msg = &msgBuffer.nlMsg; NLMSG_OK(msg, static_cast<size_t>(length)); msg = NLMSG_NEXT(msg, length))
+    {
+        switch (msg->nlmsg_type)
+        {
+        case NLMSG_ERROR:
+            HandleNetlinkResponse(msg);
+            break;
+
+        default:
+            otbrLogWarning("Unhandled/Unexpected netlink/route message (%d).", (int)msg->nlmsg_type);
+            break;
+        }
+    }
+
+exit:
+    return;
+}
+
+} // namespace Posix
+} // namespace otbr
+
+#endif // __linux__

--- a/src/ncp/posix/netif_unix.cpp
+++ b/src/ncp/posix/netif_unix.cpp
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include <openthread-br/otbr-posix-config.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#if defined(__APPLE__)
+#if OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_UTUN
+#include <net/if_utun.h>
+#endif
+#if OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_TUN
+#include <sys/ioccom.h>
+// FIX ME: include the tun_ioctl.h file (challenging, as it's location depends on where the developer puts it)
+#define TUNSIFHEAD _IOW('t', 96, int)
+#define TUNGIFHEAD _IOR('t', 97, int)
+#endif
+#include <sys/kern_control.h>
+
+#endif // defined(__APPLE__)
+
+#if defined(__NetBSD__) || defined(__FreeBSD__)
+#include <net/if_tun.h>
+#endif // defined(__NetBSD__) || defined(__FreeBSD__)
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+#ifndef OTBR_POSIX_TUN_DEVICE
+#if defined(__NetBSD__) || defined(__FreeBSD__)
+#define OTBR_POSIX_TUN_DEVICE "/dev/tun0"
+#elif defined(__APPLE__)
+#if OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_UTUN
+#define OTBR_POSIX_TUN_DEVICE // not used - calculated dynamically
+#elif OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_TUN
+#define OTBR_POSIX_TUN_DEVICE "/dev/tun0"
+#endif
+#endif // defined(__APPLE__)
+#else
+#define OTBR_POSIX_TUN_DEVICE "/dev/net/tun"
+#endif
+
+namespace otbr {
+namespace Posix {
+
+// TODO: implement platform netif functionalities on unix platforms: APPLE, NetBSD, OpenBSD
+//
+// Currently we let otbr-agent can be compiled on unix platforms and can work under RCP mode
+// but NCP mode cannot be used on unix platforms. It will crash at code here.
+
+void Netif::PlatInit(void)
+{
+    DieNow("OTBR posix not supported on this platform");
+}
+
+#if defined(__APPLE__) && (OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_UTUN)
+void Netif::PlatConfigureTunDevice(void)
+{
+    DieNow("OTBR posix not supported on this platform");
+}
+#endif // defined(__APPLE__) && (OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_UTUN)
+
+#if defined(__NetBSD__) ||                                                                         \
+    (defined(__APPLE__) && (OTBR_POSIX_CONFIG_MACOS_TUN_OPTION == OTBR_POSIX_CONFIG_MACOS_TUN)) || \
+    defined(__FreeBSD__)
+void Netif::PlatConfigureTunDevice(void)
+{
+    DieNow("OTBR posix not supported on this platform");
+}
+#endif
+
+void Netif::PlatConfigureNetLink(void)
+{
+    DieNow("OTBR posix not supported on this platform");
+}
+
+void Netif::PlatProcessNetlinkEvent(void)
+{
+    DieNow("OTBR posix not supported on this platform");
+}
+
+void Netif::PlatUpdateUnicast(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+{
+    OTBR_UNUSED_VARIABLE(aAddressInfo);
+    OTBR_UNUSED_VARIABLE(aIsAdded);
+    DieNow("OTBR posix not supported on this platform");
+}
+
+} // namespace Posix
+} // namespace otbr
+
+#endif // __APPLE__ || __NetBSD__ || __OpenBSD__

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -71,3 +71,12 @@ if(OTBR_MDNS)
     )
     gtest_discover_tests(otbr-gtest-mdns-subscribe)
 endif()
+
+add_executable(otbr-posix-gtest-unit
+    test_netif.cpp
+)
+target_link_libraries(otbr-posix-gtest-unit
+    otbr-posix
+    GTest::gmock_main
+)
+gtest_discover_tests(otbr-posix-gtest-unit)

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -1,0 +1,151 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <iostream>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <vector>
+
+#ifdef __linux__
+#include <linux/if_addr.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#endif
+
+#include <openthread/ip6.h>
+
+#include "ncp/posix/netif.hpp"
+
+// Only Test on linux platform for now.
+#ifdef __linux__
+std::vector<std::string> GetAllIp6Addrs(const char *aInterfaceName)
+{
+    struct ifaddrs          *ifaddr, *ifa;
+    int                      family;
+    std::vector<std::string> ip6Addrs;
+
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        perror("getifaddrs");
+        exit(EXIT_FAILURE);
+    }
+
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    {
+        if (ifa->ifa_addr == NULL)
+        {
+            continue;
+        }
+
+        family = ifa->ifa_addr->sa_family;
+
+        if (family == AF_INET6 && strcmp(ifa->ifa_name, aInterfaceName) == 0)
+        {
+            struct sockaddr_in6 *in6 = (struct sockaddr_in6 *)ifa->ifa_addr;
+            char                 addrstr[INET6_ADDRSTRLEN];
+            if (inet_ntop(AF_INET6, &(in6->sin6_addr), addrstr, sizeof(addrstr)) == NULL)
+            {
+                perror("inet_ntop");
+                exit(EXIT_FAILURE);
+            }
+
+            ip6Addrs.emplace_back(addrstr);
+        }
+    }
+
+    freeifaddrs(ifaddr);
+
+    return ip6Addrs;
+}
+
+TEST(Netif, UpdateUnicastAddresses)
+{
+    const char *wpan = "wpan0";
+
+    const otIp6Address kUaLl = {
+        {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x14, 0x03, 0x32, 0x4c, 0xc2, 0xf8, 0xd0}};
+    const otIp6Address kUaMlEid = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x07, 0x7f}};
+    const otIp6Address kUaMlRloc = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0xff, 0xfe, 0x00, 0xb8, 0x00}};
+    const otIp6Address kUaMlAloc = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0xff, 0xfe, 0x00, 0xfc, 0x00}};
+
+    const char *kUaLlStr     = "fe80::8014:332:4cc2:f8d0";
+    const char *kUaMlEidStr  = "fd0d:7fc:a1b9:f050:3f1:47ce:85d3:77f";
+    const char *kUaMlRlocStr = "fd0d:7fc:a1b9:f050:0:ff:fe00:b800";
+    const char *kUaMlAlocStr = "fd0d:7fc:a1b9:f050:0:ff:fe00:fc00";
+
+    otbr::Posix::Netif netif(wpan);
+    netif.Init();
+
+    otIp6AddressInfo testUaArray1[] = {
+        {&kUaLl, 64, 0, 1, 0},
+        {&kUaMlEid, 64, 0, 1, 1},
+        {&kUaMlRloc, 64, 0, 1, 1},
+    };
+    std::vector<otIp6AddressInfo> testUaVec1(testUaArray1,
+                                             testUaArray1 + sizeof(testUaArray1) / sizeof(otIp6AddressInfo));
+    netif.UpdateIp6Addresses(testUaVec1);
+    std::vector<std::string> wpan_addrs = GetAllIp6Addrs(wpan);
+    EXPECT_EQ(wpan_addrs.size(), 3);
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaLlStr));
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaMlEidStr));
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaMlRlocStr));
+
+    otIp6AddressInfo testUaArray2[] = {
+        {&kUaLl, 64, 0, 1, 0},
+        {&kUaMlEid, 64, 0, 1, 1},
+        {&kUaMlRloc, 64, 0, 1, 1},
+        {&kUaMlAloc, 64, 0, 1, 1},
+    };
+    std::vector<otIp6AddressInfo> testUaVec2(testUaArray2,
+                                             testUaArray2 + sizeof(testUaArray2) / sizeof(otIp6AddressInfo));
+    netif.UpdateIp6Addresses(testUaVec2);
+    wpan_addrs = GetAllIp6Addrs(wpan);
+    EXPECT_EQ(wpan_addrs.size(), 4);
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaLlStr));
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaMlEidStr));
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaMlRlocStr));
+    EXPECT_THAT(wpan_addrs, ::testing::Contains(kUaMlAlocStr));
+
+    netif.Deinit();
+}
+
+#endif // __linux__


### PR DESCRIPTION
This PR adds a posix platform module for NCP mode. Under NCP mode, the platform operation won't depend OT posix platform implementation and will use the posix platform implementation added in this PR instead.

This PR only adds the netif module and only support udpate IP6 addresses on the Thread network interface. The netif module hasn't been integrated with the NcpHost. In this PR, the posix platform is added as a library and has its own unit test (also implemented by gtest).

The netif implementations are different on different platforms: linux, apple, bsd... This PR only implements it on linux and adds an empty implementation for other posix platforms.