### PR TITLE
[log] fix ncp spinel log

### DIFF
--- a/src/ncp/ncp_spinel.cpp
+++ b/src/ncp/ncp_spinel.cpp
@@ -273,7 +273,7 @@ void NcpSpinel::HandleNotification(const uint8_t *aFrame, uint16_t aLength)
     HandleValueIs(key, data, static_cast<uint16_t>(len));
 
 exit:
-    otbrLogResult(error, "HandleNotification: %s", __FUNCTION__);
+    otbrLogResult(error, "%s", __FUNCTION__);
 }
 
 void NcpSpinel::HandleResponse(spinel_tid_t aTid, const uint8_t *aFrame, uint16_t aLength)


### PR DESCRIPTION
This PR fixes a tiny issue in NcpSpinel log.

Currently the logging for `HandleNotification` is:
```
otbr-agent[876792]: [INFO]-NcpSpin-: HandleNotification: HandleNotification: OK 
```
The PR removes the redundant function name.