### PR TITLE
[ncp] integrate netif multicast address update

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -86,6 +86,8 @@ void NcpHost::Init(void)
 
     mNcpSpinel.Ip6SetAddressCallback(
         [this](const std::vector<Ip6AddressInfo> &aAddrInfos) { mNetif.UpdateIp6UnicastAddresses(aAddrInfos); });
+    mNcpSpinel.Ip6SetAddressMulticastCallback(
+        [this](const std::vector<Ip6Address> &aAddrs) { mNetif.UpdateIp6MulticastAddresses(aAddrs); });
     mNcpSpinel.NetifSetStateChangedCallback([this](bool aState) { mNetif.SetNetifState(aState); });
 }
 

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -83,8 +83,9 @@ public:
 class NcpSpinel
 {
 public:
-    using Ip6AddressTableCallback   = std::function<void(const std::vector<Ip6AddressInfo> &)>;
-    using NetifStateChangedCallback = std::function<void(bool)>;
+    using Ip6AddressTableCallback          = std::function<void(const std::vector<Ip6AddressInfo> &)>;
+    using Ip6MulticastAddressTableCallback = std::function<void(const std::vector<Ip6Address> &)>;
+    using NetifStateChangedCallback        = std::function<void(bool)>;
 
     /**
      * Constructor.
@@ -161,6 +162,21 @@ public:
      *
      */
     void Ip6SetAddressCallback(const Ip6AddressTableCallback &aCallback) { mIp6AddressTableCallback = aCallback; }
+
+    /**
+     * This method sets the callback to receive the IPv6 multicast address table from the NCP.
+     *
+     * @param[in] aCallback  The callback to handle the IPv6 address table.
+     *
+     * The callback will be invoked when receiving an IPv6 multicast address table from the NCP.
+     * When the callback is invoked, the callback MUST copy the otIp6Address objects and maintain it
+     * if it's not used immediately (within the callback).
+     *
+     */
+    void Ip6SetAddressMulticastCallback(const Ip6MulticastAddressTableCallback &aCallback)
+    {
+        mIp6MulticastAddressTableCallback = aCallback;
+    }
 
     /**
      * This method enableds/disables the Thread network on the NCP.
@@ -257,6 +273,7 @@ private:
     otError SendEncodedFrame(void);
 
     otError ParseIp6AddressTable(const uint8_t *aBuf, uint16_t aLength, std::vector<Ip6AddressInfo> &aAddressTable);
+    otError ParseIp6MulticastAddresses(const uint8_t *aBuf, uint8_t aLen, std::vector<Ip6Address> &aAddressList);
 
     ot::Spinel::SpinelDriver *mSpinelDriver;
     uint16_t                  mCmdTidsInUse; ///< Used transaction ids.
@@ -283,8 +300,9 @@ private:
     AsyncTaskPtr mThreadDetachGracefullyTask;
     AsyncTaskPtr mThreadErasePersistentInfoTask;
 
-    Ip6AddressTableCallback   mIp6AddressTableCallback;
-    NetifStateChangedCallback mNetifStateChangedCallback;
+    Ip6AddressTableCallback          mIp6AddressTableCallback;
+    Ip6MulticastAddressTableCallback mIp6MulticastAddressTableCallback;
+    NetifStateChangedCallback        mNetifStateChangedCallback;
 };
 
 } // namespace Ncp

--- a/tests/scripts/expect/ncp_netif_address_update.exp
+++ b/tests/scripts/expect/ncp_netif_address_update.exp
@@ -62,6 +62,21 @@ expect -re {fd0d:7fc:a1b9:f050(:[0-9a-f]{1,4}){4,4}}
 expect -re {fe80:(:[0-9a-f]{1,4}){4,4}}
 expect eof
 
+# Multicast addresses should contain:
+#   1. ff01::1
+#   2. ff02::1
+#   3. ff02::2
+#   4. ff03::1
+#   5. ff03::2
+spawn ip maddr show dev wpan0
+expect eof
+set maddr_output $expect_out(buffer)
+if {![string match "*ff01::1*" $maddr_output]} { fail "No multicast address ff01::1" }
+if {![string match "*ff02::1*" $maddr_output]} { fail "No multicast address ff02::1" }
+if {![string match "*ff02::2*" $maddr_output]} { fail "No multicast address ff02::2" }
+if {![string match "*ff03::1*" $maddr_output]} { fail "No multicast address ff03::1" }
+if {![string match "*ff03::2*" $maddr_output]} { fail "No multicast address ff03::2" }
+
 # Step 4. Verify the wpan isUp state
 spawn ip link show wpan0
 expect -re {UP}


### PR DESCRIPTION
This PR integrates `Netif` multicast address update with `NcpSpinel` so that wpan will join the multicast group that NCP joins.