### PR TITLE
[posix] add netif TUN Ip6Receive

### DIFF
--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -88,6 +88,7 @@ enum otbrError
     OTBR_ERROR_ABORTED            = -12, ///< The operation is aborted.
     OTBR_ERROR_INVALID_STATE      = -13, ///< The target isn't in a valid state.
     OTBR_ERROR_INFRA_LINK_CHANGED = -14, ///< The infrastructure link is changed.
+    OTBR_ERROR_DROPPED            = -15, ///< The packet is dropped.
 };
 
 namespace otbr {

--- a/src/ncp/posix/netif.cpp
+++ b/src/ncp/posix/netif.cpp
@@ -202,6 +202,23 @@ exit:
     }
 }
 
+void Netif::Ip6Receive(const uint8_t *aBuf, uint16_t aLen)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(aLen <= kIp6Mtu, error = OTBR_ERROR_DROPPED);
+    VerifyOrExit(mTunFd > 0, error = OTBR_ERROR_INVALID_STATE);
+
+    otbrLogInfo("Packet from NCP (%u bytes)", aLen);
+    VerifyOrExit(write(mTunFd, aBuf, aLen) == aLen, error = OTBR_ERROR_ERRNO);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to receive, error:%s", otbrErrorString(error));
+    }
+}
+
 void Netif::Clear(void)
 {
     if (mTunFd != -1)

--- a/src/ncp/posix/netif.hpp
+++ b/src/ncp/posix/netif.hpp
@@ -56,6 +56,8 @@ public:
     otbrError UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs);
     void      SetNetifState(bool aState);
 
+    void Ip6Receive(const uint8_t *aBuf, uint16_t aLen);
+
 private:
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
     static constexpr size_t kIp6Mtu = 1280;


### PR DESCRIPTION
This PR implements netif TUN Ip6 receiving.

When netif module receives an Ip6 packet, it will pass it to the system network stack through wpan interface. The PR also adds a unit test to verify an application can receive UDP packets from wpan through netif.

This PR hasn't integrated Ip6 receiving with NCP(forward the packet from NCP to the system network stack). This will be done in future PRs.