### PR TITLE
[telemetry] remove uploading epskc_state and border_agent_state

### DIFF
--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -513,13 +513,6 @@ message TelemetryData {
     optional bool has_others_route_added = 3;
   }
 
-  enum BorderAgentState {
-    BORDER_AGENT_STATE_UNSPECIFIED = 0;
-    BORDER_AGENT_STATE_STOPPED = 1;
-    BORDER_AGENT_STATE_STARTED = 2;
-    BORDER_AGENT_STATE_ACTIVE = 3;
-  }
-
   message BorderAgentCounters {
     // The number of ePSKc activations
     optional uint32 epskc_activations = 1;
@@ -571,14 +564,8 @@ message TelemetryData {
   }
 
   message BorderAgentInfo {
-    // The border agent state
-    optional BorderAgentState border_agent_state = 1;
-
-    // The ePSKc active state
-    optional bool epskc_is_active = 2;
-
     // The border agent counters
-    optional BorderAgentCounters border_agent_counters = 3;
+    optional BorderAgentCounters border_agent_counters = 1;
   }
 
   message WpanBorderRouter {

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -225,24 +225,6 @@ void CopyMdnsResponseCounters(const MdnsResponseCounters &from, threadnetwork::T
     to->set_aborted_count(from.mAborted);
     to->set_invalid_state_count(from.mInvalidState);
 }
-
-#if OTBR_ENABLE_BORDER_AGENT
-threadnetwork::TelemetryData_BorderAgentState BorderAgentStateFromOtBorderAgentState(
-    otBorderAgentState aBorderAgentState)
-{
-    switch (aBorderAgentState)
-    {
-    case OT_BORDER_AGENT_STATE_STOPPED:
-        return threadnetwork::TelemetryData::BORDER_AGENT_STATE_STOPPED;
-    case OT_BORDER_AGENT_STATE_STARTED:
-        return threadnetwork::TelemetryData::BORDER_AGENT_STATE_STARTED;
-    case OT_BORDER_AGENT_STATE_ACTIVE:
-        return threadnetwork::TelemetryData::BORDER_AGENT_STATE_ACTIVE;
-    default:
-        return threadnetwork::TelemetryData::BORDER_AGENT_STATE_UNSPECIFIED;
-    }
-}
-#endif // OTBR_ENABLE_BORDER_AGENT
 #endif // OTBR_ENABLE_TELEMETRY_DATA_API
 } // namespace
 
@@ -1083,9 +1065,6 @@ void ThreadHelper::RetrieveBorderAgentInfo(threadnetwork::TelemetryData::BorderA
 {
     auto baCounters            = aBorderAgentInfo->mutable_border_agent_counters();
     auto otBorderAgentCounters = *otBorderAgentGetCounters(mInstance);
-
-    aBorderAgentInfo->set_border_agent_state(BorderAgentStateFromOtBorderAgentState(otBorderAgentGetState(mInstance)));
-    aBorderAgentInfo->set_epskc_is_active(otBorderAgentIsEphemeralKeyActive(mInstance));
 
     baCounters->set_epskc_activations(otBorderAgentCounters.mEpskcActivations);
     baCounters->set_epskc_deactivation_clears(otBorderAgentCounters.mEpskcDeactivationClears);

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -275,8 +275,6 @@ void CheckEphemeralKey(ThreadApiDBus *aApi)
 
 void CheckBorderAgentInfo(const threadnetwork::TelemetryData_BorderAgentInfo &aBorderAgentInfo)
 {
-    TEST_ASSERT(aBorderAgentInfo.border_agent_state() == threadnetwork::TelemetryData::BORDER_AGENT_STATE_STARTED);
-    TEST_ASSERT(aBorderAgentInfo.epskc_is_active() == false);
     TEST_ASSERT(aBorderAgentInfo.border_agent_counters().epskc_activations() == 0);
     TEST_ASSERT(aBorderAgentInfo.border_agent_counters().epskc_deactivation_clears() == 0);
     TEST_ASSERT(aBorderAgentInfo.border_agent_counters().epskc_deactivation_timeouts() == 0);


### PR DESCRIPTION
The epskc_state and border_agent_state has no clear metrics, remove from uploading.