### PR TITLE
[posix] set addr gen mode to none on linux 

### DIFF
--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -57,9 +57,15 @@ private:
     void Clear(void);
 
     otbrError CreateTunDevice(const std::string &aInterfaceName);
+    otbrError InitNetlink(void);
 
-    int mTunFd; ///< Used to exchange IPv6 packets.
-    int mIpFd;  ///< Used to manage IPv6 stack on the network interface.
+    void PlatformSpecificInit(void);
+    void SetAddrGenModeToNone(void);
+
+    int      mTunFd;           ///< Used to exchange IPv6 packets.
+    int      mIpFd;            ///< Used to manage IPv6 stack on the network interface.
+    int      mNetlinkFd;       ///< Used to receive netlink events.
+    uint32_t mNetlinkSequence; ///< Netlink message sequence.
 
     unsigned int mNetifIndex;
     std::string  mNetifName;

--- a/src/ncp/posix/netif_unix.cpp
+++ b/src/ncp/posix/netif_unix.cpp
@@ -48,6 +48,11 @@ otbrError Netif::CreateTunDevice(const std::string &aInterfaceName)
     return OTBR_ERROR_NONE;
 }
 
+void Netif::PlatformSpecificInit(void)
+{
+    /* Empty */
+}
+
 } // namespace otbr
 
 #endif // __APPLE__ || __NetBSD__ || __OpenBSD__


### PR DESCRIPTION
This PR sets the addr gen mode of wpan interface to NONE on linux.

This PR depends on https://github.com/openthread/ot-br-posix/pull/2410. #2410 needs to be merged first.