### PR TITLE
[ncp] update the frame handling of ncp spinel

### DIFF
--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -203,13 +203,16 @@ private:
 
     static otDeviceRole SpinelRoleToDeviceRole(spinel_net_role_t aRole);
 
-    void HandleNotification(const uint8_t *aFrame, uint16_t aLength);
-    void HandleResponse(spinel_tid_t aTid, const uint8_t *aFrame, uint16_t aLength);
-    void HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
-    void HandleResponseForCommand(spinel_tid_t aTid, otError aError);
+    void      HandleNotification(const uint8_t *aFrame, uint16_t aLength);
+    void      HandleResponse(spinel_tid_t aTid, const uint8_t *aFrame, uint16_t aLength);
+    void      HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
+    otbrError HandleResponseForPropSet(spinel_tid_t      aTid,
+                                       spinel_prop_key_t aKey,
+                                       const uint8_t    *aData,
+                                       uint16_t          aLength);
 
     spinel_tid_t GetNextTid(void);
-    void         FreeTid(spinel_tid_t tid) { mCmdTidsInUse &= ~(1 << tid); }
+    void         FreeTidTableItem(spinel_tid_t aTid);
 
     using EncodingFunc = std::function<otError(void)>;
     otError SetProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);


### PR DESCRIPTION
This PR updates the general logic of the handling of incoming spinel frames in NcpSpinel.

Currently the dispatching depends on the incoming key (what we actually received), which brings some implementation troubles. For example, the response of a get command and a set command could sometimes be the same thing: the property.

In this PR, we use `mCmdTable` together with `mWaitingKeyTable` to record each sent command and do the handling based on `mCmdTable[tid]` and `mWaitingKeyTable[tid]` (what we expect to receive). This makes it much easier to further add more handlings later.