### PR TITLE
[ncp] integrate netif multicast address subscription

### DIFF
--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -286,6 +286,16 @@ private:
                                        spinel_prop_key_t aKey,
                                        const uint8_t    *aData,
                                        uint16_t          aLength);
+    otbrError HandleResponseForPropInsert(spinel_tid_t      aTid,
+                                          spinel_command_t  aCmd,
+                                          spinel_prop_key_t aKey,
+                                          const uint8_t    *aData,
+                                          uint16_t          aLength);
+    otbrError HandleResponseForPropRemove(spinel_tid_t      aTid,
+                                          spinel_command_t  aCmd,
+                                          spinel_prop_key_t aKey,
+                                          const uint8_t    *aData,
+                                          uint16_t          aLength);
 
     otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded) override;
 
@@ -293,7 +303,11 @@ private:
     void         FreeTidTableItem(spinel_tid_t aTid);
 
     using EncodingFunc = std::function<otError(void)>;
+    otError SendCommand(spinel_command_t aCmd, spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError SetProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
+    otError InsertProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
+    otError RemoveProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
+
     otError SendEncodedFrame(void);
 
     otError ParseIp6AddressTable(const uint8_t *aBuf, uint16_t aLength, std::vector<Ip6AddressInfo> &aAddressTable);


### PR DESCRIPTION
This PR integrates the netif multicast address subscirption update with the NCP.

With this PR, applications can listen to a multicast address on wpan interface and receive multicast messages from the Thread network.

The implementation of `NcpSpinel::Ip6MulAddrUpdateSubscription` uses `SPINEL_CMD_PROP_VALUE_INSERT` and REMOVE. This PR extends NcpSpinel to support using these commands.

It's a little hard to add an integration test for this. Because there isn't any native tools to easily listen on a multicast address and check what has received. I've verified it locally with a simple c++ program.
![Screenshot 2024-09-19 at 18 14 26](https://github.com/user-attachments/assets/3f69e1a4-9a67-4484-beb0-f8bcb869cf72)
