### PR TITLE
[rest] Add REST JSON:API for commissioner and diagnostics

### DIFF
--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -59,6 +59,7 @@
 #define OTBR_IP4_ADDRESS_SIZE 4
 #define OTBR_NETWORK_KEY_SIZE 16
 #define OTBR_PSKC_SIZE 16
+#define CHILD_MASK 0x1FF
 
 /**
  * Forward declaration for otIp6Prefix to avoid including <openthread/ip6.h>

--- a/src/rest/CMakeLists.txt
+++ b/src/rest/CMakeLists.txt
@@ -26,6 +26,11 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+# TODO: Make this KConfig, maybe something like this
+# if(OTBR_REST_API_EXTENSIONS)
+add_subdirectory(extensions)
+# endif()
+
 add_library(otbr-rest
     rest_web_server.cpp
     connection.cpp
@@ -34,6 +39,7 @@ add_library(otbr-rest
     parser.cpp
     request.cpp
     response.cpp
+    network_diag_handler.cpp
 )
 
 target_link_libraries(otbr-rest
@@ -45,4 +51,5 @@ target_link_libraries(otbr-rest
         otbr-utils
         openthread-ftd
         openthread-posix
+        otbr-rest-extension
 )

--- a/src/rest/extensions/CMakeLists.txt
+++ b/src/rest/extensions/CMakeLists.txt
@@ -1,0 +1,53 @@
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+add_library(otbr-rest-extension
+    timestamp.cpp
+    rest_generic_collection.cpp
+    rest_diagnostics_coll.cpp
+    rest_devices_coll.cpp
+    uuid.cpp
+    rest_task_add_thread_device.cpp
+    rest_task_energy_scan.cpp
+    rest_task_handler.cpp
+    rest_task_queue.cpp
+    rest_server_common.cpp
+    commissioner_allow_list.cpp
+    rest_task_network_diagnostic.cpp
+)
+
+target_link_libraries(otbr-rest-extension
+    PUBLIC
+        http_parser
+    PRIVATE
+        cjson
+        otbr-config
+        otbr-utils
+        openthread-ftd
+        openthread-posix
+)

--- a/src/rest/extensions/README.md
+++ b/src/rest/extensions/README.md
@@ -1,0 +1,465 @@
+# Add REST JSON:API for commissioner and diagnostics
+
+## Summary
+
+In this PR, we propose an extended `REST` API functionality providing capabilities for commissioning and on-mesh diagnostics to generic off-mesh http/https clients. The implementation is guided by the [JSON:API specification](https://jsonapi.org/format/).
+
+## Use Cases
+
+The API targets following consumers and use cases:
+
+- access to commissioning and network diagnostics for http/https clients with minimal code dependency (e.g. no ot-commissioner needed)
+- field engineers for instant issue analysis and to visualize the mesh network topology
+- continuous monitoring of network quality, eg. localisation of `weak` mesh regions
+- developers for debugging and understanding network topology
+- testers
+
+A consumer may extract the data from the API and visualize it elsewhere.
+
+## Background
+
+- meshcop needs DTLS and Thread specific sources or binaries
+- RESTful http resources following JSON:API specification eases interpretation of the large number of attributes provided and eliminates dependencies to coap and DTLS.
+- enables tracking of history on-demand
+
+## New REST JSON:API resources
+
+### `/api/devices`
+
+The list of Thread network devices is provided as JSON:API collection on the devices resource `/api/devices`. The collection provides collection items of type `threadDevice`, one per active Thread device found during discovery. The `threadDevice` items shall serve as an inventory of devices and provide primarily static information, in particular a static `deviceId` for each device with some key attributes allowing to identify the device. The collection may contain devices that became inactive. It is discovered, updated or deleted on-demand.
+
+The Thread Border Router learns the list of network devices from the active network and returns the full collection or individual items in response to GET requests. The collection may be updated or deleted by a client on request. A POST request will populated the devices collection. Another POST request triggers re-discovery of existing or new Thread network devices and updates the collection accordingly. A DELETE request to `/api/devices` removes the cached collection.
+
+#### Device identification
+
+The device collection provides attributes for identifying and selecting a device. Diagnostics are accessible only via mesh local addresses (ML-EID or RLOC16) for on-mesh clients. However, none of them is known to a non-Thread client. Therefore you may use the `deviceId` in further diagnostic actions for querying diagnostic attributes from a specific device.
+
+Background: The MAC extended address serves as a stable identifier within the Thread network. In addition, the ML-EID IID (interface identifier) acts as a stable on-mesh identifier, while RLOC16 may change due to mesh network reorganization. Both ML-EID IID and the MAC extended address can be used as the stable identifier for collection items of type `threadDevice`. Since ML-EID IID is challenging to extract, we chose the MAC extended address as value for the device item `deviceId` and provide the ML-EID IID as an attribute of `threadDevice` items. OTBR REST JSON:API uses the ML-EID IID and the on-mesh prefix from the Thread network dataset to construct a mesh-local IPv6 unicast address for gathering on-mesh diagnostics TLVs from the corresponding device.
+
+This proposed id scheme and the limited number of static attributes minimize resource consumption on the OTBR, while still allowing a client to correlate a `deviceId` to device information provided elsewhere e.g. via a `hostname` also provided by SRP. A very constraint OTBR may chose to further reduce resource consumption for the device collection and only provide the stable `deviceId` and the learned ML-EID IID but no further details. A client would then have to refer to the diagnostics for gathering additional information.
+
+A timestamp attribute `created` should be used when the documents are persisted. After modifications to the document the timestamp attribute `updated` is added.
+
+#### Example collection comprising documents of type `threadDevice`
+
+An example response to `curl -G http://otbr.local/api/devices -H 'Accept: application/vnd.api+json'` for a network comprising two Thread devices may look similar to
+
+```
+{
+  "data": [
+    {
+      "id": "de62e016db392476",
+      "type": "threadDevice",
+      "attributes": {
+        "extAddress": "de62e016db392476",
+        "mlEidIid": "1d934f57e21e35",
+        "omrIpv6Address": <Ipv6Address>,
+        "hostname": "<hostname defined by SRP>",
+        "role": "router",
+        "mode": {
+          "deviceTypeFTD": true,
+          "rxOnWhenIdle": true,
+          "fullNetworkData": true
+        },
+        "created": <ISO 8601 timestamp>,
+        "updated": <ISO 8601 timestamp>
+      }
+    },
+    {
+      "id": "de62e016db392477",
+      "type": "threadDevice",
+      "attributes": {
+        "extAddress": "de62e016db392477",
+        "mlEidIid": "2ea45067f32f46",
+        "omrIpv6Address": <Ipv6Address>,
+        "eui64": "<eui64>",
+        "hostname": "<hostname defined by SRP>",
+        "role": "router",
+        "mode": {
+          "deviceTypeFTD": true,
+          "rxOnWhenIdle": true,
+          "fullNetworkData": true
+        },
+        "created": <ISO 8601 timestamp>,
+        "updated": <ISO 8601 timestamp>
+      }
+    },
+  ],
+  "meta": {
+    "collection": {
+      "offset": 0,
+      "limit": 200,
+      "total": 2
+    }
+  },
+}
+```
+
+Notes: The `threadDevice` document does only contain attributes which barely change. For now, `hostname` attribute values can only be provided if both, SRP-server and REST API, are hosted on the same OTBR.
+
+### `/api/diagnostics`
+
+The diagnostics resource serves a collection of diagnostic items. This PR comprises implementation for items of type `networkDiagnostics` corresponding to _Specification Chapter 10.11_ and the TLVs listed in _Table [Diagnostic Core Attributes](#diagnostic-core-attributes)_. In addition it serves items of type `energyScanReport`.
+
+The value of the `id` field of the collection items is a `UUID`.
+
+The TLVs are collected and the items appended to the collection based on requests to the `/api/actions` resource.
+
+### `/api/actions`
+
+A http client may send requests to the actions resource that trigger diagnostic requests into the Thread network or requests to a (on-mesh) commissioner for onboarding new devices onto the Thread network. Such requests typically may have a longer response time and results be obtained indirectly after some processing time.
+
+This PR supports following action requests to `/api/actions`:
+
+- POST
+   - `addThreadDeviceTask` - starts the on-mesh commissioner and adds the joiner candidate into the joiner table
+   - `getNetworkDiagnosticTask` - sends diagnostic requests and diagnostic queries to the destination
+   - `resetNetworkDiagCounterTask` - resets the network diagnostic mle and/or mac counter
+   - `getEnergyScanTask` - starts the commissioner and sends energy scan requests to the destination
+- GET | DELETE the full `actions` collection
+
+Currently, `getNetworkDiagnosticTask` and `getEnergyScanTask` must contain a `destination` attribute which should equal a `deviceId` contained in the `api/devices` collection. If the `deviceId` does not exists, we currently we check wheter destination might be a valid `mlEidIid` or `rloc16`.
+
+A `DELETE` request on `api/actions` cancels a ongoing action and deletes all collection items.
+
+#### Requests & Responses
+
+After receiving the request, `ApiActionPostHandler()` parses the request body using the `Request` class of the `rest` module. We validate the received data before we attempt to perform processing. Once `JSON` data is extracted it is added into a newly created instance `task_node` of `struct type task_node_t` for further processing. (`task_node` contains all the information about the task like its `status, uuid, task type, creation time, timeout`) The response is sent back using the `Response` class of the `rest` module. The reception of a accepted request is confirmed with a response status `ok` and the requests body including a new `id` for the new request to allow tracking of progress.
+
+#### Processing of request
+
+A `request` is processed by `rest_task_queue_task`. When the `task_node` is created, it is marked as `ACTIONS_TASK_STATUS_PENDING` which is then processed by thread function `rest_task_queue_task`. After processing the requests is completed the next queued request is processed.
+
+#### Request results
+
+A `request` status attribute turns `completed` after successful processing, and a reference to the request result is provided as a `relationship` attribute. Status attribute is set to `stopped` after timeout, or otherwise `failed`.
+
+In this PR, the actual request result must be collected in a separate request to the resource given in the `relationship` object.
+
+An example response to `curl -G http://otbr.local/api/actions -H 'Accept: application/vnd.api+json'` after a previous POST of `getNetworkDiagnosticTask` has completed may look similar to
+
+```
+{
+  "data": [
+    {
+      "type": "getNetworkDiagnosticTask",
+      "attributes": {
+        "destination": "32ba6e34fd4c0299",
+        "types": [
+          "extAddress",
+          "rloc16",
+          "leaderData",
+          "ipv6Addresses",
+          "macCounters",
+          "batteryLevel",
+          "supplyVoltage",
+          "channelPages",
+          "maxChildTimeout",
+          "lDevIdSubject",
+          "iDevIdCert",
+          "eui64",
+          "version",
+          "vendorName",
+          "vendorModel",
+          "vendorSwVersion",
+          "threadStackVersion",
+          "children",
+          "childIpv6Addresses",
+          "routerNeighbor",
+          "mleCounters"
+        ],
+        "timeout": 60,
+        "status": "completed"
+      },
+      "id": "54dc649d-c257-4f91-9071-a35a678b6249",
+      "relationships": {
+        "result": {
+          "data": {
+            "type": "diagnostics",
+            "id": "0a97ef16-1997-43dd-91c4-7fbcb1ec6713"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "collection": {
+      "offset": 0,
+      "limit": 100,
+      "total": 1,
+      "pending": 0
+    }
+  }
+}
+```
+
+### Examples of general resource features
+
+The request must comprise a header field `Accept` set to `application/vnd.api+json` for JSON:API content format, or `application/json` for JSON content format in the response. Accordingly, the response comprises the header field `Content-type`.
+
+#### Get collection
+
+All items of the collection are gettable in a single request, e.g.
+
+```
+curl -G http://<otbr-address>/api/<collectionName> -H 'Accept: application/vnd.api+json'
+```
+
+#### Get collection item by id
+
+Individual items are gettable from the collections, e.g.
+
+```
+curl -G http://<otbr-address>/api/<collectionName>/<itemId> -H 'Accept: application/vnd.api+json'
+```
+
+#### Get items by type
+
+The collection can be filtered by type of the items, e.g.
+
+```
+curl -G http://<otbr-address>/api/<collectionName>?fields[<type>] -H 'Accept: application/vnd.api+json'
+```
+
+#### Get items by type with limited attributes
+
+The collection can be filtered by type of the items, e.g.
+
+```
+curl -G http://<otbr-address>/api/<collectionName>?fields[<type>]=attribute1,attribute2 -H 'Accept: application/vnd.api+json'
+```
+
+Detailed request examples are provided in the test folder as a "Bruno Request Collection". Use the free opensource API client [Bruno](https://www.usebruno.com/).
+
+## Files Description
+
+- `commissioner_allow_list.cpp`,`commissioner_allow_list.hpp`
+
+  Implements functionality related to commisioner APIs.
+
+- `rest_server_common.cpp`,`rest_server_common.hpp`
+
+  Implements APIs used for conversions of data from one form to another.
+
+- `rest_task_add_thread_device.cpp`, `rest_task_add_thread_device.hpp`
+
+  Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+
+- `rest_task_handler.cpp`, `rest_task_handler.hpp`
+
+  Implements additional functionailty like `task_node` creation, update task status and conversion `task_node` to `JSON` format.
+
+- `rest_task_queue.cpp`,`rest_task_queue.hpp`
+
+  Implements APIs related to thread creation and task handling.
+
+- `uuid.cpp`,`uuid.hpp`
+
+  Implements functionality to handle UUID (generation,parse,unparse) used for `task_node` and collection items.
+
+- `tests/restjsonapi/*`
+
+  Test setup including implementation for various test cases.
+
+# How to rebuild and experience this work
+
+Please follow the following steps to install/build OTBR.
+
+1. Checkout this PR
+
+2. Build and Install OTBR as usual, e.g. on a Raspberry Pi
+
+3. Restart the OTBR. `sudo systemctl restart otbr-agent`
+
+4. To monitor the log [Errors|Warnings|Info] please open a different terminal instance and use following command:
+
+```
+tail -f /var/log/syslog | grep otbr
+```
+
+5. Send POST request using BRUNO or CURL, e.g. to join a new device into your network.
+
+```
+curl -X POST -H 'Content-Type: application/vnd.api+json' http://localhost:8081/api/actions -d '{"data": [{"type": "addThreadDeviceTask", "attributes": {"eui": "6234567890AACDEA", "pskd": "J01NME", "timeout": 3600}}]}' | jq
+```
+
+should return
+
+```
+{
+  "data": [
+    {
+      "id": "2d5a8844-b1bc-4f02-93f0-d87b8c3b4e92",
+      "type": "addThreadDeviceTask",
+      "attributes": {
+        "eui": "6234567890AACDEB",
+        "pskd": "J01NME",
+        "timeout": 3600,
+        "status": "pending"
+      },
+    }
+  ]
+}
+```
+
+6. You may check the status and get the full collection of actions.
+
+```
+curl -X GET -H 'Accept: application/vnd.api+json' http://localhost:8081/api/actions | jq
+```
+
+should return
+
+```
+{
+  "data": [
+    {
+      "id": "2d5a8844-b1bc-4f02-93f0-d87b8c3b4e92",
+      "type": "addThreadDeviceTask",
+      "attributes": {
+        "eui": "6234567890AACDEB",
+        "pskd": "J01NME",
+        "timeout": 3600,
+        "status": "pending"
+      }
+    }
+  ],
+  "meta": {
+    "collection": {
+      "offset": 0,
+      "limit": 100,
+      "total": 1
+    }
+  }
+}
+```
+
+7. View the entry added to the commissioner's table `sudo ot-ctl commissioner joiner table` and expect
+
+```
+| ID                    | PSKd                             | Expiration |
++-----------------------+----------------------------------+------------+
+|      6234567890aacdea |                           J01NME |    3459027 |
+Done
+```
+
+8. Start your joiner and after a few seconds repeat above steps 6. and 7.
+
+9. For further experiencing the diagnostic endpoints, see the python demo test script `http_action_client_demo.py` or use the Bruno request collection, you find both in the folder [tests/restjsonapi](./../../../tests/restjsonapi).
+
+10. For running the included test script install Bruno-Cli and run the bash script on your border router
+
+```
+cd tests/restjsonapi
+source ./install_bruno_cli
+./test-restjsonapi-server
+```
+
+## Glossary of Names
+
+### Diagnostic Core Attributes
+
+Below table is derrived from Thread Specification. The column `Short Name` defines the attribute names as used in this PR.
+
+| TLV Type | Name | Short Name (as used for JSON attributes) | TLV Length, Format of Value and Description | Can Reset? |
+| --- | --- | --- | --- | --- |
+| 0 | MAC Extended Address<br>(64-bit) | extAddress | Same format and semantics as the MAC Extended Address TLV (Network Layer TLV Type 1) in Section 5.19.2, MAC Extended Address TLV in Chapter 5, Network Layer. | N |
+| 1 | MAC Address (16-bit) | rloc16 | Same format and semantics as the Address16 TLV (MLE TLV Type 10) in Section 4.4.9, Address16 TLV in Chapter 4, Mesh Link Establishment. | N |
+| 2 | Mode (Capability Information) | mode | Same format and semantics as the Mode TLV (MLE TLV Type 1) in Section 4.4.2, Mode TLV in Chapter 4, Mesh Link Establishment. | N |
+| 3 | Timeout | timeout | End Devices MUST report their MLE timeout (as described in Section 4.4.3, Timeout TLV in Chapter 4, Mesh Link Establishment) in this TLV. The same format as the MLE Timeout TLV is used. Routers MUST omit this TLV in any Diagnostic Response or Answer message. | N |
+| 4 | Connectivity | connectivity | Same format and semantics as the Connectivity TLV (MLE TLV Type 15) in Section 4.4.14, Connectivity TLV in Chapter 4, Mesh Link Establishment. | N |
+| 5 | Route64 | route | Same format and semantics as the Route64 TLV (MLE TLV Type 9) in Section 4.4.8, Route64 TLV in Chapter 4, Mesh Link Establishment. | N |
+| 6 | Leader Data | leaderData | Same format and semantics as the Leader Data TLV (MLE TLV Type 11) in Section 4.4.10, Leader Data TLV in Chapter 4, Mesh Link Establishment. | N |
+| 7 | Network Data | networkData | Same format and semantics as the Network Data TLV (MLE TLV Type 12), in Section 4.4.11, Network Data TLV in Chapter 4, Mesh Link Establishment. | N |
+| 8 | IPv6 address list | ipv6Addresses | List of all link-local and higher scoped IPv6 (unicast) addresses registered by the Thread Device on this Thread Interface. With N addresses in the list the length is N\*16 bytes. All 16-byte addresses are concatenated. | N |
+| 9 | MAC Counters | macCounters | TLV that contains packet/event counters for the MAC 802.15.4 interface. Defined in Section 10.11.4.1, MAC Counters TLV (9). | Y |
+| 14 | Battery Level | batteryLevel | Indication of remaining battery energy. Defined in Section 10.11.4.2, Battery Level TLV (14). | N |
+| 15 | Supply Voltage | supplyVoltage | Indication of the current supply voltage. Defined in Section 10.11.4.3, Supply Voltage TLV (15). | N |
+| 16 | Child Table | childTable | List of all Children of a Router. Defined in Section 10.11.4.4, Child Table TLV (16). | N |
+| 17 | Channel Pages | channelPages | List of supported frequency bands. Defined in Section 10.11.4.5, Channel Pages TLV (17). | N |
+| 18 | Type List | - | List of type identifiers used to request or reset multiple diagnostic values. Defined in Section 10.11.4.6, Type List TLV (18). | N |
+| 19 | Max Child Timeout | maxChildTimeout | Reports the maximum timeout value over a Router’s MTD Children. Defined in Section 10.11.4.7, Max Child Timeout TLV (19). | N |
+| 20 | LDevID Subject Public Key Info | lDevIdSubject | The identity of the LDevID (operational) certificate of a CCM Thread Device, encoded as Subject Public Key Info. Defined in Section 10.11.4.8, LDevID Subject Public Key Info TLV (20). | N |
+| 21 | IDevID Certificate | lDevIdCert | The IDevID (manufacturer) certificate of a CCM Thread Device, encoded in X.509 format. Defined in Section 10.11.4.9, IDevID Certificate TLV (21). | N |
+| 22 | (reserved) | - | (reserved) | N |
+| 23 | EUI-64 | eui64 | The EUI-64 of a Thread Device, binary encoded with Length = 8. | N |
+| 24 | Version | version | Same format and semantics as the Version TLV (MLE TLV Type 18) in Section 4.4.17, Version TLV in Chapter 4, Mesh Link Establishment. | N |
+| 25 | Vendor Name | vendorName | Same format and semantics as the Vendor Name TLV (TMF Provisioning/Discovery TLV Type 33) in Section 8.10.3.2, Vendor Name TLV in Chapter 8, Mesh Commissioning Protocol. | N |
+| 26 | Vendor Model | vendorModel | Same format and semantics as the Vendor Model TLV (TMF Provisioning/Discovery TLV Type 34) in Section 8.10.3.3, Vendor Model TLV in Chapter 8, Mesh Commissioning Protocol. | N |
+| 27 | Vendor SW Version | vendorSwVersion | Same format and semantics as the Vendor SW Version TLV (TMF Provisioning/Discovery TLV Type 35) in Section 8.10.3.4, Vendor SW Version TLV in Chapter 8, Mesh Commissioning Protocol. | N |
+| 28 | Thread Stack Version | threadStackVersion | Thread stack version identifier as UTF-8 string. The maximum length is 64 bytes. This identifies the particular Thread stack codebase/commit/version, independent from the vendor (application) software version. | N |
+| 29 | Child<sup>1</sup> | children | List of Child Containers. Each Container with diagnostic information about a particular Child of a Router. Defined in Section 10.11.4.10, Child TLV (29). | N |
+| 30 | Child IPv6 Address List | childIpv6Addresses | Contains a list of IPv6 addresses of an MTD Child. Defined in Section 10.11.4.11, Child IPv6 Address List TLV (30). | N |
+| 31 | Router Neighbor | routerNeighbor | Container with diagnostic information about a particular Router-neighbor of a Full Thread Device. Defined in Section 10.11.4.12, Router Neighbor TLV (31). | N |
+| 32 | Answer | - | Identifies a partial answer to a diagnostic Query. Defined in Section 10.11.4.13, Answer TLV (32). | N |
+| 33 | Query ID | - | Identifies a diagnostic Query, and subsequent Answer(s) to this query. Defined in Section 10.11.4.14, Query ID TLV (33). | N |
+| 34 | MLE Counters | mleCounters | Contains MLE protocol related counters and timers. Defined in Section 10.11.4.15, MLE Counters TLV (34). | Y |
+
+#### Attribute names
+
+| Name | Short Name | Minimal supported Thread Version / DeviceType | Related TLV type |
+| --- | --- | --- | --- |
+| Active Routers in Partition | activeRouterCount | v1.1 | 4 |
+| Age | age | FTD, v1.3.1 | 29 |
+| Attach Attempts Counter | attachAttemptsCount | v1.3.1 | 34 |
+| Average RSSI | avgRssi | FTD, v1.3.1 | 29, 31 |
+| Battery Level | batteryLevel | v1.1 | 14 |
+| Better-Partition Attach Attempts Counter | betterPartIdAttachAttemptsCount | v1.3.1 | 34 |
+| C | isCslSychronized | FTD, v1.3.1 | 29 |
+| Child Role Counter | childRoleCount | v1.3.1 | 34 |
+| Child Role Time | childRoleTime | v1.3.1 | 34 |
+| Child Timeout | childTimeout | FTD, v1.1 | 16 |
+| Connection Time | linkAge | FTD, v1.3.1 | 29, 31 |
+| CSL Channel | cslChannel | FTD, v1.3.1 | 29 |
+| CSL Period | cslPeriod | FTD, v1.3.1 | 29 |
+| CSL Timeout | cslTimeout | FTD, v1.3.1 | 29 |
+| D | isFTD | FTD, v1.3.1 | 29 |
+| Detached Role Counter | detachedRoleCount | v1.3.1 | 34 |
+| Detached Role Time | detachedRoleTime | v1.3.1 | 34 |
+| E | errorTracking | FTD, v1.3.1 | 29, 31 |
+| EUI64 | eui64 | v1.3.1 | 23 |
+| Extended Address | extMacAddress | FTD, v1.3.1 | 0, 29, 31 |
+| Frame Error Rate | frameErrorRate | FTD, v1.3.1 | 29, 31 |
+| ILQ | inLQ | FTD, v1.3.1 | 16 |
+| Inbound Broadcast Packet Counter | ifInBroadcastPkts | v1.1 | 9 |
+| Inbound Packet Discarded Counter | ifInDiscards | v1.1 | 9 |
+| Inbound Packet Error Counter | ifInErrors | v1.1 | 9 |
+| Inbound Packet of Unknown Protocol Counter | ifInUnknownProtos | v1.1 | 9 |
+| Inbound Unicast Packet Counter | ifInUcastPkts | v1.1 | 9 |
+| Ipv6 Address(es) | ipv6Addresses | FTD, v1.1, FTD, v1.3.1 | 8, 30 |
+| Last RSSI | lastRssi | FTD, v1.3.1 | 29, 31 |
+| Leader Cost | leaderCost | v1.1 | 4 |
+| Leader Role Counter | leaderRoleCount | v1.3.1 | 34 |
+| Leader Role Time | leaderRoleTime | v1.3.1 | 34 |
+| Link Margin | linkMargin | FTD, v1.3.1 | 29, 31 |
+| Link Quality 1 Count | linkQuality1 | v1.1 | 4 |
+| Link Quality 2 Count | linkQuality2 | v1.1 | 4 |
+| Link Quality 3 Count | linkQuality3 | v1.1 | 4 |
+| Message Error Rate | messageErrorRate | FTD, v1.3.1 | 29, 31 |
+| N | hasNetworkData | FTD, v1.3.1 | 29 |
+| New Parent Counter | newParentCount | v1.3.1 | 34 |
+| Outbound Broadcast Packet Counter | ifOutBroadcastPkts | v1.1 | 9 |
+| Outbound Packet Discarded Counter | ifOutDiscards | v1.1 | 9 |
+| Outbound Packet Error Counter | ifOutErrors | v1.1 | 9 |
+| Outbound Unicast Packet Counter | ifOutUcastPkts | v1.1 | 9 |
+| Partition ID Changes Counter | partIdChangesCount | v1.3.1 | 34 |
+| Queued Message Count | queuedMessageCount | FTD, v1.3.1 | 29 |
+| R | rxOnWhenIdle | FTD, v1.3.1 | 29 |
+| Radio Disabled Counter | radioDisabledCount | v1.3.1 | 34 |
+| Radio Disabled Time | radioDisabledTime | v1.3.1 | 34 |
+| RLOC16 | rloc16 | FTD, v1.3.1 | 1, 29, 30, 31 |
+| Router Role Counter | routerRoleCount | v1.3.1 | 34 |
+| Router Role Time | routerRoleTime | v1.3.1 | 34 |
+| Rx-off Child Buffer Size | rxOffChildBufferSize | v1.1 | 4 |
+| Rx-off Child Datagram Count | rxOffChildDatagramCount | v1.1 | 4 |
+| Supervision Interval | supervisionInterval | FTD, v1.3.1 | 29 |
+| Thread Extended PanId | extPanId | v1.1 | - |
+| Thread Network Name | networkName | v1.1 | - |
+| Thread PanId | panId | v1.1 | - |
+| Thread Stack Version | threadStackVersion | v1.3.1 | 28 |
+| Thread Version | threadVersion | FTD, v1.3.1 | 29, 31 |
+| Thread Version | threadVersion | v1.3.1 | 24 |
+| Total Tracking Time | totalTrackingTime | v1.3.1 | 34 |
+| Vendor Model | vendorModel | v1.3.1 | 26 |
+| Vendor Name | vendorName | v1.3.1 | 25 |
+| Vendor SW Version | vendorSwVersion | v1.3.1 | 27 |

--- a/src/rest/extensions/commissioner_allow_list.cpp
+++ b/src/rest/extensions/commissioner_allow_list.cpp
@@ -1,0 +1,692 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief Implements functionality related to commisioner APIs.
+ *
+ */
+#include "commissioner_allow_list.hpp"
+#include "rest/extensions/rest_task_add_thread_device.hpp"
+#include "utils/hex.hpp"
+#include "utils/thread_helper.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "assert.h"
+#include "cJSON.h"
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <openthread/commissioner.h>
+#include <openthread/logging.h>
+#include "openthread/instance.h"
+
+#define ALLOW_LIST_NAME "allowlist"
+#define ALLOW_LIST_MOUNT "/" ALLOW_LIST_NAME
+#define ALLOW_LIST_BASE_DIR ALLOW_LIST_MOUNT "/"
+
+#define COMMISSIONER_START_WAIT_TIME_MS 100
+#define COMMISSIONER_START_MAX_ATTEMPTS 5
+
+static allow_list::LinkedList<AllowListEntry> AllowListEntryList;
+static void                                   consoleEntryPrint(AllowListEntry *aEntry);
+
+bool otExtAddressMatch(const otExtAddress *aAddress1, const otExtAddress *aAddress2)
+{
+    for (int i = 0; i < OT_EXT_ADDRESS_SIZE; i++)
+    {
+        if (aAddress1->m8[i] != aAddress2->m8[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool eui64IsNull(const otExtAddress aEui64)
+{
+    for (int i = 0; i < OT_EXT_ADDRESS_SIZE; i++)
+    {
+        if (aEui64.m8[i] != 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+AllowListEntry *entryEui64Find(const otExtAddress *aEui64)
+{
+    AllowListEntry *entry = nullptr;
+
+    if (nullptr == aEui64)
+    {
+        return entry;
+    }
+    entry = AllowListEntryList.GetHead();
+    while (entry)
+    {
+        if (otExtAddressMatch(&entry->meui64, aEui64))
+        {
+            break;
+        }
+        entry = entry->GetNext();
+    }
+    return entry;
+}
+
+otError allowListCommissionerJoinerAdd(otExtAddress aEui64,
+                                       uint32_t     aTimeout,
+                                       char        *aPskd,
+                                       otInstance  *aInstance,
+                                       uuid_t       uuid)
+{
+    otError             error;
+    AllowListEntry     *entry   = nullptr;
+    const otExtAddress *addrPtr = &aEui64;
+
+    if (eui64IsNull(aEui64))
+    {
+#ifdef OPENTHREAD_COMMISSIONER_ALLOW_ANY_JOINER
+        return OT_ERROR_INVALID_ARGS;
+#else
+        addrPtr = nullptr;
+#endif
+    }
+
+    allowListAddDevice(aEui64, aTimeout, aPskd, uuid);
+    entry = entryEui64Find(addrPtr);
+
+    // openthread_lock_acquire(LOCK_TYPE_BLOCKING, 0);
+    error = otCommissionerAddJoiner(aInstance, addrPtr, aPskd, aTimeout);
+    // openthread_lock_release();
+
+    if (OT_ERROR_NONE == error && nullptr != entry)
+    {
+        entry->update_state(AllowListEntry::kAllowListEntryPendingJoiner);
+    }
+
+    if (OT_ERROR_NONE != error)
+    {
+        otbrLogWarning("otCommissionerAddJoiner error=%d %s", error, otThreadErrorToString(error));
+    }
+    return error;
+}
+
+otError allowListEntryErase(otExtAddress aEui64)
+{
+    otError         error = OT_ERROR_FAILED;
+    AllowListEntry *entry = nullptr;
+
+    const otExtAddress *addrPtr = &aEui64;
+
+    entry = AllowListEntryList.GetHead();
+    while (entry)
+    {
+        if (otExtAddressMatch(&entry->meui64, addrPtr))
+        {
+            error = AllowListEntryList.Remove(*entry);
+            break;
+        }
+        entry = entry->GetNext();
+    }
+    return error;
+}
+
+otError allowListCommissionerJoinerRemove(otExtAddress aEui64, otInstance *aInstance)
+{
+    otError             error = OT_ERROR_FAILED;
+    otCommissionerState state = OT_COMMISSIONER_STATE_DISABLED;
+
+    const otExtAddress *addrPtr = &aEui64;
+
+    if (eui64IsNull(aEui64))
+    {
+        addrPtr = nullptr;
+    }
+
+    // openthread_lock_acquire(LOCK_TYPE_BLOCKING, 0);
+    state = otCommissionerGetState(aInstance);
+    if (OT_COMMISSIONER_STATE_DISABLED == state)
+    {
+        // openthread_lock_release();
+        return OT_ERROR_NONE;
+    }
+
+    error = otCommissionerRemoveJoiner(aInstance, addrPtr);
+    // openthread_lock_release();
+
+    if (OT_ERROR_NONE != error)
+    {
+        otLogWarnPlat("otCommissionerRemoveJoiner error=%d %s", error, otThreadErrorToString(error));
+    }
+    return error;
+}
+
+AllowListEntry *parse_buf_as_json(char *aBuf)
+{
+    // Need all vars to be declared here to use goto for graceful exit
+    cJSON *allow_entry_json = nullptr;
+    cJSON *attributesJSON   = nullptr;
+    // cJSON                              *hasActivationKeyJSON = nullptr;
+    AllowListEntry                     *pEntry = nullptr;
+    otExtAddress                        eui64;
+    uint32_t                            timeout = 0;
+    AllowListEntry::AllowListEntryState state   = AllowListEntry::kAllowListEntryNew;
+    UUID                                uuid_obj;
+    uuid_t                              uuid;
+    char                               *uuid_str     = nullptr;
+    char                               *eui64_str    = nullptr;
+    char                               *pskdValue    = nullptr;
+    size_t                              pskdValueLen = 0;
+    char                               *pskd         = nullptr;
+
+    allow_entry_json = cJSON_Parse(aBuf);
+    if (nullptr == allow_entry_json)
+    {
+        otbrLogErr("%s: Err cJSON_Parse", __func__);
+        goto exit;
+    }
+
+    attributesJSON = cJSON_GetObjectItemCaseSensitive(allow_entry_json, JSON_ATTRIBUTES);
+    if (nullptr == attributesJSON)
+    {
+        otbrLogErr("%s: Err cJSON Get %s", __func__, JSON_ATTRIBUTES);
+        goto exit;
+    }
+    /*
+        hasActivationKeyJSON = cJSON_GetObjectItemCaseSensitive(attributesJSON, JSON_HASACTIVATIONKEY);
+        if (nullptr == hasActivationKeyJSON)
+        {
+            otbrLogErr("%s: Err cJSON Get %s", __func__, JSON_HASACTIVATIONKEY);
+            goto exit;
+        }
+    */
+    eui64_str = cJSON_GetObjectItem(attributesJSON, JSON_EUI)->valuestring;
+    if (nullptr == eui64_str)
+    {
+        otbrLogErr("%s: Err cJSON Get eui64", __func__);
+        goto exit;
+    }
+
+    otbr::Utils::Hex2Bytes(eui64_str, eui64.m8, sizeof(eui64));
+
+    uuid_str = cJSON_GetObjectItem(allow_entry_json, JSON_UUID)->valuestring;
+    if (nullptr == uuid_str)
+    {
+        otbrLogErr("%s: Err cJSON Get uuid", __func__);
+        goto exit;
+    }
+    uuid_obj.parse(std::string(uuid_str));
+    uuid_obj.getUuid(uuid);
+    // uuid_parse(uuid_str, &uuid);
+
+    pskdValue = cJSON_GetObjectItem(attributesJSON, JSON_PSKD)->valuestring;
+    if (nullptr == pskdValue || strlen(pskdValue) > OT_JOINER_MAX_PSKD_LENGTH)
+    {
+        otbrLogErr("%s: Err cJSON Get pskd", __func__);
+        goto exit;
+    }
+
+    pskdValueLen = strlen(pskdValue) + 1; // account for NULL
+    pskd         = (char *)malloc(pskdValueLen);
+    if (nullptr == pskd)
+    {
+        otbrLogErr("%s: Err no mem for pskd, need %d bytes", __func__, pskdValueLen);
+        goto exit;
+    }
+    memset(pskd, 0, pskdValueLen);
+    memcpy(pskd, pskdValue, strlen(pskdValue));
+
+    timeout = cJSON_GetObjectItem(allow_entry_json, JSON_TIMEOUT)->valueint;
+    state   = (AllowListEntry::AllowListEntryState)cJSON_GetObjectItem(allow_entry_json, JSON_ALLOW_STATE)->valueint;
+    pEntry  = new AllowListEntry(eui64, uuid, timeout, state, pskd);
+
+exit:
+    if (nullptr != allow_entry_json)
+    {
+        cJSON_Delete(allow_entry_json);
+    }
+    if (nullptr == pEntry)
+    {
+        otbrLogErr("%s: Err creating a new AllowListEntry", __func__);
+        if (nullptr != pskd)
+        {
+            free(pskd);
+        }
+    }
+    return pEntry;
+}
+
+void list_files(DIR *aDir)
+{
+    AllowListEntry *pEntry = nullptr;
+    struct dirent  *dp     = nullptr;
+    char            path[255];
+    char            buf[255];
+    struct stat     file_stat;
+
+    for (;;)
+    {
+        dp = readdir(aDir);
+        if (nullptr == dp)
+        {
+            break;
+        }
+        memset(path, 0, sizeof(path));
+        strcat(path, ALLOW_LIST_BASE_DIR);
+        strcat(path, dp->d_name);
+
+        if (0 != stat(path, &file_stat))
+        {
+            otbrLogErr("Error stat file %s error=(%d) %s", path, errno, strerror(errno));
+            return;
+        }
+
+        if (file_stat.st_size > (__off_t)sizeof(buf))
+        {
+            //        otbrLogErr( "Insufficient buffer for file %s need %ld, have %u", path, file_stat.st_size,
+            //        sizeof(buf));
+            return;
+        }
+
+        FILE *fd = fopen(path, "r");
+        if (nullptr == fd)
+        {
+            //     otbrLogErr("Error opening file %s error=(%d) %s",path, errno, strerror(errno));
+            return;
+        }
+
+        memset(buf, 0, sizeof(buf)); // sanitize buf before fread()
+        size_t readSz = fread(buf, 1, file_stat.st_size, fd);
+        if (readSz != (size_t)file_stat.st_size)
+        {
+            //   otbrLogErr("Error reading from file %s got %u, expecting %ld", path, readSz, file_stat.st_size);
+            // Do not return here, we need to fclose() properly
+        }
+        else
+        {
+            // Got some data, lets parse it and add to the list if valid
+            pEntry = nullptr;
+            pEntry = parse_buf_as_json(buf);
+            if (nullptr != pEntry)
+            {
+                AllowListEntryList.Add(*pEntry);
+            }
+            else
+            {
+                //  otbrLogErr("Error parsing file %s as json", path);
+            }
+        }
+        // Close the file before re-iterating
+        if (0 != fclose(fd))
+        {
+            //  otbrLogErr("Error closing file %s", path);
+        }
+    }
+}
+
+typedef struct
+{
+    char   path[255];
+    cJSON *allow_entry_json;
+} commissioner_allow_list_write_entry_args_t;
+
+void allowListAddDevice(otExtAddress aEui64, uint32_t aTimeout, char *aPskd, uuid_t aUuid)
+{
+    assert(nullptr != aPskd);
+
+    AllowListEntry *pEntry = entryEui64Find(&aEui64);
+
+    int   pskd_len = strlen(aPskd);
+    char *pskd_new = (char *)malloc(pskd_len + 1);
+    assert(nullptr != pskd_new);
+    memset(pskd_new, 0, pskd_len + 1);
+    memcpy(pskd_new, aPskd, pskd_len);
+
+    if (nullptr != pEntry)
+    {
+        pEntry->mPSKd    = pskd_new;
+        pEntry->mTimeout = aTimeout;
+        pEntry->muuid    = aUuid;
+    }
+    else
+    {
+        // TODO if (aUuid == NULL)
+        //{
+        //     uuid_generate_random(&aUuid);
+        // }
+        pEntry = new AllowListEntry(aEui64, aUuid, aTimeout, pskd_new);
+        if (nullptr == pEntry)
+        {
+            //  otbrLogErr("%s: Err creating a new AllowListEntry", __func__);
+            free(pskd_new);
+            return;
+        }
+        AllowListEntryList.Add(*pEntry);
+    }
+
+    consoleEntryPrint(pEntry);
+}
+
+/**
+ * @brief Given an entry, prints its content to the console
+ *
+ * @param aEntry the entry to print
+ */
+static void consoleEntryPrint(AllowListEntry *aEntry)
+{
+    assert(nullptr != aEntry);
+    // char uuidStr[UUID_STR_LEN] = {0};
+
+    UUID uuid_obj = UUID();
+    uuid_obj.setUuid(aEntry->muuid);
+
+    // uuid_unparse(aEntry->muuid, uuidStr);
+    otbrLogInfo(
+        "Entry uuid: %s\n\tEUI64: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n\tJoined: %s\n\tState: %d\n\tTimeout: %d",
+        uuid_obj.toString().c_str(), aEntry->meui64.m8[0], aEntry->meui64.m8[1], aEntry->meui64.m8[2],
+        aEntry->meui64.m8[3], aEntry->meui64.m8[4], aEntry->meui64.m8[5], aEntry->meui64.m8[6], aEntry->meui64.m8[7],
+        aEntry->is_joined() ? "TRUE" : "FALSE", aEntry->mstate, aEntry->mTimeout);
+}
+
+void allow_list_print_all_entries_to_console(void)
+{
+    AllowListEntry *entry = AllowListEntryList.GetHead();
+    while (entry)
+    {
+        consoleEntryPrint(entry);
+        entry = entry->GetNext();
+    }
+}
+
+int allowListJsonifyAll(cJSON *input_object)
+{
+    assert(nullptr != input_object);
+
+    if (AllowListEntryList.IsEmpty())
+    {
+        return 0;
+    }
+
+    // Add each entry into an array called allow_list
+    cJSON *json_array = cJSON_CreateArray();
+    if (nullptr == json_array)
+    {
+        otbrLogErr("%s: Err: cJSON_CreateArray", __func__);
+        return 0;
+    }
+
+    AllowListEntry *entry = nullptr;
+    // cJSON* entryJson = nullptr;
+    int entry_count = 0;
+    for (entry = AllowListEntryList.GetHead(); nullptr != entry; entry = entry->GetNext())
+    {
+        // Typically allow list entry uses type as JSON_ALLOW_LIST_TYPE.
+        // This call is one of the exception to reuse the Allow_list_entry_as_CJSON method
+        // entryJson = entry->Allow_list_entry_as_CJSON(DEVICE_TYPE);
+        // cJSON_AddItemToArray(json_array, entryJson);
+        // entry_count++;
+    }
+
+    if (entry_count > 0)
+    {
+        cJSON_AddItemToObject(input_object, "allow_list", json_array);
+    }
+    else
+    {
+        otbrLogErr("%s: Err: cJSON Array is empty", __func__);
+        // Something is wrong, delete our array to not leak memory
+        cJSON_Delete(json_array);
+        return 0;
+    }
+
+    // @note: Caller responsible to clean json_array, usually via cJSON_Delete(input_object);
+    return entry_count;
+}
+
+void allowListEraseAll(void)
+{
+    if (!AllowListEntryList.IsEmpty())
+    {
+        AllowListEntry *entry = nullptr;
+        // Free all malloc-ed pskd to not leak memory
+        for (entry = AllowListEntryList.GetHead(); nullptr != entry; entry = entry->GetNext())
+        {
+            if (nullptr != entry->mPSKd)
+            {
+                free(entry->mPSKd);
+            }
+        }
+        AllowListEntryList.Clear(); // Mark Linked List as empty
+    }
+}
+
+void HandleStateChanged(otCommissionerState aState, void *aContext)
+{
+    OT_UNUSED_VARIABLE(aContext);
+    otbrLogWarning("%s:%d - %s - commissioner state: %d", __FILE__, __LINE__, __func__, aState);
+
+    switch (aState)
+    {
+    case OT_COMMISSIONER_STATE_ACTIVE:
+        rest_task_queue_handle();
+        break;
+    case OT_COMMISSIONER_STATE_DISABLED:
+        break;
+    case OT_COMMISSIONER_STATE_PETITION:
+        break;
+    default:
+        break;
+    }
+}
+
+uint8_t allowListGetPendingJoinersCount(void)
+{
+    uint8_t pendingJoinersCount = 0;
+
+    AllowListEntry *entry = AllowListEntryList.GetHead();
+
+    while (entry)
+    {
+        if ((AllowListEntry::kAllowListEntryJoined != entry->mstate) ||
+            (AllowListEntry::kAllowListEntryJoinFailed != entry->mstate))
+        {
+            pendingJoinersCount++;
+        }
+        entry = entry->GetNext();
+    }
+
+    return pendingJoinersCount;
+}
+
+void HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
+                       const otJoinerInfo       *aJoinerInfo,
+                       const otExtAddress       *aJoinerId,
+                       void                     *aContext)
+{
+    (void)aEvent;
+    (void)aContext;
+    OT_UNUSED_VARIABLE(aJoinerId);
+    AllowListEntry *entry               = nullptr;
+    uint8_t         pendingDevicesCount = 0;
+
+    // @note: Thread may call this for joiners that we are not supposed to join
+    //        do not assume `entry` is not null in the rest of the code.
+    entry = entryEui64Find(&aJoinerInfo->mSharedId.mEui64);
+    if (nullptr == entry && eui64IsNull(aJoinerInfo->mSharedId.mEui64))
+    {
+        otbrLogWarning("Unauthorized device %s join attempt", aJoinerInfo->mSharedId.mEui64);
+        return;
+    }
+
+    switch (aEvent)
+    {
+    case OT_COMMISSIONER_JOINER_START:
+        otbrLogWarning("Start Joiner");
+        if (nullptr != entry)
+        {
+            entry->update_state(AllowListEntry::kAllowListEntryJoinAttempted);
+            consoleEntryPrint(entry);
+        }
+        break;
+    case OT_COMMISSIONER_JOINER_CONNECTED:
+        otbrLogWarning("Connect Joiner");
+        break;
+    case OT_COMMISSIONER_JOINER_FINALIZE:
+        otbrLogWarning("Finalize Joiner");
+        if (nullptr != entry)
+        {
+            entry->update_state(AllowListEntry::kAllowListEntryJoined);
+            consoleEntryPrint(entry);
+        }
+        break;
+    case OT_COMMISSIONER_JOINER_END:
+        otbrLogWarning("End Joiner");
+        break;
+    case OT_COMMISSIONER_JOINER_REMOVED:
+        otbrLogWarning("Removed Joiner");
+
+        if (nullptr != entry)
+        {
+            // If this get called on a one of our joiners that has never attempted yet, then we mark this as expired
+            if (AllowListEntry::kAllowListEntryPendingJoiner == entry->mstate)
+            {
+                entry->update_state(AllowListEntry::kAllowListEntryExpired);
+            }
+            // If this get called on a one of our joiners that is not joined yet, then we need to mark this as failed
+            else if (AllowListEntry::kAllowListEntryJoined != entry->mstate)
+            {
+                entry->update_state(AllowListEntry::kAllowListEntryJoinFailed);
+            }
+        }
+
+        // Scan allow list see if there are still pending joiners to process
+        pendingDevicesCount = allowListGetPendingJoinersCount();
+
+        // If all entries have been attempted and nothing is pending, stop the commissioner
+        if (0 == pendingDevicesCount)
+        {
+            allowListCommissionerStopPost();
+        }
+        else
+        {
+            // Tracer print
+            otbrLogWarning("%u Pending Joiners", pendingDevicesCount);
+        }
+
+        break;
+    }
+}
+
+otError allowListCommissionerStart(otInstance *aInstance)
+{
+    otError error = OT_ERROR_FAILED;
+
+    // openthread_lock_acquire(LOCK_TYPE_BLOCKING, 0);
+    error = otCommissionerStart(aInstance, &HandleStateChanged, &HandleJoinerEvent, NULL);
+    // openthread_lock_release();
+
+    return error;
+}
+
+otError allowListCommissionerStopPost(void)
+{
+    return OT_ERROR_NONE;
+}
+
+cJSON *AllowListEntry::Allow_list_entry_as_CJSON(const char *entryType)
+{
+    assert(nullptr != entryType);
+
+    cJSON *entry_json_obj = nullptr;
+    // cJSON *hasActivationKey    = nullptr;
+    cJSON *attributes_json_obj = nullptr;
+    char   eui64_str[17]       = {0};
+    // char   uuid_str[UUID_STR_LEN] = {0};
+
+    UUID uuid_obj = UUID();
+
+    // hasActivationKey = cJSON_CreateObject();
+
+    memset(eui64_str, 0, sizeof(eui64_str));
+    sprintf(eui64_str, "%02x%02x%02x%02x%02x%02x%02x%02x", meui64.m8[0], meui64.m8[1], meui64.m8[2], meui64.m8[3],
+            meui64.m8[4], meui64.m8[5], meui64.m8[6], meui64.m8[7]);
+
+    // memset(uuid_str, 0, sizeof(uuid_str));
+    // uuid_unparse(muuid, uuid_str);
+    uuid_obj.setUuid(muuid);
+
+    attributes_json_obj = cJSON_CreateObject();
+    // cJSON_AddItemToObject(attributes_json_obj, "hasActivationKey", hasActivationKey);
+    cJSON_AddItemToObject(attributes_json_obj, "eui", cJSON_CreateString(eui64_str));
+    cJSON_AddItemToObject(attributes_json_obj, "pskd", cJSON_CreateString(mPSKd));
+
+    entry_json_obj = cJSON_CreateObject();
+
+    cJSON_AddItemToObject(entry_json_obj, JSON_UUID, cJSON_CreateString(uuid_obj.toString().c_str()));
+    cJSON_AddItemToObject(entry_json_obj, JSON_TYPE, cJSON_CreateString(entryType));
+    cJSON_AddItemToObject(entry_json_obj, JSON_ATTRIBUTES, attributes_json_obj);
+    cJSON_AddNumberToObject(entry_json_obj, JSON_TIMEOUT, mTimeout);
+    cJSON_AddNumberToObject(entry_json_obj, JSON_ALLOW_STATE, mstate);
+
+    return entry_json_obj;
+}
+
+/**
+ * @brief I (kludegy) map joiner status to otError code
+ *
+ * @param eui64 the Joiner eui64 to check
+ * @return otError OT_ERROR_NONE     == eui64 joiner joined
+ *                 OT_ERROR_FAILED   == eui64 joiner failed
+ *                 OT_ERROR_PENDING  == eui64 joiner still being processed
+ */
+otError allowListEntryJoinStatusGet(const otExtAddress *eui64)
+{
+    AllowListEntry *entry = entryEui64Find(eui64);
+
+    if ((NULL == entry) || (entry->is_failed()))
+    {
+        return OT_ERROR_FAILED;
+    }
+
+    if (true == entry->is_joined())
+    {
+        return OT_ERROR_NONE;
+    }
+
+    return OT_ERROR_PENDING;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/commissioner_allow_list.hpp
+++ b/src/rest/extensions/commissioner_allow_list.hpp
@@ -1,0 +1,276 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements a class allow list entry and declares APIs
+ *          to handle commissioner APIs.
+ *
+ */
+#ifndef EXTENSIONS_COMMISSIONER_ALLOW_LIST_HPP_
+#define EXTENSIONS_COMMISSIONER_ALLOW_LIST_HPP_
+
+#include "linked_list.hpp"
+//#include "rest/extensions/parse_cmdline.hpp"
+//#include "rest/extensions/pthread_lock.hpp"
+#include "rest/extensions/rest_server_common.hpp"
+#include "rest/extensions/rest_task_queue.hpp"
+#include "rest/extensions/uuid.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "openthread/commissioner.h"
+
+#define JSON_TYPE "type"
+#define JSON_ATTRIBUTES "attributes"
+//#define JSON_HASACTIVATIONKEY "hasActivationKey"
+#define JSON_EUI "eui"
+#define JSON_PSKD "pskd"
+#define JSON_TIMEOUT "timeout"
+#define JSON_UUID "uuid"
+#define JSON_ALLOW_STATE "state"
+
+#define JSON_ALLOW_LIST_TYPE "addThreadDeviceTask"
+
+const std::string kAllowList_status_str[] = {
+    "new",
+    "undiscovered", // not attempted
+    "completed",    // success
+    "attempted",    // failed but waiting for retries
+    "failed",       // failed after max attempts or timeout
+    "stopped",      // timeout without any attempt
+};
+
+/**
+ * This class implements an allow list entry. It maintains the device's ID,
+ * eui64, join timeout, and Joiner PSKd
+ *
+ */
+class AllowListEntry : public allow_list::LinkedListEntry<AllowListEntry>
+{
+    friend class allow_list::LinkedList<AllowListEntry>;
+    ;
+
+public:
+    enum AllowListEntryState : uint8_t
+    {
+        kAllowListEntryNew,
+        kAllowListEntryPendingJoiner, // not attempted
+        kAllowListEntryJoined,        // success
+        kAllowListEntryJoinAttempted, // failed but waiting for retries
+        kAllowListEntryJoinFailed,    // failed and expired
+        kAllowListEntryExpired,       // expired without any attempt
+        kAllowListStates
+    };
+
+    /**
+     * This constructor creates an AllowListEntry.
+     */
+    AllowListEntry(otExtAddress aEui64, uuid_t uuid, uint32_t aTimeout, char *aPskd)
+    {
+        meui64   = aEui64;
+        muuid    = uuid;
+        mTimeout = aTimeout;
+        mPSKd    = aPskd;
+        mstate   = kAllowListEntryNew;
+        mNext    = nullptr;
+    }
+
+    AllowListEntry(otExtAddress aEui64, uuid_t uuid, uint32_t aTimeout, AllowListEntryState state, char *aPskd)
+    {
+        meui64   = aEui64;
+        muuid    = uuid;
+        mTimeout = aTimeout;
+        mPSKd    = aPskd;
+        mstate   = state;
+        mNext    = nullptr;
+    }
+
+    /**
+     * Update Entry State
+     */
+    void update_state(AllowListEntryState new_state) { mstate = new_state; }
+
+    std::string getStateStr(void) { return kAllowList_status_str[mstate]; }
+
+    /**
+     *
+     * @return
+     */
+    bool is_joined(void) const { return (kAllowListEntryJoined == mstate); }
+    bool is_failed(void) const { return ((kAllowListEntryJoinFailed == mstate) || (kAllowListEntryExpired == mstate)); }
+
+    /**
+     * @brief JSON-ify Allow List Entry using the specified entryType
+     *
+     * @param entryType The string to use for "type" attribute
+     *                  (e.g. "addThreadDeviceTask" for actions or "device" for reportng)
+     * @return cJSON* The created JSON object
+     */
+    cJSON *Allow_list_entry_as_CJSON(const char *entryType);
+
+    // Members
+    otExtAddress        meui64;
+    uuid_t              muuid;
+    uint32_t            mTimeout;
+    char               *mPSKd;
+    AllowListEntryState mstate;
+    AllowListEntry     *mNext;
+};
+
+/**
+ * @brief Find an allow List entry via the device's eui64 address
+ *
+ * @param[in] aEui64 eui64 address of the device to find
+ *
+ * @return pointer to the desired entry
+ *         NULL if the entry could be found
+ */
+AllowListEntry *entryEui64Find(const otExtAddress *aEui64);
+
+/**
+ * @brief Check if the provided address is not null
+ *
+ * @param[in] aEui64 The EUI64 address to check.
+ *
+ * @return true if address is NULL, false otherwise
+ */
+bool eui64IsNull(const otExtAddress aEui64);
+
+/**
+ * @brief Add a device to the allow list and the On-Mesh commissioner
+ *
+ * @param[in]  aEui64 eui64 Address of the devive to add
+ * @param[in]  aTimeout timeout to use when adding a commissioner joiner for the device, after which a Joiner is
+ * automatically removed, in seconds.
+ * @param[in]  aPskd Pskd to use when joining the device
+ * @param[in]  aInstance Openthread instance
+ *
+ * @note If provided with a NULL eui64, this function will return immediately, unless
+ * OPENTHREAD_COMMISSIONER_ALLOW_ANY_JOINER is defined.
+ *
+ * @return OT_ERROR_NONE          Successfully added the Joiner.
+ *         OT_ERROR_NO_BUFS       No buffers available to add the Joiner.
+ *         OT_ERROR_INVALID_ARGS  @p aPskd is invalid or @p aEui64 is NULL and OPENTHREAD_COMMISSIONER_ALLOW_ANY_JOINER
+ * is not set. OT_ERROR_INVALID_STATE On-Mesh commissioner is not active.
+ *
+ */
+otError allowListCommissionerJoinerAdd(otExtAddress aEui64,
+                                       uint32_t     aTimeout,
+                                       char        *aPskd,
+                                       otInstance  *aInstance,
+                                       uuid_t       uuid);
+
+/**
+ * @brief Remove a single entry from On-Mesh commissioner joiner table
+ *
+ * @param[in] aEui64 The EUI64 address of the device to be removed from the commissioner joiner table.
+ * @param[in] aInstance Openthread instance
+ *
+ * @retval OT_ERROR_NONE          Successfully removed the Joiner.
+ *         OT_ERROR_NOT_FOUND     Joiner specified by @p aEui64 was not found.
+ *         OT_ERROR_INVALID_STATE On-Mesh commissioner is not active.
+ */
+otError allowListCommissionerJoinerRemove(otExtAddress aEui64, otInstance *aInstance);
+
+/**
+ * @brief Remove a single entry from the allow list
+ *
+ * @param[in] aEui64 The EUI64 address of the device to be removed from the allow list.
+ *
+ * @return OT_ERROR_NONE       The entry was successfully removed from the list.
+ *         OT_ERROR_NOT_FOUND  Could not find the entry in the list.
+ */
+otError allowListEntryErase(otExtAddress aEui64);
+
+/**
+ * @brief  Add a new device (entry) to the allow List internal linked list
+ *
+ * @param[in]  aEui64 eui64 Address of the devive to add
+ * @param[in]  aTimeout timeout to use when adding a commissioner joiner for the device, after which a Joiner is
+ * automatically removed, in seconds.
+ * @param[in]  aPskd Pskd to use when joinig the device
+ */
+void allowListAddDevice(otExtAddress aEui64, uint32_t aTimeout, char *aPskd, uuid_t uuid);
+
+/**
+ * @brief    Print Allow List Entries available in memory to console
+ */
+void allow_list_print_all_entries_to_console(void);
+
+/**
+ * @brief Create unwrapped JSON response for all allow list entry in RAM
+ *
+ * @param input_object The input object to place the response into
+ * @return int  Zero when allow list is empty (input_object unmodified)
+ *              N>0  when N-entres are added
+ *               <0  negative error code otherwise
+ *
+ */
+int allowListJsonifyAll(cJSON *input_object);
+
+/**
+ * @brief Erase ALL allowlist entries
+ *
+ */
+void allowListEraseAll(void);
+
+/**
+ * @brief  Start the On-Mesh commissioner functionality
+ * @param[in]  aInstance Openthread instance
+ *
+ * @return OT_ERROR_NONE           Successfully started the commissioner service.
+ *         OT_ERROR_ALREADY        Commissioner is already started.
+ *         OT_ERROR_INVALID_STATE  Device is not currently attached to a network.
+ */
+otError allowListCommissionerStart(otInstance *aInstance);
+
+/**
+ * @brief This function posts to the OpenThread queue a task to stop the commissioner
+ *
+ * @return OT_ERROR_NONE
+ */
+otError allowListCommissionerStopPost(void);
+
+/**
+ * @brief This function returns the number of pending joiners in the allow list
+ *
+ * @return The number of pending joiners in the allow list.
+ */
+uint8_t allowListGetPendingJoinersCount(void);
+
+otError allowListEntryJoinStatusGet(const otExtAddress *eui64);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXTENSIONS_COMMISSIONER_ALLOW_LIST_HPP_ */

--- a/src/rest/extensions/linked_list.hpp
+++ b/src/rest/extensions/linked_list.hpp
@@ -1,0 +1,584 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a generic single linked list.
+ */
+
+#ifndef LINKED_LIST_HPP_
+#define LINKED_LIST_HPP_
+
+#include <stdio.h>
+#include <openthread/error.h>
+
+namespace allow_list {
+
+/**
+ * @addtogroup core-linked-list
+ *
+ * @brief
+ *   This module includes definitions for OpenThread Singly Linked List.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This template class represents a linked list entry.
+ *
+ * This class provides methods to `GetNext()` and `SetNext()` in the linked list entry.
+ *
+ * Users of this class should follow CRTP-style inheritance, i.e., the `Type` class itself should publicly inherit
+ * from `LinkedListEntry<Type>`.
+ *
+ * The template type `Type` should contain a `mNext` member variable. The `mNext` should be of a type that can be
+ * down-casted to `Type` itself.
+ *
+ */
+template <class Type> class LinkedListEntry
+{
+public:
+    /**
+     * This method gets the next entry in the linked list.
+     *
+     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     *
+     */
+    const Type *GetNext(void) const { return static_cast<const Type *>(static_cast<const Type *>(this)->mNext); }
+
+    /**
+     * This method gets the next entry in the linked list.
+     *
+     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     *
+     */
+    Type *GetNext(void) { return static_cast<Type *>(static_cast<Type *>(this)->mNext); }
+
+    /**
+     * This method sets the next pointer on the entry.
+     *
+     * @param[in] aNext  A pointer to the next entry.
+     *
+     */
+    void SetNext(Type *aNext) { static_cast<Type *>(this)->mNext = aNext; }
+};
+
+/**
+ * This template class represents a singly linked list.
+ *
+ * The template type `Type` should provide `GetNext()` and `SetNext()` methods (which can be realized by `Type`
+ * inheriting from `LinkedListEntry<Type>` class).
+ *
+ */
+template <typename Type> class LinkedList
+{
+public:
+    /**
+     * This constructor initializes the linked list.
+     *
+     */
+    LinkedList(void)
+        : mHead(nullptr)
+    {
+    }
+
+    /**
+     * This method returns the entry at the head of the linked list
+     *
+     * @returns Pointer to the entry at the head of the linked list, or nullptr if the list is empty.
+     *
+     */
+    Type *GetHead(void) { return mHead; }
+
+    /**
+     * This method returns the entry at the head of the linked list.
+     *
+     * @returns Pointer to the entry at the head of the linked list, or nullptr if the list is empty.
+     *
+     */
+    const Type *GetHead(void) const { return mHead; }
+
+    /**
+     * This method sets the head of the linked list to a given entry.
+     *
+     * @param[in] aHead   A pointer to an entry to set as the head of the linked list.
+     *
+     */
+    void SetHead(Type *aHead) { mHead = aHead; }
+
+    /**
+     * This method clears the linked list.
+     *
+     */
+    void Clear(void) { mHead = nullptr; }
+
+    /**
+     * This method indicates whether the linked list is empty or not.
+     *
+     * @retval TRUE   If the linked list is empty.
+     * @retval FALSE  If the linked list is not empty.
+     *
+     */
+    bool IsEmpty(void) const { return (mHead == nullptr); }
+
+    /**
+     * This method pushes an entry at the head of the linked list.
+     *
+     * @param[in] aEntry   A reference to an entry to push at the head of linked list.
+     *
+     */
+    void Push(Type &aEntry)
+    {
+        aEntry.SetNext(mHead);
+        mHead = &aEntry;
+    }
+
+    /**
+     * This method pushes an entry after a given previous existing entry in the linked list.
+     *
+     * @param[in] aEntry       A reference to an entry to push into the list.
+     * @param[in] aPrevEntry   A reference to a previous entry (new entry @p aEntry will be pushed after this).
+     *
+     */
+    void PushAfter(Type &aEntry, Type &aPrevEntry)
+    {
+        aEntry.SetNext(aPrevEntry.GetNext());
+        aPrevEntry.SetNext(&aEntry);
+    }
+
+    /**
+     * This method pops an entry from head of the linked list.
+     *
+     * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
+     *
+     * @returns The entry that was popped if the list is not empty, or nullptr if the list is empty.
+     *
+     */
+    Type *Pop(void)
+    {
+        Type *entry = mHead;
+
+        if (mHead != nullptr)
+        {
+            mHead = mHead->GetNext();
+        }
+
+        return entry;
+    }
+
+    /**
+     * This method pops an entry after a given previous entry.
+     *
+     * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
+     *
+     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not nullptr the entry after this will be popped,
+     *                        otherwise (if it is nullptr) the entry at the head of the list is popped.
+     *
+     * @returns Pointer to the entry that was popped, or nullptr if there is no entry to pop.
+     *
+     */
+    Type *PopAfter(Type *aPrevEntry)
+    {
+        Type *entry;
+
+        if (aPrevEntry == nullptr)
+        {
+            entry = Pop();
+        }
+        else
+        {
+            entry = aPrevEntry->GetNext();
+
+            if (entry != nullptr)
+            {
+                aPrevEntry->SetNext(entry->GetNext());
+            }
+        }
+
+        return entry;
+    }
+
+    /**
+     * This method indicates whether the linked list contains a given entry.
+     *
+     * @param[in] aEntry   A reference to an entry.
+     *
+     * @retval TRUE   The linked list contains @p aEntry.
+     * @retval FALSE  The linked list does not contain @p aEntry.
+     *
+     */
+    bool Contains(const Type &aEntry) const
+    {
+        const Type *prev;
+
+        return Find(aEntry, prev) == OT_ERROR_NONE;
+    }
+
+    /**
+     * This template method indicates whether the linked list contains an entry matching a given entry indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in] aIndicator   An entry indicator to match against entries in the list.
+     *
+     * @retval TRUE   The linked list contains an entry matching @p aIndicator.
+     * @retval FALSE  The linked list contains no entry matching @p aIndicator.
+     *
+     */
+    template <typename Indicator> bool ContainsMatching(const Indicator &aIndicator) const
+    {
+        return FindMatching(aIndicator) != nullptr;
+    }
+
+    /**
+     * This method adds an entry (at the head of the linked list) if it is not already in the list.
+     *
+     * @param[in] aEntry   A reference to an entry to add.
+     *
+     * @retval OT_ERROR_NONE     The entry was successfully added at the head of the list.
+     * @retval OT_ERROR_ALREADY  The entry is already in the list.
+     *
+     */
+    otError Add(Type &aEntry)
+    {
+        otError error = OT_ERROR_NONE;
+
+        if (Contains(aEntry))
+        {
+            error = OT_ERROR_ALREADY;
+        }
+        else
+        {
+            Push(aEntry);
+        }
+
+        return error;
+    }
+
+    /**
+     * This method removes an entry from the linked list.
+     *
+     * @note This method does not change the removed entry @p aEntry itself (it is `const`), i.e., the entry next
+     * pointer of @p aEntry stays as before.
+     *
+     * @param[in] aEntry   A reference to an entry to remove.
+     *
+     * @retval OT_ERROR_NONE      The entry was successfully removed from the list.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the entry in the list.
+     *
+     */
+    otError Remove(const Type &aEntry)
+    {
+        Type   *prev;
+        otError error = Find(aEntry, prev);
+
+        if (error == OT_ERROR_NONE)
+        {
+            PopAfter(prev);
+        }
+
+        return error;
+    }
+
+    /**
+     * This template method removes an entry matching a given entry indicator from the linked list.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @note This method does not change the removed entry itself (which is returned in case of success), i.e., the
+     * entry next pointer stays as before.
+     *
+     *
+     * @param[in] aIndicator   An entry indicator to match against entries in the list.
+     *
+     * @returns A pointer to the removed matching entry if one could be found, or nullptr if no matching entry is found.
+     *
+     */
+    template <typename Indicator> Type *RemoveMatching(const Indicator &aIndicator)
+    {
+        Type *prev;
+        Type *entry = FindMatching(aIndicator, prev);
+
+        if (entry != nullptr)
+        {
+            PopAfter(prev);
+        }
+
+        return entry;
+    }
+
+    /**
+     * This method searches within the linked list to find an entry and if found returns a pointer to previous entry.
+     *
+     * @param[in]  aEntry      A reference to an entry to find.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when @p aEntry is found in the list).
+     *                         @p aPrevEntry is set to nullptr if @p aEntry is the head of the list. Otherwise it is
+     *                         updated to point to the previous entry before @p aEntry in the list.
+     *
+     * @retval OT_ERROR_NONE      The entry was found in the list and @p aPrevEntry was updated successfully.
+     * @retval OT_ERROR_NOT_FOUND  The entry was not found in the list.
+     *
+     */
+    otError Find(const Type &aEntry, const Type *&aPrevEntry) const
+    {
+        otError error = OT_ERROR_NOT_FOUND;
+
+        aPrevEntry = nullptr;
+
+        for (const Type *entry = mHead; entry != nullptr; aPrevEntry = entry, entry = entry->GetNext())
+        {
+            if (entry == &aEntry)
+            {
+                error = OT_ERROR_NONE;
+                break;
+            }
+        }
+
+        return error;
+    }
+
+    /**
+     * This method searches within the linked list to find an entry and if found returns a pointer to previous entry.
+     *
+     * @param[in]  aEntry      A reference to an entry to find.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when @p aEntry is found in the list).
+     *                         @p aPrevEntry is set to nullptr if @p aEntry is the head of the list. Otherwise it is
+     *                         updated to point to the previous entry before @p aEntry in the list.
+     *
+     * @retval OT_ERROR_NONE      The entry was found in the list and @p aPrevEntry was updated successfully.
+     * @retval OT_ERROR_NOT_FOUND  The entry was not found in the list.
+     *
+     */
+    otError Find(const Type &aEntry, Type *&aPrevEntry)
+    {
+        return const_cast<const LinkedList *>(this)->Find(aEntry, const_cast<const Type *&>(aPrevEntry));
+    }
+
+    /**
+     * This template method searches within a given range of the linked list to find an entry matching a given
+     * indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aBegin      A pointer to the begin of the range.
+     * @param[in]  aEnd        A pointer to the end of the range, or nullptr to search all entries after @p aBegin.
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
+     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
+     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator>
+    const Type *FindMatching(const Type      *aBegin,
+                             const Type      *aEnd,
+                             const Indicator &aIndicator,
+                             const Type     *&aPrevEntry) const
+    {
+        const Type *entry;
+
+        aPrevEntry = nullptr;
+
+        for (entry = aBegin; entry != aEnd; aPrevEntry = entry, entry = entry->GetNext())
+        {
+            if (entry->Matches(aIndicator))
+            {
+                break;
+            }
+        }
+
+        return entry;
+    }
+
+    /**
+     * This template method searches within a given range of the linked list to find an entry matching a given
+     * indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aBegin      A pointer to the begin of the range.
+     * @param[in]  aEnd        A pointer to the end of the range, or nullptr to search all entries after @p aBegin.
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
+     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
+     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator>
+    Type *FindMatching(const Type *aBegin, const Type *aEnd, const Indicator &aIndicator, Type *&aPrevEntry)
+    {
+        return const_cast<Type *>(FindMatching(aBegin, aEnd, aIndicator, const_cast<const Type *&>(aPrevEntry)));
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
+     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
+     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator, const Type *&aPrevEntry) const
+    {
+        return FindMatching(mHead, nullptr, aIndicator, aPrevEntry);
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator, and if found
+     * returns a pointer to its previous entry in the list.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
+     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
+     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> Type *FindMatching(const Indicator &aIndicator, Type *&aPrevEntry)
+    {
+        return const_cast<Type *>(
+            const_cast<const LinkedList *>(this)->FindMatching(aIndicator, const_cast<const Type *&>(aPrevEntry)));
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator) const
+    {
+        const Type *prev;
+
+        return FindMatching(aIndicator, prev);
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
+    {
+        return const_cast<Type *>(const_cast<const LinkedList *>(this)->FindMatching(aIndicator));
+    }
+
+    /**
+     * This method returns the tail of the linked list (i.e., the last entry in the list).
+     *
+     * @returns A pointer to the tail entry in the linked list or nullptr if the list is empty.
+     *
+     */
+    const Type *GetTail(void) const
+    {
+        const Type *tail = mHead;
+
+        if (tail != nullptr)
+        {
+            while (tail->GetNext() != nullptr)
+            {
+                tail = tail->GetNext();
+            }
+        }
+
+        return tail;
+    }
+
+    /**
+     * This method returns the tail of the linked list (i.e., the last entry in the list).
+     *
+     * @returns A pointer to the tail entry in the linked list or nullptr if the list is empty.
+     *
+     */
+    Type *GetTail(void) { return const_cast<Type *>(const_cast<const LinkedList *>(this)->GetTail()); }
+
+private:
+    Type *mHead;
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace allow_list
+
+#endif // LINKED_LIST_HPP_

--- a/src/rest/extensions/rest_devices_coll.cpp
+++ b/src/rest/extensions/rest_devices_coll.cpp
@@ -1,0 +1,206 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements api/devices collection and conversion of items and collection to json and json:api
+ *
+ */
+
+#include "rest_devices_coll.hpp"
+#include "timestamp.hpp"
+#include "common/code_utils.hpp"
+#include "rest/json.hpp"
+
+extern "C" {
+#include <cJSON.h>
+}
+
+namespace otbr {
+namespace rest {
+
+// BasicDevices class implementation
+BasicDevices::BasicDevices(std::string aExtAddr)
+    : BasicCollectionItem()
+{
+    mItemId = aExtAddr;
+}
+
+BasicDevices::~BasicDevices()
+{
+}
+
+std::string BasicDevices::toJsonApiItem(std::set<std::string> aKeys)
+{
+    return Json::jsonStr2JsonApiItem(getId(), getTypeName(), toJsonStringTs(aKeys));
+}
+
+// ThreadDevices class implementation
+ThreadDevice::ThreadDevice(std::string aExtAddr)
+    : BasicDevices(aExtAddr)
+{
+}
+
+ThreadDevice::~ThreadDevice()
+{
+}
+
+std::string ThreadDevice::getTypeName() const
+{
+    return std::string(DEVICE_TYPE_NAME);
+}
+
+void ThreadDevice::setEui64(otExtAddress aEui)
+{
+    mDeviceInfo.mEui64 = aEui;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+void ThreadDevice::setHostname(std::string aHostname)
+{
+    mDeviceInfo.mHostName = aHostname;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+void ThreadDevice::setIpv6Omr(otIp6Address aIpv6)
+{
+    mDeviceInfo.mIp6Addr = aIpv6;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+void ThreadDevice::setMlEidIid(otExtAddress aMlEidIid)
+{
+    mDeviceInfo.mMlEidIid = aMlEidIid;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+void ThreadDevice::setMode(otLinkModeConfig aMode)
+{
+    mDeviceInfo.mode = aMode;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+void ThreadDevice::setRole(std::string aRole)
+{
+    mDeviceInfo.mRole = aRole;
+    // set updated timestamp
+    mUpdated = std::chrono::system_clock::now();
+}
+
+std::string ThreadDevice::toJsonString(std::set<std::string> aKeys)
+{
+    return Json::SparseDeviceInfo2JsonString(mDeviceInfo, aKeys);
+}
+
+ThreadDevice *ThreadDevice::clone() // TODO have proper copy constructor
+{
+    ThreadDevice *cloned = new ThreadDevice(*this);
+    cloned->mItemId      = this->mItemId;
+    cloned->mUuid.parse(this->mUuid.toString());
+
+    return cloned;
+}
+
+// ThisThreadDevice class implementation
+ThisThreadDevice::ThisThreadDevice(std::string aExtAddr)
+    : ThreadDevice(aExtAddr)
+{
+}
+
+ThisThreadDevice::~ThisThreadDevice()
+{
+}
+
+std::string ThisThreadDevice::getTypeName() const
+{
+    return std::string(DEVICE_BR_TYPE_NAME);
+}
+
+std::string ThisThreadDevice::toJsonString(std::set<std::string> aKeys)
+{
+    std::string str1 = Json::SparseDeviceInfo2JsonString(mDeviceInfo, aKeys);
+    std::string str2 = Json::SparseNode2JsonString(mNodeInfo, aKeys);
+    str1.back()      = ',';
+    str2.erase(str2.begin());
+    return str1 + str2;
+}
+
+ThisThreadDevice *ThisThreadDevice::clone() // TODO have proper copy constructor
+{
+    ThisThreadDevice *cloned = new ThisThreadDevice(*this);
+    cloned->mItemId          = this->mItemId;
+    cloned->mUuid.parse(this->mUuid.toString());
+
+    return cloned;
+}
+
+// DevicesCollection class implementation
+DevicesCollection::DevicesCollection() = default;
+
+DevicesCollection::~DevicesCollection()
+{
+}
+
+void DevicesCollection::addItem(BasicDevices *aItem)
+{
+    // do not exceed a max size of the collection
+    while (mCollection.size() >= MAX_DEVICES_COLLECTION_ITEMS)
+    {
+        evictOldestItem();
+    }
+
+    BasicDevices *cloned                            = aItem->clone();
+    DevicesCollection::mCollection[cloned->getId()] = cloned;
+
+    // add to mHoldsTypes
+    incrHoldsTypes(aItem->getTypeName());
+
+    // add to age sorted list for easy erase, first in first erased
+    mAgeSortedItemIds.push_back(aItem->getId());
+
+    otbrLogWarning("%s:%d - %s - %s", __FILE__, __LINE__, __func__, cloned->getId().c_str());
+}
+
+BasicDevices *DevicesCollection::getItem(std::string aKey)
+{
+    auto it = mCollection.find(aKey);
+    if (it != mCollection.end())
+    {
+        return static_cast<BasicDevices *>(it->second);
+    }
+    return nullptr;
+}
+
+DevicesCollection gDevicesCollection;
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/extensions/rest_devices_coll.hpp
+++ b/src/rest/extensions/rest_devices_coll.hpp
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements api/devices collection and conversion of items and collection to json and json:api
+ *
+ */
+
+#ifndef OTBR_REST_DEVICES_COLLLECTION_HPP_
+#define OTBR_REST_DEVICES_COLLLECTION_HPP_
+
+#include "uuid.hpp"
+#include <chrono>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include "rest/types.hpp"
+
+#include "rest_generic_collection.hpp"
+
+namespace otbr {
+namespace rest {
+
+#define MAX_DEVICES_COLLECTION_ITEMS 200
+#define DEVICE_COLLECTION_NAME "devices"         // name of the device collection, should corespond to url api/devices
+#define DEVICE_TYPE_NAME "threadDevice"          // general Thread device
+#define DEVICE_BR_TYPE_NAME "threadBorderRouter" // also contains NodeInfo if it is this node.
+
+/**
+ * @brief This virtual class implements a general json:api item for holding device attributes.
+ *
+ */
+class BasicDevices : public BasicCollectionItem
+{
+public:
+    //
+    BasicDevices(std::string aExtAddr);
+    virtual BasicDevices *clone() = 0;
+    virtual ~BasicDevices();
+    std::string getId() { return mItemId; }
+    std::string toJsonApiItem(std::set<std::string> aKeys) override;
+
+protected:
+    std::string mItemId;
+};
+
+/**
+ * @brief This class implements a general json:api item for holding static (or mostly static) device attributes.
+ *
+ */
+class ThreadDevice : public BasicDevices
+{
+public:
+    ThreadDevice(std::string aExtAddr);
+    ~ThreadDevice();
+    otbr::rest::DeviceInfo mDeviceInfo;
+    std::string            getTypeName() const override;
+    void                   setEui64(otExtAddress aEui);
+    void                   setHostname(std::string aHostname);
+    void                   setIpv6Omr(otIp6Address aIpv6);
+    void                   setMlEidIid(otExtAddress aIid);
+    void                   setMode(otLinkModeConfig aMode);
+    void                   setRole(std::string aRole);
+    std::string            toJsonString(std::set<std::string> aKeys);
+    ThreadDevice          *clone() override;
+};
+
+/**
+ * @brief This class implements a json:api item for holding static (or mostly static) device attributes of 'this'
+ * device.
+ *
+ */
+class ThisThreadDevice : public ThreadDevice
+{
+public:
+    ThisThreadDevice(std::string aExtAddr);
+    ~ThisThreadDevice();
+    otbr::rest::NodeInfo mNodeInfo;
+    std::string          getTypeName() const override;
+    std::string          toJsonString(std::set<std::string> aKeys);
+    ThisThreadDevice    *clone() override;
+};
+
+/**
+ * @brief This class implements a json:api collection for holding device items.
+ *
+ */
+class DevicesCollection : public BasicCollection
+{
+    std::map<std::string, uint16_t> mHoldsTypes;
+
+public:
+    DevicesCollection();
+    ~DevicesCollection();
+    std::string   getCollectionName() const override { return std::string(DEVICE_COLLECTION_NAME); }
+    uint16_t      getMaxCollectionSize() const override { return MAX_DEVICES_COLLECTION_ITEMS; }
+    void          addItem(BasicDevices *aItem);
+    BasicDevices *getItem(std::string aKey);
+};
+
+// the collection
+extern DevicesCollection gDevicesCollection;
+
+} // namespace rest
+} // namespace otbr
+
+#endif // OTBR_REST_DEVICES_COLLLECTION_HPP_

--- a/src/rest/extensions/rest_diagnostics_coll.cpp
+++ b/src/rest/extensions/rest_diagnostics_coll.cpp
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements api/diagnostics collection and conversion of items and collection to json and json:api
+ *
+ */
+#include "rest_diagnostics_coll.hpp"
+#include "timestamp.hpp"
+#include "common/code_utils.hpp"
+#include "rest/json.hpp"
+
+extern "C" {
+#include <cJSON.h>
+}
+
+namespace otbr {
+namespace rest {
+
+// BasicDiagnostics class implementation
+BasicDiagnostics::BasicDiagnostics()
+    : BasicCollectionItem()
+{
+}
+
+BasicDiagnostics::~BasicDiagnostics()
+{
+}
+
+std::string BasicDiagnostics::toJsonApiItem(std::set<std::string> aKeys)
+{
+    return Json::jsonStr2JsonApiItem(mUuid.toString(), getTypeName(), toJsonStringTs(aKeys));
+}
+
+// NetworkDiagnostics class implementation
+NetworkDiagnostics::NetworkDiagnostics()
+    : BasicDiagnostics()
+{
+}
+
+NetworkDiagnostics::~NetworkDiagnostics()
+{
+}
+
+std::string NetworkDiagnostics::getTypeName() const
+{
+    return std::string(NWK_DIAG_TYPE_NAME);
+}
+
+std::string NetworkDiagnostics::toJsonString(std::set<std::string> aKeys)
+{
+    return Json::DiagSet2JsonString(mDeviceTlvSet, mChildren, mChildrenIp6Addrs, mNeighbors, mDeviceTlvSetExtension,
+                                    aKeys);
+}
+
+NetworkDiagnostics *NetworkDiagnostics::clone() // TODO have proper copy constructor
+{
+    NetworkDiagnostics *cloned = new NetworkDiagnostics(*this);
+    cloned->mUuid.parse(this->mUuid.toString());
+
+    return cloned;
+}
+
+// EnergyScanDiagnostics class implementation
+EnergyScanDiagnostics::EnergyScanDiagnostics()
+    : BasicDiagnostics()
+{
+    mReport.report.clear();
+}
+
+EnergyScanDiagnostics::~EnergyScanDiagnostics()
+{
+}
+
+std::string EnergyScanDiagnostics::getTypeName() const
+{
+    return std::string(ENERGYSCAN_TYPE_NAME);
+}
+
+std::string EnergyScanDiagnostics::toJsonString(std::set<std::string> aKeys)
+{
+    return Json::SparseEnergyReport2JsonString(mReport, aKeys);
+}
+
+EnergyScanDiagnostics *EnergyScanDiagnostics::clone() // TODO have proper copy constructor
+{
+    EnergyScanDiagnostics *cloned = new EnergyScanDiagnostics(*this);
+    cloned->mUuid.parse(this->mUuid.toString());
+
+    return cloned;
+}
+
+// DiagnosticsCollection class implementation
+DiagnosticsCollection::DiagnosticsCollection() = default;
+
+DiagnosticsCollection::~DiagnosticsCollection()
+{
+}
+
+void DiagnosticsCollection::addItem(BasicDiagnostics *aItem)
+{
+    // do not exceed a max size of the collection
+    while (mCollection.size() >= MAX_DIAG_COLLECTION_ITEMS)
+    {
+        evictOldestItem();
+    }
+
+    DiagnosticsCollection::mCollection[aItem->mUuid.toString()] = aItem->clone();
+
+    // add to mHoldsTypes
+    incrHoldsTypes(aItem->getTypeName());
+
+    // add to age sorted list for easy erase, first in first erased
+    mAgeSortedItemIds.push_back(aItem->mUuid.toString());
+
+    otbrLogWarning("%s:%d - %s - %s", __FILE__, __LINE__, __func__, aItem->mUuid.toString().c_str());
+}
+
+BasicDiagnostics *DiagnosticsCollection::getItem(std::string aKey)
+{
+    auto it = mCollection.find(aKey);
+    if (it != mCollection.end())
+    {
+        return static_cast<BasicDiagnostics *>(it->second);
+    }
+    return nullptr;
+}
+
+DiagnosticsCollection gDiagnosticsCollection;
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/extensions/rest_diagnostics_coll.hpp
+++ b/src/rest/extensions/rest_diagnostics_coll.hpp
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements api/diagnostics collection and conversion of items and collection to json and json:api
+ *
+ */
+
+#ifndef OTBR_REST_DIAGNOSTICS_COLLLECTION_HPP_
+#define OTBR_REST_DIAGNOSTICS_COLLLECTION_HPP_
+
+#include "uuid.hpp"
+#include <chrono>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include "rest/types.hpp"
+
+#include "rest_generic_collection.hpp"
+
+namespace otbr {
+namespace rest {
+
+#define MAX_DIAG_COLLECTION_ITEMS 200
+#define DIAG_COLLECTION_NAME "diagnostics"
+#define NWK_DIAG_TYPE_NAME "networkDiagnostics"
+#define ENERGYSCAN_TYPE_NAME "energyScanReport"
+
+/**
+ * @brief This virtual class implements a general json:api item for holding diagnostic attributes.
+ *
+ */
+class BasicDiagnostics : public BasicCollectionItem
+{
+public:
+    //
+    BasicDiagnostics();
+    virtual BasicDiagnostics *clone() = 0;
+    virtual ~BasicDiagnostics();
+    std::string toJsonApiItem(std::set<std::string> aKeys) override;
+};
+
+/**
+ * @brief This class implements a json:api item for holding network diagnostic attributes.
+ *
+ */
+class NetworkDiagnostics : public BasicDiagnostics
+{
+public:
+    NetworkDiagnostics();
+    ~NetworkDiagnostics();
+
+    std::vector<otNetworkDiagTlv>              mDeviceTlvSet;
+    std::vector<networkDiagTlvExtensions>      mDeviceTlvSetExtension;
+    std::vector<otMeshDiagChildEntry>          mChildren;
+    std::vector<DeviceIp6Addrs>                mChildrenIp6Addrs;
+    std::vector<otMeshDiagRouterNeighborEntry> mNeighbors;
+
+    std::string         getTypeName() const override;
+    std::string         toJsonString(std::set<std::string> aKeys);
+    NetworkDiagnostics *clone() override;
+};
+
+/**
+ * @brief This class implements a json:api item for holding energy scan diagnostic attributes.
+ *
+ */
+
+class EnergyScanDiagnostics : public BasicDiagnostics
+{
+public:
+    EnergyScanDiagnostics();
+    ~EnergyScanDiagnostics();
+    otbr::rest::EnergyScanReport mReport;
+    std::string                  getTypeName() const override;
+    std::string                  toJsonString(std::set<std::string> aKeys);
+    EnergyScanDiagnostics       *clone() override;
+};
+
+/**
+ * @brief This class implements a json:api collection for holding diagnostic items.
+ *
+ */
+class DiagnosticsCollection : public BasicCollection
+{
+    std::map<std::string, uint16_t> mHoldsTypes;
+
+public:
+    DiagnosticsCollection();
+    ~DiagnosticsCollection();
+    std::string       getCollectionName() const override { return std::string(DIAG_COLLECTION_NAME); }
+    uint16_t          getMaxCollectionSize() const override { return MAX_DIAG_COLLECTION_ITEMS; }
+    void              addItem(BasicDiagnostics *aItem);
+    BasicDiagnostics *getItem(std::string key);
+};
+
+// the collection
+extern DiagnosticsCollection gDiagnosticsCollection;
+
+} // namespace rest
+} // namespace otbr
+
+#endif // OTBR_REST_DIAGNOSTICS_COLLLECTION_HPP_

--- a/src/rest/extensions/rest_generic_collection.cpp
+++ b/src/rest/extensions/rest_generic_collection.cpp
@@ -1,0 +1,365 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements generic collection and conversion of items and collection to json and json:api
+ *
+ */
+#include "rest_generic_collection.hpp"
+#include "timestamp.hpp"
+#include "common/code_utils.hpp"
+#include "rest/json.hpp"
+
+extern "C" {
+#include <cJSON.h>
+}
+
+namespace otbr {
+namespace rest {
+
+// following few methods should go into a t.b.d. superclass for all json:api resources
+std::string Json2String(const cJSON *aJson)
+{
+    std::string ret;
+    char       *jsonOut = nullptr;
+
+    VerifyOrExit(aJson != nullptr);
+
+    jsonOut = cJSON_Print(aJson);
+    ret     = jsonOut;
+    if (jsonOut != nullptr)
+    {
+        cJSON_free(jsonOut);
+        jsonOut = nullptr;
+    }
+
+exit:
+    return ret;
+}
+
+cJSON *jsonCreateTaskMetaCollection(uint32_t aOffset, uint32_t aLimit, uint32_t aTotal)
+{
+    cJSON *meta            = cJSON_CreateObject();
+    cJSON *meta_collection = cJSON_CreateObject();
+    // Abort if we are unable to create the necessary JSON objects
+    if (NULL == meta || NULL == meta_collection)
+    {
+        return NULL;
+    }
+
+    (void)cJSON_AddNumberToObject(meta_collection, "offset", aOffset);
+    if (aLimit > 0)
+    {
+        (void)cJSON_AddNumberToObject(meta_collection, "limit", aLimit);
+    }
+    (void)cJSON_AddNumberToObject(meta_collection, "total", aTotal);
+    (void)cJSON_AddItemToObject(meta, "collection", meta_collection);
+    return meta;
+}
+
+BasicCollectionItem::BasicCollectionItem()
+{
+    mUuid.generateRandom();
+    mCreated = std::chrono::system_clock::now();
+    mUpdated = mCreated;
+}
+
+BasicCollectionItem::~BasicCollectionItem()
+{
+}
+
+std::set<std::string> BasicCollectionItem::parseQueryFieldValues(std::string aKeys)
+{
+    std::set<std::string> keys;
+    char                 *token;
+    const std::string     separators = " ,";
+    char                 *ckeys      = strdup(aKeys.c_str());
+
+    token = strtok(ckeys, separators.c_str());
+    while (token != nullptr)
+    {
+        std::string key(token);
+        keys.emplace(key); // TODO: check key is allowed
+
+        // if key contains dot, split after dot and emplace
+        // 'key.' to indicate partial subkeys are wanted
+        // currently limited to one level of subkeys
+        std::size_t pos = key.find(".");
+        if (pos != std::string::npos)
+        {
+            std::string sub  = key.substr(0, pos + 1);
+            std::size_t pos2 = key.find(".", pos + 1);
+            if (pos2 == std::string::npos)
+            {
+                keys.emplace(sub); // TODO: check key is allowed
+            }
+        }
+
+        token = strtok(nullptr, separators.c_str());
+    }
+
+    return keys;
+}
+
+std::string BasicCollectionItem::toJsonStringTs(std::set<std::string> aKeys)
+{
+    cJSON      *root = cJSON_Parse(toJsonString(aKeys).c_str());
+    std::string ret;
+
+    cJSON_AddStringToObject(root, "created", toRfc3339(mCreated).c_str());
+
+    if (mUpdated.time_since_epoch() != mCreated.time_since_epoch())
+    {
+        cJSON_AddStringToObject(root, "updated", toRfc3339(mUpdated).c_str());
+    }
+
+    ret = Json2String(root);
+    cJSON_Delete(root);
+
+    return ret;
+}
+
+// BasicCollection class implementation
+BasicCollection::BasicCollection() = default;
+
+BasicCollection::~BasicCollection()
+{
+    for (auto &it : mCollection)
+    {
+        delete it.second;
+    }
+}
+
+// example, should be overriden with proper class of attributes
+/*
+void BasicCollection::addItem(BasicCollectionItem *aItem)
+{
+    BasicCollection::mCollection[aItem->mUuid.toString()] = aItem->clone();
+
+    incrHoldsTypes(aItem->getTypeName());
+
+    otbrLogDebug("%s:%d - %s - %s", __FILE__, __LINE__, __func__, aItem->mUuid.toString().c_str());
+}
+*/
+
+void BasicCollection::incrHoldsTypes(std::string aTypeName)
+{
+    // add to mHoldsTypes
+    auto it = mHoldsTypes.find(aTypeName);
+    if (it == mHoldsTypes.end())
+    {
+        mHoldsTypes[aTypeName] = 1;
+    }
+    else
+    {
+        it->second++;
+    }
+}
+
+void BasicCollection::decrHoldsTypes(std::string aTypeName)
+{
+    // add to mHoldsTypes
+    auto it = mHoldsTypes.find(aTypeName);
+    if (it == mHoldsTypes.end())
+    {
+        // already removed
+        return;
+    }
+    else
+    {
+        if (it->second > 0)
+        {
+            it->second--;
+        }
+        if (it->second == 0)
+        {
+            mHoldsTypes.erase(it);
+        }
+    }
+}
+
+void BasicCollection::clear()
+{
+    mCollection.clear();
+}
+
+std::set<std::string> BasicCollection::getContainedTypes()
+{
+    std::set<std::string> typeNames;
+
+    for (auto &it : mCollection)
+    {
+        typeNames.emplace(it.second->getTypeName());
+    }
+    return typeNames;
+}
+
+std::string BasicCollection::toJsonStringItemId(std::string aItemId, const std::map<std::string, std::string> aFields)
+{
+    std::unordered_map<std::string, BasicCollectionItem *>::const_iterator item;
+    std::set<std::string>                                                  keySet;
+    std::map<std::string, std::string>::const_iterator                     field;
+
+    if ((!aItemId.empty()) && (mCollection.find(aItemId) != mCollection.end()))
+    {
+        item = mCollection.find(aItemId);
+        if (!aFields.empty())
+        {
+            field = aFields.find(item->second->getTypeName());
+            if (field == aFields.end())
+            {
+                // typeName not requested
+                ExitNow();
+            }
+            // else parse requested attribute keys, e.g. '?fields[<typeName>]=<key1>,<key2>'
+            keySet = item->second->parseQueryFieldValues(field->second);
+        }
+        return item->second->toJsonString(keySet);
+    }
+exit:
+    return "";
+}
+
+std::string BasicCollection::toJsonString()
+{
+    cJSON                *root = cJSON_CreateArray();
+    std::string           ret;
+    std::set<std::string> keySet;
+
+    for (auto &item : mCollection)
+    {
+        cJSON_AddItemToArray(root, cJSON_Parse(item.second->toJsonString(keySet).c_str()));
+    }
+    ret = Json2String(root);
+    cJSON_Delete(root);
+
+    return ret;
+}
+
+std::string BasicCollection::toJsonApiItemId(std::string aItemId, const std::map<std::string, std::string> aFields)
+{
+    cJSON                                             *root;
+    std::string                                        ret = "";
+    std::set<std::string>                              keySet;
+    std::map<std::string, std::string>::const_iterator field;
+
+    std::unordered_map<std::string, BasicCollectionItem *>::const_iterator item;
+
+    item = mCollection.find(aItemId);
+    if (item != mCollection.end())
+    {
+        // check if item type in query, e.g. '?fields[<typeName>]'
+        if (!aFields.empty())
+        {
+            field = aFields.find(item->second->getTypeName());
+            if (field == aFields.end())
+            {
+                // typeName not requested
+                ExitNow();
+            }
+            // else parse requested attribute keys, e.g. '?fields[<typeName>]=<key1>,<key2>'
+            keySet = item->second->parseQueryFieldValues(field->second);
+        }
+        root = cJSON_CreateObject();
+        cJSON_AddItemToObject(root, "data", cJSON_Parse(item->second->toJsonApiItem(keySet).c_str()));
+        ret = Json2String(root);
+        cJSON_Delete(root);
+    }
+exit:
+    return ret;
+}
+
+std::string BasicCollection::toJsonApiItems(const std::map<std::string, std::string> aFields)
+{
+    cJSON                                             *root = cJSON_CreateArray();
+    std::string                                        ret;
+    std::set<std::string>                              keySet;
+    std::map<std::string, std::string>::const_iterator field;
+
+    for (auto &item : mCollection)
+    {
+        // check if item type in query, e.g. '?fields[<typeName>]'
+        keySet.clear();
+        if (!aFields.empty())
+        {
+            field = aFields.find(item.second->getTypeName());
+            if (field == aFields.end())
+            {
+                // typeName not requested
+                continue;
+            }
+            // else parse requested attribute keys, e.g. '?fields[<typeName>]=<key1>,<key2>'
+            keySet = item.second->parseQueryFieldValues(field->second);
+        }
+        cJSON_AddItemToArray(root, cJSON_Parse(item.second->toJsonApiItem(keySet).c_str()));
+    }
+    ret = Json2String(root);
+    cJSON_Delete(root);
+
+    return ret;
+}
+
+std::string BasicCollection::toJsonApiColl(const std::map<std::string, std::string> aFields)
+{
+    std::string meta, data;
+
+    data = toJsonApiItems(aFields);
+    meta = Json2String(jsonCreateTaskMetaCollection(0, getMaxCollectionSize(), mCollection.size()));
+
+    return Json::jsonStr2JsonApiColl(data, meta);
+}
+
+void BasicCollection::evictOldestItem(void)
+{
+    if (!mAgeSortedItemIds.empty())
+    {
+        std::unordered_map<std::string, BasicCollectionItem *>::const_iterator it;
+
+        // Get the oldest key from the list
+        std::string oldestKey = mAgeSortedItemIds.front();
+
+        it = mCollection.find(oldestKey);
+        if (it != mCollection.end())
+        {
+            // Decrement the count of types
+            decrHoldsTypes(it->second->getTypeName());
+            // Remove from the map
+            mCollection.erase(oldestKey);
+        }
+        // Remove the oldest key from the list
+        mAgeSortedItemIds.pop_front();
+        otbrLogWarning("%s:%d - %s - %s: %s from %s", __FILE__, __LINE__, __func__, "Evicted Item", oldestKey.c_str(),
+                       this->getCollectionName().c_str());
+    }
+}
+
+// example of derived collection
+// BasicCollection gBasicCollection;
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/extensions/rest_generic_collection.hpp
+++ b/src/rest/extensions/rest_generic_collection.hpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements collection and conversion of items and collection to json and json:api
+ *
+ */
+
+#ifndef OTBR_REST_GENERIC_COLLLECTION_HPP_
+#define OTBR_REST_GENERIC_COLLLECTION_HPP_
+
+#include "uuid.hpp"
+#include <chrono>
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include "rest/types.hpp"
+
+namespace otbr {
+namespace rest {
+
+/**
+ * @brief This virtual class implements a general item of a json:api collection.
+ *
+ */
+class BasicCollectionItem
+{
+public:
+    //
+    BasicCollectionItem();
+    virtual ~BasicCollectionItem();
+
+    virtual std::string getTypeName() const                        = 0;
+    virtual std::string toJsonString(std::set<std::string> aKeys)  = 0;
+    virtual std::string toJsonApiItem(std::set<std::string> aKeys) = 0;
+
+    std::set<std::string> parseQueryFieldValues(std::string aKeys);
+    // returns a JsonString including created timestamp
+    std::string toJsonStringTs(std::set<std::string> aKeys);
+    // std::string toJsonApiItem(std::set<std::string> aKeys);
+
+    UUID                                  mUuid;
+    std::chrono::system_clock::time_point mCreated;
+    std::chrono::system_clock::time_point mUpdated;
+};
+
+/**
+ * @brief This virtual class implements a general json:api collection.
+ *
+ */
+class BasicCollection
+{
+    std::map<std::string, uint16_t> mHoldsTypes;
+
+public:
+    BasicCollection();
+    virtual ~BasicCollection();
+    virtual std::string getCollectionName() const    = 0;
+    virtual uint16_t    getMaxCollectionSize() const = 0;
+    // derived classes may implement
+    // virtual void          addItem(BasicCollectionItem *aItem) = 0;
+    // virtual BasicCollectionItem  *getItem(std::string key);
+
+    std::set<std::string> getContainedTypes();
+    std::string           toJsonStringItemId(std::string aItemId, const std::map<std::string, std::string> aFields);
+    std::string           toJsonString();
+    std::string           toJsonApiItemId(std::string aItemId, const std::map<std::string, std::string> aFields);
+    std::string           toJsonApiItems(const std::map<std::string, std::string> aFields);
+    std::string           toJsonApiColl(const std::map<std::string, std::string> aFields);
+
+    void incrHoldsTypes(std::string aTypeName);
+    void decrHoldsTypes(std::string aTypeName);
+    void evictOldestItem();
+    void clear();
+
+protected:
+    std::unordered_map<std::string, BasicCollectionItem *> mCollection;
+    std::list<std::string>                                 mAgeSortedItemIds;
+};
+
+// the collection example. We do not want a BasicCollection instance.
+// extern BasicCollection gBasicCollection;
+
+} // namespace rest
+} // namespace otbr
+
+#endif // OTBR_REST_GENERIC_COLLLECTION_HPP_

--- a/src/rest/extensions/rest_server_common.cpp
+++ b/src/rest/extensions/rest_server_common.cpp
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements APIs used for conversions of data from one form to another
+ *
+ */
+#include "rest_server_common.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cJSON.h>
+#include <ctype.h>
+#include <openthread/logging.h>
+
+// Function to combine Mesh Local Prefix and IID to form an IPv6 address
+void combineMeshLocalPrefixAndIID(const otMeshLocalPrefix        *meshLocalPrefix,
+                                  const otIp6InterfaceIdentifier *iid,
+                                  otIp6Address                   *ip6Address)
+{
+    // Copy the Mesh Local Prefix to the first 8 bytes of the IPv6 address
+    for (size_t i = 0; i < 8; ++i)
+    {
+        ip6Address->mFields.m8[i] = meshLocalPrefix->m8[i];
+    }
+
+    // Copy the IID to the last 8 bytes of the IPv6 address
+    for (size_t i = 0; i < 8; ++i)
+    {
+        ip6Address->mFields.m8[i + 8] = iid->mFields.m8[i];
+    }
+}
+
+// count number of 1s in bitmask
+int my_count_ones(uint32_t bitmask)
+{
+    int count = 0;
+    while (bitmask)
+    {
+        count += bitmask & 1; // Increment count if the least significant bit is 1
+        bitmask >>= 1;        // Shift bitmask to the right by 1
+    }
+    return count;
+}
+
+static int hex_char_to_int(char c)
+{
+    if (('A' <= c) && (c <= 'F'))
+    {
+        return (uint8_t)c - (uint8_t)'A' + 10;
+    }
+    if (('a' <= c) && (c <= 'f'))
+    {
+        return (uint8_t)c - (uint8_t)'a' + 10;
+    }
+    if (('0' <= c) && (c <= '9'))
+    {
+        return (uint8_t)c - (uint8_t)'0';
+    }
+    return -1;
+}
+
+uint8_t joiner_verify_pskd(char *pskd)
+{
+    int len = strlen(pskd);
+    if (OT_PSKD_LENGTH_MIN > len)
+    {
+        otLogWarnPlat("PSKd %s has incorrect length %d", pskd, len);
+        return OT_JOINFAILED_LENGTH;
+    }
+    if (OT_PSKD_LENGTH_MAX < len)
+    {
+        otLogWarnPlat("PSKd %s has incorrect length %d", pskd, len);
+        return OT_JOINFAILED_LENGTH;
+    }
+    for (int i = 0; i < len; i++)
+    {
+        if (!isalnum(pskd[i]))
+        {
+            otLogWarnPlat("PSKd %s has incorrect format and is not alphanumeric", pskd);
+            return OT_JOINFAILED_PSKD_FORMAT;
+        }
+        if (islower(pskd[i]))
+        {
+            otLogWarnPlat("PSKd %s has incorrect format and is not all uppercase", pskd);
+            return OT_JOINFAILED_PSKD_FORMAT;
+        }
+        if ('I' == pskd[i] || 'O' == pskd[i] || 'Q' == pskd[i] || 'Z' == pskd[i])
+        {
+            otLogWarnPlat("PSKd %s has incorrect format and contains illegal character %c", pskd, pskd[i]);
+            return OT_JOINFAILED_PSKD_FORMAT;
+        }
+    }
+    return WPANSTATUS_OK;
+}
+
+otError str_to_m8(uint8_t *m8, const char *str, uint8_t size)
+{
+    if (size * 2 > strlen(str))
+    {
+        return OT_ERROR_FAILED;
+    }
+
+    for (int i = 0; i < size; i++)
+    {
+        int hex_int_1 = hex_char_to_int(str[i * 2]);
+        int hex_int_2 = hex_char_to_int(str[i * 2 + 1]);
+        if (-1 == hex_int_1 || -1 == hex_int_2)
+        {
+            return OT_ERROR_FAILED;
+        }
+        m8[i] = (uint8_t)(hex_int_1 * 16 + hex_int_2);
+    }
+
+    return OT_ERROR_NONE;
+}
+
+bool is_hex_string(char *str)
+{
+    int offset = 0;
+    if ('x' == str[1])
+    {
+        if ('0' != str[0])
+        {
+            return false;
+        }
+        offset = 2;
+    }
+    for (size_t i = offset; i < strlen(str); i++)
+    {
+        if (!isxdigit(str[i]))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_server_common.hpp
+++ b/src/rest/extensions/rest_server_common.hpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements APIs used for conversions of data from one form to another.
+ *
+ */
+#ifndef REST_SERVER_COMMON_HPP_
+#define REST_SERVER_COMMON_HPP_
+
+#include "utils/thread_helper.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <openthread/error.h>
+
+typedef enum
+{
+    LOCK_TYPE_BLOCKING,
+    LOCK_TYPE_NONBLOCKING,
+    LOCK_TYPE_TIMED
+} LockType;
+
+#define WPANSTATUS_OK 0
+#define OT_NETWORKKEY_LENGTH 32
+#define OT_PSKD_LENGTH_MIN 6
+#define OT_PSKD_LENGTH_MAX 32
+#define OT_JOINFAILED_LENGTH 16
+#define OT_JOINFAILED_PSKD_FORMAT 17
+
+// Function to combine Mesh Local Prefix and IID to form an IPv6 address
+void combineMeshLocalPrefixAndIID(const otMeshLocalPrefix        *meshLocalPrefix,
+                                  const otIp6InterfaceIdentifier *iid,
+                                  otIp6Address                   *ip6Address);
+
+// count number of 1s in bitmask
+int my_count_ones(uint32_t bitmask);
+
+uint8_t joiner_verify_pskd(char *pskd);
+
+/**
+ * @brief   str_to_m8, is designed to convert a string of hexadecimal characters
+ *          into an array of bytes (uint8_t). It performs this conversion by processing
+ *          each pair of hexadecimal characters in the input string, converting them
+ *          into their corresponding byte value, and storing the result in the provided array.
+ * @param   uint8_t *m8: A pointer to the array where the converted bytes will be stored.
+ * @param   const char *str: A pointer to the input string containing hexadecimal characters.
+ * @param   uint8_t size: The number of bytes that the m8 array can hold, which dictates how many characters from str
+ * should be processed.
+ * @return    The function returns an otError code, indicating the success or failure of the conversion process.
+ */
+otError str_to_m8(uint8_t *m8, const char *str, uint8_t size);
+
+/**
+ * @brief [DEPRECATED] please use isValidPerRegex() for new work.
+ * This function checks if the input string is hex or not
+ * @param str Hex string to be checked
+ * @return true if the string is HEX
+ * @return false if the string is not HEX
+ */
+bool is_hex_string(char *str);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif

--- a/src/rest/extensions/rest_task_add_thread_device.cpp
+++ b/src/rest/extensions/rest_task_add_thread_device.cpp
@@ -1,0 +1,255 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#include "rest_task_add_thread_device.hpp"
+#include "rest/extensions/commissioner_allow_list.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cJSON.h>
+#include <errno.h>
+#include <time.h>
+#include <openthread/commissioner.h>
+#include <openthread/logging.h>
+#include <openthread/platform/radio.h>
+
+// Accommodating naming convention without refactoring whole codebase
+static const char *const ATTRIBUTE_PSKD = "pskd";
+
+const char *taskNameAddThreadDevice = "addThreadDeviceTask";
+
+cJSON *jsonify_add_thread_device_task(task_node_t *task_node)
+{
+    otExtAddress eui64 = {0};
+
+    cJSON *task_json  = task_node_to_json(task_node);
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task_json, "attributes");
+    //    cJSON_DeleteItemFromObject(attributes, ATTRIBUTE_PSKD);
+    cJSON *eui = cJSON_GetObjectItemCaseSensitive(attributes, "eui");
+
+    if ((task_node->status > ACTIONS_TASK_STATUS_PENDING) && (task_node->status != ACTIONS_TASK_STATUS_UNIMPLEMENTED))
+    {
+        // find allowListEntry and get more detailed status
+        str_to_m8(eui64.m8, eui->valuestring, OT_EXT_ADDRESS_SIZE);
+
+        if (entryEui64Find(&eui64) != nullptr)
+        {
+            cJSON_ReplaceItemInObjectCaseSensitive(attributes, "status",
+                                                   cJSON_CreateString(entryEui64Find(&eui64)->getStateStr().c_str()));
+        }
+        else
+        {
+            otbrLogWarning("%s:%d - %s - eui not in allowlist: %s", __FILE__, __LINE__, __func__,
+                           cJSON_Print(attributes));
+        }
+    }
+    return task_json;
+}
+
+uint8_t validate_add_thread_device_task(cJSON *attributes)
+{
+    otError      error = OT_ERROR_NONE;
+    otExtAddress eui64 = {0};
+
+    cJSON *timeout = cJSON_GetObjectItemCaseSensitive(attributes, "timeout");
+    cJSON *eui     = cJSON_GetObjectItemCaseSensitive(attributes, "eui");
+    cJSON *pskd    = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_PSKD);
+
+    VerifyOrExit((NULL != timeout && cJSON_IsNumber(timeout)), error = OT_ERROR_FAILED);
+
+    VerifyOrExit(
+        (NULL != eui && cJSON_IsString(eui) && 16 == strlen(eui->valuestring) && is_hex_string(eui->valuestring)),
+        error = OT_ERROR_FAILED);
+    // check eui is convertable
+    SuccessOrExit(error = str_to_m8(eui64.m8, eui->valuestring, OT_EXT_ADDRESS_SIZE));
+
+    VerifyOrExit((NULL != pskd && cJSON_IsString(pskd) && (WPANSTATUS_OK == joiner_verify_pskd(pskd->valuestring))),
+                 error = OT_ERROR_FAILED);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        // otLogWarnPlat("%s:%d %s %s missing or bad value in field\n%s", __FILE__, __LINE__, taskNameAddThreadDevice,
+        // __func__, cJSON_Print(attributes));
+        otbrLogWarning("%s:%d - %s - missing or bad value in a field: %s", __FILE__, __LINE__, __func__,
+                       cJSON_Print(attributes));
+        return ACTIONS_TASK_INVALID;
+    }
+    return ACTIONS_TASK_VALID;
+}
+
+otError addJoiner(task_node_t *task_node, otInstance *aInstance)
+{
+    otError      error = OT_ERROR_NONE;
+    otExtAddress eui64 = {0};
+    task_node_t *old_task;
+
+    cJSON *task       = task_node->task;
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    cJSON *eui        = cJSON_GetObjectItemCaseSensitive(attributes, "eui");
+    cJSON *pskd       = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_PSKD);
+    cJSON *timeout    = cJSON_GetObjectItemCaseSensitive(attributes, "timeout");
+
+    str_to_m8(eui64.m8, eui->valuestring, OT_EXT_ADDRESS_SIZE);
+
+    if ((entryEui64Find(&eui64) != NULL) &&
+        (entryEui64Find(&eui64)->mstate < AllowListEntry::kAllowListEntryJoinFailed))
+    {
+        // cancel active task for same joiner, by convention has same uuid as allowListEntry
+        old_task = task_node_find_by_id((entryEui64Find(&eui64)->muuid));
+        task_update_status(old_task, ACTIONS_TASK_STATUS_STOPPED);
+    }
+    SuccessOrExit(error = allowListCommissionerJoinerAdd(eui64, (uint32_t)timeout->valueint, pskd->valuestring,
+                                                         aInstance, task_node->id));
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - error: %s", __FILE__, __LINE__, __func__, otThreadErrorToString(error));
+    }
+    return error;
+}
+
+rest_actions_task_result_t process_add_thread_device_task(task_node_t      *task_node,
+                                                          otInstance       *aInstance,
+                                                          task_doneCallback aCallback)
+{
+    otError                    error             = OT_ERROR_NONE;
+    otCommissionerState        commissionerState = OT_COMMISSIONER_STATE_DISABLED;
+    rest_actions_task_result_t ret               = ACTIONS_RESULT_SUCCESS;
+
+    OT_UNUSED_VARIABLE(aCallback);
+
+    // Arg check before doing works
+    VerifyOrExit((NULL != task_node && NULL != task_node->task), error = OT_ERROR_INVALID_ARGS);
+
+    // openthread_lock_acquire(LOCK_TYPE_BLOCKING, 0);
+    commissionerState = otCommissionerGetState(aInstance);
+    // openthread_lock_release();
+
+    // If the commissioner is already ACTIVE, we can add ot-joiners right away
+    if (OT_COMMISSIONER_STATE_ACTIVE == commissionerState)
+    {
+        SuccessOrExit(error = addJoiner(task_node, aInstance));
+    }
+    else
+    {
+        // ot-commissioner is not ACTIVE yet, so we need to
+        // wait for the ot-commissioner to become ACTIVE
+        // and be called again from installed state_change callback
+        SuccessOrExit(error = allowListCommissionerStart(aInstance));
+        ret = ACTIONS_RESULT_RETRY;
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (error == OT_ERROR_FAILED)
+        {
+            // otLogCritPlat("Cannot create restTaskJoinerAddConditionalTask");
+            otbrLogCrit("%s:%d - %s - error %d - Cannot add Joiner.", __FILE__, __LINE__, __func__, error);
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+        else if (error == OT_ERROR_INVALID_STATE || error == OT_ERROR_ALREADY)
+        {
+            // otLogWarnPlat("Failed to start the commissioner, error %d", error);
+            otbrLogWarning("%s:%d - %s - error %d - Failed to start the commissioner.", __FILE__, __LINE__, __func__,
+                           error);
+            ret = ACTIONS_RESULT_RETRY;
+        }
+        else
+        {
+            otbrLogWarning("%s: error %d", __func__, error);
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+    }
+    return ret;
+}
+
+rest_actions_task_result_t evaluate_add_thread_device_task(task_node_t *task_node)
+{
+    otError             error = OT_ERROR_NONE;
+    otExtAddress        eui64 = {0};
+    const otExtAddress *addrPtr;
+
+    cJSON *task       = task_node->task;
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    cJSON *eui        = cJSON_GetObjectItemCaseSensitive(attributes, "eui");
+
+    str_to_m8(eui64.m8, eui->valuestring, OT_EXT_ADDRESS_SIZE);
+
+    addrPtr = &eui64;
+    SuccessOrExit(error = allowListEntryJoinStatusGet(addrPtr));
+
+exit:
+    if (OT_ERROR_FAILED == error)
+    {
+        return ACTIONS_RESULT_FAILURE;
+    }
+    if (OT_ERROR_NONE == error)
+    {
+        return ACTIONS_RESULT_SUCCESS; // caller will mark it as complete in our task_node.
+    }
+
+    // Don't need to check for OT_ERROR_PENDING as the task is currently pending anyway
+    return ACTIONS_RESULT_PENDING;
+}
+
+rest_actions_task_result_t clean_add_thread_device_task(task_node_t *task_node, otInstance *aInstance)
+{
+    cJSON *task       = task_node->task;
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    cJSON *eui        = cJSON_GetObjectItemCaseSensitive(attributes, "eui");
+
+    otError error = OT_ERROR_NONE;
+
+    otExtAddress eui64 = {0};
+    str_to_m8(eui64.m8, eui->valuestring, OT_EXT_ADDRESS_SIZE);
+
+    SuccessOrExit(error = allowListCommissionerJoinerRemove(eui64, aInstance));
+    SuccessOrExit(error = allowListEntryErase(eui64));
+
+exit:
+    if (OT_ERROR_NONE == error)
+    {
+        return ACTIONS_RESULT_SUCCESS;
+    }
+
+    otbrLogWarning("%s: error %d", __func__, error);
+    return ACTIONS_RESULT_FAILURE;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_task_add_thread_device.hpp
+++ b/src/rest/extensions/rest_task_add_thread_device.hpp
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#ifndef REST_TASK_ADD_THREAD_DEVICE_HPP_
+#define REST_TASK_ADD_THREAD_DEVICE_HPP_
+
+#include "rest_server_common.hpp"
+#include "rest_task_handler.hpp"
+#include "rest_task_queue.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdbool.h>
+#include <string.h>
+
+extern const char         *taskNameAddThreadDevice;
+cJSON                     *jsonify_add_thread_device_task(task_node_t *task_node);
+uint8_t                    validate_add_thread_device_task(cJSON *task);
+rest_actions_task_result_t process_add_thread_device_task(task_node_t      *task_node,
+                                                          otInstance       *aInstance,
+                                                          task_doneCallback aCallback);
+rest_actions_task_result_t evaluate_add_thread_device_task(task_node_t *task_node);
+rest_actions_task_result_t clean_add_thread_device_task(task_node_t *task_node, otInstance *aInstance);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif // REST_TASK_ADD_THREAD_DEVICE_HPP_

--- a/src/rest/extensions/rest_task_energy_scan.cpp
+++ b/src/rest/extensions/rest_task_energy_scan.cpp
@@ -1,0 +1,478 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#include "rest_task_energy_scan.hpp"
+#include "rest_diagnostics_coll.hpp"
+#include "rest/extensions/commissioner_allow_list.hpp"
+#include "rest/extensions/rest_devices_coll.hpp"
+#include "rest/extensions/uuid.hpp"
+#include "rest/types.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cJSON.h>
+#include <errno.h>
+#include <time.h>
+#include <openthread/commissioner.h>
+#include <openthread/logging.h>
+#include <openthread/platform/radio.h>
+
+const char *taskNameEnergyScan = "getEnergyScanTask";
+
+// @note: Accommodating customer naming convention without refactoring whole codebase
+static const char *const ATTRIBUTE_DESTINATION  = "destination";  // the on-mesh-mleid address, or a {deviceid}
+static const char *const ATTRIBUTE_COUNT        = "count";        // count of (repeated) scans
+static const char *const ATTRIBUTE_MASK         = "channelMask";  // channel mask
+static const char *const ATTRIBUTE_PERIOD       = "period";       // scan period
+static const char *const ATTRIBUTE_SCANDURATION = "scanDuration"; // scan duration
+
+// Current OT-API does not seem to support concurrent energy scans,
+// therefore we handle just one energy scan request at a time.
+enum class EnergyScanState : std::uint8_t
+{
+    kIdle,
+    kSendReq,
+    kCallbackWait,
+    kHandleCb,
+    kComplete,
+};
+
+// mutex to block concurrent energy scans
+static EnergyScanState sState;
+// a reference to the action that is in processing
+static task_node_t *sAction;
+
+// a struct for collecting the measure results from one scan
+otbr::rest::EnergyScanReport mEsr;
+uint8_t                      meas_count_received_total = 0;
+
+static task_doneCallback sDoneCallback; // a function pointer to be called when task is finished.
+
+static void init_energyscanreport(otIp6InterfaceIdentifier mlEidIid, uint8_t count, cJSON *mask)
+{
+    cJSON *item = nullptr;
+
+    meas_count_received_total = 0;
+    mEsr.count                = count;
+    mEsr.origin               = mlEidIid;
+    for (auto &it : mEsr.report)
+    {
+        it.maxRssi.clear();
+    }
+    mEsr.report.clear();
+
+    cJSON_ArrayForEach(item, mask)
+    {
+        otbr::rest::EnergyReport report;
+        report.channel = cJSON_GetNumberValue(item);
+        mEsr.report.push_back(report);
+    }
+
+    cJSON_Delete(item);
+}
+
+cJSON *jsonify_energy_scan_task(task_node_t *aTaskNode)
+{
+    cJSON *task_json = task_node_to_json(aTaskNode);
+
+    return task_json;
+}
+
+uint8_t validate_energy_scan_task(cJSON *attributes)
+{
+    otError      error    = OT_ERROR_NONE;
+    otExtAddress mlEidIid = {0};
+    cJSON       *item     = nullptr;
+    uint8_t      channel;
+
+    cJSON *timeout      = cJSON_GetObjectItemCaseSensitive(attributes, "timeout");
+    cJSON *destination  = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_DESTINATION);
+    cJSON *mask         = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_MASK);
+    cJSON *count        = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_COUNT);
+    cJSON *period       = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_PERIOD);
+    cJSON *scanDuration = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_SCANDURATION);
+
+    VerifyOrExit(nullptr != timeout && cJSON_IsNumber(timeout), error = OT_ERROR_FAILED);
+
+    VerifyOrExit(nullptr != destination && cJSON_IsString(destination) && 16 == strlen(destination->valuestring) &&
+                     is_hex_string(destination->valuestring),
+                 error = OT_ERROR_FAILED);
+    // check destination is convertable
+    SuccessOrExit(error = str_to_m8(mlEidIid.m8, destination->valuestring, OT_EXT_ADDRESS_SIZE));
+
+    otbrLogWarning("%s:%d - %s - cjson destination: %s", "EnergyScan", __LINE__, __func__, cJSON_Print(destination));
+
+    // TODO: check limits
+    //  && (0xFFFFFFFF <= cJSON_GetNumberValue(mask))
+    //   && (0xFF <= cJSON_GetNumberValue(count))
+    //   && (0xFFFF <= cJSON_GetNumberValue(period))
+    //   && (0xFFFF <= cJSON_GetNumberValue(scanDuration))
+
+    VerifyOrExit(nullptr != mask && cJSON_IsArray(mask), error = OT_ERROR_FAILED);
+
+    cJSON_ArrayForEach(item, mask)
+    {
+        if (cJSON_IsNumber(item))
+        {
+            channel = item->valueint;
+            VerifyOrExit(channel >= 11 && channel <= 26, error = OT_ERROR_FAILED);
+        }
+    }
+
+    VerifyOrExit(nullptr != count && cJSON_IsNumber(count), error = OT_ERROR_FAILED);
+    VerifyOrExit(nullptr != period && cJSON_IsNumber(period), error = OT_ERROR_FAILED);
+    VerifyOrExit(nullptr != scanDuration && cJSON_IsNumber(scanDuration), error = OT_ERROR_FAILED);
+
+exit:
+    if (item != nullptr)
+    {
+        cJSON_Delete(item);
+    }
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - missing or bad value in a field: %s", "EnergyScan", __LINE__, __func__,
+                       cJSON_Print(attributes));
+        return ACTIONS_TASK_INVALID;
+    }
+    return ACTIONS_TASK_VALID;
+}
+
+/**
+ * @brief A otCommissionerEnergyReportCallback.
+ *
+ * @param aChannelMask
+ * @param aEnergyList
+ * @param aEnergyListLength
+ * @param aContext
+ *
+ * Note: can be called several times for a larger chunk of results, when results are transmitted in multiple packets
+ *       expect results in aEnergyList [chA, chB, chC, ... chA, chB, chC, ...]
+ * Note: If we terminate an active task before all chunks are received, and also have a new task started and active,
+ *       we cannot distinguish a delayed chunk of results from the previous energy scan.
+ */
+void HandleEnergyReport(uint32_t aChannelMask, const uint8_t *aEnergyList, uint8_t aEnergyListLength, void *aContext)
+{
+    otError error = OT_ERROR_NONE;
+
+    uint8_t i, j;
+    uint8_t channel_count, meas_count;
+
+    OT_UNUSED_VARIABLE(aContext);
+    // task contains the task description used for validation of matching
+    // task_node_t *aTaskNode = static_cast<task_node_t *>(aContext);
+
+    // cJSON *attributes = cJSON_GetObjectItemCaseSensitive(aTaskNode->task, "attributes");
+    // cJSON *destination     = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_DESTINATION);
+    //  check results match to prepared report
+    // SuccessOrExit(strcmp(mEsr.origin_str, destination->valuestring));
+
+    VerifyOrExit(sState == EnergyScanState::kCallbackWait, error = OT_ERROR_INVALID_STATE);
+
+    channel_count = my_count_ones(aChannelMask);
+    // check sizes match expectations
+    VerifyOrExit(aEnergyListLength % channel_count == 0, error = OT_ERROR_PARSE);
+
+    meas_count = aEnergyListLength / channel_count;
+
+    for (j = 0; j < meas_count; j++)
+    {
+        for (i = 0; i < channel_count; i++)
+        {
+            mEsr.report[i].maxRssi.push_back((int8_t)(aEnergyList[i + j]));
+        }
+    }
+
+    meas_count_received_total += meas_count;
+
+    // otbrLogWarning("%s:%d - %s - listLength %d.", "EnergyScan", __LINE__, __func__, aEnergyListLength);
+
+    if (meas_count_received_total == mEsr.count)
+    {
+        // store results
+        otbr::rest::EnergyScanDiagnostics res;
+        res.mReport = mEsr; // TODO check if copy constructor needed
+
+        otbr::rest::gDiagnosticsCollection.addItem(&res);
+
+        // aTaskNode keeps reference to result
+        snprintf(sAction->relationship.mType, MAX_TYPELENGTH,
+                 otbr::rest::gDiagnosticsCollection.getCollectionName().c_str());
+        snprintf(sAction->relationship.mId, UUID_STR_LEN, res.mUuid.toString().c_str());
+
+        sState  = EnergyScanState::kComplete;
+        sAction = nullptr;
+
+        otbrLogWarning("%s:%d - %s - changed to state %d.", "EnergyScan", __LINE__, __func__, sState);
+        if (sDoneCallback != nullptr)
+        {
+            sDoneCallback();
+        }
+    }
+    // else we expect more results to come in another packet
+    else
+    {
+        otbrLogWarning("%s:%d - %s - received total %d measurements, expect %d.", "EnergyScan", __LINE__, __func__,
+                       meas_count_received_total, mEsr.count);
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - error: %s", "EnergyScan", __LINE__, __func__, otThreadErrorToString(error));
+    }
+    return;
+}
+
+otError startEnergyScan(task_node_t *aTaskNode, otInstance *aInstance)
+{
+    otError error                              = OT_ERROR_NONE;
+    char    buffer[OT_IP6_ADDRESS_STRING_SIZE] = {'\0'};
+    cJSON  *item                               = nullptr;
+    uint8_t channel;
+
+    otbr::rest::ThreadDevice *destinationDevice;
+
+    otIp6InterfaceIdentifier mlEidIid;
+    otIp6Address             ip6address;
+    const otMeshLocalPrefix *prefix;
+
+    cJSON *task       = aTaskNode->task;
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    // cJSON *timeout    = cJSON_GetObjectItemCaseSensitive(attributes, "timeout");
+
+    cJSON *destination  = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_DESTINATION);
+    cJSON *mask         = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_MASK);
+    cJSON *count        = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_COUNT);
+    cJSON *period       = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_PERIOD);
+    cJSON *scanDuration = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_SCANDURATION);
+
+    // construct uint32_t mask from list of channels
+    otChannelMask bitmask = 0;
+    cJSON_ArrayForEach(item, mask)
+    {
+        channel = cJSON_GetNumberValue(item);
+        bitmask |= (1 << channel);
+    }
+
+    uint8_t  count_val   = cJSON_GetNumberValue(count);
+    uint16_t period_val  = cJSON_GetNumberValue(period);
+    uint16_t scanDur_val = cJSON_GetNumberValue(scanDuration);
+
+    VerifyOrExit(sState == EnergyScanState::kIdle, error = OT_ERROR_INVALID_STATE);
+    sState = EnergyScanState::kSendReq;
+    otbrLogWarning("%s:%d - %s - changed to state %d.", "EnergyScan", __LINE__, __func__, sState);
+
+    otbrLogWarning("%s:%d - %s - channelMask 0x%08x.", "EnergyScan", __LINE__, __func__, bitmask);
+
+    // check if destination can be mapped to a mleidiid,
+    //       then destination has to be a known deviceId in gDevicesCollection with a known mleidiid.
+    //       if not, we use destination as a mleidiid
+    //       TODO: check mleidiid is valid.
+
+    destinationDevice =
+        dynamic_cast<otbr::rest::ThreadDevice *>(otbr::rest::gDevicesCollection.getItem(destination->valuestring));
+    if (destinationDevice != nullptr)
+    {
+        // destination is not a known deviceId
+        memcpy(mlEidIid.mFields.m8, destinationDevice->mDeviceInfo.mMlEidIid.m8, OT_EXT_ADDRESS_SIZE);
+    }
+    else
+    {
+        str_to_m8(mlEidIid.mFields.m8, destination->valuestring, OT_EXT_ADDRESS_SIZE);
+    }
+    // construct full ip6address of destination
+    prefix = otThreadGetMeshLocalPrefix(aInstance);
+    combineMeshLocalPrefixAndIID(prefix, &mlEidIid, &ip6address);
+
+    otIp6AddressToString(&ip6address, buffer, OT_IP6_ADDRESS_STRING_SIZE);
+    otbrLogWarning("%s:%d - %s - destination %s.", "EnergyScan", __LINE__, __func__, buffer);
+
+    error = otCommissionerEnergyScan(aInstance, bitmask, count_val, period_val, scanDur_val, &ip6address,
+                                     &HandleEnergyReport, (void *)aTaskNode);
+    // commissioner state should not be invalid here, as we checked before
+    VerifyOrExit(error == OT_ERROR_NONE);
+
+    // init container for results
+    init_energyscanreport(mlEidIid, count_val, mask);
+
+    sState  = EnergyScanState::kCallbackWait;
+    sAction = aTaskNode;
+    otbrLogWarning("%s:%d - %s - changed to state %d.", "EnergyScan", __LINE__, __func__, sState);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (error == OT_ERROR_INVALID_STATE)
+        {
+            // otbrLogWarning("%s:%d - %s - invalid EnergyScanState %d.", "EnergyScan", __LINE__, __func__, sState);
+            //  rewrite error
+            error = OT_ERROR_BUSY;
+        }
+        else
+        {
+            otbrLogWarning("%s:%d - %s - error: %s", "EnergyScan", __LINE__, __func__, otThreadErrorToString(error));
+        }
+    }
+    return error;
+}
+
+rest_actions_task_result_t process_energy_scan_task(task_node_t      *aTaskNode,
+                                                    otInstance       *aInstance,
+                                                    task_doneCallback aCallback)
+{
+    otError                    error             = OT_ERROR_NONE;
+    otCommissionerState        commissionerState = OT_COMMISSIONER_STATE_DISABLED;
+    rest_actions_task_result_t ret               = ACTIONS_RESULT_SUCCESS;
+
+    // Arg check before doing works
+    VerifyOrExit((nullptr != aTaskNode && nullptr != aTaskNode->task), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aTaskNode->status == ACTIONS_TASK_STATUS_PENDING, error = OT_ERROR_INVALID_STATE);
+
+    // call callback to execute other tasks after this task is completed
+    sDoneCallback = aCallback;
+
+    commissionerState = otCommissionerGetState(aInstance);
+
+    // If the commissioner is already ACTIVE, we can query the energy scan right away
+    if (OT_COMMISSIONER_STATE_ACTIVE == commissionerState)
+    {
+        SuccessOrExit(error = startEnergyScan(aTaskNode, aInstance));
+    }
+    else
+    {
+        // ot-commissioner is not ACTIVE yet, so we need to
+        // wait for the ot-commissioner to become ACTIVE
+        // and be called again from installed state_change callback
+        SuccessOrExit(error = allowListCommissionerStart(aInstance));
+        ret = ACTIONS_RESULT_RETRY;
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (error == OT_ERROR_INVALID_STATE)
+        {
+            otbrLogWarning("%s:%d - %s - error %s - Commissioner not available.", "EnergyScan", __LINE__, __func__,
+                           otThreadErrorToString(error));
+            ret = ACTIONS_RESULT_RETRY;
+        }
+        else if ((error == OT_ERROR_ALREADY) or (error == OT_ERROR_BUSY))
+        {
+            ret = ACTIONS_RESULT_RETRY;
+        }
+        else
+        {
+            otbrLogWarning("%s: error %d", __func__, otThreadErrorToString(error));
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief Evaluate success of the task.
+ *
+ * This must be called from rest_task_queue handler,
+ * only when aTaskNode->status = ACTIONS_TASK_STATUS_ACTIVE.
+ *
+ * @param aTaskNode
+ * @return ACTIONS_RESULT_SUCCESS when completing successfully
+ *         ACTIONS_RESULT_PENDING when not yet completed
+ *         ACTIONS_RESULT_FAILURE on other failures
+ */
+rest_actions_task_result_t evaluate_energy_scan_task(task_node_t *aTaskNode)
+{
+    OTBR_UNUSED_VARIABLE(aTaskNode);
+
+    otError                    error = OT_ERROR_NONE;
+    rest_actions_task_result_t ret   = ACTIONS_RESULT_SUCCESS;
+
+    VerifyOrExit(sState == EnergyScanState::kComplete, error = OT_ERROR_INVALID_STATE);
+
+    sState  = EnergyScanState::kIdle;
+    sAction = nullptr;
+    otbrLogWarning("%s:%d - %s - changed to state %d.", "EnergyScan", __LINE__, __func__, sState);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - error: %s", "EnergyScan", __LINE__, __func__, otThreadErrorToString(error));
+        switch (error)
+        {
+        case OT_ERROR_INVALID_STATE:
+            ret = ACTIONS_RESULT_PENDING;
+            break;
+        default:
+            otbrLogWarning("%s:%d - %s - error in state %d.", "EnergyScan", __LINE__, __func__, sState);
+            sState  = EnergyScanState::kIdle;
+            sAction = nullptr;
+
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief Clean resources before deleting the task.
+ *
+ * This must be called from rest_task_queue handler, e.g. on timeout of the task.
+ *
+ * @param aTaskNode
+ * @param aInstance
+ * @return ACTIONS_RESULT_NO_CHANGE_REQUIRED  task status was not changed, it was stopped already.
+ *         ACTIONS_RESULT_STOPPED   when task was stopped
+ */
+rest_actions_task_result_t clean_energy_scan_task(task_node_t *aTaskNode, otInstance *aInstance)
+{
+    rest_actions_task_result_t ret = ACTIONS_RESULT_NO_CHANGE_REQUIRED;
+
+    OT_UNUSED_VARIABLE(aInstance);
+
+    if (aTaskNode->status == ACTIONS_TASK_STATUS_ACTIVE)
+    {
+        // this task must be stopped when clean is called
+        sState  = EnergyScanState::kIdle;
+        sAction = nullptr;
+        otbrLogWarning("%s:%d - %s - changed to state %d.", "EnergyScan", __LINE__, __func__, sState);
+    }
+    ret               = ACTIONS_RESULT_STOPPED; // marks task as stopped
+    aTaskNode->status = ACTIONS_TASK_STATUS_STOPPED;
+
+    return ret;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_task_energy_scan.hpp
+++ b/src/rest/extensions/rest_task_energy_scan.hpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#ifndef REST_TASK_ENERGY_SCAN_HPP_
+#define REST_TASK_ENERGY_SCAN_HPP_
+
+#include "rest_server_common.hpp"
+#include "rest_task_handler.hpp"
+#include "rest_task_queue.hpp"
+//#include "rest/types.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdbool.h>
+#include <string.h>
+
+extern const char         *taskNameEnergyScan;
+cJSON                     *jsonify_energy_scan_task(task_node_t *task_node);
+uint8_t                    validate_energy_scan_task(cJSON *task);
+rest_actions_task_result_t process_energy_scan_task(task_node_t      *task_node,
+                                                    otInstance       *aInstance,
+                                                    task_doneCallback aCallback);
+rest_actions_task_result_t evaluate_energy_scan_task(task_node_t *task_node);
+rest_actions_task_result_t clean_energy_scan_task(task_node_t *task_node, otInstance *aInstance);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif // REST_TASK_ENERGY_SCAN_HPP_

--- a/src/rest/extensions/rest_task_handler.cpp
+++ b/src/rest/extensions/rest_task_handler.cpp
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements additional functionailty like `task_node` creation,
+ *          update task status and conversion of `task_node` to `JSON` format.
+ *
+ */
+#include "rest_task_handler.hpp"
+#include "rest_task_queue.hpp"
+#include "uuid.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cJSON.h>
+#include <stdlib.h>
+#include <time.h>
+
+static CJSON_PUBLIC(cJSON_bool)
+    cJSON_AddOrReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+{
+    if (cJSON_HasObjectItem(object, string))
+    {
+        return cJSON_ReplaceItemInObjectCaseSensitive(object, string, newitem);
+    }
+    else
+    {
+        return cJSON_AddItemToObject(object, string, newitem);
+    }
+}
+
+task_node_t *task_node_new(cJSON *task)
+{
+    task_node_t *task_node = (task_node_t *)calloc(1, sizeof(task_node_t)); // TODO: free memory
+    assert(NULL != task_node);
+
+    UUID uuid = UUID();
+
+    // Duplicate the client data associated with this task
+    task_node->task = cJSON_Duplicate(task, cJSON_True);
+
+    // Initialize the data for this new task to known defaults
+    //
+    task_node->prev       = NULL;  // Task queue management will update this
+    task_node->next       = NULL;  // Task queue management will update this
+    task_node->deleteTask = false; // New tasks are not marked for deletion
+
+    // Populate UUID
+    uuid.generateRandom();
+    uuid.getUuid(task_node->id);
+    snprintf(task_node->id_str, sizeof(task_node->id_str), uuid.toString().c_str());
+    otbrLogWarning("creating new task with id %s", task_node->id_str);
+    cJSON_AddStringToObject(task_node->task, "id", task_node->id_str);
+
+    // Populated task type by name matching
+    cJSON *task_type = cJSON_GetObjectItemCaseSensitive(task_node->task, "type");
+    task_type_id_from_name(task_type->valuestring, &task_node->type);
+
+    // Populate task creation time
+    int timestamp      = (int)time(NULL);
+    task_node->created = timestamp;
+
+    // Setup task timeout if provided
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task_node->task, "attributes");
+    cJSON *timeout    = cJSON_GetObjectItemCaseSensitive(attributes, "timeout");
+
+    if (cJSON_IsNumber(timeout))
+    {
+        // Set Up Timeout
+        task_node->timeout = timestamp + (int)(timeout->valueint);
+    }
+    else
+    {
+        task_node->timeout = ACTIONS_TASK_NO_TIMEOUT;
+    }
+
+    // @note: While we can call task_update_status() here, we maybe locking
+    // using taskNodeLockAcquire needlessly just to initialize the status
+    // of a new task to known defaults (i.e. pending)
+    //
+    // Setup task status to pending (both the enum and the string version)
+    task_update_status(task_node, ACTIONS_TASK_STATUS_PENDING);
+    if (NULL != attributes)
+    {
+        (void)cJSON_AddItemToObject(attributes, "status",
+                                    cJSON_CreateString(rest_actions_task_status_s[ACTIONS_TASK_STATUS_PENDING]));
+    }
+    // Return the prepared task node
+    return task_node;
+}
+
+void task_update_status(task_node_t *aTaskNode, rest_actions_task_status_t status)
+{
+    assert(NULL != aTaskNode);
+
+    // taskNodeLockAcquire(LOCK_TYPE_BLOCKING, 0);
+    aTaskNode->status = status;
+    // taskNodeLockRelease();
+}
+
+bool can_remove_task(task_node_t *aTaskNode)
+{
+    assert(NULL != aTaskNode);
+
+    return (ACTIONS_TASK_STATUS_COMPLETED == aTaskNode->status || ACTIONS_TASK_STATUS_STOPPED == aTaskNode->status ||
+            ACTIONS_TASK_STATUS_FAILED == aTaskNode->status);
+}
+
+cJSON *task_node_to_json(task_node_t *task_node)
+{
+    if (NULL == task_node)
+    {
+        return NULL;
+    }
+    cJSON *task_json  = cJSON_Duplicate(task_node->task, cJSON_True);
+    cJSON *task_attrs = cJSON_GetObjectItemCaseSensitive(task_json, "attributes");
+    cJSON_AddOrReplaceItemInObjectCaseSensitive(task_attrs, "status",
+                                                cJSON_CreateString(rest_actions_task_status_s[task_node->status]));
+    // add relationship
+    // relationships:{
+    //   result:{
+    //     data: {type: diagnostics, id: diagnosticsId}
+    //   }
+    // }
+    if ((task_node->status == ACTIONS_TASK_STATUS_COMPLETED) && (strlen(task_node->relationship.mType) > 0))
+    {
+        cJSON *relation    = cJSON_CreateObject();
+        cJSON *result      = cJSON_CreateObject();
+        cJSON *result_data = cJSON_CreateObject();
+
+        cJSON_AddStringToObject(result_data, "type", task_node->relationship.mType);
+        cJSON_AddStringToObject(result_data, "id", task_node->relationship.mId);
+        cJSON_AddItemToObject(result, "data", result_data);
+        cJSON_AddItemToObject(relation, "result", result);
+        cJSON_AddItemToObject(task_json, "relationships", relation);
+    }
+    return task_json;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_task_handler.hpp
+++ b/src/rest/extensions/rest_task_handler.hpp
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements additional functionailty like `task_node` creation,
+ *          update task status and conversion of `task_node` to `JSON` format.
+ *
+ */
+#ifndef REST_TASK_HANDLER_HPP_
+#define REST_TASK_HANDLER_HPP_
+
+#include "uuid.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+
+/**
+ * @brief Other api/action types can be added with the following enum.
+ *
+ */
+typedef enum
+{
+    // DISCOVER_THREAD_NETWORKS_TASK = 0,
+    // FORM_THREAD_NETWORK_TASK,
+    ADD_THREAD_DEVICE_TASK = 0,
+    GET_THREAD_NETWORK_DIAGNOSTIC_TASK,
+    RESET_THREAD_NETWORK_DIAGNOSTIC_COUNTERS_TASK,
+    GET_THREAD_ENERGY_SCAN_TASK,
+    // IDENTIFY_BORDER_ROUTER_TASK,
+    // THREAD_BORDER_ROUTER_JOIN_TASK,
+    // GENERATE_LDEVID_TASK,
+    ACTIONS_TASKS_SIZE,
+} rest_actions_task_t;
+
+static const char *const gRestActionsTaskNames[] = {"addThreadDeviceTask", "getThreadNetworkDiagnosticTask",
+                                                    "getThreadEnergyScanTask"};
+
+typedef enum
+{
+    ACTIONS_TASK_STATUS_PENDING = 0,
+    ACTIONS_TASK_STATUS_ACTIVE,
+    ACTIONS_TASK_STATUS_COMPLETED,
+    ACTIONS_TASK_STATUS_STOPPED,
+    ACTIONS_TASK_STATUS_FAILED,
+    ACTIONS_TASK_STATUS_UNIMPLEMENTED,
+} rest_actions_task_status_t;
+
+static const char *const rest_actions_task_status_s[] = {
+    "pending", "active", "completed", "stopped", "failed", "unimplemented",
+};
+
+#define ACTIONS_TASK_VALID 1 << 0
+#define ACTIONS_TASK_INVALID 1 << 1
+#define ACTIONS_TASK_NOT_IMPLEMENTED 1 << 2
+
+typedef enum
+{
+    ACTIONS_RESULT_SUCCESS,
+    ACTIONS_RESULT_PENDING,
+    ACTIONS_RESULT_RETRY,
+    ACTIONS_RESULT_FAILURE,
+    ACTIONS_RESULT_STOPPED,
+    ACTIONS_RESULT_NO_CHANGE_REQUIRED,
+} rest_actions_task_result_t;
+
+// keep a reference to the result of an action
+#define MAX_TYPELENGTH 20
+typedef struct relationship
+{
+    char mType[MAX_TYPELENGTH];
+    char mId[UUID_STR_LEN];
+} relationship_t;
+
+typedef struct task_node_s
+{
+    cJSON                     *task;
+    uuid_t                     id;
+    char                       id_str[UUID_STR_LEN];
+    rest_actions_task_t        type;
+    rest_actions_task_status_t status;
+    int                        created;
+    int                        timeout;
+    int                        last_evaluated;
+    struct task_node_s        *prev;
+    struct task_node_s        *next;
+    bool                       deleteTask;
+    relationship_t             relationship;
+} task_node_t;
+
+#define ACTIONS_TASK_NO_TIMEOUT -1
+
+/**
+ * @brief Allocate and duplicate a new JSON task to be pushed into the REST action queue.
+ *        The JSON task should be validated and no error checking is performed in this function.
+ *
+ * @param task Pointer to cJSON task to be queued
+ * @return The task_node_t pointer to the newly duplicated and allocated for the given
+ *         JSON task. The pointer is ready to be assigned into a task_node_t queue as needed.
+ */
+task_node_t *task_node_new(cJSON *task);
+
+/**
+ * @brief   This function updates the state to one of the value from
+ *          rest_actions_task_status_t
+ *
+ * @param task_node  pointer of a task to be updated with new status
+ * @param status    Intended status value from rest_actions_task_status_t
+ */
+void task_update_status(task_node_t *task_node, rest_actions_task_status_t status);
+
+/**
+ * @brief   This function converts the data from task node into JSON format.
+ *
+ * @param task_node A pointer of task node that we want to jsonify.
+ * @return cJSON*   Returns the task node that is convered into JSON format.
+ */
+cJSON *task_node_to_json(task_node_t *task_node);
+
+/**
+ * @brief  Checks if a task is completed, failed or stopped.
+ *
+ * @param aTaskNode A pointer of task that is being checked for stop, complete or fail condition.
+ * @return true     If one of the condition gets satisfied.
+ * @return false    None of the condition is satisfied.
+ */
+bool can_remove_task(task_node_t *aTaskNode);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif

--- a/src/rest/extensions/rest_task_network_diagnostic.cpp
+++ b/src/rest/extensions/rest_task_network_diagnostic.cpp
@@ -1,0 +1,380 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#include "rest_task_network_diagnostic.hpp"
+#include "unordered_map"
+#include "rest/extensions/commissioner_allow_list.hpp"
+#include "rest/extensions/rest_devices_coll.hpp"
+#include "rest/extensions/uuid.hpp"
+#include "rest/network_diag_handler.hpp"
+
+// Default TlvTypes for Diagnostic information
+static const std::unordered_map<std::string, uint8_t> kTlvTypeMap = {
+    {KEY_EXTADDRESS, 0},          ///< MAC Extended Address TLV
+    {KEY_RLOC16, 1},              ///< Address16 TLV
+    {KEY_MODE, 2},                ///< Mode TLV
+    {KEY_TIMEOUT, 3},             ///< Timeout TLV (max polling time period for SEDs)
+    {KEY_CONNECTIVITY, 4},        ///< Connectivity TLV
+    {KEY_ROUTE, 5},               ///< Route64 TLV
+    {KEY_LEADERDATA, 6},          ///< Leader Data TLV
+    {KEY_NETWORKDATA, 7},         ///< Network Data TLV
+    {KEY_IP6ADDRESSLIST, 8},      ///< IPv6 Address List TLV
+    {KEY_MACCOUNTERS, 9},         ///< MAC Counters TLV
+    {KEY_BATTERYLEVEL, 14},       ///< Battery Level TLV
+    {KEY_SUPPLYVOLTAGE, 15},      ///< Supply Voltage TLV
+    {KEY_CHILDTABLE, 16},         ///< Child Table TLV
+    {KEY_CHANNELPAGES, 17},       ///< Channel Pages TLV
+    {KEY_MAXCHILDTIMEOUT, 19},    ///< Max Child Timeout TLV
+    {KEY_LDEVID, 20},             ///< LDevID subject public key info TLV
+    {KEY_IDEV, 21},               ///< IDevID Certificate TLV
+    {KEY_EUI64, 23},              ///< EUI64 TLV
+    {KEY_VERSION, 24},            ///< Thread Version TLV
+    {KEY_VENDORNAME, 25},         ///< Vendor Name TLV
+    {KEY_VENDORMODEL, 26},        ///< Vendor Model TLV
+    {KEY_VENDORSWVERSION, 27},    ///< Vendor SW Version TLV
+    {KEY_THREADSTACKVERSION, 28}, ///< Thread Stack Version TLV (codebase/commit version)
+    {KEY_CHILDREN, 29},           ///< Child TLV
+    {KEY_CHILDRENIP6, 30},        ///< Child IPv6 Address List TLV
+    {KEY_NEIGHBORS, 31},          ///< Router Neighbor TLV
+    {KEY_MLECOUNTERS, 34}         ///< MLE Counters TLV
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cJSON.h>
+#include <errno.h>
+#include <time.h>
+#include <openthread/commissioner.h>
+#include <openthread/instance.h>
+#include <openthread/logging.h>
+#include <openthread/netdiag.h>
+#include <openthread/platform/radio.h>
+
+const char *taskNameNetworkDiagnostic      = "getNetworkDiagnosticTask";
+const char *taskNameNetworkDiagnosticReset = "resetNetworkDiagCounterTask";
+
+// a reference to the otInstance
+static otInstance *sInstance;
+
+// a function pointer to be called when task is finished.
+static task_doneCallback sDoneCallback;
+
+cJSON *jsonify_network_diagnostic_task(task_node_t *aTaskNode)
+{
+    cJSON *taskJson = task_node_to_json(aTaskNode);
+
+    return taskJson;
+}
+
+static bool validTLV(const char *aTlv)
+{
+    std::string tlvStr(aTlv);
+    return kTlvTypeMap.find(tlvStr) != kTlvTypeMap.end();
+}
+
+static bool validResetableTLV(const char *aTlv)
+{
+    return ((std::string(aTlv) == std::string(KEY_MACCOUNTERS)) || (std::string(aTlv) == std::string(KEY_MLECOUNTERS)));
+}
+
+uint8_t validate_network_diagnostic_task(cJSON *aAttributes)
+{
+    otError      error    = OT_ERROR_NONE;
+    otExtAddress mlEidIid = {0};
+    cJSON       *item     = nullptr;
+
+    cJSON *destination = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_DESTINATION);
+    cJSON *types       = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_TYPES);
+    cJSON *timeout     = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_TIMEOUT);
+
+    VerifyOrExit(nullptr != timeout && cJSON_IsNumber(timeout), error = OT_ERROR_FAILED);
+
+    // for now we enforce a valid destination string representing a deviceId or a mlEidIid.
+    // if no destination is provided, we may also default to collecting diagnostics from all deviceIds in the device
+    // collection, and/or update also the device collection (TODO).
+    VerifyOrExit(nullptr != destination && cJSON_IsString(destination) && 16 == strlen(destination->valuestring) &&
+                     is_hex_string(destination->valuestring),
+                 error = OT_ERROR_FAILED);
+
+    // check destination is convertable
+    SuccessOrExit(error = str_to_m8(mlEidIid.m8, destination->valuestring, OT_EXT_ADDRESS_SIZE));
+
+    // TODO: check if destination exists in mDeviceSet/mDiagSet
+
+    otbrLogWarning("%s:%d - %s - cjson destination: %s", __FILE__, __LINE__, __func__, cJSON_Print(destination));
+
+    VerifyOrExit(nullptr != types && cJSON_IsArray(types), error = OT_ERROR_FAILED);
+
+    // Check if requested tlv types are valid types
+    cJSON_ArrayForEach(item, types)
+    {
+        VerifyOrExit(cJSON_IsString(item), error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(validTLV(item->valuestring), error = OT_ERROR_INVALID_ARGS);
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - [%s] missing or bad value in a field: %s", __FILE__, __LINE__, __func__,
+                       otThreadErrorToString(error), cJSON_Print(aAttributes));
+        return ACTIONS_TASK_INVALID;
+    }
+    return ACTIONS_TASK_VALID;
+}
+
+rest_actions_task_result_t process_network_diagnostic_task(task_node_t      *aTaskNode,
+                                                           otInstance       *aInstance,
+                                                           task_doneCallback aCallback)
+{
+    otbrError                  error = OTBR_ERROR_NONE;
+    rest_actions_task_result_t ret   = ACTIONS_RESULT_SUCCESS;
+
+    // get handler for network diagnostics
+    otbr::rest::NetworkDiagHandler &netDiagHandler = otbr::rest::NetworkDiagHandler::getInstance(aInstance);
+
+    // Arg check before doing works
+    VerifyOrExit((nullptr != aTaskNode && nullptr != aTaskNode->task), error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aTaskNode->status == ACTIONS_TASK_STATUS_PENDING, error = OTBR_ERROR_INVALID_STATE);
+
+    sDoneCallback = aCallback; // call callback to execute other tasks after this task is completed
+    sInstance     = aInstance; // to find the NetworkDiagHandler Instance
+
+    // set some default values for NetworkDiagHandler, make configurable later from a "updateDeviceCollection" task
+    VerifyOrExit((error = netDiagHandler.configRequest(10000, 30000, 1, aCallback)) == OTBR_ERROR_NONE);
+    error = netDiagHandler.handleNetworkDiagnosticsAction(aTaskNode);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        if (error == OTBR_ERROR_INVALID_STATE)
+        {
+            ret = ACTIONS_RESULT_RETRY;
+        }
+        else
+        {
+            otbrLogWarning("%s:%d - %s - task failed. error %s", __FILE__, __LINE__, __func__, otbrErrorString(error));
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief Evaluate success of the task.
+ *
+ * This must be called from rest_task_queue handler,
+ * only when aTaskNode->status = ACTIONS_TASK_STATUS_ACTIVE.
+ *
+ * @param aTaskNode
+ * @return ACTIONS_RESULT_SUCCESS when completing successfully
+ *         ACTIONS_RESULT_PENDING when not yet completed
+ *         ACTIONS_RESULT_FAILURE on other failures
+ */
+rest_actions_task_result_t evaluate_network_diagnostic_task(task_node_t *aTaskNode)
+{
+    OTBR_UNUSED_VARIABLE(aTaskNode);
+
+    otbrError                  error = OTBR_ERROR_NONE;
+    rest_actions_task_result_t ret   = ACTIONS_RESULT_SUCCESS;
+
+    // get handler for network diagnostics
+    otbr::rest::NetworkDiagHandler &netDiagHandler = otbr::rest::NetworkDiagHandler::getInstance(sInstance);
+    error                                          = netDiagHandler.continueHandleRequest();
+
+    if (error != OTBR_ERROR_NONE)
+    {
+        switch (error)
+        {
+        case OTBR_ERROR_ERRNO:
+            OT_FALL_THROUGH;
+        case OTBR_ERROR_INVALID_STATE:
+            ret = ACTIONS_RESULT_PENDING;
+            break;
+        case OTBR_ERROR_ABORTED:
+            ret = ACTIONS_RESULT_STOPPED;
+            break;
+        default:
+            ret = ACTIONS_RESULT_FAILURE;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief Clean resources before deleting the task.
+ *
+ * This must be called from rest_task_queue handler, e.g. on timeout of the task.
+ *
+ * @param aTaskNode
+ * @param aInstance
+ * @return ACTIONS_RESULT_NO_CHANGE_REQUIRED  task status was not changed, it was stopped already.
+ *         ACTIONS_RESULT_STOPPED   when task was stopped
+ */
+rest_actions_task_result_t clean_network_diagnostic_task(task_node_t *aTaskNode, otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    rest_actions_task_result_t ret = ACTIONS_RESULT_NO_CHANGE_REQUIRED;
+
+    if (aTaskNode->status == ACTIONS_TASK_STATUS_ACTIVE)
+    {
+        // this task must be stopped when clean is called
+        // get handler for network diagnostics
+        otbr::rest::NetworkDiagHandler &netDiagHandler = otbr::rest::NetworkDiagHandler::getInstance(sInstance);
+        netDiagHandler.cancelRequest();
+
+        ret               = ACTIONS_RESULT_STOPPED; // marks task as stopped
+        aTaskNode->status = ACTIONS_TASK_STATUS_STOPPED;
+    }
+
+    return ret;
+}
+
+uint8_t validate_network_diagnostic_reset_task(cJSON *aAttributes)
+{
+    /* Example Post Request Body
+    {
+      "data": [
+        {
+          "type": "resetNetworkDiagCounterTask",
+          "attributes": {
+            "types": ["mleCounter", "macCounter"],
+            "timeout": 60
+          }
+        }
+      ]
+    }
+    */
+    otError error = OT_ERROR_NONE;
+    cJSON  *item  = nullptr;
+
+    cJSON *destination = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_DESTINATION);
+    cJSON *types       = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_TYPES);
+    cJSON *timeout     = cJSON_GetObjectItemCaseSensitive(aAttributes, ATTRIBUTE_TIMEOUT);
+
+    if (destination != nullptr)
+    {
+        // unicast requests
+        error = OT_ERROR_NOT_IMPLEMENTED;
+    }
+
+    VerifyOrExit(nullptr != types && cJSON_IsArray(types), error = OT_ERROR_FAILED);
+
+    // Check if requested tlv types are valid types
+    cJSON_ArrayForEach(item, types)
+    {
+        VerifyOrExit(cJSON_IsString(item), error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(validResetableTLV(item->valuestring), error = OT_ERROR_INVALID_ARGS);
+    }
+
+    VerifyOrExit(nullptr != timeout && cJSON_IsNumber(timeout), error = OT_ERROR_FAILED);
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - [%s] missing or bad value in a field: %s", __FILE__, __LINE__, __func__,
+                       otThreadErrorToString(error), cJSON_Print(aAttributes));
+        return ACTIONS_TASK_INVALID;
+    }
+    return ACTIONS_TASK_VALID;
+}
+
+rest_actions_task_result_t process_network_diagnostic_reset_task(task_node_t      *aTaskNode,
+                                                                 otInstance       *aInstance,
+                                                                 task_doneCallback aCallback)
+{
+    OT_UNUSED_VARIABLE(aCallback);
+    otbrError                  error = OTBR_ERROR_NONE;
+    rest_actions_task_result_t ret   = ACTIONS_RESULT_SUCCESS;
+
+    cJSON       *task;
+    cJSON       *attributes;
+    cJSON       *types;
+    cJSON       *item;
+    uint8_t      tlvTypes[2];
+    otIp6Address destination;
+
+    uint8_t count = 0;
+
+    // Arg check before doing works
+    VerifyOrExit((nullptr != aTaskNode && nullptr != aTaskNode->task), error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aTaskNode->status == ACTIONS_TASK_STATUS_PENDING, error = OTBR_ERROR_INVALID_STATE);
+
+    task       = aTaskNode->task;
+    attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    types      = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_TYPES);
+
+    cJSON_ArrayForEach(item, types)
+    {
+        count++;
+        tlvTypes[count] = kTlvTypeMap.find(std::string(item->valuestring))->second;
+    }
+
+    // reset counters at all devices via multicast
+    destination = *otThreadGetRealmLocalAllThreadNodesMulticastAddress(aInstance);
+    otThreadSendDiagnosticReset(aInstance, &destination, tlvTypes, count);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d - %s - task failed. error %s", __FILE__, __LINE__, __func__, otbrErrorString(error));
+        ret = ACTIONS_RESULT_FAILURE;
+    }
+    return ret;
+}
+
+rest_actions_task_result_t evaluate_network_diagnostic_reset_task(task_node_t *aTaskNode)
+{
+    OT_UNUSED_VARIABLE(aTaskNode);
+
+    rest_actions_task_result_t ret = ACTIONS_RESULT_SUCCESS;
+
+    return ret;
+}
+
+rest_actions_task_result_t clean_network_diagnostic_reset_task(task_node_t *aTaskNode, otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    rest_actions_task_result_t ret = ACTIONS_RESULT_NO_CHANGE_REQUIRED;
+
+    if (aTaskNode->status == ACTIONS_TASK_STATUS_ACTIVE)
+    {
+        ret = ACTIONS_RESULT_STOPPED;
+    }
+
+    return ret;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_task_network_diagnostic.hpp
+++ b/src/rest/extensions/rest_task_network_diagnostic.hpp
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements the APIs that validate, process, evaluate, jsonify and clean the task.
+ *
+ */
+#ifndef REST_TASK_NETWORK_DIAGNOSTIC_HPP_
+#define REST_TASK_NETWORK_DIAGNOSTIC_HPP_
+
+#include "rest_diagnostics_coll.hpp"
+#include "rest_server_common.hpp"
+#include "rest_task_handler.hpp"
+#include "rest_task_queue.hpp"
+#include "rest/json.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdbool.h>
+#include <string.h>
+
+#define MAX_TLV_COUNT 27 // Maximal amount of TLVs
+
+extern const char *taskNameNetworkDiagnostic;
+extern const char *taskNameNetworkDiagnosticReset;
+
+const char *const ATTRIBUTE_DESTINATION = "destination"; // the on-mesh-mleid address, or a {deviceid}
+const char *const ATTRIBUTE_TYPES       = "types";       // TLVs
+const char *const ATTRIBUTE_TIMEOUT     = "timeout";     // timeout of the task
+
+/**
+ *
+ * Converts a network diagnostic task node into its JSON representation.
+ *
+ * Takes a `task_node_t` pointer that represents a network diagnostic task
+ * and converts it into a JSON representation.
+ *
+ * @param[in] aTaskNode  The node which is to be jsonified.
+ * @return A pointer to a cJSON object representing the task node, or `nullptr` if the conversion fails.
+ */
+cJSON *jsonify_network_diagnostic_task(task_node_t *aTaskNode);
+
+/**
+ * Validates the attributes of a network diagnostic task to ensure they meet API schema requirements.
+ *
+ * Checks the provided JSON structure, verifying that all necessary fields and their values
+ * adhere to the expected format and constraints. If the attributes do not meet the criteria,
+ * it returns an appropriate validation status.
+ *
+ * @param[in] aAttributes  The JSON structure containing the attributes to be validated.
+ * @return The validation result, which can be one of the following:
+ *         - ACTIONS_TASK_VALID
+ *         - ACTIONS_TASK_INVALID
+ *         - ACTIONS_TASK_NOT_IMPLEMENTED
+ */
+uint8_t validate_network_diagnostic_task(cJSON *aAttributes);
+
+/**
+ * Processes a network diagnostic task by initiating its execution and monitoring its progress.
+ *
+ * Starts the execution of the network diagnostic task. Once the task begins,
+ * it continuously evaluates the task's state, calling the provided callback function when the task
+ * is completed. Returns an appropriate status indicating whether the task should be retried,
+ * has failed, or is successful.
+ *
+ * @param[in]  aTaskNode    The task node containing the network diagnostic task to be executed.
+ * @param[in]  aInstance    The OpenThread instance associated with the task.
+ * @param[in]  aCallback    The callback function to be called when the task is completed.
+ *
+ * @return The status of the task, which can be one of the following:
+ *         - ACTIONS_RESULT_SUCCESS
+ *         - ACTIONS_RESULT_FAILURE
+ *         - ACTIONS_RESULT_RETRY
+ *         - ACTIONS_RESULT_PENDING
+ */
+rest_actions_task_result_t process_network_diagnostic_task(task_node_t      *aTaskNode,
+                                                           otInstance       *aInstance,
+                                                           task_doneCallback aCallback);
+
+/**
+ * Monitors and evaluates the ongoing execution of a network diagnostic task.
+ *
+ * This function is responsible for the continuous processing of a network diagnostic task.
+ * It monitors the execution of the task and reports if the task has successfully completed,
+ * needs to continue running, or has failed.
+ *
+ * @param[in] aTaskNode  The task node representing the network diagnostic task being evaluated.
+ *
+ * @return The status of the task, which can be one of the following:
+ *         - ACTIONS_RESULT_SUCCESS
+ *         - ACTIONS_RESULT_FAILURE
+ *         - ACTIONS_RESULT_PENDING
+ *         - ACTIONS_RESULT_NO_CHANGE_REQUIRED
+ *         - ACTIONS_RESULT_STOPPED
+ */
+rest_actions_task_result_t evaluate_network_diagnostic_task(task_node_t *aTaskNode);
+
+/**
+ * Cleans up and releases resources associated with a network diagnostic task.
+ *
+ * Frees any resources held by the network diagnostic task, ensuring that it can be
+ * safely removed from the task queue.
+ *
+ * @param[in] aTaskNode   The task node representing the network diagnostic task to be cleaned.
+ * @param[in] aInstance   The OpenThread instance associated with the task.
+ *
+ * @return The status of the cleaning operation, which can be one of the following:
+ *         - ACTIONS_RESULT_SUCCESS
+ *         - ACTIONS_RESULT_FAILURE
+ *         - ACTIONS_RESULT_NO_CHANGE_REQUIRED
+ *         - ACTIONS_RESULT_STOPPED
+ */
+rest_actions_task_result_t clean_network_diagnostic_task(task_node_t *aTaskNode, otInstance *aInstance);
+
+/**
+ * Validates the attributes of a network diagnostic reset task to ensure they meet API schema requirements.
+ *
+ * Checks the provided JSON structure, verifying that all necessary fields and their values
+ * adhere to the expected format and constraints. If the attributes do not meet the criteria,
+ * it returns an appropriate validation status.
+ *
+ * @param[in] aAttributes  The JSON structure containing the attributes to be validated.
+ * @return The validation result, which can be one of the following:
+ *         - ACTIONS_TASK_VALID
+ *         - ACTIONS_TASK_INVALID
+ *         - ACTIONS_TASK_NOT_IMPLEMENTED
+ */
+uint8_t validate_network_diagnostic_reset_task(cJSON *aAttributes);
+
+/**
+ * Processes a network diagnostic reset task by initiating its execution and monitoring its progress.
+ *
+ * @param[in]  aTaskNode    The task node containing the network diagnostic task to be executed.
+ * @param[in]  aInstance    The OpenThread instance associated with the task.
+ * @param[in]  aCallback    (not used)
+ *
+ * @return The status of the task, which can be one of the following:
+ *         - ACTIONS_RESULT_SUCCESS
+ *         - ACTIONS_RESULT_FAILURE
+ */
+rest_actions_task_result_t process_network_diagnostic_reset_task(task_node_t      *aTaskNode,
+                                                                 otInstance       *aInstance,
+                                                                 task_doneCallback aCallback);
+
+/**
+ * @brief Evaluate success of the task.
+ *
+ * This must be called from rest_task_queue handler,
+ * only when aTaskNode->status = ACTIONS_TASK_STATUS_ACTIVE.
+ *
+ * @param aTaskNode
+ * @return ACTIONS_RESULT_SUCCESS when completing successfully
+ */
+rest_actions_task_result_t evaluate_network_diagnostic_reset_task(task_node_t *aTaskNode);
+
+/**
+ * @brief Clean resources before deleting the task.
+ *
+ * This must be called from rest_task_queue handler, e.g. on timeout of the task.
+ *
+ * @param aTaskNode
+ * @param aInstance
+ * @return ACTIONS_RESULT_NO_CHANGE_REQUIRED  task status was not changed, it was stopped already.
+ *         ACTIONS_RESULT_STOPPED   when task was stopped
+ */
+rest_actions_task_result_t clean_network_diagnostic_reset_task(task_node_t *aTaskNode, otInstance *aInstance);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif // REST_TASK_NETWORK_DIAGNOSTIC_HPP_

--- a/src/rest/extensions/rest_task_queue.cpp
+++ b/src/rest/extensions/rest_task_queue.cpp
@@ -1,0 +1,569 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements APIs related to thread creation and task handling.
+ *
+ */
+#include "rest_task_queue.hpp"
+#include "rest_task_add_thread_device.hpp"
+#include "rest_task_energy_scan.hpp"
+#include "rest_task_network_diagnostic.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <assert.h>
+#include <cJSON.h>
+//#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <openthread/logging.h>
+
+#define EVALUATE_INTERVAL 10
+
+task_node_t *task_queue     = NULL;
+uint8_t      task_queue_len = 0;
+otInstance  *mInstance;
+// pthread_mutex_t sTaskNodeLock;
+
+typedef struct
+{
+    rest_actions_task_t type_id;
+    const char        **type_name;
+    task_jsonifier      jsonify;
+    task_validator      validate;
+    task_processor      process;
+    task_evaluator      evaluate;
+    task_cleaner        clean;
+} task_handlers_t;
+
+static task_handlers_t *task_handler_by_task_type_id(rest_actions_task_t type_id);
+
+/**
+ * This list contains the handlers for each type of task, it must define the
+ * tasks in the same order as the defined id from `rest_actions_task_t`. It must
+ * also define all of the tasks (though ACTIONS_TASKS_SIZE must not have an
+ * associated task as it's a counter).
+ *
+ * If these contraints are not met, it will assert during startup.
+ */
+static task_handlers_t handlers[] = {
+
+    {
+        .type_id   = ADD_THREAD_DEVICE_TASK,
+        .type_name = &taskNameAddThreadDevice,
+        .jsonify   = jsonify_add_thread_device_task,
+        .validate  = validate_add_thread_device_task,
+        .process   = process_add_thread_device_task,
+        .evaluate  = evaluate_add_thread_device_task,
+        .clean     = clean_add_thread_device_task,
+    },
+    {
+        .type_id   = GET_THREAD_NETWORK_DIAGNOSTIC_TASK,
+        .type_name = &taskNameNetworkDiagnostic,
+        .jsonify   = jsonify_network_diagnostic_task,
+        .validate  = validate_network_diagnostic_task,
+        .process   = process_network_diagnostic_task,
+        .evaluate  = evaluate_network_diagnostic_task,
+        .clean     = clean_network_diagnostic_task,
+    },
+    {
+        .type_id   = RESET_THREAD_NETWORK_DIAGNOSTIC_COUNTERS_TASK,
+        .type_name = &taskNameNetworkDiagnosticReset,
+        .jsonify   = jsonify_network_diagnostic_task,
+        .validate  = validate_network_diagnostic_reset_task,
+        .process   = process_network_diagnostic_reset_task,
+        .evaluate  = evaluate_network_diagnostic_reset_task,
+        .clean     = clean_network_diagnostic_reset_task,
+    },
+    {
+        .type_id   = GET_THREAD_ENERGY_SCAN_TASK,
+        .type_name = &taskNameEnergyScan,
+        .jsonify   = jsonify_energy_scan_task,
+        .validate  = validate_energy_scan_task,
+        .process   = process_energy_scan_task,
+        .evaluate  = evaluate_energy_scan_task,
+        .clean     = clean_energy_scan_task,
+    },
+};
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+/**
+ * @brief Finds a task_handlers_t struct for a specific type id if it exists.
+ *
+ * @return a task_handlers_t pointer for the specified type id, or NULL if one
+ *  could not be found.
+ */
+static task_handlers_t *task_handler_by_task_type_id(rest_actions_task_t type_id)
+{
+    if (type_id < ACTIONS_TASKS_SIZE)
+    {
+        return &handlers[type_id];
+    }
+    return NULL;
+}
+
+cJSON *task_to_json(task_node_t *aTaskNode)
+{
+    if (NULL == aTaskNode || NULL == aTaskNode->task)
+    {
+        return NULL;
+    }
+    task_handlers_t *handlers = task_handler_by_task_type_id(aTaskNode->type);
+    if (NULL == handlers || NULL == handlers->jsonify)
+    {
+        return NULL;
+    }
+    return handlers->jsonify(aTaskNode);
+}
+
+task_node_t *task_node_find_by_id(uuid_t uuid)
+{
+    task_node_t *head = task_queue;
+    while (NULL != head)
+    {
+        if (uuid_equals(uuid, head->id))
+        {
+            return head;
+        }
+        head = head->next;
+    }
+    return NULL;
+}
+
+uint8_t can_remove_task_max()
+{
+    uint8_t      can_remove = 0;
+    task_node_t *head       = task_queue;
+    while (NULL != head)
+    {
+        if (can_remove_task(head))
+        {
+            can_remove++;
+        }
+        head = head->next;
+    }
+    return can_remove;
+}
+
+static bool remove_oldest_non_running_task()
+{
+    int             timestamp = (int)time(NULL);
+    struct timespec ts;
+    ts.tv_sec  = 0;         // Seconds
+    ts.tv_nsec = 10000000L; // Nanoseconds (10 millisecond)
+    task_node_t *head;
+    head                          = task_queue;
+    task_node_t *task_node_delete = NULL;
+
+    while (NULL != head)
+    {
+        // Find the oldest task by finding the smallest timestamp
+        if (timestamp > head->created && can_remove_task(head))
+        {
+            timestamp        = head->created;
+            task_node_delete = head;
+        }
+        head = head->next;
+    }
+
+    if (NULL != task_node_delete)
+    {
+        // we don't call task_update_status as the task should delete shortly
+        // after this
+        task_node_delete->status     = ACTIONS_TASK_STATUS_STOPPED;
+        task_node_delete->deleteTask = true;
+        nanosleep(&ts, NULL); // 10 millisecond delay
+        return true;
+    }
+
+    return false;
+}
+
+void remove_all_task()
+{
+    task_node_t *head;
+    head = task_queue;
+
+    while (NULL != head)
+    {
+        head->deleteTask = true;
+        head             = head->next;
+    }
+}
+
+uint8_t validate_task(cJSON *task)
+{
+    if (NULL == task)
+    {
+        return ACTIONS_TASK_INVALID;
+    }
+    otbrLogWarning("Validating task: %s", cJSON_PrintUnformatted(task));
+
+    cJSON *task_type = cJSON_GetObjectItemCaseSensitive(task, "type");
+    if (NULL == task_type || !cJSON_IsString(task_type))
+    {
+        otbrLogWarning("%s:%d task missing type field", __FILE__, __LINE__);
+        return ACTIONS_TASK_INVALID;
+    }
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+    if (NULL == attributes || !cJSON_IsObject(attributes))
+    {
+        otbrLogWarning("%s:%d task missing attributes field", __FILE__, __LINE__);
+        return ACTIONS_TASK_INVALID;
+    }
+
+    rest_actions_task_t task_type_id = ACTIONS_TASKS_SIZE;
+    if (task_type_id_from_name(task_type->valuestring, &task_type_id))
+    {
+        if (task_type_id >= ACTIONS_TASKS_SIZE || NULL == handlers[task_type_id].validate)
+        {
+            otbrLogWarning("Could not find a validate handler for %d", task_type_id);
+            return ACTIONS_TASK_INVALID;
+        }
+        // validate task specific attributes
+        return handlers[task_type_id].validate(attributes);
+    }
+
+    return ACTIONS_TASK_INVALID;
+}
+
+bool queue_task(cJSON *task, uuid_t *task_id)
+{
+    otbrLogWarning("Queueing task: %s", cJSON_PrintUnformatted(task));
+    if (TASK_QUEUE_MAX <= task_queue_len)
+    {
+        if (!remove_oldest_non_running_task())
+        {
+            // Note: This case should not be possible as we already check to see if we exceed queue max before getting
+            // to this queue fcn
+            // otLogWarnPlat(
+            //    "Maximum number of tasks hit, and no completed task available for removal, not queueing task");
+            otbrLogWarning("%s:%d - %s - %s", __FILE__, __LINE__, __func__,
+                           "Maximum number of tasks hit, not queueing task.");
+            return false;
+        }
+    }
+    // Generate the task object, and copy the ID to the output
+    task_node_t *task_node = task_node_new(task);
+    memcpy(task_id, &(task_node->id), sizeof(uuid_t));
+
+    if (NULL == task_queue)
+    {
+        task_queue     = task_node;
+        task_queue_len = 1;
+    }
+    else
+    {
+        task_node_t *head = task_queue;
+        while (NULL != head->next)
+        {
+            head = head->next;
+        }
+        head->next      = task_node;
+        task_node->prev = head;
+        task_queue_len++;
+    }
+    return true;
+}
+
+void process_task(task_node_t *task_node, otInstance *aInstance, task_doneCallback aDoneCallback)
+{
+    task_handlers_t           *handlers;
+    rest_actions_task_result_t processed;
+
+    VerifyOrExit(NULL != task_node);
+    VerifyOrExit(ACTIONS_TASK_STATUS_PENDING == task_node->status);
+
+    handlers = task_handler_by_task_type_id(task_node->type);
+
+    VerifyOrExit((NULL != handlers) && (NULL != handlers->process));
+
+    processed = handlers->process(task_node, aInstance, aDoneCallback);
+
+    switch (processed)
+    {
+    case ACTIONS_RESULT_FAILURE:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_FAILED);
+        break;
+    case ACTIONS_RESULT_RETRY:
+        // fall through
+    case ACTIONS_RESULT_NO_CHANGE_REQUIRED:
+        break;
+    case ACTIONS_RESULT_PENDING:
+        // fall through
+    case ACTIONS_RESULT_SUCCESS:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_ACTIVE);
+        break;
+    case ACTIONS_RESULT_STOPPED:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_STOPPED);
+        break;
+    }
+
+exit:
+    // otLogWarnPlat("nullptr error");
+    return;
+}
+
+void evaluate_task(task_node_t *task_node)
+{
+    task_handlers_t           *handlers;
+    rest_actions_task_result_t result;
+
+    VerifyOrExit(NULL != task_node);
+
+    VerifyOrExit(ACTIONS_TASK_STATUS_ACTIVE == task_node->status);
+
+    handlers = task_handler_by_task_type_id(task_node->type);
+    VerifyOrExit((NULL != handlers) && (NULL != handlers->process));
+
+    result = handlers->evaluate(task_node);
+
+    switch (result)
+    {
+    case ACTIONS_RESULT_FAILURE:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_FAILED);
+        break;
+    case ACTIONS_RESULT_SUCCESS:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_COMPLETED);
+        break;
+    case ACTIONS_RESULT_STOPPED:
+        task_update_status(task_node, ACTIONS_TASK_STATUS_STOPPED);
+        break;
+    default:
+        // do nothing, wait for next evaluation
+        break;
+    }
+
+    task_node->last_evaluated = (int)time(NULL);
+
+exit:
+    return;
+}
+
+cJSON *jsonCreateTaskMetaCollection(uint32_t aOffset, uint32_t aLimit, uint32_t aTotal)
+{
+    cJSON *meta            = cJSON_CreateObject();
+    cJSON *meta_collection = cJSON_CreateObject();
+    // Abort if we are unable to create the necessary JSON objects
+    if (NULL == meta || NULL == meta_collection)
+    {
+        return NULL;
+    }
+
+    (void)cJSON_AddNumberToObject(meta_collection, "offset", aOffset);
+    if (aLimit > 0)
+    {
+        (void)cJSON_AddNumberToObject(meta_collection, "limit", aLimit);
+    }
+    (void)cJSON_AddNumberToObject(meta_collection, "total", aTotal);
+    // add the count of unfinished actions
+    cJSON_AddItemToObject(meta_collection, "pending", cJSON_CreateNumber(task_queue_len - can_remove_task_max()));
+    (void)cJSON_AddItemToObject(meta, "collection", meta_collection);
+    return meta;
+}
+
+/**
+ * @brief The main function that iterates through the task_queue and process each task
+ *        High level processing steps:
+ *
+ *        1. Delete any tasks that are marked for deletion
+ *        2. Process any PENDING or ACTIVE tasks
+ *           3.1 If task is timed out, the task is marked STOPPED (and deleted)
+ *           3.2 If task is PENDING, call its process() function to make it ACTIVE
+ *           3.3 If task is ACTIVE, call its evaluate() function to see if it is PENDING|SUCCESS|FAILED
+ *
+ */
+void rest_task_queue_handle(void)
+{
+    task_node_t *head = task_queue;
+    /*
+        struct timespec ts;
+        ts.tv_sec  = 0;        // Seconds
+        ts.tv_nsec = 1000000L; // Nanoseconds (1 millisecond)
+    */
+
+    while (1)
+    {
+        if (NULL == head)
+        {
+            // Hit end of queue
+            break;
+        }
+
+        // Is this task marked for deletion?
+        if (head->deleteTask)
+        {
+            task_handlers_t *handlers = task_handler_by_task_type_id(head->type);
+            if (NULL == handlers || NULL == handlers->clean)
+            {
+                otbrLogWarning("Could not find a clean handler for %d, assuming no clean needed", head->type);
+            }
+            else
+            {
+                // calls the clean function defined in handlers[]
+                handlers->clean(head, mInstance);
+            }
+
+            if (ACTIONS_TASK_STATUS_STOPPED != head->status)
+            {
+                // we don't call task_update_status as we're going to be
+                // deleting this a few lines below.
+                head->status = ACTIONS_TASK_STATUS_STOPPED;
+            }
+
+            task_node_t *next = head->next;
+            if (NULL == head->prev)
+            {
+                // If prev is empty, then we are the start of the list
+                task_queue = next;
+                if (NULL != next)
+                {
+                    next->prev = NULL;
+                }
+            }
+            else
+            {
+                head->prev->next = next;
+                if (NULL != next)
+                {
+                    next->prev = head->prev;
+                }
+            }
+            {
+                // Delete the cJSON task as well as the task_node
+                otbrLogInfo("Deleting task id %s", head->id_str);
+                cJSON_Delete(head->task);
+                head->task = NULL;
+                free(head);
+                if (task_queue_len > 0)
+                {
+                    task_queue_len--;
+                }
+            }
+
+            head = next;
+            continue;
+        }
+
+        // Is this task PENDING or ACTIVE?
+        if (ACTIONS_TASK_STATUS_PENDING == head->status || ACTIONS_TASK_STATUS_ACTIVE == head->status)
+        {
+            // Check if task has timed out if so we need to clean it and  mark it as stopped
+            // We do not delete the task because the GET handler want to keep tabs on what is happening to the tasks.
+            int current_time = (int)time(NULL);
+            if (head->timeout >= 0 && head->timeout < current_time)
+            {
+                /* Mark tasks that have timed-out without failing/being completed as "Stopped" and stop evaluating */
+                otbrLogWarning("%s:%d - %s - task timed out %s.", __FILE__, __LINE__, __func__,
+                               cJSON_PrintUnformatted(head->task));
+                task_handlers_t *handlers = task_handler_by_task_type_id(head->type);
+                if (NULL == handlers || NULL == handlers->clean)
+                {
+                    otbrLogWarning("Could not find a clean handler for %d, assuming no clean needed", head->type);
+                }
+                else
+                {
+                    handlers->clean(head, mInstance);
+                }
+
+                task_update_status(head, ACTIONS_TASK_STATUS_STOPPED);
+            }
+            // If task has not timed out, carry on with its processing
+            else
+            {
+                // If ACTIONS_TASK_STATUS_PENDING, run its process() function to see if we can make it active
+                if (ACTIONS_TASK_STATUS_PENDING == head->status)
+                {
+                    process_task(head, mInstance, rest_task_queue_handle);
+                }
+                // Else If ACTIONS_TASK_STATUS_ACTIVE, run its evaluate, to see if it is completed/failed
+                else if (ACTIONS_TASK_STATUS_ACTIVE == head->status)
+                {
+                    evaluate_task(head);
+                }
+            }
+        }
+        // Get ready to process the next task in the queue
+        head = head->next;
+    }
+    // otbrLogWarning("EXITING rest_task_queue_task");
+    // pthread_exit(NULL);
+
+    // return NULL;
+}
+
+void rest_task_queue_task_init(otInstance *aInstance)
+{
+    mInstance = aInstance;
+
+    // As noted above, the handler list needs to have an entry for each
+    // task type defined in `rest_actions_task_t
+    assert(ARRAY_SIZE(handlers) > 0);
+    assert(ARRAY_SIZE(handlers) == ACTIONS_TASKS_SIZE);
+
+    // To optimize during runtime, we want to ensure that the list is ordered
+    // and contains each of the entries. This allows us to just index in via
+    // the task type id rather than having to iterate.
+    //
+    // This check iterates over the list an ensures that each entry has a
+    // type_id which is exactly 1 greater than the previous entry.
+    rest_actions_task_t previous_id = handlers[0].type_id;
+    for (size_t idx = 1; idx < ARRAY_SIZE(handlers); idx++)
+    {
+        assert(previous_id + 1 == handlers[idx].type_id);
+        previous_id = handlers[idx].type_id;
+    }
+}
+
+bool task_type_id_from_name(const char *task_name, rest_actions_task_t *type_id)
+{
+    if (NULL == task_name || NULL == type_id)
+    {
+        return false;
+    }
+
+    for (size_t idx = 0; idx < ACTIONS_TASKS_SIZE; idx++)
+    {
+        size_t name_length = strlen(*handlers[idx].type_name);
+        if (0 == strncmp(task_name, *handlers[idx].type_name, name_length))
+        {
+            *type_id = handlers[idx].type_id;
+            return true;
+        }
+    }
+    return false;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/rest/extensions/rest_task_queue.hpp
+++ b/src/rest/extensions/rest_task_queue.hpp
@@ -1,0 +1,244 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief   Implements APIs related to thread creation and task handling.
+ *
+ */
+#ifndef REST_TASK_QUEUE_HPP_
+#define REST_TASK_QUEUE_HPP_
+
+#include "rest_server_common.hpp"
+#include "rest_task_handler.hpp"
+//#include "rest/extensions/pthread_lock.hpp"
+#include "utils/thread_helper.hpp"
+
+struct cJSON;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TASK_QUEUE_MAX 100
+
+typedef void (*task_doneCallback)(void);
+
+/**
+ * @brief Specifies the function signature that the task jsonifier function
+ *        must adhere to.
+ *
+ * A task jsonifier is responsible for taking a `task_node_t` pointer
+ * and creating a JSON representation which can be returned to a
+ * client.
+ *
+ * @param task_node the node which is to be jsonified
+ * @return a cJSON pointer representing the task node.
+ */
+typedef cJSON *(*task_jsonifier)(task_node_t *task_node);
+
+/**
+ * @brief Specifies the function signature that the task validator function
+ *        must adhere to.
+ *
+ * A task validator is responsible for taking the input cJSON from a user and
+ * ensuring all the various fields and structures meet the requirements set out
+ * in the API schema.
+ *
+ * See the `validate_task` function below for more info.
+ *
+ * @param task the JSON structure to return
+ * @return the value must be one of ACTIONS_TASK_VALID ACTIONS_TASK_INVALID, or
+ *         ACTIONS_TASK_NOT_IMPLEMENTED.
+ */
+typedef uint8_t (*task_validator)(cJSON *task);
+
+/**
+ * @brief Specifies the function signature that the task processor function
+ *        must adhere to.
+ *
+ * A task processor is responsible for starting the execution of a task. Once
+ * the execution has started, the evaluation function is called regularly for
+ * updates.
+ *
+ * @param task the task which is to be executed.
+ * @param aInstance openthread instance
+ * @param aDoneCallback is called when process has completed.
+ * @return the status of the task, which should ACTIONS_RESULT_SUCCESS,
+ *         ACTIONS_RESULT_FAILURE, ACTIONS_RESULT_RETRY, or
+ *         ACTIONS_RESULT_PENDING.
+ */
+typedef rest_actions_task_result_t (*task_processor)(task_node_t      *task_node,
+                                                     otInstance       *aInstance,
+                                                     task_doneCallback aDoneCallback);
+
+/**
+ * @brief Specifies the function signature that the task processor function
+ *        must adhere to.
+ *
+ * A task evaluator is responsible for continued execution and processing of
+ * a task. This is responsible for monitoring the execution of a task and
+ * reporting when the execution has finished (either successfully or in
+ * failure).
+ *
+ * @param task the task which is being evaluated.
+ * @return the status of the task, which should be ACTIONS_RESULT_SUCCESS,
+ *         ACTIONS_RESULT_FAILURE, ACTIONS_RESULT_PENDING, or
+ *         ACTIONS_RESULT_NO_CHANGE_REQUIRED.
+ */
+typedef rest_actions_task_result_t (*task_evaluator)(task_node_t *task_node);
+
+/**
+ * @brief Specifies the function signature that the task processor function
+ *        must adhere to.
+ *
+ * A task cleaner is responsible for releasing any resources that the task
+ * is holding so that it can be removed from the queue.
+ *
+ * @param task the task which is being cleaned
+ * @param aInstance openthread instance
+ * @return the status of the cleaning operation, which should be
+ *         ACTIONS_RESULT_SUCCESS or ACTIONS_RESULT_FAILURE.
+ */
+typedef rest_actions_task_result_t (*task_cleaner)(task_node_t *task_node, otInstance *aInstance);
+
+/**
+ * @brief Validate the REST POST Action Task with the given JSON array
+ *
+ * @param task Pointer to cJSON task to be validated
+ * @return ACTIONS_TASK_VALID if the task is valid,
+ *         ACTIONS_TASK_INVALID if the task is invalid,
+ *         ACTIONS_TASK_NOT_IMPLEMENTED if the task has not been implemented
+ */
+uint8_t validate_task(cJSON *task);
+
+/**
+ * @brief Generates the new task object (task_node) of type 'task_node_t'.
+ *        Initializes task_queue with the newly created task object which will
+ *        be proccessed on different thread.
+ *
+ * @param task A pointer to JSON array item.
+ * @param uuid_t *task_id A reference to get the task_id
+ * @return true     Task queued
+ *  @return false    Not able to queue task
+ */
+bool         queue_task(cJSON *task, uuid_t *task_id);
+cJSON       *task_to_json(task_node_t *task_node);
+task_node_t *task_node_find_by_id(uuid_t uuid);
+
+/**
+ * @brief When called, I generate a CJSON object for the task metadata
+ * as specified in the openapi.yaml
+ *
+ * sample output:
+ *
+ * meta:
+ *    collection:
+ *        offset: 0 // based on the args passed to this function
+ *        limit:  4 // based on the args passed to this function
+ *        total:  4 // determined by the total number of tasks in the queue
+ *
+ * @param aOffset the value to use for meta.collection.offset
+ * @param aLimit  the value to use for meta.collection.limit
+ * @param aTotal  the value to use for meta.collection.total
+ *
+ * @return cJSON* a populated meta.collection json object, NULL on error
+ */
+cJSON *jsonCreateTaskMetaCollection(uint32_t aOffset, uint32_t aLimit, uint32_t aTotal);
+
+/**
+ * @brief Number of tasks that have finished processing.
+ *
+ * @return uint8_t   Count of inactive tasks, that are 'completed', 'stopped' or 'failed'.
+ */
+uint8_t can_remove_task_max();
+
+void remove_all_task();
+
+void rest_task_queue_task_init(otInstance *aInstance);
+
+/**
+ * @brief Iterates through list of tasks for processing and evaluation
+ *
+ */
+void rest_task_queue_handle(void);
+
+void evaluate_task(task_node_t *task_node);
+void process_task(task_node_t *task_node, otInstance *aInstance, task_doneCallback aDoneCallback);
+
+/**
+ * @brief Looks up the type id for a given task name and updates the `type_id`
+ *        argument if found.
+ *
+ * @param task_name the task name to look up the id for
+ * @param type_id [out] a pointer to place the result into
+ * @return true if found, false otherwise.
+ */
+bool task_type_id_from_name(const char *task_name, rest_actions_task_t *type_id);
+
+/**
+ * @brief Create the semaphore used to protect a task node against being accessed simultaneously
+ *        by different tasks.
+ *        Must be called before locks are used.
+ *
+ * @return 0:         Success
+ *         non-zero:  Failed
+ *
+ */
+uint8_t taskNodeLockInit(void);
+
+/**
+ * @brief Delete and nullify a task node lock
+ */
+uint8_t taskNodeLockDeinit(void);
+
+/**
+ * @brief Acquire lock before proceeding to access/modify a task node
+ *        Must be used whenever task_node_t* aNode is used
+ *
+ * @param[in] LockType lock_type Select the lock type [blocking,non-blocking,timed]
+ * @param[in] long timeout_sec   timeout value in ms
+ *
+ * @return 0:         Success
+ *         non-zero:  Failed
+ *
+ */
+uint8_t taskNodeLockAcquire(LockType lock_type, long timeout_ms);
+
+/**
+ * @brief Release lock and make available so that other tasks can use the task node
+ *
+ * @return 0:         Success
+ *        non-zero:  Failed
+ */
+uint8_t taskNodeLockRelease(void);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif

--- a/src/rest/extensions/timestamp.cpp
+++ b/src/rest/extensions/timestamp.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "timestamp.hpp"
+
+#include <chrono>
+#include <ctime>
+//#include <iomanip>
+//#include <sstream>
+#include <cstring>
+
+using namespace std;
+using namespace std::chrono;
+
+std::string now_rfc3339()
+{
+    return toRfc3339(system_clock::now());
+}
+
+/*
+// create UTC timestamp
+std::string toRfc3339Utc(system_clock::time_point timepoint)
+{
+    const auto now_ms = time_point_cast<milliseconds>(timepoint);
+    const auto now_s = time_point_cast<seconds>(now_ms);
+    const auto millis = now_ms - now_s;
+    const auto c_now = system_clock::to_time_t(now_s);
+
+    std::stringstream ss;
+    ss << put_time(gmtime(&c_now), "%FT%T")
+       << '.' << setfill('0') << setw(3) << millis.count() << 'Z';
+    return ss.str();
+}
+*/
+
+std::string toRfc3339(system_clock::time_point timepoint)
+{
+    char        updated_str[26] = {'\0'};
+    std::time_t time_since_epoch;
+    std::time_t utc_offset;
+    char        offset_str[6] = {'\0'};
+    char        sign[2]       = {'\0'};
+
+    time_since_epoch = std::chrono::system_clock::to_time_t(timepoint);
+    utc_offset =
+        std::difftime(std::mktime(std::localtime(&time_since_epoch)), std::mktime(std::gmtime(&time_since_epoch)));
+
+    std::strftime(offset_str, sizeof(offset_str), "%H:%M", std::localtime(&utc_offset));
+    strftime(updated_str, sizeof(updated_str), "%Y-%m-%dT%H:%M:%S", std::localtime(&time_since_epoch));
+
+    sign[0] = utc_offset < 0 ? '-' : '+';
+    sign[1] = '\0';
+
+    strcat(updated_str, sign);
+    strcat(updated_str, offset_str);
+
+    return std::string(updated_str);
+}

--- a/src/rest/extensions/timestamp.hpp
+++ b/src/rest/extensions/timestamp.hpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <chrono>
+#include <string>
+
+std::string now_rfc3339();
+
+// std::string toRfc3339Utc(std::chrono::system_clock::time_point timepoint);
+
+std::string toRfc3339(std::chrono::system_clock::time_point timepoint);

--- a/src/rest/extensions/uuid.cpp
+++ b/src/rest/extensions/uuid.cpp
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "uuid.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <sstream>
+
+UUID::UUID()
+{
+    std::memset(&uuid, 0, sizeof(uuid));
+}
+
+void UUID::generateRandom()
+{
+    std::random_device              rd;           // Seed for random number engine
+    std::mt19937                    gen(rd());    // Mersenne Twister RNG
+    std::uniform_int_distribution<> dist(0, 255); // Byte range: 0 to 255
+
+    for (size_t i = 0; i < UUID_LEN; ++i)
+    {
+        uuid.buf[i] = static_cast<unsigned char>(dist(gen));
+    }
+
+    // Mark off appropriate bits as per RFC4122 sction 4.4
+    uuid.clock_seq_hi_and_reserved = (uuid.clock_seq_hi_and_reserved & 0x3F) | 0x80;
+    uuid.time_hi_and_version       = (uuid.time_hi_and_version & 0x0FFF) | 0x4000;
+}
+
+std::string UUID::toString() const
+{
+    char out[UUID_STR_LEN];
+    std::snprintf(out, UUID_STR_LEN, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x", uuid.time_low, uuid.time_mid,
+                  uuid.time_hi_and_version, uuid.clock_seq_hi_and_reserved, uuid.clock_seq_low, uuid.node[0],
+                  uuid.node[1], uuid.node[2], uuid.node[3], uuid.node[4], uuid.node[5]);
+    return std::string(out);
+}
+
+void UUID::getUuid(uuid_t &aId) const
+{
+    std::memcpy(aId.buf, uuid.buf, sizeof(aId.buf));
+}
+
+void UUID::setUuid(uuid_t &aId)
+{
+    std::memcpy(aId.buf, uuid.buf, sizeof(uuid.buf));
+}
+
+bool UUID::parse(const std::string &str)
+{
+    if (str.length() != UUID_STR_LEN - 1)
+    {
+        return false;
+    }
+
+    int temp[11] = {0};
+    int r = std::sscanf(str.c_str(), "%8x-%4x-%4x-%2x%2x-%2x%2x%2x%2x%2x%2x", &temp[0], &temp[1], &temp[2], &temp[3],
+                        &temp[4], &temp[5], &temp[6], &temp[7], &temp[8], &temp[9], &temp[10]);
+
+    if (r != 11)
+    {
+        return false;
+    }
+
+    uuid.time_low                  = temp[0];
+    uuid.time_mid                  = temp[1];
+    uuid.time_hi_and_version       = temp[2];
+    uuid.clock_seq_hi_and_reserved = temp[3];
+    uuid.clock_seq_low             = temp[4];
+    for (int i = 0; i < 6; i++)
+    {
+        uuid.node[i] = temp[5 + i];
+    }
+    return true;
+}
+
+bool UUID::equals(const UUID &other) const
+{
+    return uuid.time_low == other.uuid.time_low && uuid.time_mid == other.uuid.time_mid &&
+           uuid.time_hi_and_version == other.uuid.time_hi_and_version &&
+           uuid.clock_seq_hi_and_reserved == other.uuid.clock_seq_hi_and_reserved &&
+           uuid.clock_seq_low == other.uuid.clock_seq_low &&
+           std::memcmp(uuid.node, other.uuid.node, sizeof(uuid.node)) == 0;
+}
+
+int uuid_equals(uuid_t uuid1, uuid_t uuid2)
+{
+    return uuid1.time_low == uuid2.time_low && uuid1.time_mid == uuid2.time_mid &&
+           uuid1.time_hi_and_version == uuid2.time_hi_and_version &&
+           uuid1.clock_seq_hi_and_reserved == uuid2.clock_seq_hi_and_reserved &&
+           uuid1.clock_seq_low == uuid2.clock_seq_low && uuid1.node[0] == uuid2.node[0] &&
+           uuid1.node[1] == uuid2.node[1] && uuid1.node[2] == uuid2.node[2] && uuid1.node[3] == uuid2.node[3] &&
+           uuid1.node[4] == uuid2.node[4] && uuid1.node[5] == uuid2.node[5];
+}

--- a/src/rest/extensions/uuid.hpp
+++ b/src/rest/extensions/uuid.hpp
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef UUID_HPP
+#define UUID_HPP
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+const int UUID_LEN     = 16;
+const int UUID_STR_LEN = 37;
+
+typedef union uuid_t
+{
+    struct
+    {
+        uint32_t time_low;
+        uint16_t time_mid;
+        uint16_t time_hi_and_version;
+        uint8_t  clock_seq_hi_and_reserved;
+        uint8_t  clock_seq_low;
+        uint8_t  node[6];
+    };
+    uint8_t buf[UUID_LEN];
+
+} uuid_t;
+
+class UUID
+{
+    // uint8_t buf[UUID_LEN];
+
+public:
+    UUID();
+    void        generateRandom();
+    std::string toString() const;
+    bool        parse(const std::string &str);
+    bool        equals(const UUID &other) const;
+
+    // retrieve the internal uuid data for backwards compatibility
+    void getUuid(uuid_t &aId) const;
+
+    // set the internal uuid data for backwards compatibility
+    void setUuid(uuid_t &aId);
+
+    // copy constructor
+    UUID(const UUID &other) { std::memcpy(&uuid, &other.uuid, sizeof(UUIDData)); }
+
+    bool operator<(const UUID &other) const { return std::memcmp(uuid.buf, other.uuid.buf, UUID_LEN) < 0; }
+
+    bool operator==(const UUID &other) const { return equals(other); }
+
+    // assigment operator
+    UUID &operator=(const UUID &other)
+    {
+        if (this != &other)
+        {
+            std::memcpy(&uuid, &other.uuid, sizeof(UUIDData));
+        }
+        return *this;
+    }
+
+private:
+    union UUIDData
+    {
+        struct
+        {
+            uint32_t time_low;
+            uint16_t time_mid;
+            uint16_t time_hi_and_version;
+            uint8_t  clock_seq_hi_and_reserved;
+            uint8_t  clock_seq_low;
+            uint8_t  node[6];
+        };
+        uint8_t buf[UUID_LEN];
+    } uuid;
+};
+
+/**
+ * @fn    uuid_equals
+ *
+ * @brief Check if the two provided UUIDs are equal.
+ *
+ * @param uuid1
+ * @param uuid2
+ * @return
+ */
+int uuid_equals(uuid_t uuid1, uuid_t uuid2);
+
+#endif // UUID_HPP

--- a/src/rest/network_diag_handler.cpp
+++ b/src/rest/network_diag_handler.cpp
@@ -1,0 +1,1584 @@
+#include "rest/network_diag_handler.hpp"
+
+#include "openthread/mesh_diag.h"
+#include "openthread/platform/toolchain.h"
+#include "rest/json.hpp"
+#include "rest/types.hpp"
+
+#include <cstring>
+#include <set>
+#include <openthread/srp_server.h>
+#include "common/logging.hpp"
+#include "common/task_runner.hpp"
+#include "rest/extensions/rest_task_network_diagnostic.hpp"
+#include "rest/resource.hpp"
+#include "utils/string_utils.hpp"
+
+extern "C" {
+#include <cJSON.h>
+extern task_node_t *task_queue;
+extern uint8_t      task_queue_len;
+}
+
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::steady_clock;
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+namespace otbr {
+namespace rest {
+
+// MaxAge (in Milliseconds) for accepting previously collected diagnostics
+static const uint32_t kDiagMaxAge            = 30000;
+static const uint32_t kDiagMaxAge_UpperLimit = 10 * kDiagMaxAge;
+
+// Timeout (in Milliseconds) for collecting diagnostics, default if not given in actionTask
+static const uint32_t kDiagCollectTimeout            = 10000;
+static const uint32_t kDiagCollectTimeout_UpperLimit = 10 * kDiagCollectTimeout;
+
+static const uint32_t kDiagMaxRetries = 3;
+
+// Retry delay (in Milliseconds) for retry DiagRequest to FTDs
+static const uint32_t kDiagRetryDelayFTD = 100;
+
+// Default TlvTypes for Diagnostic information
+static const std::unordered_map<std::string, uint8_t> kTlvTypeMap = {
+    {KEY_EXTADDRESS, 0},          ///< MAC Extended Address TLV
+    {KEY_RLOC16, 1},              ///< Address16 TLV
+    {KEY_MODE, 2},                ///< Mode TLV
+    {KEY_TIMEOUT, 3},             ///< Timeout TLV (max polling time period for SEDs)
+    {KEY_CONNECTIVITY, 4},        ///< Connectivity TLV
+    {KEY_ROUTE, 5},               ///< Route64 TLV
+    {KEY_LEADERDATA, 6},          ///< Leader Data TLV
+    {KEY_NETWORKDATA, 7},         ///< Network Data TLV
+    {KEY_IP6ADDRESSLIST, 8},      ///< IPv6 Address List TLV
+    {KEY_MACCOUNTERS, 9},         ///< MAC Counters TLV
+    {KEY_BATTERYLEVEL, 14},       ///< Battery Level TLV
+    {KEY_SUPPLYVOLTAGE, 15},      ///< Supply Voltage TLV
+    {KEY_CHILDTABLE, 16},         ///< Child Table TLV
+    {KEY_CHANNELPAGES, 17},       ///< Channel Pages TLV
+    {KEY_MAXCHILDTIMEOUT, 19},    ///< Max Child Timeout TLV
+    {KEY_LDEVID, 20},             ///< LDevID subject public key info TLV
+    {KEY_IDEV, 21},               ///< IDevID Certificate TLV
+    {KEY_EUI64, 23},              ///< EUI64 TLV
+    {KEY_VERSION, 24},            ///< Thread Version TLV
+    {KEY_VENDORNAME, 25},         ///< Vendor Name TLV
+    {KEY_VENDORMODEL, 26},        ///< Vendor Model TLV
+    {KEY_VENDORSWVERSION, 27},    ///< Vendor SW Version TLV
+    {KEY_THREADSTACKVERSION, 28}, ///< Thread Stack Version TLV (codebase/commit version)
+    {KEY_CHILDREN, 29},           ///< Child TLV
+    {KEY_CHILDRENIP6, 30},        ///< Child IPv6 Address List TLV
+    {KEY_NEIGHBORS, 31},          ///< Router Neighbor TLV
+    {KEY_MLECOUNTERS, 34}         ///< MLE Counters TLV
+};
+
+// check all fields of DeviceInfo are set
+bool isDeviceComplete(DeviceInfo &aDeviceInfo);
+
+// check aExtAddr has a plausible value
+bool isOtExtAddrEmpty(otExtAddress aExtAddr);
+
+// check aAddr has a plausible value
+bool isOtIp6AddrEmpty(otIp6Address aIpv6Addr);
+
+// extract the OMR Ipv6 address and the MlEidIid from ipv6Addr
+void filterIpv6(DeviceInfo &aDeviceInfo, const otIp6Address &aIpv6Addr, const otIp6NetworkPrefix *aMlPrefix);
+
+bool isOtExtAddrEmpty(otExtAddress aExtAddr)
+{
+    for (int i = 0; i < OT_EXT_ADDRESS_SIZE; i++)
+    {
+        if (aExtAddr.m8[i] != 0)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool isOtIp6AddrEmpty(otIp6Address aIpv6Addr)
+{
+    for (int i = 0; i < OT_IP6_ADDRESS_SIZE; ++i)
+    {
+        if (aIpv6Addr.mFields.m8[i] != 0)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool isDeviceComplete(DeviceInfo &aDeviceInfo)
+{
+    VerifyOrExit(aDeviceInfo.mRole != "");
+    // VerifyOrExit(device.mHostName != "");
+
+    VerifyOrExit(!isOtExtAddrEmpty(aDeviceInfo.mMlEidIid));
+    VerifyOrExit(!isOtExtAddrEmpty(aDeviceInfo.mEui64));
+    VerifyOrExit(!isOtIp6AddrEmpty(aDeviceInfo.mIp6Addr));
+
+    return true;
+
+exit:
+    return false;
+}
+
+void filterIpv6(DeviceInfo &aDeviceInfo, const otIp6Address &aIpv6Addr, const otIp6NetworkPrefix *aMlPrefix)
+{
+    otIp6NetworkPrefix DeviceIPPrefix;
+
+    // rloc and aloc prefix == 0000:00FF:FE00 -> 0000:FF00:00FE == "0:65280:254"
+    if (aIpv6Addr.mFields.m16[4] == 0 && aIpv6Addr.mFields.m16[5] == 65280 && aIpv6Addr.mFields.m16[6] == 254)
+    {
+        return;
+    }
+
+    DeviceIPPrefix = aIpv6Addr.mFields.mComponents.mNetworkPrefix;
+    if (std::equal(std::begin(aMlPrefix->m8), std::end(aMlPrefix->m8), std::begin(DeviceIPPrefix.m8)))
+    {
+        for (uint16_t i = 8; i < 16; ++i)
+        {
+            aDeviceInfo.mMlEidIid.m8[i - 8] = aIpv6Addr.mFields.m8[i];
+        }
+    }
+
+    // link local prefix == fe80 -> 00fe == 33022, Off-Mesh-Routable Multicast prefix ff00 == 65280 and ff0f == 65295
+    else if (aIpv6Addr.mFields.m16[0] != 33022 &&
+             (htons(aIpv6Addr.mFields.m16[0]) < 65280 || htons(aIpv6Addr.mFields.m16[0]) > 65295))
+    {
+        aDeviceInfo.mIp6Addr = aIpv6Addr;
+    }
+}
+
+void NetworkDiagHandler::clear(void)
+{
+    mDiagSet.clear();
+    mChildTables.clear();
+    mChildIps.clear();
+    mRouterNeighbors.clear();
+}
+
+otbrError NetworkDiagHandler::cancelRequest(void)
+{
+    mRequestState          = RequestState::kIdle;
+    mDiagQueryRequestState = RequestState::kIdle;
+    mCallback              = nullptr;
+    return OTBR_ERROR_NONE;
+};
+
+otbrError NetworkDiagHandler::configRequest(uint32_t          aTimeout,
+                                            uint32_t          aMaxAge,
+                                            uint8_t           aRetryCount,
+                                            task_doneCallback aCallback)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    if (mRequestState == RequestState::kIdle)
+    {
+        mTimeout = steady_clock::now() +
+                   milliseconds(std::min(std::max(kDiagCollectTimeout, aTimeout), kDiagCollectTimeout_UpperLimit));
+        mMaxAge = steady_clock::now() - milliseconds(std::min(std::max(kDiagMaxAge, aMaxAge), kDiagMaxAge_UpperLimit));
+
+        mMaxRetries = aRetryCount;
+        mCallback   = aCallback;
+    }
+    else
+    {
+        error = OTBR_ERROR_INVALID_STATE;
+    }
+    return error;
+}
+
+// minimal TLVs required to fill device collection
+// call if no TLV types are given in the action task
+void NetworkDiagHandler::SetDefaultTlvs(void)
+{
+    // pre-defined DiagRequest TLVs
+    mDiagReqTlvs[0] = OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS;
+    mDiagReqTlvs[1] = OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS;
+    mDiagReqTlvs[2] = OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST;
+    // mDiagReqTlvs[3] = OT_NETWORK_DIAGNOSTIC_TLV_VERSION;
+    mDiagReqTlvsCount = 3;
+
+    // pre-defined DiagQuery TLVs
+    mDiagQueryTlvs.clear();
+    mDiagQueryTlvs.emplace_back(OT_NETWORK_DIAGNOSTIC_TLV_CHILD);
+    mDiagQueryTlvs.emplace_back(OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST);
+}
+
+otbrError NetworkDiagHandler::LookupDestinationAddr(std::string aDestination, otIp6Address *aIp6address)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    otbr::rest::ThreadDevice *deviceItem;
+    const otMeshLocalPrefix  *prefix;
+    otIp6InterfaceIdentifier  mlEidIid;
+    uint16_t                  rloc                               = 0xfffe;
+    char                      buffer[OT_IP6_ADDRESS_STRING_SIZE] = {'\0'};
+
+    // check if destination is a known deviceId
+    // and if this deviceItem has already a learned mleidiid attribute
+    deviceItem = dynamic_cast<otbr::rest::ThreadDevice *>(otbr::rest::gDevicesCollection.getItem(aDestination));
+    if (deviceItem != nullptr)
+    {
+        memcpy(mlEidIid.mFields.m8, deviceItem->mDeviceInfo.mMlEidIid.m8, OT_EXT_ADDRESS_SIZE);
+        // construct full ip6address of destination
+        prefix = otThreadGetMeshLocalPrefix(mInstance);
+        combineMeshLocalPrefixAndIID(prefix, &mlEidIid, aIp6address);
+
+        if (isOtExtAddrEmpty(deviceItem->mDeviceInfo.mMlEidIid))
+        {
+            error = OTBR_ERROR_PARSE;
+        }
+    }
+    else if (aDestination.size() == 16)
+    {
+        // come here, when ML-Eid-Iid had not been learned
+        // assume destination is ML-Eid-IID
+        // TODO: check mleidiid is valid.
+        str_to_m8(mlEidIid.mFields.m8, aDestination.c_str(), OT_EXT_ADDRESS_SIZE);
+        // construct full ip6address of destination
+        prefix = otThreadGetMeshLocalPrefix(mInstance);
+        combineMeshLocalPrefixAndIID(prefix, &mlEidIid, aIp6address);
+    }
+    else if (aDestination.size() == 6)
+    {
+        // come here, when ML-Eid-Iid had not been learned
+        // assume destination is rloc16, eg. 0x0800
+        sscanf(aDestination.c_str(), "%hx", &rloc);
+        memcpy(aIp6address, otThreadGetRloc(mInstance), sizeof(otIp6Address));
+        aIp6address->mFields.m16[7] = htons(rloc);
+    }
+    else
+    {
+        error = OTBR_ERROR_PARSE;
+    }
+
+    otIp6AddressToString(aIp6address, buffer, OT_IP6_ADDRESS_STRING_SIZE);
+    otbrLogWarning("%s:%d - %s - destination %s, error: %s.", __FILE__, __LINE__, __func__, buffer,
+                   otbrErrorString(error));
+
+    return error;
+}
+
+otbrError NetworkDiagHandler::handleNetworkDiscoveryRequest(std::string aDestination, std::string aRelationshipType)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    if (aDestination.empty() && (aRelationshipType == gDevicesCollection.getCollectionName()) &&
+        (mRequestState == RequestState::kIdle))
+    {
+        mRequestState = RequestState::kWaiting;
+        otbrLogWarning("%s:%d - %s - changed to state %d.", __FILE__, __LINE__, __func__, mRequestState);
+
+        SetDefaultTlvs();
+
+        // run network discovery and collect pre-defined TLVs
+        error             = startDiscovery();
+        mRelationshipType = aRelationshipType;
+    }
+    else
+    {
+        error = OTBR_ERROR_INVALID_STATE;
+    }
+
+    return error;
+}
+
+otbrError NetworkDiagHandler::startDiscovery()
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    otIp6Address ip6address;
+    memcpy(&ip6address, otThreadGetRloc(mInstance), sizeof(otIp6Address));
+
+    switch (mDiagQueryRequestState)
+    {
+    case RequestState::kIdle:
+        // init or remove outdated entries
+        // learn and update router rloc16s in mDiagSet
+        ResetRouterDiag(true);
+        ResetChildDiag(mMaxAge);
+
+        // collect fresh info and send diagnostic requests to all routers
+        for (const auto &it : mDiagSet)
+        {
+            ip6address.mFields.m16[7] = htons(it.first);
+            otbrLogWarning("%s:%d - %s - send DiagReq to 0x%04x.", __FILE__, __LINE__, __func__, it.first);
+            VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &ip6address, mDiagReqTlvs, mDiagReqTlvsCount,
+                                                   NetworkDiagHandler::DiagnosticResponseHandler,
+                                                   this) == OT_ERROR_NONE,
+                         error = OTBR_ERROR_REST);
+        }
+
+        // init or remove outdated entries
+        ResetChildTables(true);
+        ResetChildIp6Addrs(true);
+        ResetRouterNeighbors(true);
+
+        // we skip waiting for DiagReq responses, as we do already have the router rloc16s
+        mDiagQueryRequestState = RequestState::kPending;
+        otbrLogWarning("%s:%d - %s - changed to DiagQuery state %d.", __FILE__, __LINE__, __func__,
+                       mDiagQueryRequestState);
+        // give time for responses comming in and continue on next callback
+    default:
+        ExitNow();
+    }
+
+exit:
+    return error;
+}
+
+otbrError NetworkDiagHandler::continueHandleRequest()
+{
+    otbrError error    = OTBR_ERROR_NONE;
+    bool      complete = true;
+    bool      timeout  = false;
+
+    // rloc16 destination
+    otIp6Address ip6address;
+    memcpy(&ip6address, otThreadGetRloc(mInstance), sizeof(otIp6Address));
+
+    VerifyOrExit(mTimeout > steady_clock::now(), timeout = true);
+
+    switch (mDiagQueryRequestState)
+    {
+    case RequestState::kIdle:
+        break;
+    case RequestState::kWaiting:
+        // in case of unknown rloc16, we need to wait for the DiagReq response first.
+        if (((mTimeLastAttempt + milliseconds(kDiagRetryDelayFTD)) < steady_clock::now()) && (mMaxRetries <= mRetries))
+        {
+            timeout = true;
+        }
+        if ((mTimeLastAttempt + milliseconds(kDiagRetryDelayFTD)) < steady_clock::now())
+        {
+            // retry
+            mRetries += 1;
+            mTimeLastAttempt = steady_clock::now();
+            otbrLogWarning("%s:%d - %s - retry send DiagReq.", __FILE__, __LINE__, __func__);
+            VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &mIp6address, mDiagReqTlvs, mDiagReqTlvsCount,
+                                                   NetworkDiagHandler::DiagnosticResponseHandler,
+                                                   this) == OT_ERROR_NONE,
+                         error = OTBR_ERROR_REST);
+        }
+        complete = false;
+        break;
+    case RequestState::kPending:
+        VerifyOrExit(HandleNextDiagQuery(), complete = false);
+        mDiagQueryRequestState = RequestState::kDone;
+        otbrLogWarning("%s:%d - %s - changed to DiagQuery state %d.", __FILE__, __LINE__, __func__,
+                       mDiagQueryRequestState);
+        OT_FALL_THROUGH;
+    case RequestState::kDone:
+        // check if we have FTD children = REEDs
+        if (mRelationshipType == gDevicesCollection.getCollectionName())
+        {
+            // we want to learn / update stable address also from REEDs
+            // and get its ML-EID-IID, OMR and hostname
+            for (auto &parent : mChildTables)
+            {
+                for (auto &child : parent.second.mChildTable)
+                {
+                    if (child.mDeviceTypeFtd && (mDiagSet.find(child.mRloc16) == mDiagSet.end()))
+                    {
+                        // prepare placeholder for expected result from REEDs
+                        otbrLogWarning("%s:%d - %s - have REED 0x%04x.", __FILE__, __LINE__, __func__, child.mRloc16);
+                        DiagInfo info           = {};
+                        mDiagSet[child.mRloc16] = info;
+                        mRetries                = 0;
+                        complete                = false;
+                    }
+                }
+            }
+        }
+
+        // check we have at least response from every node
+        // including from the eventually found rx-on-when-idle children
+        // otherwise start retries
+        if (((mTimeLastAttempt + milliseconds(kDiagRetryDelayFTD)) < steady_clock::now()) && (mMaxRetries <= mRetries))
+        {
+            timeout = true;
+        }
+        if ((mTimeLastAttempt + milliseconds(kDiagRetryDelayFTD)) < steady_clock::now())
+        {
+            // retry
+            mRetries += 1;
+            mTimeLastAttempt = steady_clock::now();
+            for (const auto &it : mDiagSet)
+            {
+                if (it.second.mDiagContent.empty()) // TODO: check all expected TLVs are present
+                {
+                    complete                  = false;
+                    ip6address.mFields.m16[7] = htons(it.first);
+                    otbrLogWarning("%s:%d - %s - retry send DiagReq to 0x%04x.", __FILE__, __LINE__, __func__,
+                                   it.first);
+                    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &ip6address, mDiagReqTlvs, mDiagReqTlvsCount,
+                                                           NetworkDiagHandler::DiagnosticResponseHandler,
+                                                           this) == OT_ERROR_NONE,
+                                 error = OTBR_ERROR_REST);
+                }
+            }
+        }
+
+        // check if we already have responses to all retries
+        VerifyOrExit(complete);
+        for (const auto &it : mDiagSet)
+        {
+            if (it.second.mDiagContent.empty())
+            {
+                complete = false;
+                break;
+            }
+        }
+
+    default:
+        // busy, retry on next callback
+        break;
+    }
+
+exit:
+    if (error == OTBR_ERROR_NONE)
+    {
+        if (mActionTask != nullptr)
+        {
+            if (timeout)
+            {
+                mActionTask->status = ACTIONS_TASK_STATUS_STOPPED;
+            }
+            if (complete)
+            {
+                mActionTask->status = ACTIONS_TASK_STATUS_COMPLETED;
+            }
+        }
+
+        if ((complete || timeout) && (mRequestState != RequestState::kIdle))
+        {
+            if (mRelationshipType == gDevicesCollection.getCollectionName())
+            {
+                FillDeviceCollection();
+            }
+            else if (mRelationshipType == gDiagnosticsCollection.getCollectionName())
+            {
+                FillDiagnosticCollection();
+            }
+            mRelationshipType      = "";
+            mActionTask            = nullptr;
+            mRequestState          = RequestState::kIdle;
+            mDiagQueryRequestState = RequestState::kIdle;
+            otbrLogWarning("%s:%d - %s - changed to state %d.", __FILE__, __LINE__, __func__, mRequestState);
+            if (mCallback != nullptr)
+            {
+                mCallback();
+            }
+        }
+
+        if (timeout)
+        {
+            error = OTBR_ERROR_ABORTED;
+        }
+        else if (!complete)
+        {
+            // indicate result pending
+            error = OTBR_ERROR_ERRNO;
+        }
+    }
+    else
+    {
+        otbrLogWarning("%s:%d - %s - otbr error: %s.", __FILE__, __LINE__, __func__, otbrErrorString(error));
+    }
+    return error;
+}
+
+// start unicast NetworkDiagnostic requests
+otbrError NetworkDiagHandler::handleNetworkDiagnosticsAction(task_node_t *aTaskNode)
+{
+    otbrError                      error = OTBR_ERROR_NONE;
+    otbr::rest::NetworkDiagnostics deviceDiag;
+
+    cJSON *task       = aTaskNode->task;
+    cJSON *task_type  = cJSON_GetObjectItemCaseSensitive(task, "type");
+    cJSON *attributes = cJSON_GetObjectItemCaseSensitive(task, "attributes");
+
+    cJSON *destination = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_DESTINATION);
+    cJSON *types       = cJSON_GetObjectItemCaseSensitive(attributes, ATTRIBUTE_TYPES);
+
+    // we only run a single diagnostic request or query simultaneously
+    VerifyOrExit(mRequestState == RequestState::kIdle, error = OTBR_ERROR_INVALID_STATE);
+    mRequestState     = RequestState::kWaiting;
+    aTaskNode->status = ACTIONS_TASK_STATUS_ACTIVE;
+    otbrLogWarning("%s:%d - %s - changed to state %d.", __FILE__, __LINE__, __func__, mRequestState);
+
+    if (std::string(task_type->valuestring) == std::string(taskNameNetworkDiagnostic))
+    {
+        // results should go into api/diagnostics collection
+        mRelationshipType = gDiagnosticsCollection.getCollectionName();
+    }
+    // else if (std::string(task_type->valuestring) == std::string(taskNameUpdateDeviceCollection))
+    // {
+    //     // results should go into api/devices collection
+    //     mRelationshipType = gDevicesCollection.getCollectionName();
+    //     SetDefaultTlvs();
+    // }
+
+    // keep a reference to the task to add relationship details when done.
+    mActionTask = aTaskNode;
+
+    VerifyOrExit((error = extractTlvSet(types)) == OTBR_ERROR_NONE);
+
+    otbrLogWarning("%s:%d - %s - Following tlv types will be requested: %s from %s", __FILE__, __LINE__, __func__,
+                   cJSON_Print(types), cJSON_Print(destination));
+
+    if (strlen(destination->valuestring) == 0)
+    {
+        // no destination given, so we discover the network
+        error = startDiscovery();
+        ExitNow();
+    }
+    else // unicast requests to a single destination
+    {
+        // remove all previous entries
+        ResetRouterDiag(false);
+        ResetChildDiag(steady_clock::now());
+
+        ResetChildTables(false);
+        ResetChildIp6Addrs(false);
+        ResetRouterNeighbors(false);
+
+        VerifyOrExit((error = LookupDestinationAddr(std::string(destination->valuestring), &mIp6address)) ==
+                     OTBR_ERROR_NONE);
+
+        mRetries               = 0;
+        mDiagQueryRequestState = RequestState::kWaiting;
+        otbrLogWarning("%s:%d - %s - changed to DiagQuery state %d.", __FILE__, __LINE__, __func__,
+                       mDiagQueryRequestState);
+        VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &mIp6address, mDiagReqTlvs, mDiagReqTlvsCount,
+                                               NetworkDiagHandler::DiagnosticResponseHandler, this) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_REST);
+        // wait for response
+    }
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        if (error == OTBR_ERROR_ABORTED)
+        {
+            otbrLogWarning("%s:%d - %s - TIMEOUT -> set a valid timeout.", __FILE__, __LINE__, __func__);
+        }
+        else if (error != OTBR_ERROR_INVALID_STATE)
+        {
+            // something went wrong clear internal state to run another network diagnostic action
+            mRequestState          = RequestState::kIdle;
+            mDiagQueryRequestState = RequestState::kIdle;
+            // aTaskNode->status      = ACTIONS_TASK_STATUS_FAILED;
+            // otbrLogWarning("%s:%d - %s - changed to state %d, error: %s.", __FILE__, __LINE__, __func__,
+            // mRequestState, otbrErrorString(error));
+        }
+    }
+    return error;
+}
+
+otbrError NetworkDiagHandler::extractTlvSet(cJSON *aTypes)
+{
+    std::string tlvStr;
+    cJSON      *item = nullptr;
+
+    otbrError error = OTBR_ERROR_NONE;
+    uint8_t   tlvType;
+    bool      rlocRequested;
+
+    mDiagQueryTlvs.clear();
+
+    cJSON_ArrayForEach(item, aTypes)
+    {
+        // loop for each item
+        if (cJSON_IsString(item) && mDiagReqTlvsCount < MAX_TLV_COUNT)
+        {
+            tlvStr  = std::string(item->valuestring);
+            tlvType = kTlvTypeMap.at(tlvStr);
+
+            if (tlvType < 29 || tlvType > 33) // diagnostic requests
+            {
+                if (tlvType == OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS)
+                {
+                    rlocRequested = true;
+                }
+
+                mDiagReqTlvs[mDiagReqTlvsCount++] = kTlvTypeMap.at(tlvStr);
+            }
+            else // diagnostic queries
+            {
+                switch (tlvType)
+                {
+                case OT_NETWORK_DIAGNOSTIC_TLV_CHILD:
+                    mDiagQueryTlvs.emplace_back(OT_NETWORK_DIAGNOSTIC_TLV_CHILD);
+                    break;
+
+                case OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST:
+                    mDiagQueryTlvs.emplace_back(OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST);
+                    break;
+
+                case OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR:
+                    mDiagQueryTlvs.emplace_back(OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR);
+                    break;
+
+                default:
+                    error = OTBR_ERROR_INVALID_ARGS;
+                }
+            }
+        }
+    }
+    if (!rlocRequested)
+    {
+        mDiagReqTlvs[mDiagReqTlvsCount++] = kTlvTypeMap.at(KEY_RLOC16);
+    }
+    return error;
+}
+
+void NetworkDiagHandler::AddSingleRloc16LookUp(uint16_t aRloc16)
+{
+    if ((aRloc16 & 0x1FF) == 0)
+    {
+        // destination is router and we may want DiagQuery TLVs
+        RouterChildTable infoCt{};
+        mChildTables[aRloc16] = infoCt;
+
+        RouterChildIp6Addrs infoIp{};
+        mChildIps[aRloc16] = infoIp;
+
+        RouterNeighbors infoR{};
+        mRouterNeighbors[aRloc16] = infoR;
+    }
+}
+
+void NetworkDiagHandler::ResetRouterDiag(bool aLearnRloc16)
+{
+    for (uint16_t id = 0; id <= OT_NETWORK_MAX_ROUTER_ID; id++)
+    {
+        uint16_t     rloc = id << 10;
+        otRouterInfo routerInfo;
+
+        if ((otThreadGetRouterInfo(mInstance, rloc, &routerInfo) == OT_ERROR_NONE) && aLearnRloc16)
+        {
+            if (mDiagSet.find(rloc) == mDiagSet.end())
+            {
+                DiagInfo info;
+                mDiagSet[rloc] = info;
+            }
+        }
+        else
+        {
+            if (mDiagSet.erase(rloc) > 0)
+            {
+                otbrLogWarning("%s:%d Deleted outdated router diag from 0x%04x", __FILE__, __LINE__, rloc);
+            }
+        }
+    }
+}
+
+void NetworkDiagHandler::ResetChildDiag(steady_clock::time_point aMaxAge)
+{
+    // reset entries that are not a router rloc
+    // delete empty entries or entries older than mMaxAge
+    std::vector<uint16_t> remove;
+    for (const auto &it : mDiagSet)
+    {
+        if ((it.first & 0x1FF) > 0)
+        {
+            // from child
+            if (it.second.mStartTime < aMaxAge)
+            {
+                remove.emplace_back(it.first);
+            }
+        }
+    }
+    for (const auto &item : remove)
+    {
+        mDiagSet.erase(item);
+        otbrLogWarning("%s:%d Deleted outdated child diag from 0x%04x", __FILE__, __LINE__, item);
+    }
+}
+
+void NetworkDiagHandler::ResetChildTables(bool aLearnRloc16)
+{
+    for (uint16_t id = 0; id <= OT_NETWORK_MAX_ROUTER_ID; id++)
+    {
+        uint16_t     rloc = id << 10;
+        otRouterInfo routerInfo;
+
+        if ((otThreadGetRouterInfo(mInstance, rloc, &routerInfo) == OT_ERROR_NONE) && aLearnRloc16)
+        {
+            if (mChildTables.find(rloc) == mChildTables.end())
+            {
+                RouterChildTable info{};
+                mChildTables[rloc] = info;
+            }
+            else
+            {
+                mChildTables[rloc].mChildTable.clear();
+            }
+        }
+        else
+        {
+            mChildTables.erase(rloc);
+        }
+    }
+}
+
+void NetworkDiagHandler::ResetChildIp6Addrs(bool aLearnRloc16)
+{
+    for (uint16_t id = 0; id <= OT_NETWORK_MAX_ROUTER_ID; id++)
+    {
+        uint16_t     rloc = id << 10;
+        otRouterInfo routerInfo;
+
+        if ((otThreadGetRouterInfo(mInstance, rloc, &routerInfo) == OT_ERROR_NONE) && aLearnRloc16)
+        {
+            if (mChildIps.find(rloc) == mChildIps.end())
+            {
+                RouterChildIp6Addrs info{};
+                mChildIps[rloc] = info;
+            }
+            else
+            {
+                mChildIps[rloc].mChildren.clear();
+            }
+        }
+        else
+        {
+            mChildIps.erase(rloc);
+        }
+    }
+}
+
+void NetworkDiagHandler::ResetRouterNeighbors(bool aLearnRloc16)
+{
+    for (uint16_t id = 0; id <= OT_NETWORK_MAX_ROUTER_ID; id++)
+    {
+        uint16_t     rloc = id << 10;
+        otRouterInfo routerInfo;
+
+        if ((otThreadGetRouterInfo(mInstance, rloc, &routerInfo) == OT_ERROR_NONE) && aLearnRloc16)
+        {
+            if (mRouterNeighbors.find(rloc) == mRouterNeighbors.end())
+            {
+                RouterNeighbors info{};
+                mRouterNeighbors[rloc] = info;
+            }
+            else
+            {
+                mRouterNeighbors[rloc].mNeighbors.clear();
+            }
+        }
+        else
+        {
+            mRouterNeighbors.erase(rloc);
+        }
+    }
+}
+
+void NetworkDiagHandler::UpdateDiag(uint16_t aKey, std::vector<otNetworkDiagTlv> &aDiag)
+{
+    DiagInfo value;
+    value.mStartTime = steady_clock::now();
+
+    bool                                    replaced;
+    std::vector<otNetworkDiagTlv>::iterator newit;
+
+    // Check if mDiagSet contains aKey and if mDiagContent is not empty
+    auto it = mDiagSet.find(aKey);
+    if (it != mDiagSet.end() && !it->second.mDiagContent.empty())
+    {
+        auto &existingDiag = mDiagSet[aKey].mDiagContent;
+        // we expect this called multiple times.
+        // Thus we only update the tlvs in aDiag ...
+        for (auto &existingTlv : existingDiag)
+        {
+            replaced = false;
+            for (newit = aDiag.begin(); newit != aDiag.end(); ++newit)
+            {
+                if (existingTlv.mType == newit->mType)
+                {
+                    value.mDiagContent.push_back(*newit); // update existing TLV
+                    replaced = true;
+                    break;
+                }
+            }
+            if (replaced)
+            {
+                aDiag.erase(newit); // remove processed TLV
+            }
+            else
+            {
+                value.mDiagContent.push_back(existingTlv); // retain old TLV
+            }
+        }
+    }
+    if (it == mDiagSet.end())
+    {
+        // we have a single unicast request and may want to also get DiagQuery TLVs
+        AddSingleRloc16LookUp(aKey);
+    }
+    // Add remaining new TLVs that weren't present in the original set
+    value.mDiagContent.insert(value.mDiagContent.end(), aDiag.begin(), aDiag.end());
+
+    mDiagSet[aKey] = value;
+}
+
+bool NetworkDiagHandler::HandleNextDiagQuery()
+{
+    for (auto &query_tlv : mDiagQueryTlvs)
+    {
+        switch (query_tlv)
+        {
+        case OT_NETWORK_DIAGNOSTIC_TLV_CHILD:
+            for (auto &item : mChildTables)
+            {
+                VerifyOrExit(RequestChildTable(item.first, mMaxAge, &item.second));
+            }
+            break;
+        case OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST:
+            for (auto &item : mChildIps)
+            {
+                VerifyOrExit(RequestChildIp6Addrs(item.first, mMaxAge, &item.second));
+            }
+            break;
+        case OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR:
+            for (auto &item : mRouterNeighbors)
+            {
+                VerifyOrExit(RequestRouterNeighbors(item.first, mMaxAge, &item.second));
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    return true;
+exit:
+    return false;
+}
+
+void NetworkDiagHandler::DiagnosticResponseHandler(otError              aError,
+                                                   otMessage           *aMessage,
+                                                   const otMessageInfo *aMessageInfo,
+                                                   void                *aContext)
+{
+    static_cast<NetworkDiagHandler *>(aContext)->DiagnosticResponseHandler(aError, aMessage, aMessageInfo);
+}
+
+void NetworkDiagHandler::DiagnosticResponseHandler(otError              aError,
+                                                   const otMessage     *aMessage,
+                                                   const otMessageInfo *aMessageInfo)
+{
+    std::vector<otNetworkDiagTlv> diagSet;
+    otNetworkDiagTlv              diagTlv;
+    otNetworkDiagIterator         iterator = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT;
+    otError                       error;
+    uint16_t                      keyRloc = 0xfffe;
+
+    SuccessOrExit(aError);
+
+    OTBR_UNUSED_VARIABLE(aMessageInfo);
+
+    while ((error = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
+    {
+        if (diagTlv.mType == OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS)
+        {
+            keyRloc = diagTlv.mData.mAddr16;
+        }
+        diagSet.push_back(diagTlv);
+    }
+    VerifyOrExit(keyRloc != 0xfffe, aError = OT_ERROR_FAILED);
+    UpdateDiag(keyRloc, diagSet);
+
+    if (mDiagQueryRequestState == RequestState::kWaiting)
+    {
+        mDiagQueryRequestState = RequestState::kPending;
+        otbrLogWarning("%s:%d - %s - changed to DiagQuery state %d.", __FILE__, __LINE__, __func__,
+                       mDiagQueryRequestState);
+    }
+
+exit:
+    if (aError != OT_ERROR_NONE)
+    {
+        otbrLogWarning("%s:%d Failed to get diagnostic data: %s", __FILE__, __LINE__, otThreadErrorToString(aError));
+    }
+    continueHandleRequest();
+}
+
+bool NetworkDiagHandler::RequestChildTable(uint16_t                 aRloc16,
+                                           steady_clock::time_point aMaxAge,
+                                           RouterChildTable        *aChildTable)
+{
+    bool    retval = false;
+    otError aError;
+
+    switch (aChildTable->mState)
+    {
+    case RequestState::kIdle:
+    case RequestState::kDone:
+        // Check if we can use the cached results
+        if (aChildTable->mUpdateTime > aMaxAge)
+        {
+            retval = true;
+            break;
+        }
+        aChildTable->mState = RequestState::kWaiting;
+        OT_FALL_THROUGH;
+    case RequestState::kWaiting:
+        aError = otMeshDiagQueryChildTable(mInstance, aRloc16, NetworkDiagHandler::MeshChildTableResponseHandler, this);
+
+        switch (aError)
+        {
+        case OT_ERROR_NONE:
+            mDiagQueryRequestRloc = aRloc16;
+            aChildTable->mState   = RequestState::kPending;
+            break;
+
+        case OT_ERROR_BUSY:
+        case OT_ERROR_NO_BUFS:
+        case OT_ERROR_INVALID_ARGS:
+            otbrLogWarning("%s:%d Failed to get diagnostic data: %s", __FILE__, __LINE__,
+                           otThreadErrorToString(aError));
+            break;
+
+        default:
+            aChildTable->mState = RequestState::kDone;
+            retval              = true;
+            break;
+        }
+        break;
+
+    case RequestState::kPending:
+        break;
+    }
+
+    return retval;
+}
+
+void NetworkDiagHandler::MeshChildTableResponseHandler(otError                     aError,
+                                                       const otMeshDiagChildEntry *aChildEntry,
+                                                       void                       *aContext)
+{
+    static_cast<NetworkDiagHandler *>(aContext)->MeshChildTableResponseHandler(aError, aChildEntry);
+}
+
+void NetworkDiagHandler::MeshChildTableResponseHandler(otError aError, const otMeshDiagChildEntry *aChildEntry)
+{
+    auto it = mChildTables.find(mDiagQueryRequestRloc);
+
+    VerifyOrExit(it != mChildTables.end());
+    VerifyOrExit(it->second.mState == RequestState::kPending);
+
+    if (aError == OT_ERROR_NONE || aError == OT_ERROR_RESPONSE_TIMEOUT)
+    {
+        it->second.mUpdateTime = steady_clock::now();
+        it->second.mState      = RequestState::kDone;
+        continueHandleRequest();
+    }
+
+    VerifyOrExit(aChildEntry != nullptr);
+
+    it->second.mChildTable.emplace_back(*aChildEntry);
+
+    // otbrLogWarning("%s:%d Have child table from 0x%04x for child 0x%04x", __FILE__, __LINE__, mDiagQueryRequestRloc,
+    //                 aChildEntry->mRloc16);
+
+exit:
+    return;
+}
+
+bool NetworkDiagHandler::RequestChildIp6Addrs(uint16_t                 aParentRloc16,
+                                              steady_clock::time_point aMaxAge,
+                                              RouterChildIp6Addrs     *aChild)
+{
+    bool    retval = false;
+    otError aError;
+
+    switch (aChild->mState)
+    {
+    case RequestState::kIdle:
+    case RequestState::kDone:
+        // Check if we can use the cached results
+        if (aChild->mUpdateTime > aMaxAge)
+        {
+            retval = true;
+            break;
+        }
+        aChild->mState = RequestState::kWaiting;
+        OT_FALL_THROUGH;
+    case RequestState::kWaiting:
+        aError = otMeshDiagQueryChildrenIp6Addrs(mInstance, aParentRloc16,
+                                                 NetworkDiagHandler::MeshChildIp6AddrResponseHandler, this);
+        switch (aError)
+        {
+        case OT_ERROR_NONE:
+            mDiagQueryRequestRloc = aParentRloc16;
+            aChild->mState        = RequestState::kPending;
+            break;
+
+        case OT_ERROR_BUSY:
+        case OT_ERROR_NO_BUFS:
+        case OT_ERROR_INVALID_ARGS:
+            otbrLogWarning("%s:%d Failed to get diagnostic data: %s", __FILE__, __LINE__,
+                           otThreadErrorToString(aError));
+            break;
+
+        default:
+            aChild->mState = RequestState::kDone;
+            retval         = true;
+            break;
+        }
+        break;
+
+    case RequestState::kPending:
+        break;
+    }
+
+    return retval;
+}
+
+void NetworkDiagHandler::MeshChildIp6AddrResponseHandler(otError                    aError,
+                                                         uint16_t                   aChildRloc16,
+                                                         otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                         void                      *aContext)
+{
+    static_cast<NetworkDiagHandler *>(aContext)->MeshChildIp6AddrResponseHandler(aError, aChildRloc16,
+                                                                                 aIp6AddrIterator);
+}
+
+void NetworkDiagHandler::MeshChildIp6AddrResponseHandler(otError                    aError,
+                                                         uint16_t                   aChildRloc16,
+                                                         otMeshDiagIp6AddrIterator *aIp6AddrIterator)
+{
+    DeviceIp6Addrs new_device;
+    otIp6Address   ip6Address;
+    auto           it = mChildIps.find(mDiagQueryRequestRloc);
+
+    VerifyOrExit(aError == OT_ERROR_NONE || aError == OT_ERROR_PENDING);
+    VerifyOrExit(aIp6AddrIterator != nullptr);
+    VerifyOrExit(aChildRloc16 != 65534);
+
+    VerifyOrExit(it != mChildIps.end());
+    VerifyOrExit(it->second.mState == RequestState::kPending);
+
+    // otbrLogWarning("%s:%d Have child IP from 0x%04x for child 0x%04x", __FILE__, __LINE__, mDiagQueryRequestRloc,
+    //                aChildRloc16);
+    new_device.mRloc16 = aChildRloc16;
+
+    while (otMeshDiagGetNextIp6Address(aIp6AddrIterator, &ip6Address) == OT_ERROR_NONE)
+    {
+        new_device.mIp6Addrs.emplace_back(ip6Address);
+    }
+
+    it->second.mChildren.emplace_back(new_device);
+
+exit:
+    if (aError == OT_ERROR_NONE || aError == OT_ERROR_RESPONSE_TIMEOUT)
+    {
+        it->second.mUpdateTime = steady_clock::now();
+        it->second.mState      = RequestState::kDone;
+        continueHandleRequest();
+    }
+    return;
+}
+
+bool NetworkDiagHandler::RequestRouterNeighbors(uint16_t                 aRloc16,
+                                                steady_clock::time_point aMaxAge,
+                                                RouterNeighbors         *aRouterNeighbor)
+{
+    bool    retval = false;
+    otError aError;
+
+    switch (aRouterNeighbor->mState)
+    {
+    case RequestState::kIdle:
+    case RequestState::kDone:
+        // Check if we can use the cached results
+        if (aRouterNeighbor->mUpdateTime > aMaxAge)
+        {
+            retval = true;
+            break;
+        }
+        aRouterNeighbor->mState = RequestState::kWaiting;
+        OT_FALL_THROUGH;
+    case RequestState::kWaiting:
+        aError = otMeshDiagQueryRouterNeighborTable(mInstance, aRloc16,
+                                                    NetworkDiagHandler::MeshRouterNeighborsResponseHandler, this);
+        switch (aError)
+        {
+        case OT_ERROR_NONE:
+            mDiagQueryRequestRloc   = aRloc16;
+            aRouterNeighbor->mState = RequestState::kPending;
+            break;
+
+        case OT_ERROR_BUSY:
+        case OT_ERROR_NO_BUFS:
+        case OT_ERROR_INVALID_ARGS:
+            otbrLogWarning("%s:%d Failed to get diagnostic data: %s", __FILE__, __LINE__,
+                           otThreadErrorToString(aError));
+            break;
+
+        default:
+            aRouterNeighbor->mState = RequestState::kDone;
+            retval                  = true;
+            break;
+        }
+        break;
+
+    case RequestState::kPending:
+        break;
+    }
+
+    return retval;
+}
+
+void NetworkDiagHandler::MeshRouterNeighborsResponseHandler(otError                              aError,
+                                                            const otMeshDiagRouterNeighborEntry *aNeighborEntry,
+                                                            void                                *aContext)
+{
+    static_cast<NetworkDiagHandler *>(aContext)->MeshRouterNeighborsResponseHandler(aError, aNeighborEntry);
+}
+
+void NetworkDiagHandler::MeshRouterNeighborsResponseHandler(otError                              aError,
+                                                            const otMeshDiagRouterNeighborEntry *aNeighborEntry)
+{
+    auto it = mRouterNeighbors.find(mDiagQueryRequestRloc);
+
+    VerifyOrExit(it->second.mState == RequestState::kPending);
+
+    if (aError == OT_ERROR_NONE || aError == OT_ERROR_RESPONSE_TIMEOUT)
+    {
+        it->second.mUpdateTime = steady_clock::now();
+        it->second.mState      = RequestState::kDone;
+        continueHandleRequest();
+    }
+
+    VerifyOrExit(aNeighborEntry != nullptr);
+
+    it->second.mNeighbors.emplace_back(*aNeighborEntry);
+
+exit:
+    return;
+}
+
+void NetworkDiagHandler::SetDeviceItemAttributes(std::string aExtAddr, DeviceInfo &aDeviceInfo)
+{
+    // if this device`s extAddr equals aDeviceInfo.extaddr
+    // add a item of type ThisThreadDevice and set also nodeInfo
+    // otherwise add a generic item of type ThreadDevice to the collection of devices
+
+    const otExtAddress *thisextaddr = otLinkGetExtendedAddress(mInstance);
+    std::string         thisextaddr_str;
+
+    char hex[2 * OT_EXT_ADDRESS_SIZE + 1];
+    otbr::Utils::Bytes2Hex(thisextaddr->m8, OT_EXT_ADDRESS_SIZE, hex);
+    hex[2 * OT_EXT_ADDRESS_SIZE] = '\0';
+    thisextaddr_str              = std::string(StringUtils::ToLowercase(hex));
+
+    otRouterInfo routerInfo;
+    uint8_t      maxRouterId;
+
+    if (gDevicesCollection.getItem(aExtAddr) == nullptr)
+    {
+        aDeviceInfo.mNeedsUpdate = !isDeviceComplete(aDeviceInfo);
+        if (aDeviceInfo.mNeedsUpdate)
+        {
+            otbrLogWarning("%s:%d lacking some attributes for deviceId %s", __FILE__, __LINE__, aExtAddr.c_str());
+        }
+
+        if (thisextaddr_str == aExtAddr)
+        {
+            // create ThisThreadDevice with additional NodeInfo
+            ThisThreadDevice thisItem = ThisThreadDevice(aExtAddr);
+
+            otBorderAgentGetId(mInstance, &thisItem.mNodeInfo.mBaId);
+            thisItem.mNodeInfo.mBaState = otBorderAgentGetState(mInstance);
+            otThreadGetLeaderData(mInstance, &thisItem.mNodeInfo.mLeaderData);
+
+            thisItem.mNodeInfo.mNumOfRouter = 0;
+            maxRouterId                     = otThreadGetMaxRouterId(mInstance);
+            for (uint8_t i = 0; i <= maxRouterId; ++i)
+            {
+                if (otThreadGetRouterInfo(mInstance, i, &routerInfo) != OT_ERROR_NONE)
+                {
+                    continue;
+                }
+                ++thisItem.mNodeInfo.mNumOfRouter;
+            }
+
+            thisItem.mNodeInfo.mRole        = GetDeviceRoleName(otThreadGetDeviceRole(mInstance));
+            thisItem.mNodeInfo.mExtAddress  = reinterpret_cast<const uint8_t *>(otLinkGetExtendedAddress(mInstance));
+            thisItem.mNodeInfo.mNetworkName = otThreadGetNetworkName(mInstance);
+            thisItem.mNodeInfo.mRloc16      = otThreadGetRloc16(mInstance);
+            thisItem.mNodeInfo.mExtPanId    = reinterpret_cast<const uint8_t *>(otThreadGetExtendedPanId(mInstance));
+            thisItem.mNodeInfo.mRlocAddress = *otThreadGetRloc(mInstance);
+
+            thisItem.mDeviceInfo = aDeviceInfo;
+            // GetLocalCounters(&thisItem);
+            gDevicesCollection.addItem(&thisItem);
+        }
+        else
+        {
+            // create a general ThreadDevice
+            ThreadDevice generalItem = ThreadDevice(aExtAddr);
+            generalItem.mDeviceInfo  = aDeviceInfo;
+            gDevicesCollection.addItem(&generalItem);
+        }
+    }
+    else // update existing deviceItem
+    {
+        ThreadDevice *item = dynamic_cast<ThreadDevice *>(gDevicesCollection.getItem(aExtAddr));
+        if (item)
+        {
+            // check eui64 value is valid before updating it
+            if (!isOtExtAddrEmpty(aDeviceInfo.mEui64))
+            {
+                item->setEui64(aDeviceInfo.mEui64);
+                otbrLogWarning("%s:%d updated eui64 for deviceId %s", __FILE__, __LINE__, aExtAddr.c_str());
+            }
+
+            // check ipv6 value is valid before updating it
+            if (!isOtIp6AddrEmpty(aDeviceInfo.mIp6Addr))
+            {
+                item->setIpv6Omr(aDeviceInfo.mIp6Addr);
+                otbrLogWarning("%s:%d updated ipv6 for deviceId %s", __FILE__, __LINE__, aExtAddr.c_str());
+            }
+
+            // check mleidiid value is valid before updating it
+            if (!isOtExtAddrEmpty(aDeviceInfo.mMlEidIid))
+            {
+                item->setMlEidIid(aDeviceInfo.mMlEidIid);
+                otbrLogWarning("%s:%d updated mlEidIid for deviceId %s", __FILE__, __LINE__, aExtAddr.c_str());
+            }
+            // update hostname
+            if (aDeviceInfo.mHostName.size() > 0)
+            {
+                item->setHostname(aDeviceInfo.mHostName);
+            }
+            // update role
+            if (aDeviceInfo.mRole.size() > 0)
+            {
+                item->setRole(aDeviceInfo.mRole);
+            }
+            // update mode
+            if ((aDeviceInfo.mode.mRxOnWhenIdle != item->mDeviceInfo.mode.mRxOnWhenIdle) ||
+                (aDeviceInfo.mode.mDeviceType != item->mDeviceInfo.mode.mDeviceType))
+            {
+                item->setMode(aDeviceInfo.mode);
+            }
+        }
+        else
+        {
+            otbrLogWarning("%s:%d error : dynamic_cast failed.", __FILE__, __LINE__);
+        }
+    }
+}
+
+void NetworkDiagHandler::GetChildren(const uint16_t &aParentRloc16)
+{
+    DeviceInfo  deviceInfo;
+    std::string extAddr;
+
+    std::vector<otMeshDiagChildEntry> child_table     = mChildTables.find(aParentRloc16)->second.mChildTable;
+    std::vector<DeviceIp6Addrs>       child_ip6_lists = mChildIps.find(aParentRloc16)->second.mChildren;
+
+    for (const auto &item : child_table)
+    {
+        deviceInfo.mMlEidIid    = {{0}};
+        deviceInfo.mEui64       = {{0}};
+        deviceInfo.mIp6Addr     = {{{0}}};
+        deviceInfo.mHostName    = "";
+        deviceInfo.mRole        = "child";
+        deviceInfo.mNeedsUpdate = true;
+
+        deviceInfo.mode.mDeviceType   = item.mDeviceTypeFtd;
+        deviceInfo.mode.mRxOnWhenIdle = item.mRxOnWhenIdle;
+        deviceInfo.mode.mNetworkData  = item.mFullNetData;
+
+        char hex[2 * OT_EXT_ADDRESS_SIZE + 1];
+        otbr::Utils::Bytes2Hex(item.mExtAddress.m8, OT_EXT_ADDRESS_SIZE, hex);
+        hex[2 * OT_EXT_ADDRESS_SIZE] = '\0';
+        extAddr                      = std::string(StringUtils::ToLowercase(hex));
+
+        otbrLogWarning("%s:%d - %s - %s", __FILE__, __LINE__, __func__, extAddr.c_str());
+
+        memcpy(deviceInfo.mExtAddress.m8, item.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+
+        // get the MTD child`s ipv6 addresses from the children ipv6address list
+        for (const auto &device : child_ip6_lists)
+        {
+            if (device.mRloc16 == item.mRloc16)
+            {
+                for (uint16_t i = 0; i < device.mIp6Addrs.size(); ++i)
+                {
+                    // iterate through the device´s ipv6 adresses and
+                    // extract OMR ipv6 address and MlEidIid
+                    filterIpv6(deviceInfo, device.mIp6Addrs[i], otThreadGetMeshLocalPrefix(mInstance));
+                }
+                GetHostName(deviceInfo);
+                break;
+            }
+        }
+        if (!extAddr.empty())
+        {
+            SetDeviceItemAttributes(extAddr, deviceInfo);
+        }
+        else
+        {
+            otbrLogWarning("%s:%d error : missing extAddr", __FILE__, __LINE__);
+        }
+    }
+}
+
+void NetworkDiagHandler::SetDiagQueryTlvs(otbr::rest::NetworkDiagnostics *aDeviceDiag, const uint16_t &aParentRloc16)
+{
+    if (((aParentRloc16 & 0x1FF) == 0) && (mChildTables.find(aParentRloc16) != mChildTables.end()))
+    {
+        std::vector<otMeshDiagChildEntry>          child_table = mChildTables.find(aParentRloc16)->second.mChildTable;
+        std::vector<DeviceIp6Addrs>                child_ip6_lists = mChildIps.find(aParentRloc16)->second.mChildren;
+        std::vector<otMeshDiagRouterNeighborEntry> router_neighbors =
+            mRouterNeighbors.find(aParentRloc16)->second.mNeighbors;
+
+        aDeviceDiag->mChildren.assign(child_table.begin(), child_table.end());
+        aDeviceDiag->mChildrenIp6Addrs.assign(child_ip6_lists.begin(), child_ip6_lists.end());
+        aDeviceDiag->mNeighbors.assign(router_neighbors.begin(), router_neighbors.end());
+    }
+}
+
+void NetworkDiagHandler::FillDeviceCollection(void)
+{
+    DeviceInfo  deviceInfo;
+    std::string extAddr;
+
+    for (auto &diag : mDiagSet)
+    {
+        if (diag.second.mDiagContent.empty())
+        {
+            otbrLogWarning("%s:%d error : no response from 0x%04x", __FILE__, __LINE__, diag.first);
+            continue;
+        }
+        deviceInfo.mMlEidIid    = {{0}};
+        deviceInfo.mEui64       = {{0}};
+        deviceInfo.mIp6Addr     = {{{0}}};
+        deviceInfo.mHostName    = "";
+        deviceInfo.mRole        = "";
+        deviceInfo.mNeedsUpdate = true;
+        extAddr                 = "";
+
+        for (const auto &diagTlv : diag.second.mDiagContent)
+        {
+            switch (diagTlv.mType)
+            {
+            case OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS:
+
+                char hex[2 * OT_EXT_ADDRESS_SIZE + 1];
+                otbr::Utils::Bytes2Hex(diagTlv.mData.mExtAddress.m8, OT_EXT_ADDRESS_SIZE, hex);
+                hex[2 * OT_EXT_ADDRESS_SIZE] = '\0';
+                extAddr                      = StringUtils::ToLowercase(hex);
+
+                memcpy(deviceInfo.mExtAddress.m8, diagTlv.mData.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+                break;
+
+            case OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS:
+                if ((diagTlv.mData.mAddr16 & 0x1FF) > 0)
+                {
+                    deviceInfo.mRole = "child";
+                }
+                else
+                {
+                    deviceInfo.mRole              = "router";
+                    deviceInfo.mode.mDeviceType   = true;
+                    deviceInfo.mode.mRxOnWhenIdle = true;
+                    deviceInfo.mode.mNetworkData  = true;
+                    deviceInfo.mNeedsUpdate       = false;
+                    GetChildren(diagTlv.mData.mAddr16);
+                }
+                break;
+
+            case OT_NETWORK_DIAGNOSTIC_TLV_EUI64:
+                deviceInfo.mEui64 = diagTlv.mData.mEui64;
+                break;
+
+            case OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST:
+                for (uint16_t i = 0; i < diagTlv.mData.mIp6AddrList.mCount; ++i)
+                {
+                    // iterate through the device´s ipv6 adresses and
+                    // extract OMR ipv6 address and MlEidIid
+                    filterIpv6(deviceInfo, diagTlv.mData.mIp6AddrList.mList[i], otThreadGetMeshLocalPrefix(mInstance));
+                }
+                GetHostName(deviceInfo);
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        if (!extAddr.empty())
+        {
+            SetDeviceItemAttributes(extAddr, deviceInfo);
+        }
+        else
+        {
+            otbrLogWarning("%s:%d error : missing extAddr", __FILE__, __LINE__);
+        }
+    }
+}
+
+void NetworkDiagHandler::FillDiagnosticCollection(void)
+{
+    const otExtAddress *thisExtAddr;
+
+    for (auto &diag : mDiagSet)
+    {
+        if (diag.second.mDiagContent.empty())
+        {
+            otbrLogWarning("%s:%d error : no response from 0x%04x", __FILE__, __LINE__, diag.first);
+            continue;
+        }
+        else
+        {
+            otbrLogWarning("%s:%d Have data from 0x%04x", __FILE__, __LINE__, diag.first);
+        }
+
+        // create a new diagnostic item
+        otbr::rest::NetworkDiagnostics deviceDiag;
+
+        // copy data to diagnostic item
+        for (const auto &diagTlv : diag.second.mDiagContent)
+        {
+            switch (diagTlv.mType)
+            {
+            case OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS:
+                // if we have `this` node
+                thisExtAddr = otLinkGetExtendedAddress(mInstance);
+                if (std::memcmp(diagTlv.mData.mExtAddress.m8, thisExtAddr->m8, OT_EXT_ADDRESS_SIZE) == 0)
+                {
+                    // add BrCounters
+                    GetLocalCounters(&deviceDiag);
+                }
+                break;
+            case OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS:
+                SetDiagQueryTlvs(&deviceDiag, diagTlv.mData.mAddr16);
+                break;
+            case OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST:
+                SetServiceRoleFlags(&deviceDiag, diagTlv);
+                break;
+            default:
+                break;
+            }
+
+            deviceDiag.mDeviceTlvSet.push_back(diagTlv);
+        }
+
+        // store diagnostic item
+        otbr::rest::gDiagnosticsCollection.addItem(&deviceDiag);
+
+        // mActionTask keeps reference to result
+        // TODO: keep reference to multiple result items
+        snprintf(mActionTask->relationship.mType, MAX_TYPELENGTH,
+                 otbr::rest::gDiagnosticsCollection.getCollectionName().c_str());
+        snprintf(mActionTask->relationship.mId, UUID_STR_LEN, deviceDiag.mUuid.toString().c_str());
+    }
+
+    otbrLogWarning("%s:%d - %s - done", __FILE__, __LINE__, __func__);
+}
+
+void NetworkDiagHandler::GetHostName(DeviceInfo &aDeviceInfo)
+{
+    const otSrpServerHost *host = nullptr;
+    const otIp6Address    *addresses;
+    uint8_t                addressesNum;
+
+    while ((host = otSrpServerGetNextHost(mInstance, host)) != nullptr)
+    {
+        if (otSrpServerHostIsDeleted(host))
+        {
+            continue;
+        }
+
+        addresses = otSrpServerHostGetAddresses(host, &addressesNum);
+
+        for (uint8_t i = 0; i < addressesNum; ++i)
+        {
+            if (std::equal(std::begin(aDeviceInfo.mIp6Addr.mFields.m8), std::end(aDeviceInfo.mIp6Addr.mFields.m8),
+                           std::begin(addresses[i].mFields.m8)))
+            {
+                std::string hostname(otSrpServerHostGetFullName(host));
+                aDeviceInfo.mHostName = hostname.substr(0, hostname.find('.'));
+                break;
+            }
+        }
+    }
+}
+
+void NetworkDiagHandler::GetLocalCounters(otbr::rest::NetworkDiagnostics *aDeviceDiag)
+{
+    otbr::rest::networkDiagTlvExtensions localCounter;
+    const otBorderRoutingCounters       *brCounters = otIp6GetBorderRoutingCounters(mInstance);
+
+    localCounter.mType             = NETWORK_DIAGNOSTIC_TLVEXT_BR_COUNTER;
+    localCounter.mData.mBrCounters = *brCounters;
+    aDeviceDiag->mDeviceTlvSetExtension.push_back(localCounter);
+}
+
+void NetworkDiagHandler::SetServiceRoleFlags(otbr::rest::NetworkDiagnostics *aDeviceDiag, otNetworkDiagTlv aTlv)
+{
+    if (aTlv.mType != OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST)
+    {
+        return;
+    }
+    otbr::rest::networkDiagTlvExtensions diagTlvExt;
+    otIp6Address                         ipv6Addr;
+
+    uint16_t              localRloc16 = otThreadGetRloc16(mInstance);
+    otNetworkDataIterator iterator    = OT_NETWORK_DATA_ITERATOR_INIT;
+    otExternalRouteConfig config;
+
+    diagTlvExt.mType                                   = NETWORK_DIAGNOSTIC_TLVEXT_SERVICEROLEFLAGS;
+    diagTlvExt.mData.mServiceRoleFlags.mIsLeader       = false;
+    diagTlvExt.mData.mServiceRoleFlags.mIsPrimaryBBR   = false;
+    diagTlvExt.mData.mServiceRoleFlags.mHostsService   = false;
+    diagTlvExt.mData.mServiceRoleFlags.mIsBorderRouter = false;
+
+    // iterate through the device´s ipv6 adresses
+    for (uint16_t i = 0; i < aTlv.mData.mIp6AddrList.mCount; ++i)
+    {
+        ipv6Addr = aTlv.mData.mIp6AddrList.mList[i];
+
+        // rloc and aloc prefix == 0000:00FF:FE00 -> 0000:FF00:00FE
+        if (ipv6Addr.mFields.m16[4] == 0x0000 && ipv6Addr.mFields.m16[5] == 0xff00 && ipv6Addr.mFields.m16[6] == 0x00fe)
+        {
+            // Leader Aloc is FC00 -> 00FC
+            diagTlvExt.mData.mServiceRoleFlags.mIsLeader |= (ipv6Addr.mFields.m16[7] == 0x00fc);
+
+            // Primary BBR Aloc is FC38 -> 38FC
+            diagTlvExt.mData.mServiceRoleFlags.mIsPrimaryBBR |= (ipv6Addr.mFields.m16[7] == 0x38fc);
+
+            // Service Aloc is in range FC10 to FC2F
+            diagTlvExt.mData.mServiceRoleFlags.mHostsService |=
+                (htons(ipv6Addr.mFields.m16[7]) >= 0xfc10 && htons(ipv6Addr.mFields.m16[7]) <= 0xfc2f);
+            continue;
+        }
+    }
+
+    while (otNetDataGetNextRoute(mInstance, &iterator, &config) == OT_ERROR_NONE)
+    {
+        if (config.mRloc16 == localRloc16)
+        {
+            diagTlvExt.mData.mServiceRoleFlags.mIsBorderRouter = true;
+        }
+
+        ++iterator;
+    }
+
+    aDeviceDiag->mDeviceTlvSetExtension.push_back(diagTlvExt);
+}
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/network_diag_handler.hpp
+++ b/src/rest/network_diag_handler.hpp
@@ -1,0 +1,416 @@
+/**
+ * @file
+ *   This file includes Handler definition for network diagnostics collector.
+ */
+
+#ifndef OTBR_REST_NETWORK_DIAG_HANDLER_HPP_
+#define OTBR_REST_NETWORK_DIAG_HANDLER_HPP_
+
+/*
+Include necessary headers for OpenThread functions, REST utilities, and JSON processing.
+*/
+
+#include "openthread-br/config.h"
+
+#include <unordered_map>
+
+#include <openthread/border_agent.h>
+#include <openthread/border_router.h>
+
+#include "common/api_strings.hpp"
+#include "openthread/dataset.h"
+#include "openthread/dataset_ftd.h"
+#include "openthread/mesh_diag.h"
+#include "rest/extensions/rest_devices_coll.hpp"
+#include "rest/extensions/rest_diagnostics_coll.hpp"
+#include "rest/extensions/rest_task_handler.hpp"
+#include "rest/extensions/rest_task_queue.hpp"
+#include "rest/json.hpp"
+#include "rest/request.hpp"
+#include "utils/thread_helper.hpp"
+
+extern "C" {
+#include <cJSON.h>
+}
+
+using std::chrono::steady_clock;
+
+namespace otbr {
+namespace rest {
+
+#define MAX_TLV_COUNT 27 // Maximal amount of TLVs
+
+/**
+ * This class implements the handlers for collecting diagnostic requests (DiagReq) and diagnostic queries (DiagQuery)
+ * for OTBR-REST.
+ *
+ */
+class NetworkDiagHandler
+{
+public:
+    static NetworkDiagHandler &getInstance(otInstance *aOtInstance)
+    {
+        static NetworkDiagHandler instance;
+        instance.setOtInstance(aOtInstance);
+        return instance;
+    };
+
+    /**
+     * @brief Handle a diagnostic action request.
+     *
+     * Parses the destination into an ipv6 address and sorts the aTlvTypes into types for DiagRequests and types for
+     * DiagQuerys. Then begins collecting the DiagRequest TLVs sequentially via unicast request, if not a multicast
+     * destination was given. Next, unicast DiagQuerys are started.
+     *
+     * A call to continueHandleRequest must follow in order to continue and complete the request.
+     *
+     * @param destination       The destination of the diagnostic request. Can be empty (default, unicast to all
+     * routers), or (TODO) an existing deviceId, a ML-EID-IID, a rloc16, or a multicast address.
+     * @param relationshipType  The type of result, that should be created after a successful request.
+     *                          'devices'     -> creates results in api/devices collection
+     *                          'diagnostics' -> creates results in api/diagnostics collection
+     *
+     * @retval OTBR_ERROR_NONE            Completed successfully.
+     * @retval OTBR_ERROR_INVALID_STATE   Another request is in processing.
+     * @retval OTBR_ERROR_ABORT           Timeout
+     * @retval OTBR_ERROR_REST            Insufficient message buffers available to send DIAG_GET.req.
+     */
+    otbrError handleNetworkDiscoveryRequest(std::string destination, std::string relationshipType);
+
+    /**
+     * @brief Processes an action of type 'getNetworkDiagnosticTask'.
+     *
+     * A call to continueHandleRequest must follow in order to continue and complete the request.
+     *
+     * @param aTaskNode
+     * @retval OTBR_ERROR_NONE            Completed successfully.
+     * @retval OTBR_ERROR_INVALID_STATE   Another request is in processing.
+     * @retval OTBR_ERROR_ABORT           Timeout
+     * @retval OTBR_ERROR_REST            Insufficient message buffers available to send DIAG_GET.req.
+     */
+    otbrError handleNetworkDiagnosticsAction(task_node_t *aTaskNode);
+
+    /**
+     * @brief Continue a ongoing request assuring retries and completeness of responses.
+     *
+     * @retval OTBR_ERROR_NONE            Completed successfully.
+     * @retval OTBR_ERROR_ERRNO           Result pending, call again later.
+     * @retval OTBR_ERROR_ABORT           Timeout, processing stopped.
+     * @retval OTBR_ERROR_REST            Insufficient message buffers available to send DIAG_GET.req.
+     */
+    otbrError continueHandleRequest(void);
+
+    /**
+     * @brief Configures internal parameters for next request.
+     *
+     * @param aTimeout      (0) Defaults to now() + 10s.
+     * @param aMaxAge       (0) Defaults to now() - 30s.
+     * @param aRetryCount   Max retries for DiagReq and (TODO) DiagQuery.
+     *
+     * @retval OTBR_ERROR_INVALID_STATE  Change of configuration denied, while another request is in processing.
+     * @retval OTBR_ERROR_NONE           Changed configuration successfully.
+     */
+    otbrError configRequest(uint32_t aTimeout, uint32_t aMaxAge, uint8_t aRetryCount, task_doneCallback aCallback);
+
+    /**
+     * @brief Cancels an active request.
+     *
+     * @retval OTBR_ERROR_NONE
+     */
+    otbrError cancelRequest(void);
+
+    /**
+     * @brief Clear internal buffer.
+     *
+     */
+    void clear(void);
+
+private:
+    enum class RequestState : uint8_t
+    {
+        kIdle,
+        kWaiting,
+        kPending,
+        kDone,
+    };
+
+    otInstance *mInstance;
+
+    // private constructor to keep this a singleton class and prevent multiple instantiation
+    NetworkDiagHandler()
+    {
+        mRequestState          = RequestState::kIdle;
+        mDiagQueryRequestState = RequestState::kIdle;
+    }
+
+    // disable copy constructor
+    NetworkDiagHandler(const NetworkDiagHandler &) = delete;
+
+    // disable the copy assignment operator
+    NetworkDiagHandler &operator=(const NetworkDiagHandler &) = delete;
+
+    void setOtInstance(otInstance *aOtInstance) { mInstance = aOtInstance; }
+
+    struct RouterChildTable
+    {
+        steady_clock::time_point          mUpdateTime;
+        RequestState                      mState;
+        std::vector<otMeshDiagChildEntry> mChildTable;
+    };
+
+    struct RouterChildIp6Addrs
+    {
+        steady_clock::time_point    mUpdateTime;
+        RequestState                mState;
+        std::vector<DeviceIp6Addrs> mChildren;
+    };
+
+    struct RouterNeighbors
+    {
+        steady_clock::time_point                   mUpdateTime;
+        RequestState                               mState;
+        std::vector<otMeshDiagRouterNeighborEntry> mNeighbors;
+    };
+
+    // oldest timestamp of previous diagnostic responses considered still valid
+    steady_clock::time_point mMaxAge;
+    steady_clock::time_point mTimeout;
+    steady_clock::time_point mTimeLastAttempt; // time of last attempt
+
+    uint8_t mMaxRetries;
+    uint8_t mRetries; // actual retry count
+
+    /**
+     * Buffer for DiagRequest Responses.
+     *
+     * May be filled with rloc16s from which responses are expected. See 'ResetRouterDiag()' and 'ResetChildDiag()'
+     */
+    std::unordered_map<uint64_t, DiagInfo> mDiagSet;
+
+    RequestState mRequestState; // overall state of a DiagRequest
+    otIp6Address mIp6address;   // destination of a request. Used for retry when no rloc16 is known.
+
+    uint8_t mDiagReqTlvs[MAX_TLV_COUNT];
+    size_t  mDiagReqTlvsCount;
+
+    /**
+     * Buffer for DiagQuery Responses.
+     *
+     * May be filled with rloc16s from which responses are expected. See 'ResetChildTables()'.
+     */
+    std::unordered_map<uint16_t, RouterChildTable> mChildTables;
+
+    /**
+     * Buffer for DiagQuery Responses.
+     *
+     * May be filled with rloc16s from which responses are expected. See 'ResetChildIp6Addrs()'.
+     */
+    std::unordered_map<uint16_t, RouterChildIp6Addrs> mChildIps;
+
+    /**
+     * Buffer for DiagQuery Responses.
+     *
+     * May be filled with rloc16s from which responses are expected. See 'ResetRouterNeighbors()'.
+     */
+    std::unordered_map<uint16_t, RouterNeighbors> mRouterNeighbors;
+
+    std::vector<uint8_t> mDiagQueryTlvs;         // TLVs for DiagQuery
+    RequestState         mDiagQueryRequestState; // state of the DiagQuery
+    uint16_t             mDiagQueryRequestRloc;  // destination of the DiagQuery
+
+    std::string       mRelationshipType; // type of relationship requested, e.g. "devices" or "diagnostics"
+    task_node_t      *mActionTask;       // reference to the task in the action collection that has started the request
+    task_doneCallback mCallback;
+
+    /**
+     * @brief Reset router entries in mDiagSet buffer.
+     *
+     * @param aLearnRloc16 Remove old entries (false), remove old entries and learn rloc16 address from router table
+     * (true).
+     */
+    void ResetRouterDiag(bool aLearnRloc16);
+
+    /**
+     * @brief Reset child entries in mDiagSet buffer.
+     *
+     * Reset entries in mDiagSet that are not a router rloc16
+     * and delete empty entries or entries older than aMaxAge
+     *
+     * @param aMaxAge Oldest timestamp of previous diagnostic responses considered still valid.
+     */
+    void ResetChildDiag(steady_clock::time_point aMaxAge);
+
+    /**
+     * @brief Add or update existing item in mDiagSet with new responses
+     *
+     * @param aKey  a rloc16
+     * @param aDiag a vector of TLVs received from rloc16
+     */
+    void UpdateDiag(uint16_t aKey, std::vector<otNetworkDiagTlv> &aDiag);
+
+    /**
+     * @brief Reset entries in mChildTables buffer.
+     *
+     * @param aLearnRloc16 Remove old entries (false), remove old entries and learn rloc16 address from router table
+     * (true).
+     */
+    void ResetChildTables(bool aLearnRloc16);
+
+    /**
+     * @brief Reset entries in mChildIps buffer.
+     *
+     * @param aLearnRloc16 Remove old entries (false), remove old entries and learn rloc16 address from router table
+     * (true).
+     */
+    void ResetChildIp6Addrs(bool aLearnRloc16);
+
+    /**
+     * @brief Reset entries in mRouterNeighbors buffer.
+     *
+     * @param aLearnRloc16 Remove old entries (false), remove old entries and learn rloc16 address from router table
+     * (true).
+     */
+    void ResetRouterNeighbors(bool aLearnRloc16);
+
+    // set buffer and address for unicast to a single destination
+    void AddSingleRloc16LookUp(uint16_t aRloc16);
+
+    /**
+     * @brief Set minimal TLVs needed to collect for filling device collection
+     *
+     */
+    void SetDefaultTlvs(void);
+
+    /**
+     * @brief Convert destination string into an ip6address.
+     *
+     * Lookup destination in device collection to find ML-Eid-Iid and construct ML-Eid address,
+     * or if not found converts a valid string of length 16 to ML-Eid address,
+     * or if string of length 6 converts to ML rloc16 address.
+     *
+     * @param aDestination string of length 16 or 6.
+     * @param aIp6address result of conversion.
+     *
+     * @retval OTBR_ERROR_PARSE if not successfull
+     * @retval OTBR_ERROR_NONE on success
+     */
+    otbrError LookupDestinationAddr(std::string aDestination, otIp6Address *aIp6address);
+
+    /**
+     * @brief Translate list of string TLV type names to list of integer TLV types
+     *        to handle DiagRequests and DiagQueries separately.
+     *
+     * @param aTypes types from a action of type 'getNetworkDiagnosticTask'.
+     *
+     * @retval OTBR_ERROR_NONE
+     * @retval OTBR_ERROR_INVALID_ARGS  Unknown DiagQuery TLV type
+     */
+    otbrError extractTlvSet(cJSON *aTypes);
+
+    /**
+     * @brief Discover thread devices and fill or update the device collection.
+     *
+     * Called from 'handleNetworkDiscoveryRequest' when destination is empty and relationshipType == "devices".
+     * Or called directly from tbd 'updateDeviceCollectionTask'.
+     *
+     * @retval OTBR_ERROR_NONE
+     *         OTBR_ERROR_INVALID_STATE   Another request is in processing.
+     *         OTBR_ERROR_REST            Insufficient message buffers available to send DIAG_GET.req.
+     */
+    otbrError startDiscovery(void);
+
+    // Handlers for DiagRequests
+    static void DiagnosticResponseHandler(otError              aError,
+                                          otMessage           *aMessage,
+                                          const otMessageInfo *aMessageInfo,
+                                          void                *aContext);
+    void        DiagnosticResponseHandler(otError aError, const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
+    // look-up hostname registered for ipv6 of the device in SRP server
+    void GetHostName(DeviceInfo &aDeviceInfo);
+
+    // transfer responses in mChildTables and mChildIps buffer into device collection
+    void GetChildren(const uint16_t &aParentRloc16);
+
+    // transfer responses in mDiagSet buffer into device collection
+    void FillDeviceCollection(void);
+
+    // add or update item in device collection
+    void SetDeviceItemAttributes(std::string aExtAddr, DeviceInfo &aDevice);
+
+    // add local border router counters
+    void GetLocalCounters(otbr::rest::NetworkDiagnostics *aDeviceDiag);
+
+    // add service flags
+    void SetServiceRoleFlags(otbr::rest::NetworkDiagnostics *aDeviceDiag, otNetworkDiagTlv aTlv);
+
+    // transfer DiagQuery responses to aDeviceDiag item
+    void SetDiagQueryTlvs(otbr::rest::NetworkDiagnostics *aDeviceDiag, const uint16_t &aParentRloc16);
+
+    // transfer responses in mDiagSet buffer into diagnostic collection
+    void FillDiagnosticCollection(void);
+
+    /**
+     * @brief Send Diagnostic Query to get the child table TLV 'OT_NETWORK_DIAGNOSTIC_TLV_CHILD'.
+     *
+     * @param aRloc16     short address of a router
+     * @param aMaxAge     oldest timestamp of previous diagnostic responses considered still valid
+     * @param aChildTable RouterChildTable state of request and content of request responses.
+     * @retval true       Query completed and response received.
+     * @retval false      Waiting for results.
+     */
+    bool RequestChildTable(uint16_t aRloc16, steady_clock::time_point aMaxAge, RouterChildTable *aChildTable);
+
+    // Handlers for DiagQuery Requests for TLV 'OT_NETWORK_DIAGNOSTIC_TLV_CHILD'
+    static void MeshChildTableResponseHandler(otError aError, const otMeshDiagChildEntry *aChildEntry, void *aContext);
+    void        MeshChildTableResponseHandler(otError aError, const otMeshDiagChildEntry *aChildEntry);
+
+    /**
+     * @brief Send Diagnostic Query to get the child ipv6 address TLV 'OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST'.
+     *
+     * @param aParentRloc16     short address of a router
+     * @param aMaxAge     oldest timestamp of previous diagnostic responses considered still valid
+     * @param aChild RouterChildIp6Addr state of request and content of request responses.
+     * @retval true       Query completed and response received.
+     * @retval false      Waiting for results.
+     */
+    bool RequestChildIp6Addrs(uint16_t aParentRloc16, steady_clock::time_point aMaxAge, RouterChildIp6Addrs *aChild);
+
+    // Handlers for DiagQuery Requests for TLV 'OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST'
+    static void MeshChildIp6AddrResponseHandler(otError                    aError,
+                                                uint16_t                   aChildRloc16,
+                                                otMeshDiagIp6AddrIterator *aIp6AddrIterator,
+                                                void                      *aContext);
+    void        MeshChildIp6AddrResponseHandler(otError                    aError,
+                                                uint16_t                   aChildRloc16,
+                                                otMeshDiagIp6AddrIterator *aIp6AddrIterator);
+
+    /**
+     * @brief Send Diagnostic Query to get the child ipv6 address TLV 'OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR'.
+     *
+     * @param aRloc16     short address of a router
+     * @param aMaxAge     oldest timestamp of previous diagnostic responses considered still valid
+     * @param aRouterNeighbor RouterNeighbor state of request and content of request responses.
+     * @retval true       Query completed and response received.
+     * @retval false      Waiting for results.
+     */
+    bool RequestRouterNeighbors(uint16_t aRloc16, steady_clock::time_point aMaxAge, RouterNeighbors *aRouterNeighbor);
+
+    // Handlers for DiagQuery Requests for TLV 'OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR'
+    static void MeshRouterNeighborsResponseHandler(otError                              aError,
+                                                   const otMeshDiagRouterNeighborEntry *aNeighborEntry,
+                                                   void                                *aContext);
+    void        MeshRouterNeighborsResponseHandler(otError aError, const otMeshDiagRouterNeighborEntry *aNeighborEntry);
+
+    /**
+     * @brief Iterate through mDiagQueryTlvs and sequentially collect Query TLVs.
+     *
+     * @retval true  Completed all DiagQuery Requests.
+     * @retval false Waiting for more results.
+     */
+    bool HandleNextDiagQuery(void);
+};
+
+} // namespace rest
+} // namespace otbr
+#endif // OTBR_REST_NETWORK_DIAG_HANDLER_HPP_

--- a/src/rest/parser.cpp
+++ b/src/rest/parser.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "rest/parser.hpp"
+#include "utils/string_utils.hpp"
 
 #include <string>
 #include <vector>
@@ -34,104 +35,147 @@
 namespace otbr {
 namespace rest {
 
-static int OnUrl(http_parser *parser, const char *at, size_t len)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-
-    if (len > 0)
-    {
-        request->SetUrl(at, len);
-    }
-
-    return 0;
-}
-
-static int OnBody(http_parser *parser, const char *at, size_t len)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-
-    if (len > 0)
-    {
-        request->SetBody(at, len);
-    }
-
-    return 0;
-}
-
-static int OnMessageComplete(http_parser *parser)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-
-    request->SetReadComplete();
-
-    return 0;
-}
-
-static int OnMessageBegin(http_parser *parser)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-    request->ResetReadComplete();
-
-    return 0;
-}
-
-static int OnHeaderComplete(http_parser *parser)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-    request->SetMethod(parser->method);
-    return 0;
-}
-
-static int OnHandlerData(http_parser *, const char *, size_t)
-{
-    return 0;
-}
-
-static int OnHeaderField(http_parser *parser, const char *at, size_t len)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-
-    if (len > 0)
-    {
-        request->SetNextHeaderField(at, len);
-    }
-
-    return 0;
-}
-
-static int OnHeaderData(http_parser *parser, const char *at, size_t len)
-{
-    Request *request = reinterpret_cast<Request *>(parser->data);
-
-    if (len > 0)
-    {
-        request->SetHeaderValue(at, len);
-    }
-
-    return 0;
-}
-
 Parser::Parser(Request *aRequest)
 {
-    mParser.data = aRequest;
+    mState.mRequest = aRequest;
+
+    mParser.data = &mState;
 }
 
 void Parser::Init(void)
 {
-    mSettings.on_message_begin    = OnMessageBegin;
-    mSettings.on_url              = OnUrl;
-    mSettings.on_status           = OnHandlerData;
-    mSettings.on_header_field     = OnHeaderField;
-    mSettings.on_header_value     = OnHeaderData;
-    mSettings.on_body             = OnBody;
-    mSettings.on_headers_complete = OnHeaderComplete;
-    mSettings.on_message_complete = OnMessageComplete;
+    mSettings.on_message_begin    = Parser::OnMessageBegin;
+    mSettings.on_url              = Parser::OnUrl;
+    mSettings.on_status           = Parser::OnHandlerData;
+    mSettings.on_header_field     = Parser::OnHeaderField;
+    mSettings.on_header_value     = Parser::OnHeaderData;
+    mSettings.on_body             = Parser::OnBody;
+    mSettings.on_headers_complete = Parser::OnHeaderComplete;
+    mSettings.on_message_complete = Parser::OnMessageComplete;
     http_parser_init(&mParser, HTTP_REQUEST);
 }
 
 void Parser::Process(const char *aBuf, size_t aLength)
 {
     http_parser_execute(&mParser, &mSettings, aBuf, aLength);
+}
+
+int Parser::OnUrl(http_parser *parser, const char *at, size_t len)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+
+    if (len > 0)
+    {
+        state->mUrl.append(at, len);
+    }
+
+    return 0;
+}
+
+int Parser::OnBody(http_parser *parser, const char *at, size_t len)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+
+    if (len > 0)
+    {
+        state->mRequest->SetBody(at, len);
+    }
+
+    return 0;
+}
+
+int Parser::OnMessageComplete(http_parser *parser)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+
+    http_parser_url urlParser;
+    http_parser_url_init(&urlParser);
+    http_parser_parse_url(state->mUrl.c_str(), state->mUrl.length(), 1, &urlParser);
+
+    if (urlParser.field_set & (1 << UF_PATH))
+    {
+        std::string path = state->mUrl.substr(urlParser.field_data[UF_PATH].off, urlParser.field_data[UF_PATH].len);
+        state->mRequest->SetUrlPath(path);
+    }
+
+    if (urlParser.field_set & (1 << UF_QUERY))
+    {
+        uint16_t offset = urlParser.field_data[UF_QUERY].off;
+        uint16_t end    = offset + urlParser.field_data[UF_QUERY].len;
+
+        while (offset < end)
+        {
+            std::string::size_type next = state->mUrl.find('&', offset);
+            if (next == std::string::npos)
+            {
+                next = end;
+            }
+
+            std::string::size_type split = state->mUrl.find('=', offset);
+            if (split == std::string::npos)
+            {
+                std::string query = state->mUrl.substr(offset, next - offset);
+                state->mRequest->AddQueryField(query, "");
+            }
+            else if (static_cast<uint16_t>(split) < next)
+            {
+                std::string query = state->mUrl.substr(offset, split - offset);
+                std::string value = state->mUrl.substr(split + 1, next - split - 1);
+
+                state->mRequest->AddQueryField(query, value);
+            }
+
+            offset = static_cast<uint16_t>(next + 1);
+        }
+    }
+
+    state->mRequest->SetReadComplete();
+
+    return 0;
+}
+
+int Parser::OnMessageBegin(http_parser *parser)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+    state->mRequest->ResetReadComplete();
+
+    return 0;
+}
+
+int Parser::OnHeaderComplete(http_parser *parser)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+    state->mRequest->SetMethod(parser->method);
+    return 0;
+}
+
+int Parser::OnHandlerData(http_parser *, const char *, size_t)
+{
+    return 0;
+}
+
+int Parser::OnHeaderField(http_parser *parser, const char *at, size_t len)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+
+    if (len > 0)
+    {
+        state->mNextHeaderField = StringUtils::ToLowercase(std::string(at, len));
+    }
+
+    return 0;
+}
+
+int Parser::OnHeaderData(http_parser *parser, const char *at, size_t len)
+{
+    State *state = reinterpret_cast<State *>(parser->data);
+
+    if (len > 0)
+    {
+        state->mRequest->AddHeaderField(state->mNextHeaderField, std::string(at, len));
+    }
+
+    return 0;
 }
 
 } // namespace rest

--- a/src/rest/parser.hpp
+++ b/src/rest/parser.hpp
@@ -76,8 +76,26 @@ public:
     void Process(const char *aBuf, size_t aLength);
 
 private:
+    class State
+    {
+    public:
+        Request    *mRequest;
+        std::string mUrl;
+        std::string mNextHeaderField;
+    };
+
+    static int OnUrl(http_parser *parser, const char *at, size_t len);
+    static int OnBody(http_parser *parser, const char *at, size_t len);
+    static int OnMessageComplete(http_parser *parser);
+    static int OnMessageBegin(http_parser *parser);
+    static int OnHeaderComplete(http_parser *parser);
+    static int OnHandlerData(http_parser *, const char *, size_t);
+    static int OnHeaderField(http_parser *parser, const char *at, size_t len);
+    static int OnHeaderData(http_parser *parser, const char *at, size_t len);
+
     http_parser          mParser;
     http_parser_settings mSettings;
+    State                mState;
 };
 
 } // namespace rest

--- a/src/rest/request.cpp
+++ b/src/rest/request.cpp
@@ -37,9 +37,9 @@ Request::Request(void)
 {
 }
 
-void Request::SetUrl(const char *aString, size_t aLength)
+void Request::SetUrlPath(std::string aPath)
 {
-    mUrl += std::string(aString, aLength);
+    mUrlPath = aPath;
 }
 
 void Request::SetBody(const char *aString, size_t aLength)
@@ -57,14 +57,14 @@ void Request::SetMethod(int32_t aMethod)
     mMethod = aMethod;
 }
 
-void Request::SetNextHeaderField(const char *aString, size_t aLength)
+void Request::AddHeaderField(std::string aField, std::string aValue)
 {
-    mNextHeaderField = StringUtils::ToLowercase(std::string(aString, aLength));
+    mHeaders[aField] = aValue;
 }
 
-void Request::SetHeaderValue(const char *aString, size_t aLength)
+void Request::AddQueryField(std::string aField, std::string aValue)
 {
-    mHeaders[mNextHeaderField] = std::string(aString, aLength);
+    mQueryParameters[aField] = aValue;
 }
 
 HttpMethod Request::GetMethod() const
@@ -77,25 +77,9 @@ std::string Request::GetBody() const
     return mBody;
 }
 
-std::string Request::GetUrl(void) const
+std::string Request::GetUrlPath(void) const
 {
-    std::string url = mUrl;
-
-    size_t urlEnd = url.find("?");
-
-    if (urlEnd != std::string::npos)
-    {
-        url = url.substr(0, urlEnd);
-    }
-    while (!url.empty() && url[url.size() - 1] == '/')
-    {
-        url.pop_back();
-    }
-
-    VerifyOrExit(url.size() > 0, url = "/");
-
-exit:
-    return url;
+    return mUrlPath;
 }
 
 std::string Request::GetHeaderValue(const std::string aHeaderField) const
@@ -103,6 +87,20 @@ std::string Request::GetHeaderValue(const std::string aHeaderField) const
     auto it = mHeaders.find(StringUtils::ToLowercase(aHeaderField));
 
     return (it == mHeaders.end()) ? "" : it->second;
+}
+
+std::string Request::GetQueryParameter(const std::string aQueryName) const
+{
+    auto it = mQueryParameters.find(aQueryName);
+
+    return (it == mQueryParameters.end()) ? "" : it->second;
+}
+
+bool Request::HasQuery(const std::string aQueryName) const
+{
+    auto it = mQueryParameters.find(aQueryName);
+
+    return (it == mQueryParameters.end()) ? false : true;
 }
 
 void Request::SetReadComplete(void)

--- a/src/rest/request.hpp
+++ b/src/rest/request.hpp
@@ -57,12 +57,12 @@ public:
     Request(void);
 
     /**
-     * This method sets the Url field of a request.
+     * This method sets the Url Path field of a request.
      *
-     * @param[in] aString  A pointer points to url string.
-     * @param[in] aLength  Length of the url string
+     * @param[in] aPath  The url path
+     *
      */
-    void SetUrl(const char *aString, size_t aLength);
+    void SetUrlPath(std::string aPath);
 
     /**
      * This method sets the body field of a request.
@@ -89,18 +89,19 @@ public:
     /**
      * This method sets the next header field of a request.
      *
-     * @param[in] aString  A pointer points to body string.
-     * @param[in] aLength  Length of the body string
+     * @param[in] aField  The field name.
+     * @param[in] aValue  The value of the field.
+     *
      */
-    void SetNextHeaderField(const char *aString, size_t aLength);
+    void AddHeaderField(std::string aField, std::string aValue);
 
     /**
-     * This method sets the header value of the previously set header of a request.
+     * This method adds a query field to the request.
      *
-     * @param[in] aString  A pointer points to body string.
-     * @param[in] aLength  Length of the body string
+     * @param[in] aField  The field name.
+     * @param[in] aValue  The value of the field.
      */
-    void SetHeaderValue(const char *aString, size_t aLength);
+    void AddQueryField(std::string aField, std::string aValue);
 
     /**
      * This method labels the request as complete which means it no longer need to be parsed one more time .
@@ -131,7 +132,7 @@ public:
      *
      * @returns A string contains the url of this request.
      */
-    std::string GetUrl(void) const;
+    std::string GetUrlPath(void) const;
 
     /**
      * This method returns the specified header field for this request.
@@ -142,6 +143,22 @@ public:
     std::string GetHeaderValue(const std::string aHeaderField) const;
 
     /**
+     * This method returns a boolean describing the presence of the specified query name in this request.
+     *
+     * @param aQueryName  A query name.
+     * @return True if the query name is found or False if the query name could not be found.
+     */
+    bool HasQuery(const std::string aQueryName) const;
+
+    /**
+     * This method returns the specified query parameter for this request.
+     *
+     * @param aQueryName  A query name.
+     * @return A string containing the value of the query or an empty string if the query could not be found.
+     */
+    std::string GetQueryParameter(const std::string aQueryName) const;
+
+    /**
      * This method indicates whether this request is parsed completely.
      */
     bool IsComplete(void) const;
@@ -149,10 +166,10 @@ public:
 private:
     int32_t                            mMethod;
     size_t                             mContentLength;
-    std::string                        mUrl;
+    std::string                        mUrlPath;
     std::string                        mBody;
-    std::string                        mNextHeaderField;
     std::map<std::string, std::string> mHeaders;
+    std::map<std::string, std::string> mQueryParameters;
     bool                               mComplete;
 };
 

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -26,14 +26,33 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define OTBR_LOG_TAG "REST"
+#include "openthread/mesh_diag.h"
+#include "openthread/platform/toolchain.h"
+#include "rest/json.hpp"
+#include "rest/types.hpp"
 
+#ifndef OTBR_LOG_TAG
+#define OTBR_LOG_TAG "REST"
+#endif
+
+#include <set>
+#include <openthread/srp_server.h>
+#include "common/logging.hpp"
+#include "common/task_runner.hpp"
+//#include "rest/extensions/rest_task_network_diagnostic.hpp"
+#include "rest/network_diag_handler.hpp"
 #include "rest/resource.hpp"
+#include "utils/string_utils.hpp"
+
+extern "C" {
+#include <cJSON.h>
+extern task_node_t *task_queue;
+extern uint8_t      task_queue_len;
+}
 
 #define OT_PSKC_MAX_LENGTH 16
 #define OT_EXTENDED_PANID_LENGTH 8
 
-#define OT_REST_RESOURCE_PATH_DIAGNOSTICS "/diagnostics"
 #define OT_REST_RESOURCE_PATH_NODE "/node"
 #define OT_REST_RESOURCE_PATH_NODE_BAID "/node/ba-id"
 #define OT_REST_RESOURCE_PATH_NODE_RLOC "/node/rloc"
@@ -46,10 +65,14 @@
 #define OT_REST_RESOURCE_PATH_NODE_EXTPANID "/node/ext-panid"
 #define OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE "/node/dataset/active"
 #define OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING "/node/dataset/pending"
-#define OT_REST_RESOURCE_PATH_NETWORK "/networks"
-#define OT_REST_RESOURCE_PATH_NETWORK_CURRENT "/networks/current"
-#define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_COMMISSION "/networks/commission"
-#define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_PREFIX "/networks/current/prefix"
+
+// API endpoint path definition
+#define OT_REST_RESOURCE_PATH_API "/api"
+#define OT_REST_RESOURCE_PATH_API_ACTIONS OT_REST_RESOURCE_PATH_API "/actions"
+#define OT_REST_RESOURCE_PATH_API_DEVICES OT_REST_RESOURCE_PATH_API "/devices"
+#define OT_REST_RESOURCE_PATH_API_DIAGNOSTICS OT_REST_RESOURCE_PATH_API "/diagnostics"
+#define OT_REST_RESOURCE_PATH_API_NODE OT_REST_RESOURCE_PATH_API OT_REST_RESOURCE_PATH_NODE
+#define OT_REST_RESOURCE_PATH_API_NETWORKS OT_REST_RESOURCE_PATH_API "/networks"
 
 #define OT_REST_HTTP_STATUS_200 "200 OK"
 #define OT_REST_HTTP_STATUS_201 "201 Created"
@@ -59,10 +82,13 @@
 #define OT_REST_HTTP_STATUS_405 "405 Method Not Allowed"
 #define OT_REST_HTTP_STATUS_408 "408 Request Timeout"
 #define OT_REST_HTTP_STATUS_409 "409 Conflict"
+#define OT_REST_HTTP_STATUS_415 "415 Unsupported Media Type"
 #define OT_REST_HTTP_STATUS_500 "500 Internal Server Error"
+#define OT_REST_HTTP_STATUS_503 "503 Service Unavailable"
 
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
+using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 
 using std::placeholders::_1;
@@ -71,17 +97,34 @@ using std::placeholders::_2;
 namespace otbr {
 namespace rest {
 
-// MulticastAddr
-static const char *kMulticastAddrAllRouters = "ff03::2";
-
-// Default TlvTypes for Diagnostic inforamtion
-static const uint8_t kAllTlvTypes[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 14, 15, 16, 17, 19};
-
-// Timeout (in Microseconds) for deleting outdated diagnostics
-static const uint32_t kDiagResetTimeout = 3000000;
-
-// Timeout (in Microseconds) for collecting diagnostics
-static const uint32_t kDiagCollectTimeout = 2000000;
+// Default TlvTypes for Diagnostic information
+static const uint8_t kAllTlvTypes[] = {
+    OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS,          ///< MAC Extended Address TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS,        ///< Address16 TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_MODE,                 ///< Mode TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT,              ///< Timeout TLV (max polling time period for SEDs)
+    OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY,         ///< Connectivity TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_ROUTE,                ///< Route64 TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA,          ///< Leader Data TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA,         ///< Network Data TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST,        ///< IPv6 Address List TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS,         ///< MAC Counters TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL,        ///< Battery Level TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_SUPPLY_VOLTAGE,       ///< Supply Voltage TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE,          ///< Child Table TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES,        ///< Channel Pages TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT,    ///< Max Child Timeout TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_EUI64,                ///< EUI64 TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VERSION,              ///< Thread Version TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_NAME,          ///< Vendor Name TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_MODEL,         ///< Vendor Model TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_VENDOR_SW_VERSION,    ///< Vendor SW Version TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_THREAD_STACK_VERSION, ///< Thread Stack Version TLV (codebase/commit version)
+    OT_NETWORK_DIAGNOSTIC_TLV_CHILD,                ///< Child TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_CHILD_IP6_ADDR_LIST,  ///< Child IPv6 Address List TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_ROUTER_NEIGHBOR,      ///< Router Neighbor TLV
+    OT_NETWORK_DIAGNOSTIC_TLV_MLE_COUNTERS          ///< MLE Counters TLV
+};
 
 static std::string GetHttpStatus(HttpStatusCode aErrorCode)
 {
@@ -113,20 +156,31 @@ static std::string GetHttpStatus(HttpStatusCode aErrorCode)
     case HttpStatusCode::kStatusConflict:
         httpStatus = OT_REST_HTTP_STATUS_409;
         break;
+    case HttpStatusCode::kStatusUnsupportedMediaType:
+        httpStatus = OT_REST_HTTP_STATUS_415;
+        break;
     case HttpStatusCode::kStatusInternalServerError:
         httpStatus = OT_REST_HTTP_STATUS_500;
+        break;
+    case HttpStatusCode::kStatusServiceUnavailable:
+        httpStatus = OT_REST_HTTP_STATUS_503;
         break;
     }
 
     return httpStatus;
 }
 
+// extract ItemId from request url
+std::string getItemIdFromUrl(const Request &aRequest, std::string aCollectionName);
+
+/**
+ * Initialize the Resource class with a pointer to the ControllerOpenThread instance.
+ */
 Resource::Resource(RcpHost *aHost)
     : mInstance(nullptr)
     , mHost(aHost)
 {
     // Resource Handler
-    mResourceMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::Diagnostic);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE, &Resource::NodeInfo);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_BAID, &Resource::BaId);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_STATE, &Resource::State);
@@ -140,19 +194,56 @@ Resource::Resource(RcpHost *aHost)
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, &Resource::DatasetActive);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, &Resource::DatasetPending);
 
+    // API Resource Handler
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_API_ACTIONS, &Resource::ApiActionHandler);
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_API_DEVICES, &Resource::ApiDeviceHandler);
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_API_DIAGNOSTICS, &Resource::ApiDiagnosticHandler);
+
     // Resource callback handler
-    mResourceCallbackMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::HandleDiagnosticCallback);
+    mResourceCallbackMap.emplace(OT_REST_RESOURCE_PATH_API_DEVICES, &Resource::ApiDevicePostCallbackHandler);
 }
 
 void Resource::Init(void)
 {
     mInstance = mHost->GetThreadHelper()->GetInstance();
+    // prepare to handle commissioner state changes
+    mHost->AddThreadStateChangedCallback((Ncp::RcpHost::ThreadStateChangedCallback)HandleThreadStateChanges);
+    // start task runner for api/actions
+    ApiActionRepeatedTaskRunner(2000);
 }
 
-void Resource::Handle(Request &aRequest, Response &aResponse) const
+std::string Resource::redirectToCollection(Request &aRequest)
 {
-    std::string url = aRequest.GetUrl();
-    auto        it  = mResourceMap.find(url);
+    size_t  endpointSize;
+    uint8_t apiPathLength = strlen("/api/");
+
+    std::string url = aRequest.GetUrlPath();
+
+    // redirect OT_REST_RESOURCE_PATH_NODE to /api/devices/{thisDeviceId}
+    if ((url == std::string(OT_REST_RESOURCE_PATH_NODE)) || (url == std::string(OT_REST_RESOURCE_PATH_API_NODE)))
+    {
+        redirectNodeToDeviceItem(aRequest);
+        url = aRequest.GetUrlPath();
+    }
+
+    VerifyOrExit(url.compare(0, apiPathLength, std::string("/api/")) == 0);
+    // check url matches structure /api/{collection}/{itemId}
+    endpointSize = url.find('/', apiPathLength);
+    // redirect to /api/{collection}
+    if (endpointSize != std::string::npos)
+    {
+        url = url.substr(0, endpointSize);
+    }
+
+exit:
+    return url;
+}
+
+void Resource::Handle(Request &aRequest, Response &aResponse)
+{
+    std::string url = redirectToCollection(aRequest);
+
+    auto it = mResourceMap.find(url);
 
     if (it != mResourceMap.end())
     {
@@ -167,8 +258,9 @@ void Resource::Handle(Request &aRequest, Response &aResponse) const
 
 void Resource::HandleCallback(Request &aRequest, Response &aResponse)
 {
-    std::string url = aRequest.GetUrl();
-    auto        it  = mResourceCallbackMap.find(url);
+    std::string url = redirectToCollection(aRequest);
+
+    auto it = mResourceCallbackMap.find(url);
 
     if (it != mResourceCallbackMap.end())
     {
@@ -177,29 +269,11 @@ void Resource::HandleCallback(Request &aRequest, Response &aResponse)
     }
 }
 
-void Resource::HandleDiagnosticCallback(const Request &aRequest, Response &aResponse)
+// calls rest_task_queue_handler after delay_ms
+void Resource::ApiActionRepeatedTaskRunner(uint16_t delay_ms)
 {
-    OT_UNUSED_VARIABLE(aRequest);
-    std::vector<std::vector<otNetworkDiagTlv>> diagContentSet;
-    std::string                                body;
-    std::string                                errorCode;
-
-    auto duration = duration_cast<microseconds>(steady_clock::now() - aResponse.GetStartTime()).count();
-    if (duration >= kDiagCollectTimeout)
-    {
-        DeleteOutDatedDiagnostic();
-
-        for (auto it = mDiagSet.begin(); it != mDiagSet.end(); ++it)
-        {
-            diagContentSet.push_back(it->second.mDiagContent);
-        }
-
-        body      = Json::Diag2JsonString(diagContentSet);
-        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
-        aResponse.SetResponsCode(errorCode);
-        aResponse.SetBody(body);
-        aResponse.SetComplete();
-    }
+    // TODO: post repeatedly
+    mHost->PostTimerTask(milliseconds(delay_ms), rest_task_queue_handle);
 }
 
 void Resource::ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) const
@@ -282,14 +356,35 @@ exit:
     }
 }
 
-void Resource::NodeInfo(const Request &aRequest, Response &aResponse) const
+void Resource::redirectNodeToDeviceItem(Request &aRequest)
+{
+    uint64_t            keyExtaddr = 0;
+    const otExtAddress *extAddr;
+    char                buffer[18];
+    std::string         url;
+
+    extAddr = otLinkGetExtendedAddress(mInstance);
+
+    for (int i = 0; i < OT_EXT_ADDRESS_SIZE; i++)
+    {
+        keyExtaddr = (keyExtaddr << 8) | extAddr->m8[i];
+    }
+
+    std::sprintf(buffer, "/%016lx", keyExtaddr);
+
+    url = OT_REST_RESOURCE_PATH_API_DEVICES + std::string(buffer);
+
+    aRequest.SetUrlPath(url);
+}
+
+void Resource::NodeInfo(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
     switch (aRequest.GetMethod())
     {
     case HttpMethod::kGet:
-        GetNodeInfo(aResponse);
+        ApiDeviceGetHandler(aRequest, aResponse);
         break;
     case HttpMethod::kDelete:
         DeleteNodeInfo(aResponse);
@@ -324,7 +419,7 @@ exit:
     }
 }
 
-void Resource::BaId(const Request &aRequest, Response &aResponse) const
+void Resource::BaId(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -349,7 +444,7 @@ void Resource::GetDataExtendedAddr(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::ExtendedAddr(const Request &aRequest, Response &aResponse) const
+void Resource::ExtendedAddr(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -419,7 +514,7 @@ exit:
     }
 }
 
-void Resource::State(const Request &aRequest, Response &aResponse) const
+void Resource::State(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -455,7 +550,7 @@ void Resource::GetDataNetworkName(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::NetworkName(const Request &aRequest, Response &aResponse) const
+void Resource::NetworkName(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -494,7 +589,7 @@ exit:
     }
 }
 
-void Resource::LeaderData(const Request &aRequest, Response &aResponse) const
+void Resource::LeaderData(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
     if (aRequest.GetMethod() == HttpMethod::kGet)
@@ -532,7 +627,7 @@ void Resource::GetDataNumOfRoute(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::NumOfRoute(const Request &aRequest, Response &aResponse) const
+void Resource::NumOfRoute(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -559,7 +654,7 @@ void Resource::GetDataRloc16(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::Rloc16(const Request &aRequest, Response &aResponse) const
+void Resource::Rloc16(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -584,7 +679,7 @@ void Resource::GetDataExtendedPanId(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::ExtendedPanId(const Request &aRequest, Response &aResponse) const
+void Resource::ExtendedPanId(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -611,7 +706,7 @@ void Resource::GetDataRloc(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::Rloc(const Request &aRequest, Response &aResponse) const
+void Resource::Rloc(const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -767,7 +862,7 @@ exit:
     }
 }
 
-void Resource::Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
+void Resource::Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse)
 {
     std::string errorCode;
 
@@ -790,111 +885,547 @@ void Resource::Dataset(DatasetType aDatasetType, const Request &aRequest, Respon
     }
 }
 
-void Resource::DatasetActive(const Request &aRequest, Response &aResponse) const
+void Resource::DatasetActive(const Request &aRequest, Response &aResponse)
 {
     Dataset(DatasetType::kActive, aRequest, aResponse);
 }
 
-void Resource::DatasetPending(const Request &aRequest, Response &aResponse) const
+void Resource::DatasetPending(const Request &aRequest, Response &aResponse)
 {
     Dataset(DatasetType::kPending, aRequest, aResponse);
 }
 
-void Resource::DeleteOutDatedDiagnostic(void)
+void Resource::ApiActionHandler(const Request &aRequest, Response &aResponse)
 {
-    auto eraseIt = mDiagSet.begin();
-    for (eraseIt = mDiagSet.begin(); eraseIt != mDiagSet.end();)
-    {
-        auto diagInfo = eraseIt->second;
-        auto duration = duration_cast<microseconds>(steady_clock::now() - diagInfo.mStartTime).count();
+    std::string errorCode;
+    std::string methods = "OPTIONS, GET, POST, DELETE";
 
-        if (duration >= kDiagResetTimeout)
+    switch (aRequest.GetMethod())
+    {
+    case HttpMethod::kPost:
+        ApiActionPostHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kGet:
+        ApiActionGetHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kDelete:
+        ApiActionDeleteHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kOptions:
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+        aResponse.SetAllowMethods(methods);
+        aResponse.SetResponsCode(errorCode);
+        aResponse.SetComplete();
+        break;
+    default:
+        aResponse.SetAllowMethods(methods);
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+        break;
+    }
+}
+
+void Resource::HandleThreadStateChanges(otChangedFlags aFlags)
+{
+    if (aFlags & OT_CHANGED_COMMISSIONER_STATE)
+    {
+        otbrLogDebug("%s:%d - %s - commissioner state change.", __FILE__, __LINE__, __func__);
+        rest_task_queue_handle();
+    }
+}
+
+void Resource::ApiActionPostHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string    responseMessage;
+    std::string    errorCode;
+    HttpStatusCode statusCode = HttpStatusCode::kStatusOk;
+    cJSON         *root;
+    cJSON         *dataArray;
+    cJSON         *resp_data;
+    cJSON         *datum;
+    uuid_t         task_id;
+    task_node_t   *task_node;
+    cJSON         *resp;
+    const char    *resp_str;
+
+    VerifyOrExit((aRequest.GetHeaderValue(OT_REST_CONTENT_TYPE_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0),
+                 statusCode = HttpStatusCode::kStatusUnsupportedMediaType);
+
+    root = cJSON_Parse(aRequest.GetBody().c_str());
+    VerifyOrExit(root != NULL, statusCode = HttpStatusCode::kStatusBadRequest);
+
+    // perform general validation before we attempt to
+    // perform any task specific validation
+    dataArray = cJSON_GetObjectItemCaseSensitive(root, "data");
+    VerifyOrExit((dataArray != NULL) && cJSON_IsArray(dataArray), statusCode = HttpStatusCode::kStatusConflict);
+
+    // validate the form and arguments of all tasks
+    // before we attempt to perform processing on any of the tasks.
+    for (int idx = 0; idx < cJSON_GetArraySize(dataArray); idx++)
+    {
+        // Require all items in the list to be valid Task items with all required attributes;
+        // otherwise rejects whole list and returns 409 Conflict.
+        // Unimplemented tasks counted as failed / invalid tasks
+        VerifyOrExit(ACTIONS_TASK_VALID == validate_task(cJSON_GetArrayItem(dataArray, idx)),
+                     statusCode = HttpStatusCode::kStatusConflict);
+    }
+
+    // Check queueing all tasks does not exceed the max number of tasks we can have queued
+    VerifyOrExit((TASK_QUEUE_MAX - task_queue_len + can_remove_task_max()) > cJSON_GetArraySize(dataArray),
+                 statusCode = HttpStatusCode::kStatusConflict);
+
+    // Queue the tasks and prepare response data
+    resp_data = cJSON_CreateArray();
+    for (int i = 0; i < cJSON_GetArraySize(dataArray); i++)
+    {
+        datum = cJSON_GetArrayItem(dataArray, i);
+        if (queue_task(datum, &task_id))
         {
-            eraseIt = mDiagSet.erase(eraseIt);
+            task_node = task_node_find_by_id(task_id);
+            cJSON_AddItemToArray(resp_data, task_to_json(task_node));
+            // attempt first process of task
+            rest_task_queue_handle();
+            // and another attempt after 2s
+            ApiActionRepeatedTaskRunner(2000);
+        }
+    }
+
+    // prepare reponse object
+    resp = cJSON_CreateObject();
+    cJSON_AddItemToObject(resp, "data", resp_data);
+    cJSON_AddItemToObject(resp, "meta", jsonCreateTaskMetaCollection(0, TASK_QUEUE_MAX, cJSON_GetArraySize(resp_data)));
+
+    resp_str = cJSON_PrintUnformatted(resp);
+    otbrLogDebug("%s:%d - %s - Sending (%d):\n%s", __FILE__, __LINE__, __func__, strlen(resp_str), resp_str);
+
+    responseMessage = resp_str;
+    aResponse.SetBody(responseMessage);
+    aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSONAPI);
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
+
+    free((void *)resp_str);
+    cJSON_Delete(resp);
+
+    // Clear the 'root' JSON object and release its memory (this should also delete 'data')
+    cJSON_Delete(root);
+    root = NULL;
+
+exit:
+    if (statusCode != HttpStatusCode::kStatusOk)
+    {
+        if (root != NULL)
+        {
+            cJSON_Delete(root);
+        }
+        otbrLogWarning("Error (%d)", statusCode);
+        ErrorHandler(aResponse, statusCode);
+    }
+}
+
+void Resource::ApiActionGetHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string    resp_body;
+    std::string    errorCode;
+    HttpStatusCode statusCode = HttpStatusCode::kStatusOk;
+    task_node_t   *task_node;
+    cJSON         *resp;
+    cJSON         *resp_data;
+
+    std::string itemId = getItemIdFromUrl(aRequest, "actions");
+
+    VerifyOrExit(aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0,
+                 statusCode = HttpStatusCode::kStatusUnsupportedMediaType);
+
+    // update the task status in the queue
+    rest_task_queue_handle();
+    // and another attempt after 2s
+    ApiActionRepeatedTaskRunner(2000);
+
+    if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSONAPI);
+
+        if (!itemId.empty())
+        {
+            // return the item
+            task_node = task_queue;
+            while (std::string(task_node->id_str) != itemId)
+            {
+                VerifyOrExit(task_node->next != nullptr, statusCode = HttpStatusCode::kStatusResourceNotFound);
+
+                task_node = task_node->next;
+            }
+            evaluate_task(task_node);
+
+            resp = cJSON_CreateObject();
+            cJSON_AddItemToObject(resp, "data", task_to_json(task_node));
+            resp_body = std::string(cJSON_PrintUnformatted(resp));
         }
         else
         {
-            eraseIt++;
+            // return all items
+            task_node = task_queue;
+            resp      = cJSON_CreateObject();
+
+            resp_data = cJSON_CreateArray();
+            while (task_node != NULL)
+            {
+                evaluate_task(task_node);
+                cJSON_AddItemToObject(resp_data, "data", task_to_json(task_node));
+                task_node = task_node->next;
+            }
+
+            cJSON_AddItemToObject(resp, "data", resp_data);
+            cJSON_AddItemToObject(resp, "meta",
+                                  jsonCreateTaskMetaCollection(0, TASK_QUEUE_MAX, cJSON_GetArraySize(resp_data)));
+
+            resp_body = std::string(cJSON_PrintUnformatted(resp));
         }
+    }
+
+    aResponse.SetBody(resp_body);
+    cJSON_Delete(resp);
+
+    errorCode = GetHttpStatus(statusCode);
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
+
+exit:
+    if (statusCode != HttpStatusCode::kStatusOk)
+    {
+        ErrorHandler(aResponse, statusCode);
     }
 }
 
-void Resource::UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag)
+void Resource::ApiActionDeleteHandler(const Request &aRequest, Response &aResponse)
 {
-    DiagInfo value;
+    std::string errorCode;
 
-    value.mStartTime = steady_clock::now();
-    value.mDiagContent.assign(aDiag.begin(), aDiag.end());
-    mDiagSet[aKey] = value;
+    OTBR_UNUSED_VARIABLE(aRequest);
+
+    remove_all_task();
+    rest_task_queue_handle();
+
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
 }
 
-void Resource::Diagnostic(const Request &aRequest, Response &aResponse) const
+void Resource::ApiDiagnosticGetHandler(const Request &aRequest, Response &aResponse)
 {
-    otbrError error = OTBR_ERROR_NONE;
-    OT_UNUSED_VARIABLE(aRequest);
-    struct otIp6Address rloc16address = *otThreadGetRloc(mInstance);
-    struct otIp6Address multicastAddress;
+    std::string    errorCode  = GetHttpStatus(HttpStatusCode::kStatusOk);
+    HttpStatusCode statusCode = HttpStatusCode::kStatusOk;
 
-    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &rloc16address, kAllTlvTypes, sizeof(kAllTlvTypes),
-                                           &Resource::DiagnosticResponseHandler,
-                                           const_cast<Resource *>(this)) == OT_ERROR_NONE,
-                 error = OTBR_ERROR_REST);
-    VerifyOrExit(otIp6AddressFromString(kMulticastAddrAllRouters, &multicastAddress) == OT_ERROR_NONE,
-                 error = OTBR_ERROR_REST);
-    VerifyOrExit(otThreadSendDiagnosticGet(mInstance, &multicastAddress, kAllTlvTypes, sizeof(kAllTlvTypes),
-                                           &Resource::DiagnosticResponseHandler,
-                                           const_cast<Resource *>(this)) == OT_ERROR_NONE,
-                 error = OTBR_ERROR_REST);
+    std::string                        resp_body;
+    std::map<std::string, std::string> queries;
+    std::string                        itemId;
+
+    VerifyOrExit(((aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0) ||
+                  (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSON) == 0)),
+                 statusCode = HttpStatusCode::kStatusUnsupportedMediaType);
+
+    itemId = getItemIdFromUrl(aRequest, otbr::rest::gDiagnosticsCollection.getCollectionName());
+
+    if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSONAPI);
+        for (auto &it : otbr::rest::gDiagnosticsCollection.getContainedTypes())
+        {
+            if (aRequest.HasQuery("fields[" + it + "]"))
+            {
+                queries[it] = aRequest.GetQueryParameter("fields[" + it + "]");
+            }
+        }
+        if (!itemId.empty())
+        {
+            // return the item
+            resp_body = otbr::rest::gDiagnosticsCollection.toJsonApiItemId(itemId, queries);
+            VerifyOrExit(!resp_body.empty(), statusCode = HttpStatusCode::kStatusResourceNotFound);
+        }
+        else
+        {
+            // return all items
+            resp_body = otbr::rest::gDiagnosticsCollection.toJsonApiColl(queries);
+        }
+    }
+    else if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSON) == 0)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSON);
+        if (!itemId.empty())
+        {
+            // return the item
+            resp_body = otbr::rest::gDiagnosticsCollection.toJsonStringItemId(itemId, queries);
+            VerifyOrExit(!resp_body.empty(), statusCode = HttpStatusCode::kStatusResourceNotFound);
+        }
+        else
+        {
+            // return all items
+            resp_body = otbr::rest::gDiagnosticsCollection.toJsonString();
+        }
+    }
+
+    aResponse.SetBody(resp_body);
+    aResponse.SetStartTime(steady_clock::now());
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
 
 exit:
+    if (statusCode != HttpStatusCode::kStatusOk)
+    {
+        ErrorHandler(aResponse, statusCode);
+    }
+}
 
+void Resource::ApiDiagnosticDeleteHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string errorCode;
+
+    OTBR_UNUSED_VARIABLE(aRequest);
+
+    // get handler for network diagnostics
+    NetworkDiagHandler &netDiagHandler = NetworkDiagHandler::getInstance(mInstance);
+    netDiagHandler.clear();
+
+    otbr::rest::gDiagnosticsCollection.clear();
+
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
+}
+
+void Resource::ApiDiagnosticHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string errorCode;
+    std::string methods = "OPTIONS, GET, DELETE";
+
+    switch (aRequest.GetMethod())
+    {
+    case HttpMethod::kGet:
+        ApiDiagnosticGetHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kDelete:
+        ApiDiagnosticDeleteHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kOptions:
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
+        aResponse.SetAllowMethods(methods);
+        aResponse.SetResponsCode(errorCode);
+        aResponse.SetComplete();
+        break;
+    case HttpMethod::kPost:
+    default:
+        aResponse.SetAllowMethods(methods);
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+        break;
+    }
+}
+
+void Resource::ApiDeviceHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string errorCode;
+
+    switch (aRequest.GetMethod())
+    {
+    case HttpMethod::kDelete:
+        ApiDeviceDeleteHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kGet:
+        ApiDeviceGetHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kPost:
+        ApiDevicePostHandler(aRequest, aResponse);
+        break;
+    case HttpMethod::kOptions:
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+        aResponse.SetResponsCode(errorCode);
+        aResponse.SetComplete();
+        break;
+    default:
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
+        break;
+    }
+}
+
+void Resource::ApiDeviceDeleteHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string errorCode;
+
+    OTBR_UNUSED_VARIABLE(aRequest);
+
+    gDevicesCollection.clear();
+
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusNoContent);
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
+}
+
+std::string getItemIdFromUrl(const Request &aRequest, std::string aCollectionName)
+{
+    std::string itemId = "";
+    std::string url    = aRequest.GetUrlPath();
+    uint8_t     basePathLength =
+        strlen(OT_REST_RESOURCE_PATH_API) + aCollectionName.length() + 2; // +2 for '/' before and after aCollectionName
+    size_t idSize = url.find('/', basePathLength);
+
+    VerifyOrExit(url.size() >= basePathLength);
+
+    if (idSize != std::string::npos)
+    {
+        idSize = idSize - basePathLength;
+    }
+
+    itemId = url.substr(basePathLength, idSize);
+
+    if (!itemId.empty())
+    {
+        otbrLogWarning("%s:%d get ItemId %s/%s", __FILE__, __LINE__, aCollectionName.c_str(), itemId.c_str());
+    }
+
+exit:
+    return itemId;
+}
+
+void Resource::ApiDeviceGetHandler(const Request &aRequest, Response &aResponse)
+{
+    std::string    errorCode  = GetHttpStatus(HttpStatusCode::kStatusOk);
+    HttpStatusCode statusCode = HttpStatusCode::kStatusOk;
+
+    std::string                        resp_body;
+    std::map<std::string, std::string> queries;
+
+    std::string itemId = getItemIdFromUrl(aRequest, otbr::rest::gDevicesCollection.getCollectionName());
+
+    VerifyOrExit(((aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0) ||
+                  (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSON) == 0)),
+                 statusCode = HttpStatusCode::kStatusUnsupportedMediaType);
+
+    if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSONAPI) == 0)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSONAPI);
+        for (auto &it : otbr::rest::gDevicesCollection.getContainedTypes())
+        {
+            if (aRequest.HasQuery("fields[" + it + "]"))
+            {
+                queries[it] = aRequest.GetQueryParameter("fields[" + it + "]");
+            }
+        }
+        if (!itemId.empty())
+        {
+            // return the item
+            resp_body = otbr::rest::gDevicesCollection.toJsonApiItemId(itemId, queries);
+            VerifyOrExit(!resp_body.empty(), statusCode = HttpStatusCode::kStatusResourceNotFound);
+        }
+        else
+        {
+            // return all items
+            resp_body = otbr::rest::gDevicesCollection.toJsonApiColl(queries);
+        }
+    }
+    else if (aRequest.GetHeaderValue(OT_REST_ACCEPT_HEADER).compare(OT_REST_CONTENT_TYPE_JSON) == 0)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSON);
+        for (auto &it : otbr::rest::gDevicesCollection.getContainedTypes())
+        {
+            if (aRequest.HasQuery("fields[" + it + "]"))
+            {
+                queries[it] = aRequest.GetQueryParameter("fields[" + it + "]");
+            }
+        }
+        if (!itemId.empty())
+        {
+            // return the item
+            resp_body = otbr::rest::gDevicesCollection.toJsonStringItemId(itemId, queries);
+            VerifyOrExit(!resp_body.empty(), statusCode = HttpStatusCode::kStatusResourceNotFound);
+        }
+        else
+        {
+            // return all items
+            resp_body = otbr::rest::gDevicesCollection.toJsonString();
+        }
+    }
+
+    aResponse.SetBody(resp_body);
+    aResponse.SetStartTime(steady_clock::now());
+    aResponse.SetResponsCode(errorCode);
+    aResponse.SetComplete();
+
+exit:
+    if (statusCode != HttpStatusCode::kStatusOk)
+    {
+        // otbrLogWarning("%s:%d REST query error %d", __FILE__, __LINE__, error);
+        ErrorHandler(aResponse, statusCode);
+    }
+}
+
+// Discover device in the network and update the device collection.
+void Resource::ApiDevicePostHandler(const Request &aRequest, Response &aResponse)
+{
+    otbrError   error = OTBR_ERROR_NONE;
+    std::string resp_body;
+    std::string errorCode;
+
+    OT_UNUSED_VARIABLE(aRequest);
+
+    aResponse.SetStartTime(steady_clock::now());
+
+    // get handler for network diagnostics
+    NetworkDiagHandler &netDiagHandler = NetworkDiagHandler::getInstance(mInstance);
+    VerifyOrExit((error = netDiagHandler.configRequest(10000, 30000, 1, nullptr)) == OTBR_ERROR_NONE);
+    VerifyOrExit((error = netDiagHandler.handleNetworkDiscoveryRequest("", gDevicesCollection.getCollectionName())) ==
+                 OTBR_ERROR_NONE);
+
+exit:
     if (error == OTBR_ERROR_NONE)
     {
-        aResponse.SetStartTime(steady_clock::now());
         aResponse.SetCallback();
+    }
+    else if (error == OTBR_ERROR_INVALID_STATE)
+    {
+        otbrLogWarning("%s:%d otbr error %s", __FILE__, __LINE__, otbrErrorString(error));
+        ErrorHandler(aResponse, HttpStatusCode::kStatusServiceUnavailable);
     }
     else
     {
+        otbrLogWarning("%s:%d otbr error %s", __FILE__, __LINE__, otbrErrorString(error));
         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
     }
 }
 
-void Resource::DiagnosticResponseHandler(otError              aError,
-                                         otMessage           *aMessage,
-                                         const otMessageInfo *aMessageInfo,
-                                         void                *aContext)
+void Resource::ApiDevicePostCallbackHandler(const Request &aRequest, Response &aResponse)
 {
-    static_cast<Resource *>(aContext)->DiagnosticResponseHandler(aError, aMessage, aMessageInfo);
-}
+    OT_UNUSED_VARIABLE(aRequest);
+    otbrError                          error = OTBR_ERROR_NONE;
+    std::string                        resp_body;
+    std::string                        errorCode;
+    std::map<std::string, std::string> queries; // empty query
 
-void Resource::DiagnosticResponseHandler(otError aError, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
-{
-    std::vector<otNetworkDiagTlv> diagSet;
-    otNetworkDiagTlv              diagTlv;
-    otNetworkDiagIterator         iterator = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT;
-    otError                       error;
-    char                          rloc[7];
-    std::string                   keyRloc = "0xffee";
+    // get handler for network diagnostics
+    NetworkDiagHandler &netDiagHandler = NetworkDiagHandler::getInstance(mInstance);
 
-    SuccessOrExit(aError);
-
-    OTBR_UNUSED_VARIABLE(aMessageInfo);
-
-    while ((error = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
-    {
-        if (diagTlv.mType == OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS)
-        {
-            snprintf(rloc, sizeof(rloc), "0x%04x", diagTlv.mData.mAddr16);
-            keyRloc = Json::CString2JsonString(rloc);
-        }
-        diagSet.push_back(diagTlv);
-    }
-    UpdateDiag(keyRloc, diagSet);
+    VerifyOrExit((error = netDiagHandler.continueHandleRequest()) == OTBR_ERROR_NONE);
 
 exit:
-    if (aError != OT_ERROR_NONE)
+    if (error == OTBR_ERROR_NONE)
     {
-        otbrLogWarning("Failed to get diagnostic data: %s", otThreadErrorToString(aError));
+        ApiDeviceGetHandler(aRequest, aResponse);
+    }
+    else if (error == OTBR_ERROR_ABORTED)
+    {
+        aResponse.SetContentType(OT_REST_CONTENT_TYPE_JSONAPI);
+
+        // return all items collected until timeout
+        resp_body = otbr::rest::gDevicesCollection.toJsonApiColl(queries);
+
+        aResponse.SetBody(resp_body);
+        errorCode = GetHttpStatus(HttpStatusCode::kStatusRequestTimeout);
+        aResponse.SetResponsCode(errorCode);
+        aResponse.SetComplete();
+    }
+    else if (error != OTBR_ERROR_ERRNO)
+    {
+        otbrLogWarning("%s:%d otbr error %s", __FILE__, __LINE__, otbrErrorString(error));
+        ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
     }
 }
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -34,6 +34,10 @@
 #ifndef OTBR_REST_RESOURCE_HPP_
 #define OTBR_REST_RESOURCE_HPP_
 
+/*
+Include necessary headers for OpenThread functions, REST utilities, and JSON processing.
+*/
+
 #include "openthread-br/config.h"
 
 #include <unordered_map>
@@ -45,6 +49,12 @@
 #include "ncp/rcp_host.hpp"
 #include "openthread/dataset.h"
 #include "openthread/dataset_ftd.h"
+#include "openthread/mesh_diag.h"
+#include "rest/extensions/rest_devices_coll.hpp"
+#include "rest/extensions/rest_diagnostics_coll.hpp"
+#include "rest/extensions/rest_task_add_thread_device.hpp"
+#include "rest/extensions/rest_task_handler.hpp"
+#include "rest/extensions/rest_task_queue.hpp"
 #include "rest/json.hpp"
 #include "rest/request.hpp"
 #include "rest/response.hpp"
@@ -81,7 +91,7 @@ public:
      * @param[in]     aRequest  A request instance referred by the Resource handler.
      * @param[in,out] aResponse  A response instance will be set by the Resource handler.
      */
-    void Handle(Request &aRequest, Response &aResponse) const;
+    void Handle(Request &aRequest, Response &aResponse);
 
     /**
      * This method distributes a callback handler for each connection needs a callback.
@@ -101,6 +111,14 @@ public:
     void ErrorHandler(Response &aResponse, HttpStatusCode aErrorCode) const;
 
 private:
+    enum class RequestState : uint8_t
+    {
+        kIdle,
+        kWaiting,
+        kPending,
+        kDone,
+    };
+
     /**
      * This enumeration represents the Dataset type (active or pending).
      */
@@ -110,23 +128,21 @@ private:
         kPending, ///< Pending Dataset
     };
 
-    typedef void (Resource::*ResourceHandler)(const Request &aRequest, Response &aResponse) const;
+    typedef void (Resource::*ResourceHandler)(const Request &aRequest, Response &aResponse);
     typedef void (Resource::*ResourceCallbackHandler)(const Request &aRequest, Response &aResponse);
-    void NodeInfo(const Request &aRequest, Response &aResponse) const;
-    void BaId(const Request &aRequest, Response &aResponse) const;
-    void ExtendedAddr(const Request &aRequest, Response &aResponse) const;
-    void State(const Request &aRequest, Response &aResponse) const;
-    void NetworkName(const Request &aRequest, Response &aResponse) const;
-    void LeaderData(const Request &aRequest, Response &aResponse) const;
-    void NumOfRoute(const Request &aRequest, Response &aResponse) const;
-    void Rloc16(const Request &aRequest, Response &aResponse) const;
-    void ExtendedPanId(const Request &aRequest, Response &aResponse) const;
-    void Rloc(const Request &aRequest, Response &aResponse) const;
-    void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
-    void DatasetActive(const Request &aRequest, Response &aResponse) const;
-    void DatasetPending(const Request &aRequest, Response &aResponse) const;
-    void Diagnostic(const Request &aRequest, Response &aResponse) const;
-    void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
+    void NodeInfo(const Request &aRequest, Response &aResponse);
+    void BaId(const Request &aRequest, Response &aResponse);
+    void ExtendedAddr(const Request &aRequest, Response &aResponse);
+    void State(const Request &aRequest, Response &aResponse);
+    void NetworkName(const Request &aRequest, Response &aResponse);
+    void LeaderData(const Request &aRequest, Response &aResponse);
+    void NumOfRoute(const Request &aRequest, Response &aResponse);
+    void Rloc16(const Request &aRequest, Response &aResponse);
+    void ExtendedPanId(const Request &aRequest, Response &aResponse);
+    void Rloc(const Request &aRequest, Response &aResponse);
+    void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse);
+    void DatasetActive(const Request &aRequest, Response &aResponse);
+    void DatasetPending(const Request &aRequest, Response &aResponse);
 
     void GetNodeInfo(Response &aResponse) const;
     void DeleteNodeInfo(Response &aResponse) const;
@@ -143,14 +159,148 @@ private:
     void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
 
-    void DeleteOutDatedDiagnostic(void);
-    void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);
+    /**
+     * Redirects requests from '/api/{collection}/{collectionItem}' to the corresponding collection.
+     *
+     * @param[in]     aRequest A request instance to be checked and redirected.
+     * @returns       A string containing the redirected url.
+     */
+    std::string redirectToCollection(Request &aRequest);
 
-    static void DiagnosticResponseHandler(otError              aError,
-                                          otMessage           *aMessage,
-                                          const otMessageInfo *aMessageInfo,
-                                          void                *aContext);
-    void        DiagnosticResponseHandler(otError aError, const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    /**
+     * Rewrites the URL in the request to redirect to the corresponding deviceItem.
+     *
+     * @param[in,out] aRequest  A request instance containing the URL to be rewritten.
+     */
+    void redirectNodeToDeviceItem(Request &aRequest);
+
+    /**
+     * Handles all requests received on 'api/action'. [POST|GET|DELETE]
+     *
+     * Routes POST, GET, and DELETE requests to their respective handlers.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated based on the request.
+     */
+    void ApiActionHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Repeatedly iterates through the list of tasks.
+     *
+     * Calls `rest_task_queue_handle` after a specified delay, continuing the iteration.
+     * TODO: post repeatedly
+     *
+     * @param[in] delay_ms  The delay in milliseconds between each iteration.
+     */
+    void ApiActionRepeatedTaskRunner(uint16_t delay_ms);
+
+    /**
+     * Handles the POST request received on 'api/actions'.
+     *
+     * This method parses the received JSON data, validates it, and updates the task status
+     * for further processing. The request will be processed and evaluated by the
+     * "rest_task_queue_task" thread function.
+     *
+     * @param[in]  aRequest   A request instance containing the POST data.
+     * @param[out] aResponse  A response instance that will be set by an appropriate rest task action.
+     */
+    void ApiActionPostHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the GET request received on 'api/actions'.
+     *
+     * This method retrieves the collection of actions.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated with the collection of actions.
+     */
+    void ApiActionGetHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the DELETE request received on 'api/actions'.
+     *
+     * This method clears all items in the collection of actions.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance populated with the outcome of the request.
+     */
+    void ApiActionDeleteHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles all requests received on 'api/diagnostics'. [GET|DELETE]
+     *
+     * Routes GET, and DELETE requests to their respective handlers.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated based on the request.
+     */
+    void ApiDiagnosticHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the GET request received on 'api/diagnostics'.
+     *
+     * This method returns the collection of diagnostics. The items in this collection are created
+     * as a result of a POST request with type 'getNetworkDiagnosticTask' to 'api/actions'.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated with the collection of diagnostics.
+     */
+    void ApiDiagnosticGetHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the DELETE request received on 'api/diagnostics'.
+     *
+     * This method clears all items in the collection of diagnostics.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated to confirm the deletion.
+     */
+    void ApiDiagnosticDeleteHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles all requests received on 'api/devices'. [GET|POST|DELETE]
+     *
+     * Routes POST, GET, and DELETE requests to their respective handlers.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated based on the request.
+     */
+    void ApiDeviceHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the GET request received on 'api/devices'.
+     *
+     * This method returns the collection of devices.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated with the collection of devices.
+     */
+    void ApiDeviceGetHandler(const Request &aRequest, Response &aResponse);
+
+    /**
+     * Handles the DELETE request received on 'api/devices'.
+     *
+     * This method clears all items in the collection of devices.
+     *
+     * @param[in]  aRequest   A request instance.
+     * @param[out] aResponse  A response instance that will be populated to confirm the deletion of the device
+     * collection.
+     */
+    void ApiDeviceDeleteHandler(const Request &aRequest, Response &aResponse);
+
+    /*********************************************************************************************************************
+     * TODO: redirect a POST request from api/devices to actions to fill up the device collection
+     *********************************************************************************************************************/
+    /**
+     * Handles the POST request received on 'api/devices'.
+     *
+     * This method discovers devices in the network and updates the collection of devices.
+     *
+     * @param[in]  aRequest   A request instance containing details for device discovery.
+     * @param[out] aResponse  A response instance that will be populated to confirm the update of the device collection.
+     */
+    void ApiDevicePostHandler(const Request &aRequest, Response &aResponse);
+    void ApiDevicePostCallbackHandler(const Request &aRequest, Response &aResponse);
 
     otInstance *mInstance;
     RcpHost    *mHost;
@@ -158,7 +308,13 @@ private:
     std::unordered_map<std::string, ResourceHandler>         mResourceMap;
     std::unordered_map<std::string, ResourceCallbackHandler> mResourceCallbackMap;
 
-    std::unordered_map<std::string, DiagInfo> mDiagSet;
+    /**
+     * @brief A state change handler. Handle list of actions waiting for commissioner
+     *
+     * @param aFlags
+     * @return * void
+     */
+    static void HandleThreadStateChanges(otChangedFlags aFlags);
 };
 
 } // namespace rest

--- a/src/rest/response.cpp
+++ b/src/rest/response.cpp
@@ -34,7 +34,7 @@
 #define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_HEADERS                                                              \
     "Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
     "Access-Control-Request-Headers"
-#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "DELETE, GET, OPTIONS, PUT"
+#define OT_REST_RESPONSE_ACCESS_CONTROL_ALLOW_METHOD "DELETE, GET, OPTIONS, PUT, POST"
 #define OT_REST_RESPONSE_CONNECTION "close"
 
 namespace otbr {
@@ -78,6 +78,11 @@ bool Response::IsComplete()
 void Response::SetResponsCode(std::string &aCode)
 {
     mCode = aCode;
+}
+
+void Response::SetAllowMethods(const std::string &aMethods)
+{
+    mHeaders[OT_REST_ALLOW_HEADER] = aMethods;
 }
 
 void Response::SetContentType(const std::string &aContentType)

--- a/src/rest/response.hpp
+++ b/src/rest/response.hpp
@@ -84,6 +84,14 @@ public:
     void SetResponsCode(std::string &aCode);
 
     /**
+     * This method sets the supported methods in "Allow" header field.
+     *
+     * @param[in] aCode  A string representing supported methods such as 'GET, POST, OPTIONS'.
+     *
+     */
+    void SetAllowMethods(const std::string &aMethods);
+
+    /**
      * This method sets the content type.
      *
      * @param[in] aCode  A string representing response content type such as text/plain.

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -49,6 +49,7 @@ static const uint32_t kMaxServeNum = 500;
 
 RestWebServer::RestWebServer(RcpHost &aHost, const std::string &aRestListenAddress, int aRestListenPort)
     : mResource(Resource(&aHost))
+    , mHost(aHost)
     , mListenFd(-1)
 {
     mAddress.sin6_family = AF_INET6;
@@ -74,6 +75,23 @@ RestWebServer::~RestWebServer(void)
 void RestWebServer::Init(void)
 {
     mResource.Init();
+
+    // Initialize the openthread instance
+    auto threadHelper = mHost.GetThreadHelper();
+    mInstance         = threadHelper->GetInstance();
+    if (mInstance != NULL)
+    {
+        // Initialize the mutex and creates a thread to process the 'api/actions'
+        // Pass the openthread instance that can be used to call openthread apis.
+
+        // removed 'task' (pthread) in the sense of a task for multithreading and do not create such
+        // parallel task objects that consequently require complicated lock and semaphore mechanisms.
+        // TODO: stick with term 'action' for an activity that requires indirect response.
+
+        // Initialize the instance pointer
+        rest_task_queue_task_init(mInstance);
+    }
+
     InitializeListenFd();
 }
 

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -42,6 +42,9 @@
 
 #include "common/mainloop.hpp"
 #include "rest/connection.hpp"
+#include "rest/extensions/rest_task_add_thread_device.hpp"
+#include "rest/extensions/rest_task_queue.hpp"
+#include "rest/resource.hpp"
 
 using otbr::Ncp::RcpHost;
 using std::chrono::steady_clock;
@@ -85,6 +88,12 @@ private:
 
     // Resource handler
     Resource mResource;
+
+    // OpenThread Controller reference
+    RcpHost &mHost;
+
+    // Openthread Instance pointer
+    otInstance *mInstance;
     // Struct for server configuration
     sockaddr_in6 mAddress;
     // File descriptor for listening

--- a/tests/restjsonapi/actions/Delete_Actions_Collection.bru
+++ b/tests/restjsonapi/actions/Delete_Actions_Collection.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Delete Actions Collection
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 204
+}
+
+docs {
+  Delete all items stored in the Collection.
+}

--- a/tests/restjsonapi/actions/Get_ActionItem_by_ItemId_404.bru
+++ b/tests/restjsonapi/actions/Get_ActionItem_by_ItemId_404.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get Action Item by ActionId
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions/{{actionId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+  ~Accept: application/json
+}
+
+vars:pre-request {
+  actionId: 9ecae480-07a0-4b72-869d-15858196144f
+}
+
+assert {
+  res.status: eq 404
+}

--- a/tests/restjsonapi/actions/Get_Actions_Collection.bru
+++ b/tests/restjsonapi/actions/Get_Actions_Collection.bru
@@ -1,0 +1,47 @@
+meta {
+  name: Get Actions Collection
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.meta.collection.pending: isDefined
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}
+
+tests {
+  
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    expect(data).to.be.an.instanceOf(Array);
+    for (let i=0; i < size; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("status");
+    }
+  });
+}
+
+docs {
+  Return all items stored in the Collection.
+}

--- a/tests/restjsonapi/actions/Get_Actions_Collection_completed.bru
+++ b/tests/restjsonapi/actions/Get_Actions_Collection_completed.bru
@@ -1,0 +1,59 @@
+meta {
+  name: Get Actions Collection
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.meta.collection.pending: eq 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}
+
+tests {
+  
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    expect(data).to.be.an.instanceOf(Array);
+    for (let i=0; i < size; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("status");
+      if (['getEnergyScanTask', 'getNetworkDiagnosticTask'].includes(item.type)){
+        expect(item.attributes.status == "completed");
+        expect(item).to.have.property("relationships");
+        expect(item.relationships).to.have.property("result");
+        expect(item.relationships.result).to.have.property("data");
+      };
+      if (['resetNetworkDiagCounterTask'].includes(item.type)){
+        expect(item.attributes.status == "completed");
+      };
+      if (['addThreadDeviceTask'].includes(item.type)){
+        expect(item.attributes.status == "pending");
+      };
+    }
+  });
+}
+
+docs {
+  Return all items stored in the Collection.
+}

--- a/tests/restjsonapi/actions/Options.bru
+++ b/tests/restjsonapi/actions/Options.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Options
+  type: http
+  seq: 5
+}
+
+options {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: none
+  auth: none
+}
+
+assert {
+  res.headers['allow']: contains OPTIONS, GET, POST, DELETE
+}

--- a/tests/restjsonapi/actions/Post_Add_ThreadDevice.bru
+++ b/tests/restjsonapi/actions/Post_Add_ThreadDevice.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Post Add ThreadDevice Joiner
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/vnd.api+json
+}
+
+body:json {
+  {
+    "data": [
+      {
+        "type": "addThreadDeviceTask",
+        "attributes": {
+          "eui": "f4ce36bac3135ee2",
+          "pskd": "J01NMERANGETEST",
+          "timeout": 3600
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}

--- a/tests/restjsonapi/actions/Post_Get_EnergyScan.bru
+++ b/tests/restjsonapi/actions/Post_Get_EnergyScan.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Post Get EnergyScan
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/vnd.api+json
+}
+
+body:json {
+  {
+    "data": [
+      {
+        "type": "getEnergyScanTask",
+        "attributes": {
+          "destination": "32ba6e34fd4c0299",
+          "channelMask": [11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26],
+          "count": 4,
+          "period": 32,
+          "scanDuration": 16,
+          "timeout": 10
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}

--- a/tests/restjsonapi/actions/Post_Get_NetworkDiagnostics.bru
+++ b/tests/restjsonapi/actions/Post_Get_NetworkDiagnostics.bru
@@ -1,0 +1,61 @@
+meta {
+  name: Post Get NetworkDiagnostics
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/vnd.api+json
+}
+
+body:json {
+  {
+    "data": [
+      {
+        "type": "getNetworkDiagnosticTask",
+        "attributes": {
+          "destination": "32ba6e34fd4c0299",
+          "types": [
+            "extAddress",
+            "rloc16",
+            "leaderData",
+            "ipv6Addresses",
+            "macCounters",
+            "batteryLevel",
+            "supplyVoltage",
+            "channelPages",
+            "maxChildTimeout",
+            "lDevIdSubject",
+            "iDevIdCert",
+            "eui64",
+            "version",
+            "vendorName",
+            "vendorModel",
+            "vendorSwVersion",
+            "threadStackVersion",
+            "children",
+            "childIpv6Addresses",
+            "routerNeighbor",
+            "mleCounters"
+          ],
+          "timeout": 10
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}

--- a/tests/restjsonapi/actions/Post_Reset_NetworkDiagnosticsCounter.bru
+++ b/tests/restjsonapi/actions/Post_Reset_NetworkDiagnosticsCounter.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Post Reset NetworkDiagnostics Counter
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/vnd.api+json
+}
+
+body:json {
+  {
+    "data": [
+      {
+        "type": "resetNetworkDiagCounterTask",
+        "attributes": {
+          "types": [
+            "macCounters",
+            "mleCounters"
+          ],
+          "timeout": 10
+        }
+      }
+    ]
+  }
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].attributes.status: isDefined
+}

--- a/tests/restjsonapi/bruno.json
+++ b/tests/restjsonapi/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "OpenThread REST JSON:API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/tests/restjsonapi/devices/Delete_Devices_Collection.bru
+++ b/tests/restjsonapi/devices/Delete_Devices_Collection.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Delete Devices Collection
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/devices
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 204
+}
+
+docs {
+  Delete all items stored in the Collection.
+}

--- a/tests/restjsonapi/devices/Get_DeviceItem_by_ItemId_404.bru
+++ b/tests/restjsonapi/devices/Get_DeviceItem_by_ItemId_404.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Device Item by DeviceId
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/devices/{{deviceId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+  ~Accept: application/json
+}
+
+vars:pre-request {
+  ~deviceId: 9e34bf94725f930e
+  deviceId: abcdef1234567890
+}
+
+assert {
+  res.status: eq 404
+}

--- a/tests/restjsonapi/devices/Get_Devices_Collection.bru
+++ b/tests/restjsonapi/devices/Get_Devices_Collection.bru
@@ -1,0 +1,66 @@
+meta {
+  name: Get Devices Collection
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/devices
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].type: neq ""
+  res.body.data[0].attributes.created: isDefined
+}
+
+tests {
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    const offset = res.getBody().meta.collection.offset;
+    const limit = res.getBody().meta.collection.limit;
+    const total = res.getBody().meta.collection.total;
+    
+    expect(data).to.be.an.instanceOf(Array);
+    expect(offset).to.be.a('number');
+    expect(limit).to.be.a('number');
+    expect(total).to.be.a('number');
+    
+    for (let i=0; i < size-1; i++){
+      let item = data[i];
+      
+      expect(item, `Item at index ${i}/${size} is null or undefined`).to.exist;
+  
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item.type).to.be.oneOf(["threadDevice", "threadBorderRouter"]);
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("extAddress").that.is.not.oneOf(["", "0000000000000000"]);
+      expect(item.attributes).to.have.property("mlEidIid").that.is.not.oneOf(["", "0000000000000000"]);
+      expect(item.attributes).to.have.property("omrIpv6Address").that.is.not.oneOf(["", "::"]);
+      expect(item.attributes).to.have.property("mode");
+      expect(item.attributes).to.have.property("hostName");
+      expect(item.attributes).to.have.property("created").that.is.not.empty;
+      expect(item.attributes).to.have.property("updated").that.is.not.empty;
+    }
+  });
+}
+
+docs {
+  Returns basic static device attributes.
+  On first GET request, requests diagnostic TLVs from each device,
+  otherwise returns buffered information.
+}

--- a/tests/restjsonapi/devices/Get_Devices_Collection_SparseFields.bru
+++ b/tests/restjsonapi/devices/Get_Devices_Collection_SparseFields.bru
@@ -1,0 +1,70 @@
+meta {
+  name: Get Devices Collection SparseFields
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/devices?fields[threadDevice]=extAddress,mlEidIid
+  body: none
+  auth: none
+}
+
+query {
+  fields[threadDevice]: extAddress,mlEidIid
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].type: neq ""
+  res.body.data[0].attributes.created: isDefined
+}
+
+tests {
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    const offset = res.getBody().meta.collection.offset;
+    const limit = res.getBody().meta.collection.limit;
+    const total = res.getBody().meta.collection.total;
+    
+    expect(data).to.be.an.instanceOf(Array);
+    expect(offset).to.be.a('number');
+    expect(limit).to.be.a('number');
+    expect(total).to.be.a('number');
+    
+    for (let i=0; i < size-1; i++){
+      let item = data[i];
+      
+      expect(item, `Item at index ${i}/${size} is null or undefined`).to.exist;
+  
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item.type).to.be.oneOf(["threadDevice", "threadBorderRouter"]);
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("extMacAddress").that.is.not.oneOf(["", "0000000000000000"]);
+      expect(item.attributes).to.have.property("mlEidIid").that.is.not.oneOf(["", "0000000000000000"]);
+      expect(item.attributes).to.not.have.property("omrIpv6Address").that.is.not.oneOf(["", "::"]);
+      expect(item.attributes).to.not.have.property("eui64").that.is.not.oneOf(["", "0000000000000000"]);
+      expect(item.attributes).to.not.have.property("hostName");
+      expect(item.attributes).to.have.property("created").that.is.not.empty;
+      expect(item.attributes).to.have.property("updated").that.is.not.empty;
+    }
+  });
+}
+
+docs {
+  Returns basic static device attributes.
+  On first GET request, requests diagnostic TLVs from each device,
+  otherwise returns buffered filtered information.
+}

--- a/tests/restjsonapi/devices/Get_Node.bru
+++ b/tests/restjsonapi/devices/Get_Node.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Node
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/node
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+  ~Accept: application/json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+}

--- a/tests/restjsonapi/devices/Get_Node_json.bru
+++ b/tests/restjsonapi/devices/Get_Node_json.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Node (json)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/node
+  body: none
+  auth: none
+}
+
+headers {
+  ~Accept: application/vnd.api+json
+  Accept: application/json
+}
+
+assert {
+  res.headers['content-type']: eq application/json
+  res.body: isJson
+  res.status: eq 200
+}

--- a/tests/restjsonapi/devices/Options.bru
+++ b/tests/restjsonapi/devices/Options.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Options
+  type: http
+  seq: 7
+}
+
+options {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/actions
+  body: none
+  auth: none
+}
+
+assert {
+  res.headers['allow']: contains OPTIONS, GET, POST, DELETE
+}

--- a/tests/restjsonapi/devices/Post_DeviceCollection_Update.bru
+++ b/tests/restjsonapi/devices/Post_DeviceCollection_Update.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Post update DeviceCollection
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/devices
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: in [200, 408]
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].type: neq ""
+  res.body.data[0].attributes.created: isDefined
+  res.body.data[0].attributes.mlEidIid: neq ""
+}
+
+docs {
+  Update device collection.
+}

--- a/tests/restjsonapi/diagnostics/Delete_Diagnostics_Collection.bru
+++ b/tests/restjsonapi/diagnostics/Delete_Diagnostics_Collection.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Delete Diagnostics Collection
+  type: http
+  seq: 1
+}
+
+delete {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 204
+}
+
+docs {
+  Delete all items stored in the Collection.
+}

--- a/tests/restjsonapi/diagnostics/Get_DiagnosticItem_by_ItemId_404.bru
+++ b/tests/restjsonapi/diagnostics/Get_DiagnosticItem_by_ItemId_404.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get NetworkDiagnostics by ItemId
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics/{{diagnosticItemId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+  ~Accept: application/json
+}
+
+vars:pre-request {
+  diagnosticItemId: 9ecae480-07a0-4b72-869d-15858196144f
+}
+
+assert {
+  res.status: eq 404
+}

--- a/tests/restjsonapi/diagnostics/Get_Diagnostics_Collection.bru
+++ b/tests/restjsonapi/diagnostics/Get_Diagnostics_Collection.bru
@@ -1,0 +1,72 @@
+meta {
+  name: Get Diagnostics Collection
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].type: neq ""
+  res.body.data[0].attributes.created: isDefined
+}
+
+tests {
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+
+    const offset = res.getBody().meta.collection.offset;
+    const limit = res.getBody().meta.collection.limit;
+    const total = res.getBody().meta.collection.total;
+    
+    expect(data).to.be.an.instanceOf(Array);
+    expect(offset).to.be.a('number');
+    expect(limit).to.be.a('number');
+    expect(total).to.be.a('number');
+
+    expect(data).to.be.an.instanceOf(Array);
+    for (let i=0; i < total; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("created");
+      
+      if (item.type.includes("Diag")){
+        expect(item.attributes).to.have.property("eui64");
+        expect(item.attributes).to.have.property("macCounters");
+        expect(item.attributes).to.have.property("mleCounters");
+        expect(item.attributes).to.have.property("children");
+      }
+  
+      if (item.type.includes("energyScanReport")){
+        expect(item.attributes).to.have.property("origin");
+        expect(item.attributes).to.have.property("count");
+        expect(item.attributes).to.have.property("report");
+        expect(item.attributes.report).to.be.an.instanceOf(Array);
+        expect(item.attributes.report[0]).to.have.property("channel");
+        expect(item.attributes.report[0]).to.have.property("maxRssi");
+      }
+    }
+  });
+  
+}
+
+docs {
+  Return all items stored in the Diagnostics Collection.
+}

--- a/tests/restjsonapi/diagnostics/Get_EnergyScanReport_Items.bru
+++ b/tests/restjsonapi/diagnostics/Get_EnergyScanReport_Items.bru
@@ -1,0 +1,56 @@
+meta {
+  name: Get EnergyScanReport Items
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics?fields[energyScanReport]
+  body: json
+  auth: none
+}
+
+query {
+  fields[energyScanReport]: 
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+}
+
+tests {
+  
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    expect(data).to.be.an.instanceOf(Array);
+    for (let i=0; i < size; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item.type).to.equal("energyScanReport");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("created");
+      expect(item.attributes).to.have.property("origin");
+      expect(item.attributes).to.have.property("count");
+      expect(item.attributes).to.have.property("report");
+      expect(item.attributes.report).to.be.an.instanceOf(Array);
+      expect(item.attributes.report[0]).to.have.property("channel");
+      expect(item.attributes.report[0]).to.have.property("maxRssi");
+    }
+  });
+  
+}
+
+docs {
+  Return all items of type EnergyScanReport stored in the Diagnostics Collection.
+}

--- a/tests/restjsonapi/diagnostics/Get_EnergyScanReport_Items_SparseFields.bru
+++ b/tests/restjsonapi/diagnostics/Get_EnergyScanReport_Items_SparseFields.bru
@@ -1,0 +1,56 @@
+meta {
+  name: Get EnergyScanReport SparseFields
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics?fields[energyScanReport]=report.maxRssi
+  body: json
+  auth: none
+}
+
+query {
+  fields[energyScanReport]: report.maxRssi
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+}
+
+tests {
+  
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().data.size;
+    expect(data).to.be.an.instanceOf(Array);
+    for (let i=0; i < size; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item.type).to.equal("energyScanReport");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("created");
+      expect(item.attributes).to.not.have.property("origin");
+      expect(item.attributes).to.not.have.property("count");
+      expect(item.attributes).to.have.property("report");
+      expect(item.attributes.report).to.be.an.instanceOf(Array);
+      expect(item.attributes.report[0]).to.not.have.property("channel");
+      expect(item.attributes.report[0]).to.have.property("maxRssi");
+    }
+  });
+  
+}
+
+docs {
+  Return only requested fields in EnergyScanReport stored in the Diagnostics Collection.
+}

--- a/tests/restjsonapi/diagnostics/Get_NetworkDiagnostics_Items.bru
+++ b/tests/restjsonapi/diagnostics/Get_NetworkDiagnostics_Items.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Get NetworkDiagnostics Items
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics?fields[networkDiagnostics]
+  body: json
+  auth: none
+}
+
+query {
+  fields[networkDiagnostics]: 
+}
+
+headers {
+  Accept: application/vnd.api+json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+}
+
+docs {
+  Return all items of type NetworkDiagnostics stored in the Diagnostics Collection.
+}

--- a/tests/restjsonapi/diagnostics/Get_NetworkDiagnostics_Items_SparseFields.bru
+++ b/tests/restjsonapi/diagnostics/Get_NetworkDiagnostics_Items_SparseFields.bru
@@ -1,0 +1,77 @@
+meta {
+  name: Get NetworkDiagnostics Items SparseFields
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics?fields[networkDiagnostics]=extAddress
+  body: none
+  auth: none
+}
+
+query {
+  fields[networkDiagnostics]: extAddress
+}
+
+headers {
+  Accept: application/vnd.api+json
+  ~Accept: application/json
+}
+
+assert {
+  res.headers['content-type']: eq application/vnd.api+json
+  res.body: isJson
+  res.status: eq 200
+  res.body.meta.collection: isDefined
+  res.body.meta.collection.total: gte 1
+  res.body.data: isDefined
+  res.body.data[0].id: isDefined
+  res.body.data[0].type: neq ""
+  res.body.data[0].attributes.created: isDefined
+}
+
+tests {
+  test("Data contains fields requested", function() {
+    const data = res.getBody().data;
+    const size = res.getBody().meta.collection.total;
+    expect(data).to.be.an.instanceOf(Array);
+    expect(data.length).to.equal(1)
+
+    for (let i=0; i < 1; i++){
+      item = data[i];
+      expect(item).to.have.property("id");
+      expect(item).to.have.property("type");
+      expect(item).to.have.property("attributes");
+      expect(item.attributes).to.have.property("created");
+      expect(item.attributes).to.have.property("extAddress");
+
+      expect(item.attributes).to.not.have.property("eui64");
+      expect(item.attributes).to.not.have.property("macCounters");
+      expect(item.attributes).to.not.have.property("mleCounters");
+      expect(item.attributes).to.not.have.property("children");
+      expect(item.attributes).to.not.have.property("rloc16");
+      expect(item.attributes).to.not.have.property("routerId");
+      expect(item.attributes).to.not.have.property("leaderData");
+      expect(item.attributes).to.not.have.property("ip6Addresses");
+      expect(item.attributes).to.not.have.property("channelPages");
+      expect(item.attributes).to.not.have.property("version");
+      expect(item.attributes).to.not.have.property("vendorName");
+      expect(item.attributes).to.not.have.property("vendorModel");
+      expect(item.attributes).to.not.have.property("vendorSwVersion");
+      expect(item.attributes).to.not.have.property("threadStackVersion");
+      expect(item.attributes).to.not.have.property("childrenIp6");
+      expect(item.attributes).to.not.have.property("neighbors");
+      expect(item.attributes).to.not.have.property("brCounters");
+      expect(item.attributes).to.not.have.property("isLeader");
+      expect(item.attributes).to.not.have.property("hostsService");
+      expect(item.attributes).to.not.have.property("isPrimaryBBR");
+      expect(item.attributes).to.not.have.property("isBorderRouter");
+    }
+  });
+  
+}
+
+docs {
+  Return filtered items stored in the Diagnostics Collection.
+}

--- a/tests/restjsonapi/diagnostics/Options.bru
+++ b/tests/restjsonapi/diagnostics/Options.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Options
+  type: http
+  seq: 1
+}
+
+options {
+  url: {{protocol}}://{{host}}:{{port}}{{base_path}}/diagnostics
+  body: none
+  auth: none
+}
+
+assert {
+  res.headers['allow']: contains OPTIONS, GET, DELETE
+}

--- a/tests/restjsonapi/environments/localhost.bru
+++ b/tests/restjsonapi/environments/localhost.bru
@@ -1,0 +1,6 @@
+vars {
+  host: localhost
+  base_path: /api
+  port: 8081
+  protocol: http
+}

--- a/tests/restjsonapi/http_action_client_demo.py
+++ b/tests/restjsonapi/http_action_client_demo.py
@@ -1,0 +1,489 @@
+#!/usr/bin/python3
+
+# Standard imports
+import json
+import logging
+import logging.handlers
+import os, sys
+from time import sleep, time
+
+# Third party imports
+import requests
+
+# Logging setup
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+# Create logger to stdout
+std_handler = logging.StreamHandler(sys.stdout)
+std_handler.setLevel(logging.DEBUG)
+
+# Add handler to logger
+logger.addHandler(std_handler)
+
+# set environment variables
+OTBR_SERVER_URL = "127.0.0.1"
+OTBR_REST_API_PORT = "8081"
+
+logger.info(f"Found OTBR server configuration for {OTBR_SERVER_URL}")
+
+headers = {"Content-type": "application/vnd.api+json"}
+accept_headers = {"Accept": "application/vnd.api+json"}
+
+base_url = "http://" + OTBR_SERVER_URL + ":" + OTBR_REST_API_PORT + "/api/"
+url_actions = base_url + "actions"
+
+MAX_RETRIES = 3
+SKIP_RXOFFWHENIDLE = True  # requests to rx-off-when-idle devices may be very slow
+
+class Action:
+
+    def __init__(self, destination, eui64="fedcba9876543210", timeout=30):
+
+        self.action_type = "notDefined"
+        self.result_type = "notDefined"
+        self.action_id = None
+        self.result_id = None
+        self.url = None
+        self.retries = 0
+        self.status = None
+
+        self.destination = destination
+        self.eui64 = eui64
+        self.timeout = timeout
+
+    def __repr__(self):
+        return (
+            f"type={self.action_type}, id={self.action_id}, dest={self.destination}, "
+            + f"result_id={self.result_id}, retries={self.retries}, status={self.status}"
+        )
+
+    def post_action(self, url=url_actions):
+
+        body = self._default_action()
+        self.url = url
+        response = requests.post(url, headers=headers, data=json.dumps(body), timeout=10)
+        if response.ok:
+            self.action_id = response.json()["data"][0]["id"]
+        else:
+            logger.warning(f"{response.status_code} - {response.reason} - {self._default_action()}")
+
+    def get_action(self):
+
+        if self.action_id:
+            response = requests.get(
+                self.url + "/" + self.action_id, headers=accept_headers, timeout=10
+            )
+        else:
+            return
+
+        action = response.json()["data"]
+        self.status = action["attributes"]["status"]
+        match self.status:
+            case "completed":
+                try:
+                    self.result_id = action["relationships"]["result"]["data"]["id"]
+                except KeyError:
+                    logger.exception("Error")
+            case "stopped" | "failed":
+                # retry
+                if self.retries <= MAX_RETRIES:
+                    self.retries += 1
+                    self.post_action()
+                    self.status = "pending"
+                else:
+                    self.status = "stopped"
+                # logger.info(f"stopped {self.destination}")
+            case "stored":
+                # nothing to do
+                pass
+            case _:
+                # wait longer
+                # logger.info(f"wait longer for {self.destination}")
+                pass
+
+    def get_results(self) -> bool:
+
+        if self.result_id and self.status and self.status not in "stored":
+            response = None
+            url_diagnostic_id = base_url + self.result_type + "/" + self.result_id
+            response = requests.get(url_diagnostic_id, headers=accept_headers, timeout=2)
+            if not response.ok:
+                logger.warning(response.reason)
+                return False
+
+            try:
+                result = response.json()["data"]["attributes"]
+                logger.info(f"{self.result_id}: {json.dumps(result)}")
+                self.store_result(result)
+                self.status = "stored"
+                return True
+            except Exception:
+                logger.exception("Failed getting results")
+        return False
+
+    def store_result(self, result):
+        # do something
+        raise NotImplementedError()
+
+    def _default_action(self):
+        raise NotImplementedError()
+
+
+class EnergyScanAction(Action):
+    def __init__(
+        self,
+        destination,
+        eui64="fedcba9876543210",
+        channel_mask=[
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+        ],
+        count=2,
+        period=32,
+        duration=16,
+        timeout=30,
+    ):
+        super().__init__(destination, eui64, timeout)
+
+        self.action_type = "getEnergyScanTask"
+        self.result_type = "diagnostics"
+
+        self.count = count
+        self.period = period
+        self.scan_duration = duration
+        self.channel_mask = channel_mask
+
+    def _default_action(self):
+        return {
+            "data": [
+                {
+                    "type": self.action_type,
+                    "attributes": {
+                        "destination": str(self.destination),
+                        "channelMask": self.channel_mask,
+                        "count": self.count,
+                        "period": self.period,
+                        "scanDuration": self.scan_duration,
+                        "timeout": self.timeout,
+                    },
+                },
+            ]
+        }
+
+    def store_result(self, result):
+        logger.info(result)
+
+
+class NetworkDiagnosticsAction(Action):
+    def __init__(
+        self, destination, eui64="fedcba9876543210", types=["extAddress", "eui64"], timeout=30
+    ):
+
+        super().__init__(destination, eui64, timeout)
+
+        self.action_type = "getNetworkDiagnosticTask"
+        self.result_type = "diagnostics"
+
+        self.types = types
+
+    def _default_action(self):
+        return {
+            "data": [
+                {
+                    "type": self.action_type,
+                    "attributes": {
+                        "destination": str(self.destination),
+                        "types": self.types,
+                        "timeout": self.timeout,
+                    },
+                },
+            ]
+        }
+
+    def store_result(self, result):
+        logger.info(result)
+
+
+def update_device_collection():
+    """If successfull, returns json:api doc."""
+
+    url_devices = "http://" + OTBR_SERVER_URL + ":" + OTBR_REST_API_PORT + "/api/devices"
+
+    retry = 0
+    while retry <= 5:
+        try:
+            response = requests.post(url_devices, headers=accept_headers, timeout=10)
+            break
+        except (
+            requests.RequestException,
+            requests.ReadTimeout,
+            requests.Timeout,
+            TimeoutError,
+        ) as error:
+            logger.error(
+                f"{repr(error)} bootstraping device collection. Going for retry {retry+1}."
+            )
+            sleep(5)
+            retry += 1
+
+    if not response.status_code == 200:
+        logger.info(response.json())
+    else:
+        logger.info(f"Got Device Collection {response.json()['meta']}")
+
+    return response.json()
+
+
+def get_device_collection():
+    """If successfull, returns json:api doc."""
+
+    url_devices = "http://" + OTBR_SERVER_URL + ":" + OTBR_REST_API_PORT + "/api/devices"
+    response = requests.get(url_devices, headers=accept_headers, timeout=10)
+    return response.json()
+
+
+def get_actions(action_id):
+    """Get a action item by its action_id."""
+    url_action_id = url_actions + action_id
+
+    response = requests.get(url_action_id, headers=accept_headers, timeout=10)
+    return response.json()
+
+
+def delete_actions():
+    logger.warning("Deleting actions on server.")
+    requests.delete(url_actions, headers=accept_headers, timeout=10)
+
+
+def check_completeness(devices):
+    """Check all devices have a valid mlEidIid attribute value."""
+
+    for device in devices:
+        if "0000000000000000" in device["attributes"]["mlEidIid"]:
+            logger.info(f"Missing ML-EID IID of device {device['id']}")
+            return False
+    return True
+
+
+def prepare_device_coll(max_device_count):
+    """Check collection of devices contains expected minimal number of items."""
+    
+    logger.info(f"Get/update network inventory from api/devices ...")
+    retry = 0
+
+    device_coll = get_device_collection()
+    device_count = device_coll["meta"]["collection"]["total"]
+
+    haveall_mleidiid = False
+    while (device_count < max_device_count) or not haveall_mleidiid:
+        device_coll = update_device_collection()
+        try:
+            device_count = device_coll["meta"]["collection"]["total"]
+            haveall_mleidiid = check_completeness(device_coll["data"])
+            if not haveall_mleidiid:
+                retry = min(retry + 1, 60)
+                retry_delay = 2 * retry
+                logger.info(f" - delay retry {retry} by {retry_delay}s ...")
+                sleep(retry_delay)
+        except KeyError:
+            retry = min(retry + 1, 60)
+            retry_delay = 2 * retry
+            logger.info(f"Devices {device_count}/{max_device_count} - delay retry by {retry_delay}s ...")
+            sleep(retry_delay)
+        if retry > 6:
+            break
+
+
+    logger.info(f"Devices {device_count}/{max_device_count}. {len(device_coll['data'])} in device collection.")
+
+    return device_coll["data"]
+
+
+def _process_pending_actions(active, completed):
+    # check previous actions are completed and get results
+    active_action_dest = ""
+    for action in active:
+        action.get_action()
+        if action.get_results() or action.status not in ["pending", "active"]:
+            completed.append(action)
+        if action.status == "active":
+            active_action_dest = action.destination
+
+    for action in completed:
+        try:
+            active.remove(action)
+        except ValueError:
+            # already removed
+            pass
+        except Exception:
+            logger.exception("Error")
+
+    if len(active) > 0:
+        logger.info(
+            f"Results: {len(active)} pending, {len(completed)} complete; currently active action to destination {active_action_dest}."
+        )
+    else:
+        logger.info("Completed.")
+
+    return (active, completed)
+
+
+def run_energy_scan(count_of_devices, channel_mask, count, period, duration):
+
+    logger.info("Start energy scan.")
+
+    device_set = prepare_device_coll(count_of_devices)
+
+    active_actions = []
+    completed_actions = []
+
+    timeout = time() + (count_of_devices * 15)
+
+    # to keep the test simple, we start with an empty collection
+    delete_actions()
+    actions = get_actions("")
+    if actions["meta"]["collection"]["total"] != 0:
+        logger.warning("Actions not empty.")
+
+    for device in device_set:
+        if not device["attributes"]["mode"]["rxOnWhenIdle"] and SKIP_RXOFFWHENIDLE:
+            logger.info("Skip rx-off-when-idle child ...")
+            continue
+        try:
+            eui = device["attributes"]["eui64"]
+        except KeyError:
+            eui = "0000000000000000"
+        act = EnergyScanAction(device["id"], eui, channel_mask, count, period, duration)
+        act.post_action()
+        active_actions.append(act)
+
+        # the best case duration of the energy scans at one device
+        wait = act.count * (act.scan_duration + act.period) * len(act.channel_mask) / 1000
+
+        # Only a single scan runs at a time
+        # We may post all the actions,
+        # but we want to wait a bit and not create bursts.
+        logger.info(f"Wait for completion after {wait} s")
+        sleep(wait)
+
+    while len(active_actions) > 0:
+
+        (active_actions, completed_actions) = _process_pending_actions(
+            active_actions, completed_actions
+        )
+
+        if time() > timeout:
+            logger.warning("Timeout for energy scan.")
+            for action in active_actions:
+                logger.warning(action)
+            break
+        if len(active_actions) > 0:
+            sleep(10)
+
+    return completed_actions
+
+
+def run_network_diagnostics(count_of_devices, types):
+
+    logger.info("Start network diagnostics.")
+
+    device_set = prepare_device_coll(count_of_devices)
+
+    active_actions = []
+    completed_actions = []
+
+    timeout = time() + (count_of_devices * 15)
+
+    # to keep the test simple, we start with an empty collection
+    delete_actions()
+    actions = get_actions("")
+    if actions["meta"]["collection"]["total"] != 0:
+        logger.warning("Actions not empty.")
+
+    for device in device_set:
+        if not device["attributes"]["mode"]["rxOnWhenIdle"] and SKIP_RXOFFWHENIDLE:
+            logger.info("Skip rx-off-when-idle child ...")
+            continue
+        try:
+            eui = device["attributes"]["eui64"]
+        except KeyError:
+            eui = "0000000000000000"
+        act = NetworkDiagnosticsAction(device["id"], eui, types)
+        act.post_action()
+        active_actions.append(act)
+
+    while len(active_actions) > 0:
+        sleep(0.5)
+        (active_actions, completed_actions) = _process_pending_actions(
+            active_actions, completed_actions
+        )
+
+        if time() > timeout:
+            logger.warning("Timeout for network diagnostics.")
+            for action in active_actions:
+                logger.warning(action)
+            break
+
+    return completed_actions
+
+
+if __name__ == "__main__":
+    # a short test script
+    DEVICE_COUNT = 15  # expected minimal device count
+    ACTION_TYPE = 1  # 0: energy scan, 1: networkDiagnostic
+    
+    #logger = logging.getLogger(__name__)
+
+    logger.info(f"Found server configuration for {OTBR_SERVER_URL}")
+
+    for i in range(1):
+        logger.info(f"Iteration: {i}")
+        start_time = time()
+        match ACTION_TYPE:
+            case 0:
+                compl_actions = run_energy_scan(DEVICE_COUNT, [24, 25, 26], 2, 32, 16)
+            case 1:
+                compl_actions = run_network_diagnostics(
+                    DEVICE_COUNT,
+                    [
+                        "extAddress",
+                        "rloc16",
+                        "mode",
+                        "timeout",
+                        "leaderData",
+                        "ipv6Addresses",
+                        "maxChildTimeout",
+                        "version",
+                        "vendorName",
+                        "vendorModel",
+                        "vendorSwVersion",
+                        "threadStackVersion",
+                        "children",
+                        "childIpv6Addresses",
+                        "routerNeighbor",
+                    ],
+                )
+            case _:
+                logger.warning("Set a valid value for ACTION_TYPE.")
+        # log final status
+        for action in compl_actions:
+            logger.info(action)
+
+        actions = get_actions("")
+        logger.info(f'Action items on server: {actions["meta"]["collection"]["total"]}')
+
+        logger.info(f"Iteration took {time()-start_time} seconds.")

--- a/tests/restjsonapi/install_bruno_cli
+++ b/tests/restjsonapi/install_bruno_cli
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+# Install Bruno CLI
+#
+
+# installs fnm (Fast Node Manager)
+curl -fsSL https://fnm.vercel.app/install | bash
+# activate fnm
+source ~/.bashrc
+# download and install Node.js
+fnm use --install-if-missing 20
+# verifies the right Node.js version is in the environment
+node -v # should print `v20.17.0`
+# verifies the right npm version is in the environment
+npm -v # should print `10.8.2`
+# install Bruno CLI
+npm install -g @usebruno/cli

--- a/tests/restjsonapi/test-restjsonapi-server
+++ b/tests/restjsonapi/test-restjsonapi-server
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+# Run Bruno tests
+#
+# Note: The border router is expected to be connected to a network and not in detached state.
+
+# Check DELETE collections
+bru run actions/Delete_Actions_Collection.bru --env localhost --output results_$LINENO.json
+bru run devices/Delete_Devices_Collection.bru --env localhost --output results_$LINENO.json
+bru run diagnostics/Delete_Diagnostics_Collection.bru --env localhost --output results_$LINENO.json
+
+##############################################################
+## Devices
+##############################################################
+# POST, Bootstrap/update Device Collection as an inventory of Thread network devices
+bru run devices/Post_DeviceCollection_Update.bru --env localhost --output results_$LINENO.json
+# we may not have gotten all responses. Repeat to have all ml-eid and the 'updated' timestamp
+sleep 5
+bru run devices/Post_DeviceCollection_Update.bru --env localhost --output results_$LINENO.json
+# wait a few seconds and retry again
+sleep 8
+bru run devices/Post_DeviceCollection_Update.bru --env localhost --output results_$LINENO.json
+
+# GET
+# do not continue on error in device collection
+bru run devices/Get_Devices_Collection.bru --env localhost --bail --output results_$LINENO.json
+bru run devices/Get_Devices_Collection_SparseFields.bru --env localhost --output results_$LINENO.json
+
+bru run devices/Get_Node.bru --env localhost --output results_$LINENO.json
+bru run devices/Get_Node_json.bru --env localhost --output results_$LINENO.json
+# GET a non-existing item
+bru run devices/Get_DeviceItem_by_ItemId_404.bru --env localhost --output results_$LINENO.json
+
+# TODO: replace '9e34bf94725f930e' with extaddr of DUT
+
+##############################################################
+## Actions ##
+##############################################################
+# POST Actions
+bru run actions/Post_Get_EnergyScan.bru --env localhost --output results_$LINENO.json
+bru run actions/Post_Get_NetworkDiagnostics.bru --env localhost --output results_$LINENO.json
+# add a Thread Joiner Device. Note: we will not check success of joining in this script.
+bru run actions/Post_Add_ThreadDevice.bru --env localhost --output results_$LINENO.json
+bru run actions/Post_Reset_NetworkDiagnosticsCounter.bru --env localhost --output results_$LINENO.json
+
+# GET Actions
+bru run actions/Get_Actions_Collection.bru --env localhost --output results_$LINENO.json
+# GET by itemId
+# GET a non-existing item
+bru run actions/Get_ActionItem_by_ItemId_404.bru --env localhost --output results_$LINENO.json
+
+# give time for the tasks to complete
+echo "Wait for actions to complete ..."
+sleep 10
+# repeat to check success of completion
+bru run actions/Get_Actions_Collection_completed.bru --env localhost --output results_$LINENO.json
+
+##############################################################
+## Diagnostics
+##############################################################
+# GET the collection
+bru run diagnostics/Get_Diagnostics_Collection.bru --env localhost --output results_$LINENO.json
+# GET networkDiagnostic fields
+bru run diagnostics/Get_NetworkDiagnostics_Items.bru --env localhost --output results_$LINENO.json
+bru run diagnostics/Get_NetworkDiagnostics_Items_SparseFields.bru --env localhost --output results_$LINENO.json
+# GET by itemId
+# GET a non-existing item
+bru run diagnostics/Get_DiagnosticItem_by_ItemId_404.bru --env localhost --output results_$LINENO.json
+#TODO replace dummy itemid
+
+# GET energy_scan_report fields
+bru run diagnostics/Get_EnergyScanReport_Items.bru --env localhost --output results_$LINENO.json
+bru run diagnostics/Get_EnergyScanReport_Items_SparseFields.bru --env localhost --output results_$LINENO.json
+
+# Check valid options
+bru run actions/Options.bru --env localhost --output results_$LINENO.json
+bru run devices/Options.bru --env localhost --output results_$LINENO.json
+bru run diagnostics/Options.bru --env localhost --output results_$LINENO.json

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -61,6 +61,7 @@ set(OT_NAT64_BORDER_ROUTING ${OTBR_NAT64} CACHE STRING "enable NAT64 in border r
 set(OT_NAT64_TRANSLATOR ${OTBR_NAT64} CACHE STRING "enable NAT64 translator" FORCE)
 set(OT_NETDATA_PUBLISHER ON CACHE STRING "enable netdata publisher" FORCE)
 set(OT_NETDIAG_CLIENT ON CACHE STRING "enable Network Diagnostic client" FORCE)
+set(OT_MESH_DIAG ON CACHE STRING "enable Mesh Diagnostics" FORCE)
 set(OT_PLATFORM "posix" CACHE STRING "use posix platform" FORCE)
 set(OT_PLATFORM_NETIF ON CACHE STRING "enable platform netif" FORCE)
 set(OT_PLATFORM_UDP ON CACHE STRING "enable platform UDP" FORCE)


### PR DESCRIPTION
In this PR, we propose an extended `REST` API functionality providing capabilities for commissioning and on-mesh diagnostics to generic off-mesh http clients. The implementation is guided by the [JSON:API specification](https://jsonapi.org/format/) and provides following parts

- `api/node` - pointing to api/devices/_thisdevice_
- `api/devices` - a collection of discovered devices
- `api/actions` - indirect processing of tasks, in particular for those that may need more time
    - `addThreadDeviceTask` - starts the on-mesh commissioner and adds the joiner candidate into the joiner table
   - `getNetworkDiagnosticTask` - sends diagnostic requests and diagnostic queries to the destination
   - `resetNetworkDiagCounterTask` - resets the network diagnostic mle and/or mac counter
   - `getEnergyScanTask` - starts the commissioner and sends energy scan requests to the destination
- `api/diagnostics`
   -  networkDiagnostic - all the Diagnostic TLV details
   -  energyScanReport - results of energy scans

The commit also provides integration tests, see tests/restjsonapi.
[The Readme provides more details](src/rest/extensions) in src/rest/extensions folder.