### PR TITLE
[border-agent] improve the documentation returned by --help

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -60,10 +60,12 @@
 #endif
 #endif
 
-static const char kDefaultInterfaceName[] = "wpan0";
+#define DEFAULT_INTERFACE_NAME "wpan0"
+static const char kDefaultInterfaceName[] = DEFAULT_INTERFACE_NAME;
 
 // Port number used by Rest server.
 static const uint32_t kPortNumber = 8081;
+#define HELP_DEFAULT_REST_PORT_NUMBER "8081"
 
 enum
 {
@@ -144,8 +146,20 @@ static void PrintHelp(const char *aProgramName)
     fprintf(stderr,
             "Usage: %s [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] [-s] [--auto-attach[=0/1]] "
             "RADIO_URL [RADIO_URL]\n"
-            "    --auto-attach defaults to 1\n"
-            "    -s disables syslog and prints to standard out\n",
+            "     -I, --thread-ifname    Name of the Thread network interface (default: " DEFAULT_INTERFACE_NAME ").\n"
+            "     -B, --backbone-ifname  Name of the backbone network interfaces (can be specified multiple times).\n"
+            "     -d, --debug-level      The log level (EMERG=0, ALERT=1, CRIT=2, ERR=3, WARNING=4, NOTICE=5, INFO=6, "
+            "DEBUG=7).\n"
+            "     -v, --verbose          Enable verbose logging.\n"
+            "     -s, --syslog-disable   Disable syslog and print to standard out.\n"
+            "     -h, --help             Show this help text.\n"
+            "     -V, --version          Print the application's version and exit.\n"
+            "     --radio-version        Print the radio coprocessor version and exit.\n"
+            "     --auto-attach          Whether or not to automatically attach to the saved network (default: 1).\n"
+            "     --rest-listen-address  Network address to listen on for the REST API (default: [::]).\n"
+            "     --rest-listen-port     Network port to listen on for the REST API "
+            "(default: " HELP_DEFAULT_REST_PORT_NUMBER ").\n"
+            "\n",
             aProgramName);
     fprintf(stderr, "%s", otSysGetRadioUrlHelpString());
 }


### PR DESCRIPTION
This PR expands on the existing `--help` text by including short and long option names when available, and by adding options that were missing.

The current `--help` text is now:

```
Usage: ./otbr-agent [-I interfaceName] [-B backboneIfName] [-d DEBUG_LEVEL] [-v] [-s] [--auto-attach[=0/1]] RADIO_URL [RADIO_URL]
     -I, --thread-ifname    Name of the Thread network interface (default: wpan0).
     -B, --backbone-ifname  Name of the backbone network interfaces (can be specified multiple times).
     -d, --debug-level      The log level (EMERG=0, ALERT=1, CRIT=2, ERR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7).
     -v, --verbose          Enable verbose logging.
     -s, --syslog-disable   Disable syslog and print to standard out.
     -h, --help             Show this help text.
     -V, --version          Print the application's version and exit.
     --radio-version        Print the radio coprocessor version and exit.
     --auto-attach          Whether or not to automatically attach to the saved network (default: 1).
     --rest-listen-address  Network address to listen on for the REST API (default: [::]).
     --rest-listen-port     Network port to listen on for the REST API (default: 8081).

RadioURL:
Radio Url format:    {Protocol}://${PATH_TO_DEVICE}?${Parameters}

Protocol=[spinel+hdlc*]           Specify the Spinel interface as the Spinel HDLC interface
    forkpty-arg[=argument string]  Command line arguments for subprocess, can be repeated.
    spinel+hdlc+uart://${PATH_TO_UART_DEVICE}?${Parameters} for real uart device
    spinel+hdlc+forkpty://${PATH_TO_UART_DEVICE}?${Parameters} for forking a pty subprocess.
Parameters:
    uart-parity[=even|odd]         Uart parity config, optional.
    uart-stop[=number-of-bits]     Uart stop bit, default is 1.
    uart-baudrate[=baudrate]       Uart baud rate, default is 115200 (460800 is another common value).
    uart-flow-control              Enable flow control, disabled by default.
    uart-reset                     Reset connection after hard resetting RCP(USB CDC ACM).

    region[=region-code]          Set the radio's region code. The region code must be an
                                  ISO 3166 alpha-2 code.
    cca-threshold[=dbm]           Set the radio's CCA ED threshold in dBm measured at antenna connector.
    enable-coex[=1|0]             If not specified, RCP coex operates with its default configuration.
                                  Disable coex with 0, and enable it with other values.
    fem-lnagain[=dbm]             Set the Rx LNA gain in dBm of the external FEM.
    no-reset                      Do not send Spinel reset command to RCP on initialization.
    skip-rcp-compatibility-check  Skip checking RCP API version and capabilities during initialization.
    bus-latency[=usec]            Communication latency in usec, default is 0.
```