### PR TITLE
[posix] add netif TUN Ip6 Sending

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -82,7 +82,8 @@ void NcpHost::Init(void)
 {
     otSysInit(&mConfig);
     mNcpSpinel.Init(mSpinelDriver, *this);
-    mNetif.Init(mConfig.mInterfaceName);
+    mNetif.Init(mConfig.mInterfaceName,
+                [this](const uint8_t *aData, uint16_t aLength) { return mNcpSpinel.Ip6Send(aData, aLength); });
 
     mNcpSpinel.Ip6SetAddressCallback(
         [this](const std::vector<Ip6AddressInfo> &aAddrInfos) { mNetif.UpdateIp6UnicastAddresses(aAddrInfos); });

--- a/src/ncp/ncp_spinel.cpp
+++ b/src/ncp/ncp_spinel.cpp
@@ -151,6 +151,15 @@ exit:
     return;
 }
 
+otbrError NcpSpinel::Ip6Send(const uint8_t *aData, uint16_t aLength)
+{
+    // TODO: Impelement this function.
+    OTBR_UNUSED_VARIABLE(aData);
+    OTBR_UNUSED_VARIABLE(aLength);
+
+    return OTBR_ERROR_NONE;
+}
+
 void NcpSpinel::ThreadSetEnabled(bool aEnable, AsyncTaskPtr aAsyncTask)
 {
     otError      error        = OT_ERROR_NONE;

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -179,6 +179,18 @@ public:
     }
 
     /**
+     * This methods sends an IP6 datagram through the NCP.
+     *
+     * @param[in] aData      A pointer to the beginning of the IP6 datagram.
+     * @param[in] aLength    The length of the datagram.
+     *
+     * @retval OTBR_ERROR_NONE  The datagram is sent to NCP successfully.
+     * @retval OTBR_ERROR_BUSY  NcpSpinel is busy with other requests.
+     *
+     */
+    otbrError Ip6Send(const uint8_t *aData, uint16_t aLength);
+
+    /**
      * This method enableds/disables the Thread network on the NCP.
      *
      * If this method is called again before the previous call completed, no action will be taken.

--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -36,10 +36,12 @@
 
 #include <net/if.h>
 
+#include <functional>
 #include <vector>
 
 #include <openthread/ip6.h>
 
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
@@ -47,12 +49,16 @@ namespace otbr {
 class Netif
 {
 public:
+    using Ip6SendFunc = std::function<otbrError(const uint8_t *, uint16_t)>;
+
     Netif(void);
 
-    otbrError Init(const std::string &aInterfaceName);
+    otbrError Init(const std::string &aInterfaceName, const Ip6SendFunc &aIp6SendFunc);
     void      Deinit(void);
 
-    void      UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aOtAddrInfos);
+    void      Process(const MainloopContext *aContext);
+    void      UpdateFdSet(MainloopContext *aContext);
+    void      UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos);
     otbrError UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs);
     void      SetNetifState(bool aState);
 
@@ -71,6 +77,7 @@ private:
     void      SetAddrGenModeToNone(void);
     void      ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
     otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
+    void      ProcessIp6Send(void);
 
     int      mTunFd;           ///< Used to exchange IPv6 packets.
     int      mIpFd;            ///< Used to manage IPv6 stack on the network interface.
@@ -82,6 +89,7 @@ private:
 
     std::vector<Ip6AddressInfo> mIp6UnicastAddresses;
     std::vector<Ip6Address>     mIp6MulticastAddresses;
+    Ip6SendFunc                 mIp6SendFunc;
 };
 
 } // namespace otbr


### PR DESCRIPTION
This PR implements netif TUN Ip6 forwarding.

In specific, when a packet from the system is sent to the wpan interface, the Netif module will do the Ip6 sending. In this PR the actual sending (let NCP send the IP6 packet) hasn't been implemented and an empty implementation is used.

The PR also adds a unit test to verify IP packet sent through wpan interface can be successfully handled in netif.