### PR TITLE
[ncp] update implementation of NcpSpinel DatasetSetActiveTlvs

### DIFF
--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -218,10 +218,6 @@ private:
     otError SetProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError SendEncodedFrame(void);
 
-    void GetFlagsFromSecurityPolicy(const otSecurityPolicy *aSecurityPolicy, uint8_t *aFlags, uint8_t aFlagsLength);
-
-    otError EncodeDatasetSetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs);
-
     ot::Spinel::SpinelDriver *mSpinelDriver;
     uint16_t                  mCmdTidsInUse; ///< Used transaction ids.
     spinel_tid_t              mCmdNextTid;   ///< Next available transaction id.


### PR DESCRIPTION
This PR resolves the remaining issue as [discussed](https://github.com/openthread/ot-br-posix/pull/2355#discussion_r1699198730) in https://github.com/openthread/ot-br-posix/pull/2355 

This PR updates the implementation of `NcpSpinel::DatasetSetActiveTlvs` to use the new spinel property `SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS` to set the active dataset on NCP. In this way, the dataset is transported as TLVs instead of a structure.