### PR TITLE
[logging] use the same default log level for Android and other platforms

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -165,16 +165,6 @@ static otbrLogLevel GetDefaultLogLevel(void)
 {
     otbrLogLevel level = OTBR_LOG_INFO;
 
-#if OTBR_ENABLE_PLATFORM_ANDROID
-    char value[PROPERTY_VALUE_MAX];
-
-    property_get("ro.build.type", value, "user");
-    if (!strcmp(value, "user"))
-    {
-        level = OTBR_LOG_WARNING;
-    }
-#endif
-
     return level;
 }
 


### PR DESCRIPTION
There's no need currently to reduce the logs on Android user images.