### PR TITLE
[posix] add posix netif module

### DIFF
--- a/script/test
+++ b/script/test
@@ -152,7 +152,8 @@ do_check()
 {
     (cd "${OTBR_TOP_BUILDDIR}" \
         && ninja && sudo ninja install \
-        && CTEST_OUTPUT_ON_FAILURE=1 ninja test)
+        && CTEST_OUTPUT_ON_FAILURE=1 ctest -LE sudo \
+        && CTEST_OUTPUT_ON_FAILURE=1 sudo ctest -L sudo) # Seperate running tests for sudo and non-sudo cases.
 }
 
 do_doxygen()

--- a/src/ncp/posix/CMakeLists.txt
+++ b/src/ncp/posix/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2021, The OpenThread Authors.
+#  Copyright (c) 2024, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -26,23 +26,14 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_subdirectory(posix)
-
-add_library(otbr-ncp
-    async_task.cpp
-    async_task.hpp
-    ncp_host.cpp
-    ncp_host.hpp
-    ncp_spinel.cpp
-    ncp_spinel.hpp
-    rcp_host.cpp
-    rcp_host.hpp
-    thread_host.cpp
-    thread_host.hpp
+add_library(otbr-posix
+    netif.cpp
+    netif_linux.cpp
+    netif_unix.cpp
+    netif.hpp
 )
 
-target_link_libraries(otbr-ncp PRIVATE
+target_link_libraries(otbr-posix
     otbr-common
-    $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
-    $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
+    otbr-utils
 )

--- a/src/ncp/posix/netif.cpp
+++ b/src/ncp/posix/netif.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/types.hpp"
+#include "utils/socket_utils.hpp"
+
+namespace otbr {
+
+Netif::Netif(void)
+    : mTunFd(-1)
+    , mIpFd(-1)
+    , mNetifIndex(0)
+{
+}
+
+otbrError Netif::Init(const std::string &aInterfaceName)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    mIpFd = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, kSocketNonBlock);
+    VerifyOrExit(mIpFd >= 0, error = OTBR_ERROR_ERRNO);
+
+    SuccessOrExit(error = CreateTunDevice(aInterfaceName));
+
+    mNetifIndex = if_nametoindex(mNetifName.c_str());
+    VerifyOrExit(mNetifIndex > 0, error = OTBR_ERROR_INVALID_STATE);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        Clear();
+    }
+    return error;
+}
+
+void Netif::Deinit(void)
+{
+    Clear();
+}
+
+void Netif::Clear(void)
+{
+    if (mTunFd != -1)
+    {
+        close(mTunFd);
+        mTunFd = -1;
+    }
+
+    if (mIpFd != -1)
+    {
+        close(mIpFd);
+        mIpFd = -1;
+    }
+
+    mNetifIndex = 0;
+}
+
+} // namespace otbr

--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions of the posix Netif of otbr-agent.
+ */
+
+#ifndef OTBR_AGENT_POSIX_NETIF_HPP_
+#define OTBR_AGENT_POSIX_NETIF_HPP_
+
+#include <net/if.h>
+
+#include <openthread/ip6.h>
+
+#include "common/types.hpp"
+
+namespace otbr {
+
+class Netif
+{
+public:
+    Netif(void);
+
+    otbrError Init(const std::string &aInterfaceName);
+    void      Deinit(void);
+
+private:
+    // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
+    static constexpr size_t kIp6Mtu = 1280;
+
+    void Clear(void);
+
+    otbrError CreateTunDevice(const std::string &aInterfaceName);
+
+    int mTunFd; ///< Used to exchange IPv6 packets.
+    int mIpFd;  ///< Used to manage IPv6 stack on the network interface.
+
+    unsigned int mNetifIndex;
+    std::string  mNetifName;
+};
+
+} // namespace otbr
+
+#endif // OTBR_AGENT_POSIX_NETIF_HPP_

--- a/src/ncp/posix/netif_linux.cpp
+++ b/src/ncp/posix/netif_linux.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __linux__
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/types.hpp"
+
+#ifndef OTBR_POSIX_TUN_DEVICE
+#define OTBR_POSIX_TUN_DEVICE "/dev/net/tun"
+#endif
+
+namespace otbr {
+
+otbrError Netif::CreateTunDevice(const std::string &aInterfaceName)
+{
+    ifreq     ifr;
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(aInterfaceName.size() < IFNAMSIZ, error = OTBR_ERROR_INVALID_ARGS);
+
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TUN | IFF_NO_PI;
+    if (aInterfaceName.size() > 0)
+    {
+        strncpy(ifr.ifr_name, aInterfaceName.c_str(), aInterfaceName.size());
+    }
+    else
+    {
+        strncpy(ifr.ifr_name, "wpan%d", IFNAMSIZ);
+    }
+
+    mTunFd = open(OTBR_POSIX_TUN_DEVICE, O_RDWR | O_CLOEXEC | O_NONBLOCK);
+    VerifyOrExit(mTunFd >= 0, error = OTBR_ERROR_ERRNO);
+
+    VerifyOrExit(ioctl(mTunFd, TUNSETIFF, &ifr) == 0, error = OTBR_ERROR_ERRNO);
+
+    mNetifName.assign(ifr.ifr_name, strlen(ifr.ifr_name));
+    otbrLogInfo("Netif name: %s", mNetifName.c_str());
+
+    VerifyOrExit(ioctl(mTunFd, TUNSETLINK, ARPHRD_NONE) == 0, error = OTBR_ERROR_ERRNO);
+
+    ifr.ifr_mtu = static_cast<int>(kIp6Mtu);
+    VerifyOrExit(ioctl(mIpFd, SIOCSIFMTU, &ifr) == 0, error = OTBR_ERROR_ERRNO);
+
+exit:
+    return error;
+}
+
+} // namespace otbr
+
+#endif // __linux__

--- a/src/ncp/posix/netif_unix.cpp
+++ b/src/ncp/posix/netif_unix.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+#define OTBR_LOG_TAG "NETIF"
+
+#include "netif.hpp"
+
+#include "common/code_utils.hpp"
+
+namespace otbr {
+
+// TODO: implement platform netif functionalities on unix platforms: APPLE, NetBSD, OpenBSD
+//
+// Currently we let otbr-agent can be compiled on unix platforms and can work under RCP mode
+// but NCP mode cannot be used on unix platforms. It will crash at code here.
+
+otbrError Netif::CreateTunDevice(const std::string &aInterfaceName)
+{
+    OTBR_UNUSED_VARIABLE(aInterfaceName);
+    DieNow("OTBR posix not supported on this platform");
+    return OTBR_ERROR_NONE;
+}
+
+} // namespace otbr
+
+#endif // __APPLE__ || __NetBSD__ || __OpenBSD__

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -73,3 +73,12 @@ if(OTBR_MDNS)
     )
     gtest_discover_tests(otbr-gtest-mdns-subscribe)
 endif()
+
+add_executable(otbr-posix-gtest-unit
+    test_netif.cpp
+)
+target_link_libraries(otbr-posix-gtest-unit
+    otbr-posix
+    GTest::gmock_main
+)
+gtest_discover_tests(otbr-posix-gtest-unit PROPERTIES LABELS "sudo")

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -1,0 +1,180 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <ifaddrs.h>
+#include <iostream>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <vector>
+
+#include <openthread/ip6.h>
+
+#include "common/types.hpp"
+#include "ncp/posix/netif.hpp"
+
+// Only Test on linux platform for now.
+#ifdef __linux__
+
+static constexpr size_t kMaxIp6Size = 1280;
+
+TEST(Netif, WpanInitWithFullInterfaceName)
+{
+    const char  *wpan = "wpan0";
+    int          sockfd;
+    struct ifreq ifr;
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0)
+    {
+        FAIL() << "Error creating socket: " << std::strerror(errno);
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, wpan, IFNAMSIZ - 1);
+
+    EXPECT_GE(ioctl(sockfd, SIOCGIFFLAGS, &ifr), 0) << "'" << wpan << "' not found";
+
+    netif.Deinit();
+}
+
+TEST(Netif, WpanInitWithFormatInterfaceName)
+{
+    const char  *wpan    = "tun%d";
+    const char  *if_name = "tun0";
+    int          sockfd;
+    struct ifreq ifr;
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0)
+    {
+        FAIL() << "Error creating socket: " << std::strerror(errno);
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
+
+    EXPECT_GE(ioctl(sockfd, SIOCGIFFLAGS, &ifr), 0) << "'" << if_name << "' not found";
+
+    netif.Deinit();
+}
+
+TEST(Netif, WpanInitWithEmptyInterfaceName)
+{
+    const char  *if_name = "wpan0";
+    int          sockfd;
+    struct ifreq ifr;
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(""), OT_ERROR_NONE);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0)
+    {
+        FAIL() << "Error creating socket: " << std::strerror(errno);
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, if_name, IFNAMSIZ - 1);
+
+    EXPECT_GE(ioctl(sockfd, SIOCGIFFLAGS, &ifr), 0) << "'" << if_name << "' not found";
+
+    netif.Deinit();
+}
+
+TEST(Netif, WpanInitWithInvalidInterfaceName)
+{
+    const char *invalid_netif_name = "invalid_netif_name";
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(invalid_netif_name), OTBR_ERROR_INVALID_ARGS);
+}
+
+TEST(Netif, WpanMtuSize)
+{
+    const char  *wpan = "wpan0";
+    int          sockfd;
+    struct ifreq ifr;
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0)
+    {
+        FAIL() << "Error creating socket: " << std::strerror(errno);
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, wpan, IFNAMSIZ - 1);
+    EXPECT_GE(ioctl(sockfd, SIOCGIFMTU, &ifr), 0) << "Error getting MTU for '" << wpan << "': " << std::strerror(errno);
+    EXPECT_EQ(ifr.ifr_mtu, kMaxIp6Size) << "MTU isn't set correctly";
+
+    netif.Deinit();
+}
+
+TEST(Netif, WpanDeinit)
+{
+    const char  *wpan = "wpan0";
+    int          sockfd;
+    struct ifreq ifr;
+
+    otbr::Netif netif;
+    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0)
+    {
+        FAIL() << "Error creating socket: " << std::strerror(errno);
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, wpan, IFNAMSIZ - 1);
+    EXPECT_GE(ioctl(sockfd, SIOCGIFFLAGS, &ifr), 0) << "'" << wpan << "' not found";
+
+    netif.Deinit();
+    EXPECT_LT(ioctl(sockfd, SIOCGIFFLAGS, &ifr), 0) << "'" << wpan << "' isn't shutdown";
+}
+
+#endif // __linux__


### PR DESCRIPTION
This PR adds a posix platform module for NCP mode. Under NCP mode, the platform operation won't depend OT posix platform implementation and will use the posix platform implementation added in this PR instead.

This PR only adds the netif module and support creating the Thread network interface (wpan0) and setting the MTU. The other functionalities will be added in following PRs. The netif module hasn't been integrated with the NcpHost. In this PR, the posix platform is added as a library and has its own unit test (also implemented by gtest).

The netif implementations are different on different platforms: linux, apple, bsd... This PR only implements it on linux and adds an empty implementation for other posix platforms.