### PR TITLE
[posix] add netif SetState

### DIFF
--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -54,6 +54,7 @@ public:
 
     void      UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aOtAddrInfos);
     otbrError UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs);
+    void      SetNetifState(bool aState);
 
 private:
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.


### PR DESCRIPTION
This PR adds the SetState for Netif module to set the interface ON/OFF.

In this PR this hasn't been integrated with NCP yet. (After receiving NCP property update, the state of wpan interface changed accordingly). This will be done later.