### PR TITLE
[posix] add unicast address update in netif module

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -41,6 +41,11 @@ Ip6Address::Ip6Address(const uint8_t (&aAddress)[16])
     memcpy(m8, aAddress, sizeof(m8));
 }
 
+Ip6Address::Ip6Address(const otIp6Address &aAddress)
+{
+    memcpy(m8, aAddress.mFields.m8, sizeof(m8));
+}
+
 std::string Ip6Address::ToString() const
 {
     char strbuf[INET6_ADDRSTRLEN];

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include <openthread/error.h>
+#include <openthread/ip6.h>
 
 #include "common/byteswap.hpp"
 
@@ -142,6 +143,14 @@ public:
      *
      */
     Ip6Address(const uint8_t (&aAddress)[16]);
+
+    /**
+     * Constructor with an otIp6Address.
+     *
+     * @param[in] aAddress  A const reference to an otIp6Address.
+     *
+     */
+    explicit Ip6Address(const otIp6Address &aAddress);
 
     /**
      * Constructor with a string.

--- a/src/ncp/posix/netif_unix.cpp
+++ b/src/ncp/posix/netif_unix.cpp
@@ -53,6 +53,12 @@ void Netif::PlatformSpecificInit(void)
     /* Empty */
 }
 
+void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+{
+    OTBR_UNUSED_VARIABLE(aAddressInfo);
+    OTBR_UNUSED_VARIABLE(aIsAdded);
+}
+
 } // namespace otbr
 
 #endif // __APPLE__ || __NetBSD__ || __OpenBSD__


### PR DESCRIPTION
This PR implements `UpdateIp6UnicastAddresses` method for `Posix::Netif` module to add/remove unicast address on the wpan interface. A unit test is added together.

The method `UpdateIp6UnicastAddresses` takes a vector of Ip6 addresses as input (because the address update from the NCP is the entire address table) and update the entire address list to the interface. However, it doesn't do it by removing all and then adding all. Instead, it compares the existing unicast addresses against the new addresses to decide which addresses to add/remove and then issue netlink requests to do the changes.