### PR TITLE
[bootstrap] install iperf3 for reference devices

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -116,7 +116,7 @@ install_packages_apt()
     sudo apt-get install --no-install-recommends -y libjsoncpp-dev
 
     # reference device
-    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils avahi-utils
+    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils avahi-utils iperf3
 
     # backbone-router
     without BACKBONE_ROUTER || sudo apt-get install --no-install-recommends -y libnetfilter-queue1 libnetfilter-queue-dev


### PR DESCRIPTION
1.4 certification testing requires some throughput testing as part of test case 7.1 BR TCP throughput performance