### PR TITLE
[ncp] integrate netif isUp state update

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -86,6 +86,7 @@ void NcpHost::Init(void)
 
     mNcpSpinel.Ip6SetAddressCallback(
         [this](const std::vector<Ip6AddressInfo> &aAddrInfos) { mNetif.UpdateIp6UnicastAddresses(aAddrInfos); });
+    mNcpSpinel.NetifSetStateChangedCallback([this](bool aState) { mNetif.SetNetifState(aState); });
 }
 
 void NcpHost::Deinit(void)

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -83,7 +83,8 @@ public:
 class NcpSpinel
 {
 public:
-    using Ip6AddressTableCallback = std::function<void(const std::vector<Ip6AddressInfo> &)>;
+    using Ip6AddressTableCallback   = std::function<void(const std::vector<Ip6AddressInfo> &)>;
+    using NetifStateChangedCallback = std::function<void(bool)>;
 
     /**
      * Constructor.
@@ -195,6 +196,17 @@ public:
      */
     void ThreadErasePersistentInfo(AsyncTaskPtr aAsyncTask);
 
+    /**
+     * This method sets the callback invoked when the network interface state changes.
+     *
+     * @param[in] aCallback  The callback invoked when the network interface state changes.
+     *
+     */
+    void NetifSetStateChangedCallback(const NetifStateChangedCallback &aCallback)
+    {
+        mNetifStateChangedCallback = aCallback;
+    }
+
 private:
     using FailureHandler = std::function<void(otError)>;
 
@@ -271,7 +283,8 @@ private:
     AsyncTaskPtr mThreadDetachGracefullyTask;
     AsyncTaskPtr mThreadErasePersistentInfoTask;
 
-    Ip6AddressTableCallback mIp6AddressTableCallback;
+    Ip6AddressTableCallback   mIp6AddressTableCallback;
+    NetifStateChangedCallback mNetifStateChangedCallback;
 };
 
 } // namespace Ncp

--- a/tests/scripts/expect/ncp_netif_address_update.exp
+++ b/tests/scripts/expect/ncp_netif_address_update.exp
@@ -62,11 +62,16 @@ expect -re {fd0d:7fc:a1b9:f050(:[0-9a-f]{1,4}){4,4}}
 expect -re {fe80:(:[0-9a-f]{1,4}){4,4}}
 expect eof
 
-# Step 4. Use dbus leave method to let the node leave the network
+# Step 4. Verify the wpan isUp state
+spawn ip link show wpan0
+expect -re {UP}
+expect eof
+
+# Step 5. Use dbus leave method to let the node leave the network
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.LeaveNetwork
 expect eof
 
-# Step 5. Verify the addresses on wpan.
+# Step 6. Verify the addresses on wpan.
 # There should be:
 #   1. link local
 spawn ip addr show wpan0


### PR DESCRIPTION
This PR integrates the `Netif::SetNetifState` with `NcpSpinel` so that when the netif state on NCP changes, the wpan state on the host updates accordingly.