### PR TITLE
[application] simplify fdset update

### DIFF
--- a/src/backbone_router/nd_proxy.cpp
+++ b/src/backbone_router/nd_proxy.cpp
@@ -121,14 +121,12 @@ void NdProxyManager::Update(MainloopContext &aMainloop)
 {
     if (mIcmp6RawSock >= 0)
     {
-        FD_SET(mIcmp6RawSock, &aMainloop.mReadFdSet);
-        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mIcmp6RawSock);
+        aMainloop.AddFdToReadSet(mIcmp6RawSock);
     }
 
     if (mUnicastNsQueueSock >= 0)
     {
-        FD_SET(mUnicastNsQueueSock, &aMainloop.mReadFdSet);
-        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mUnicastNsQueueSock);
+        aMainloop.AddFdToReadSet(mUnicastNsQueueSock);
     }
 }
 

--- a/src/common/mainloop.cpp
+++ b/src/common/mainloop.cpp
@@ -40,4 +40,36 @@ MainloopProcessor::~MainloopProcessor(void)
 {
     MainloopManager::GetInstance().RemoveMainloopProcessor(this);
 }
+
+void MainloopContext::AddFdToReadSet(int aFd)
+{
+    AddFdToSet(aFd, kReadFdSet);
+}
+
+void MainloopContext::AddFdToSet(int aFd, uint8_t aFdSetsMask)
+{
+    bool isSet = false;
+
+    if (aFdSetsMask & kErrorFdSet)
+    {
+        FD_SET(aFd, &mErrorFdSet);
+        isSet = true;
+    }
+    if (aFdSetsMask & kReadFdSet)
+    {
+        FD_SET(aFd, &mReadFdSet);
+        isSet = true;
+    }
+    if (aFdSetsMask & kWriteFdSet)
+    {
+        FD_SET(aFd, &mWriteFdSet);
+        isSet = true;
+    }
+
+    if (isSet)
+    {
+        mMaxFd = std::max(mMaxFd, aFd);
+    }
+}
+
 } // namespace otbr

--- a/src/common/mainloop.hpp
+++ b/src/common/mainloop.hpp
@@ -44,7 +44,30 @@ namespace otbr {
  * This type defines the context data for running a mainloop.
  *
  */
-using MainloopContext = otSysMainloopContext;
+class MainloopContext : public otSysMainloopContext
+{
+public:
+    static constexpr uint8_t kErrorFdSet = 1 << 0;
+    static constexpr uint8_t kReadFdSet  = 1 << 1;
+    static constexpr uint8_t kWriteFdSet = 1 << 2;
+
+    /**
+     * This method adds a fd to the read fd set inside the MainloopContext.
+     *
+     * @param[in] aFd  The fd to add.
+     *
+     */
+    void AddFdToReadSet(int aFd);
+
+    /**
+     * This method adds a fd to the fd sets inside the MainloopContext.
+     *
+     * @param[in] aFd          The fd to add.
+     * @param[in] aFdSetsMask  A bitmask indicating which fd sets to add.
+     *
+     */
+    void AddFdToSet(int aFd, uint8_t aFdSetsMask);
+};
 
 /**
  * This abstract class defines the interface of a mainloop processor

--- a/src/common/task_runner.cpp
+++ b/src/common/task_runner.cpp
@@ -82,8 +82,7 @@ TaskRunner::TaskId TaskRunner::Post(Milliseconds aDelay, Task<void> aTask)
 
 void TaskRunner::Update(MainloopContext &aMainloop)
 {
-    FD_SET(mEventFd[kRead], &aMainloop.mReadFdSet);
-    aMainloop.mMaxFd = std::max(mEventFd[kRead], aMainloop.mMaxFd);
+    aMainloop.AddFdToReadSet(mEventFd[kRead]);
 
     {
         std::lock_guard<std::mutex> _(mTaskQueueMutex);

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -139,6 +139,7 @@ void DBusAgent::Update(MainloopContext &aMainloop)
 {
     unsigned int flags;
     int          fd;
+    uint8_t      fdSetMask = MainloopContext::kErrorFdSet;
 
     if (dbus_connection_get_dispatch_status(mConnection.get()) == DBUS_DISPATCH_DATA_REMAINS)
     {
@@ -162,17 +163,15 @@ void DBusAgent::Update(MainloopContext &aMainloop)
 
         if (flags & DBUS_WATCH_READABLE)
         {
-            FD_SET(fd, &aMainloop.mReadFdSet);
+            fdSetMask |= MainloopContext::kReadFdSet;
         }
 
         if ((flags & DBUS_WATCH_WRITABLE))
         {
-            FD_SET(fd, &aMainloop.mWriteFdSet);
+            fdSetMask |= MainloopContext::kWriteFdSet;
         }
 
-        FD_SET(fd, &aMainloop.mErrorFdSet);
-
-        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, fd);
+        aMainloop.AddFdToSet(fd, fdSetMask);
     }
 }
 

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -312,9 +312,7 @@ void PublisherMDnsSd::Update(MainloopContext &aMainloop)
 
         assert(fd != -1);
 
-        FD_SET(fd, &aMainloop.mReadFdSet);
-
-        aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, fd);
+        aMainloop.AddFdToReadSet(fd);
     }
 
     for (const auto &service : mSubscribedServices)
@@ -419,8 +417,7 @@ void PublisherMDnsSd::DnssdServiceRegistration::Update(MainloopContext &aMainloo
     fd = DNSServiceRefSockFD(mServiceRef);
     VerifyOrExit(fd != -1);
 
-    FD_SET(fd, &aMainloop.mReadFdSet);
-    aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, fd);
+    aMainloop.AddFdToReadSet(fd);
 
 exit:
     return;
@@ -1041,8 +1038,7 @@ void PublisherMDnsSd::ServiceRef::Update(MainloopContext &aMainloop) const
 
     fd = DNSServiceRefSockFD(mServiceRef);
     assert(fd != -1);
-    FD_SET(fd, &aMainloop.mReadFdSet);
-    aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, fd);
+    aMainloop.AddFdToReadSet(fd);
 exit:
     return;
 }

--- a/src/ncp/posix/netif.cpp
+++ b/src/ncp/posix/netif.cpp
@@ -110,13 +110,7 @@ void Netif::UpdateFdSet(MainloopContext *aContext)
     assert(mTunFd >= 0);
     assert(mIpFd >= 0);
 
-    FD_SET(mTunFd, &aContext->mReadFdSet);
-    FD_SET(mTunFd, &aContext->mErrorFdSet);
-
-    if (mTunFd > aContext->mMaxFd)
-    {
-        aContext->mMaxFd = mTunFd;
-    }
+    aContext->AddFdToSet(mTunFd, MainloopContext::kErrorFdSet | MainloopContext::kReadFdSet);
 }
 
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -1824,13 +1824,7 @@ void UBusAgent::Update(MainloopContext &aMainloop)
 {
     VerifyOrExit(otbr::ubus::sUbusEfd != -1);
 
-    FD_SET(otbr::ubus::sUbusEfd, &aMainloop.mReadFdSet);
-
-    if (aMainloop.mMaxFd < otbr::ubus::sUbusEfd)
-    {
-        aMainloop.mMaxFd = otbr::ubus::sUbusEfd;
-    }
-
+    aMainloop.AddFdToReadSet(otbr::ubus::sUbusEfd);
 exit:
     mThreadMutex.unlock();
     return;

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -79,8 +79,7 @@ void RestWebServer::Init(void)
 
 void RestWebServer::Update(MainloopContext &aMainloop)
 {
-    FD_SET(mListenFd, &aMainloop.mReadFdSet);
-    aMainloop.mMaxFd = std::max(aMainloop.mMaxFd, mListenFd);
+    aMainloop.AddFdToReadSet(mListenFd);
 
     return;
 }

--- a/src/utils/infra_link_selector.cpp
+++ b/src/utils/infra_link_selector.cpp
@@ -235,8 +235,7 @@ void InfraLinkSelector::Update(MainloopContext &aMainloop)
 {
     if (mNetlinkSocket != -1)
     {
-        FD_SET(mNetlinkSocket, &aMainloop.mReadFdSet);
-        aMainloop.mMaxFd = std::max(mNetlinkSocket, aMainloop.mMaxFd);
+        aMainloop.AddFdToReadSet(mNetlinkSocket);
     }
 }
 


### PR DESCRIPTION
This PR adds methods to `MainloopContext` to encapsulate the process to add an fd to some fd sets of it and update the maxFd. This simplifies the implementation. Previous [discussion](https://github.com/openthread/ot-br-posix/pull/2452#discussion_r1739337131) for this change.