### PR TITLE
[version] update 1.4 to 1.4.0 for conformance

### DIFF
--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -385,7 +385,7 @@ const char *RcpHost::GetThreadVersion(void)
         version = "1.3.0";
         break;
     case kThreadVersion14:
-        version = "1.4";
+        version = "1.4.0";
         break;
     default:
         otbrLogEmerg("Unexpected thread version %hu", otThreadGetVersion());


### PR DESCRIPTION
`TXT: tv=1.4.0` is expected as in Table 8-4