### PR TITLE
[rest] add commissioner api

### DIFF
--- a/src/common/api_strings.cpp
+++ b/src/common/api_strings.cpp
@@ -82,3 +82,23 @@ std::string GetDhcp6PdStateName(otBorderRoutingDhcp6PdState aState)
     return stateName;
 }
 #endif // OTBR_ENABLE_DHCP6_PD
+
+std::string GetCommissionerStateName(otCommissionerState aState)
+{
+    std::string stateName;
+
+    switch (aState)
+    {
+    case OT_COMMISSIONER_STATE_DISABLED:
+        stateName = OTBR_COMMISSIONER_STATE_NAME_DISABLED;
+        break;
+    case OT_COMMISSIONER_STATE_PETITION:
+        stateName = OTBR_COMMISSIONER_STATE_NAME_PETITION;
+        break;
+    case OT_COMMISSIONER_STATE_ACTIVE:
+        stateName = OTBR_COMMISSIONER_STATE_NAME_ACTIVE;
+        break;
+    }
+
+    return stateName;
+}

--- a/src/common/api_strings.hpp
+++ b/src/common/api_strings.hpp
@@ -54,10 +54,16 @@
 #define OTBR_DHCP6_PD_STATE_NAME_IDLE "idle"
 #endif
 
+#define OTBR_COMMISSIONER_STATE_NAME_DISABLED "disabled"
+#define OTBR_COMMISSIONER_STATE_NAME_PETITION "petitioning"
+#define OTBR_COMMISSIONER_STATE_NAME_ACTIVE "active"
+
 std::string GetDeviceRoleName(otDeviceRole aRole);
 
 #if OTBR_ENABLE_DHCP6_PD
 std::string GetDhcp6PdStateName(otBorderRoutingDhcp6PdState aDhcp6PdState);
 #endif // OTBR_ENABLE_DHCP6_PD
+
+std::string GetCommissionerStateName(otCommissionerState aState);
 
 #endif // OTBR_COMMON_API_STRINGS_HPP_

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -939,7 +939,7 @@ cJSON *JoinerInfo2Json(const otJoinerInfo &aJoinerInfo)
         char hexValue[((OT_JOINER_MAX_DISCERNER_LENGTH / 8) * 2) + 1]                              = {0};
         char string[sizeof("0x") + ((OT_JOINER_MAX_DISCERNER_LENGTH / 8) * 2) + sizeof("/xx") + 1] = {0};
 
-        otbr::Utils::Uint2Hex(aJoinerInfo.mSharedId.mDiscerner.mValue, (OT_JOINER_MAX_DISCERNER_LENGTH / 8), hexValue);
+        otbr::Utils::Long2Hex(aJoinerInfo.mSharedId.mDiscerner.mValue, hexValue);
         snprintf(string, sizeof(string), "0x%s/%d", hexValue, aJoinerInfo.mSharedId.mDiscerner.mLength);
         cJSON_AddItemToObject(node, "Discerner", cJSON_CreateString(string));
     }

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -30,7 +30,6 @@
 #include <sstream>
 
 #include "common/code_utils.hpp"
-#include "common/types.hpp"
 
 extern "C" {
 #include <cJSON.h>
@@ -930,8 +929,22 @@ cJSON *JoinerInfo2Json(const otJoinerInfo &aJoinerInfo)
 {
     cJSON *node = cJSON_CreateObject();
 
-    cJSON_AddItemToObject(node, "Pskd", Bytes2HexJson((const uint8_t *) aJoinerInfo.mPskd.m8, OT_JOINER_MAX_PSKD_LENGTH));
-    cJSON_AddItemToObject(node, "Eui64", Bytes2HexJson(aJoinerInfo.mSharedId.mEui64.m8, OT_EXT_ADDRESS_SIZE));
+    cJSON_AddItemToObject(node, "Pskd", cJSON_CreateString(aJoinerInfo.mPskd.m8));
+    if (aJoinerInfo.mType == OT_JOINER_INFO_TYPE_EUI64) 
+    {
+        cJSON_AddItemToObject(node, "Eui64", Bytes2HexJson(aJoinerInfo.mSharedId.mEui64.m8, OT_EXT_ADDRESS_SIZE));
+    } 
+    else if (aJoinerInfo.mType == OT_JOINER_INFO_TYPE_DISCERNER)  
+    {
+        char hexValue[((OT_JOINER_MAX_DISCERNER_LENGTH / 8) * 2) + 1] = {0};
+        char string[sizeof("0x") + ((OT_JOINER_MAX_DISCERNER_LENGTH / 8) * 2) + sizeof("/xx") + 1] = {0};
+
+        otbr::Utils::Uint2Hex(aJoinerInfo.mSharedId.mDiscerner.mValue, (OT_JOINER_MAX_DISCERNER_LENGTH / 8), hexValue);
+        snprintf(string, sizeof(string), "0x%s/%d", hexValue, aJoinerInfo.mSharedId.mDiscerner.mLength);
+        cJSON_AddItemToObject(node, "Discerner", cJSON_CreateString(string));
+    } else {
+        cJSON_AddItemToObject(node, "JoinerId", cJSON_CreateString("*"));
+    }
     cJSON_AddItemToObject(node, "Timeout", cJSON_CreateNumber(aJoinerInfo.mExpirationTime));
 
     return node;
@@ -949,10 +962,45 @@ std::string JoinerInfo2JsonString(const otJoinerInfo &aJoinerInfo)
     return ret;
 }
 
+otbrError StringDiscerner2Discerner(char *aString, otJoinerDiscerner &aDiscerner) 
+{
+    otbrError error = OTBR_ERROR_NONE;
+    char *separator;
+    uint8_t byteLength;
+    uint8_t byteSwapBuffer[8] = {0};
+    uint8_t *buffer = (uint8_t *) &aDiscerner.mValue;
+
+    separator = strstr(aString, "/");
+    VerifyOrExit(separator != nullptr, error = OTBR_ERROR_NOT_FOUND);
+    VerifyOrExit(sscanf(separator + 1, "%hhu", &aDiscerner.mLength) == 1, error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aDiscerner.mLength > 0 && aDiscerner.mLength <= OT_JOINER_MAX_DISCERNER_LENGTH, 
+                    error = OTBR_ERROR_INVALID_ARGS);
+
+    if (memcmp(aString, "0x", 2) == 0)
+    {
+        aString += 2;
+    }
+
+    *separator = '\0';
+    byteLength = Hex2BytesJsonString(std::string(aString), byteSwapBuffer, 
+                                    OT_JOINER_MAX_DISCERNER_LENGTH);
+    VerifyOrExit(byteLength <= (1 + ((aDiscerner.mLength - 1) / 8)), error = OTBR_ERROR_INVALID_ARGS);
+
+    // The discerner is expected to be big endian
+    for (uint8_t i = 0; i < byteLength; i++) {
+       buffer[i] = byteSwapBuffer[byteLength - i - 1];
+    }
+
+exit:
+    return error;
+}
+
 bool JsonJoinerInfo2JoinerInfo(const cJSON *jsonJoinerInfo, otJoinerInfo &aJoinerInfo)
 {
     cJSON      *value;
     bool        ret = true;
+    aJoinerInfo.mType = OT_JOINER_INFO_TYPE_ANY;
+    memset(&aJoinerInfo.mSharedId.mEui64, 0, OT_EXT_ADDRESS_SIZE);
 
     value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "Pskd");
     if (cJSON_IsString(value))
@@ -966,20 +1014,55 @@ bool JsonJoinerInfo2JoinerInfo(const cJSON *jsonJoinerInfo, otJoinerInfo &aJoine
         ExitNow(ret = false);
     } 
 
-    value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "Eui64");
-    memset(&aJoinerInfo.mSharedId.mEui64, 0, OT_EXT_ADDRESS_SIZE);
+    value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "JoinerId");
     if (cJSON_IsString(value))
     {
+        VerifyOrExit(aJoinerInfo.mType == OT_JOINER_INFO_TYPE_ANY, ret = false); 
         VerifyOrExit(value->valuestring != nullptr, ret = false);
         if (strncmp(value->valuestring, "*", 1) != 0) 
         {
-            VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), aJoinerInfo.mSharedId.mEui64.m8,
+            otbrError err = StringDiscerner2Discerner(value->valuestring, aJoinerInfo.mSharedId.mDiscerner);
+            if (err == OTBR_ERROR_NOT_FOUND) 
+            {
+                VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), 
+                                                aJoinerInfo.mSharedId.mEui64.m8,
+                                                OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE,
+                            ret = false);
+                aJoinerInfo.mType = OT_JOINER_INFO_TYPE_EUI64;
+            } 
+            else 
+            {
+                VerifyOrExit(err == OTBR_ERROR_NONE, ret = false);
+                aJoinerInfo.mType = OT_JOINER_INFO_TYPE_DISCERNER;
+            }
+        } 
+    }
+
+    value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "Discerner");
+    if (cJSON_IsString(value))
+    {
+        VerifyOrExit(aJoinerInfo.mType == OT_JOINER_INFO_TYPE_ANY, ret = false); 
+        VerifyOrExit(value->valuestring != nullptr, ret = false);
+        if (strncmp(value->valuestring, "*", 1) != 0) 
+        {
+            VerifyOrExit(StringDiscerner2Discerner(value->valuestring, aJoinerInfo.mSharedId.mDiscerner) == OTBR_ERROR_NONE, 
+                            ret = false);
+            aJoinerInfo.mType = OT_JOINER_INFO_TYPE_DISCERNER;
+        }
+    }
+
+    value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "Eui64");
+    if (cJSON_IsString(value))
+    {
+        VerifyOrExit(aJoinerInfo.mType == OT_JOINER_INFO_TYPE_ANY, ret = false); 
+        VerifyOrExit(value->valuestring != nullptr, ret = false);
+        if (strncmp(value->valuestring, "*", 1) != 0) 
+        {
+            VerifyOrExit(Hex2BytesJsonString(std::string(value->valuestring), 
+                                            aJoinerInfo.mSharedId.mEui64.m8,
                                             OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE,
                         ret = false);
-        } 
-        else 
-        {
-            memset(&aJoinerInfo.mSharedId.mEui64, 0, OT_EXT_ADDRESS_SIZE);
+            aJoinerInfo.mType = OT_JOINER_INFO_TYPE_EUI64;
         }
     }
 

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1000,7 +1000,8 @@ exit:
 bool JsonJoinerInfo2JoinerInfo(const cJSON *jsonJoinerInfo, otJoinerInfo &aJoinerInfo)
 {
     cJSON *value;
-    bool   ret        = true;
+    bool   ret  = true;
+
     aJoinerInfo.mType = OT_JOINER_INFO_TYPE_ANY;
     memset(&aJoinerInfo.mSharedId.mEui64, 0, OT_EXT_ADDRESS_SIZE);
 
@@ -1097,6 +1098,7 @@ exit:
 cJSON *JoinerTable2Json(const std::vector<otJoinerInfo> &aJoinerTable)
 {
     cJSON *table = cJSON_CreateArray();
+
     for (const otJoinerInfo joiner : aJoinerTable)
     {
         cJSON *joinerJson = JoinerInfo2Json(joiner);

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1007,7 +1007,8 @@ bool JsonJoinerInfo2JoinerInfo(const cJSON *jsonJoinerInfo, otJoinerInfo &aJoine
     bool   ret = false;
 
     aJoinerInfo.mType = OT_JOINER_INFO_TYPE_ANY;
-    memset(&aJoinerInfo.mSharedId.mEui64, 0, OT_EXT_ADDRESS_SIZE);
+    memset(&aJoinerInfo.mSharedId.mEui64, 0, sizeof(aJoinerInfo.mSharedId.mEui64));
+    memset(&aJoinerInfo.mPskd.m8, 0, sizeof(aJoinerInfo.mPskd.m8));
 
     value = cJSON_GetObjectItemCaseSensitive(jsonJoinerInfo, "Pskd");
     if (cJSON_IsString(value))

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -40,9 +40,9 @@
 #include "openthread/link.h"
 #include "openthread/thread_ftd.h"
 
+#include "common/types.hpp"
 #include "rest/types.hpp"
 #include "utils/hex.hpp"
-#include "common/types.hpp"
 
 namespace otbr {
 namespace rest {

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -42,6 +42,7 @@
 
 #include "rest/types.hpp"
 #include "utils/hex.hpp"
+#include "common/types.hpp"
 
 namespace otbr {
 namespace rest {
@@ -252,6 +253,8 @@ bool JsonActiveDatasetString2Dataset(const std::string &aJsonActiveDataset, otOp
 bool JsonPendingDatasetString2Dataset(const std::string &aJsonPendingDataset, otOperationalDataset &aDataset);
 
 std::string JoinerInfo2JsonString(const otJoinerInfo &aJoinerInfo);
+
+otbrError StringDiscerner2Discerner(char *aString, otJoinerDiscerner &aDiscerner);
 
 bool JsonJoinerInfoString2JoinerInfo(const std::string &aJsonJoinerInfo, otJoinerInfo &aJoinerInfo);
 

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -251,6 +251,12 @@ bool JsonActiveDatasetString2Dataset(const std::string &aJsonActiveDataset, otOp
  */
 bool JsonPendingDatasetString2Dataset(const std::string &aJsonPendingDataset, otOperationalDataset &aDataset);
 
+std::string JoinerInfo2JsonString(const otJoinerInfo &aJoinerInfo);
+
+bool JsonJoinerInfoString2JoinerInfo(const std::string &aJsonJoinerInfo, otJoinerInfo &aJoinerInfo);
+
+std::string JoinerTable2JsonString(const std::vector<otJoinerInfo> &aJoinerTable);
+
 }; // namespace Json
 
 } // namespace rest

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -374,7 +374,11 @@ paths:
           application/json:
             schema:
                 type: string
-                description: Eui64 address or discerner of joiner to remove
+                description: |-
+                  Joiner ID to remove, can be either:
+                   - An EUI64 in the form of a 16 character hex string
+                   - A discerner in the form of the discerner hex value 
+                     (optionally with leading 0x) and bit length separated by a '/'
                 example: "0xabc/12"
       responses:
         "200":
@@ -575,7 +579,10 @@ components:
           example: "0123456789abcdef"
         Discerner:
           type: string
-          description: A string of the joiner discerner, mutually exclusive with JoinerId and Eui64
+          description: |- 
+            A discerner in the form of the discerner hex value (optionally with leading 0x) 
+            and bit length separated by a '/'.
+            Field is mutually exclusive with JoinerId and Eui64.
           example: "0xabc/12"
         Timeout:
           type: integer

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -363,6 +363,8 @@ paths:
           description: Invalid request body.
         "409":
           description: Adding joiner rejected because commissioner is not active.
+        "507":
+          description: Number of joiners the commissioner supports is full and the new one cannot be added.
     delete:
       tags: 
         - node

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -345,10 +345,10 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/JoinerData"
-    put:
+    post:
       tags:
         - node
-      summary: Creates a new joiner
+      summary: Adds a new joiner
       requestBody:
         content:
           application/json:
@@ -370,11 +370,13 @@ paths:
           application/json:
             schema:
                 type: string
-                description: Eui64 address of joiner to remove
-                example: "0123456789abcdef"
+                description: Eui64 address or discerner of joiner to remove
+                example: "0xabc/12"
       responses:
         "200":
           description: Successfully removed joiner.
+        "204":
+          description: Joiner not found.
         "400":
           description: Invalid request body.
         "409":
@@ -558,12 +560,20 @@ components:
           type: string
           description: Joining device's pre-shared key
           example: J01N
+        JoinerId:
+          type: string
+          description: A string of the EUI-64, Discerner, or "*", mutually exclusive with Eui64 and Discerner
+          example: "0xabc/12"
+          default: "*"
         Eui64:
           type: string
-          description: A string of the EUI-64 of the device to join or "*" for any
+          description: A string of the EUI-64, mutually exclusive with JoinerId and Discerner
           example: "0123456789abcdef"
-          default: "*"
+        Discerner:
+          type: string
+          description: A string of the joiner discerner, mutually exclusive with JoinerId and Eui64
+          example: "0xabc/12"
         Timeout:
-          type: uint32
+          type: integer
           description: Joiner expiration time in milliseconds on response and seconds on request 
           default: 60 

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -321,6 +321,8 @@ paths:
       responses:
         "200":
           description: Successful operation.
+        "204":
+          description: Already in state.
         "409":
           description: Cannot set commissioner state because border router state is not active
       requestBody:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -317,7 +317,7 @@ paths:
         - commissioner
       summary: Set current Commissioner state.
       description: |-
-        Enable and disable the Commissioner.
+        Enable or disable the Commissioner.
       responses:
         "200":
           description: Successful operation.

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -291,6 +291,83 @@ paths:
           description: Successfully created the pending operational dataset.
         "400":
           description: Invalid request body.
+  /node/commissioner/state:
+    get:
+      tags: 
+        - node
+        - commissioner
+      summary: Get current Commissioner state.
+      description: |-
+        State describing the current Commissioner role of this Thread node.
+        - disabled
+        - petitioning
+        - active
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Current state
+                example: "active"
+    put:
+      tags:
+        - node
+        - commissioner
+      summary: Set current Commissioner state.
+      description: |-
+        Enable and disable the Commissioner.
+      responses:
+        "200":
+          description: Successful operation.
+        "304":
+          description: Commissioner is already in requested state
+      requestBody:
+        description: New Commissioner state
+        content:
+          application/json:
+            schema:
+              type: string
+              description: Can be "enable" or "disable".
+              example: "enable"
+  /node/commissioner/joiner:
+    get:
+      tags:
+        - node
+      summary: Get current joiner data
+      responses:
+        "200":
+          description: Returns an array of currently active joiner data
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/JoinerData"
+        "204":
+          description: No active operational dataset
+    put:
+      tags:
+        - node
+      summary: Creates or updates the active operational dataset
+      requestBody:
+        content:
+          application/json:
+            schema:
+                $ref: "#/components/schemas/JoinerData"
+      responses:
+        "200":
+          description: Successfully added joiner.
+        "400":
+          description: Invalid request body.
+        "409":
+          description: Adding joiner rejected because commissioner is not active.
+    delete:
+      tags: 
+        - node
+      summary: Removes a joiner from the node
+
 components:
   schemas:
     LeaderData:
@@ -462,3 +539,18 @@ components:
       type: string
       description: Operational dataset as hex-encoded TLVs.
       example: 0E080000000000010000000300000F35060004001FFFE0020811111111222222220708FDAD70BFE5AA15DD051000112233445566778899AABBCCDDEEFF030E4F70656E54687265616444656D6F010212340410445F2B5CA6F2A93A55CE570A70EFEECB0C0402A0F7F8
+    JoinerData:
+      type: object
+      properties:
+        Pksd:
+          type: string
+          description: Joining device's pre-shared key
+          example: J01N
+        Eui64:
+          type: string
+          description: A string of the EUI-64 of the device to join
+          example: "0123456789abcdef"
+        Timeout:
+          type: uint32
+          description: Joiner expiration time in milliseconds 
+          default:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -321,8 +321,8 @@ paths:
       responses:
         "200":
           description: Successful operation.
-        "304":
-          description: Commissioner is already in requested state
+        "409":
+          description: Cannot set commissioner state because border router state is not active
       requestBody:
         description: New Commissioner state
         content:
@@ -338,19 +338,17 @@ paths:
       summary: Get current joiner data
       responses:
         "200":
-          description: Returns an array of currently active joiner data
+          description: Returns an array of currently active joiners
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/JoinerData"
-        "204":
-          description: No active operational dataset
     put:
       tags:
         - node
-      summary: Creates or updates the active operational dataset
+      summary: Creates a new joiner
       requestBody:
         content:
           application/json:
@@ -367,6 +365,20 @@ paths:
       tags: 
         - node
       summary: Removes a joiner from the node
+      requestBody:
+        content:
+          application/json:
+            schema:
+                type: string
+                description: Eui64 address of joiner to remove
+                example: "0123456789abcdef"
+      responses:
+        "200":
+          description: Successfully removed joiner.
+        "400":
+          description: Invalid request body.
+        "409":
+          description: request rejected because commissioner is not active.
 
 components:
   schemas:
@@ -548,9 +560,10 @@ components:
           example: J01N
         Eui64:
           type: string
-          description: A string of the EUI-64 of the device to join
+          description: A string of the EUI-64 of the device to join or "*" for any
           example: "0123456789abcdef"
+          default: "*"
         Timeout:
           type: uint32
-          description: Joiner expiration time in milliseconds 
-          default:
+          description: Joiner expiration time in milliseconds on response and seconds on request 
+          default: 60 

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -738,7 +738,6 @@ void Resource::SetDataset(DatasetType aDatasetType, const Request &aRequest, Res
     {
         if (aDatasetType == DatasetType::kActive)
         {
-            otbrLogInfo("SET DATASET: %s", aRequest.GetBody());
             VerifyOrExit(Json::JsonActiveDatasetString2Dataset(aRequest.GetBody(), dataset),
                          error = OTBR_ERROR_INVALID_ARGS);
         }

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -806,20 +806,20 @@ void Resource::DatasetPending(const Request &aRequest, Response &aResponse) cons
     Dataset(DatasetType::kPending, aRequest, aResponse);
 }
 
-void Resource::GetCommissionerState(Response &aResponse) const 
+void Resource::GetCommissionerState(Response &aResponse) const
 {
-    std::string  state;
-    std::string  errorCode;
+    std::string         state;
+    std::string         errorCode;
     otCommissionerState stateCode;
 
     stateCode = otCommissionerGetState(mInstance);
-    state = Json::String2JsonString(GetCommissionerStateName(stateCode));
+    state     = Json::String2JsonString(GetCommissionerStateName(stateCode));
     aResponse.SetBody(state);
     errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse) const 
+void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse) const
 {
     otbrError   error = OTBR_ERROR_NONE;
     std::string errorCode;
@@ -828,12 +828,15 @@ void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse
     VerifyOrExit(Json::JsonString2String(aRequest.GetBody(), body), error = OTBR_ERROR_INVALID_ARGS);
     if (body == "enable")
     {
-        VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED, error = OTBR_ERROR_DUPLICATED);
-        VerifyOrExit(otCommissionerStart(mInstance, NULL, NULL, NULL) == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
+        VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED,
+                     error = OTBR_ERROR_DUPLICATED);
+        VerifyOrExit(otCommissionerStart(mInstance, NULL, NULL, NULL) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_INVALID_STATE);
     }
     else if (body == "disable")
     {
-        VerifyOrExit(otCommissionerGetState(mInstance) != OT_COMMISSIONER_STATE_DISABLED, error = OTBR_ERROR_DUPLICATED);
+        VerifyOrExit(otCommissionerGetState(mInstance) != OT_COMMISSIONER_STATE_DISABLED,
+                     error = OTBR_ERROR_DUPLICATED);
         VerifyOrExit(otCommissionerStop(mInstance) == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
     }
     else
@@ -860,7 +863,7 @@ exit:
     else if (error != OTBR_ERROR_NONE)
     {
         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
-    } 
+    }
 }
 
 void Resource::CommissionerState(const Request &aRequest, Response &aResponse) const
@@ -884,18 +887,18 @@ void Resource::CommissionerState(const Request &aRequest, Response &aResponse) c
         ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
         break;
     }
-
 }
 
-void Resource::GetJoiners(Response &aResponse) const 
+void Resource::GetJoiners(Response &aResponse) const
 {
-    uint16_t     iter = 0;
-    otJoinerInfo joinerInfo;
+    uint16_t                  iter = 0;
+    otJoinerInfo              joinerInfo;
     std::vector<otJoinerInfo> joinerTable;
-    std::string joinerJson;
-    std::string  errorCode;
+    std::string               joinerJson;
+    std::string               errorCode;
 
-    while (otCommissionerGetNextJoinerInfo(mInstance, &iter, &joinerInfo) == OT_ERROR_NONE) {
+    while (otCommissionerGetNextJoinerInfo(mInstance, &iter, &joinerInfo) == OT_ERROR_NONE)
+    {
         joinerTable.push_back(joinerInfo);
     }
 
@@ -905,30 +908,35 @@ void Resource::GetJoiners(Response &aResponse) const
     aResponse.SetResponsCode(errorCode);
 }
 
-void Resource::AddJoiner(const Request &aRequest, Response &aResponse) const 
+void Resource::AddJoiner(const Request &aRequest, Response &aResponse) const
 {
-    otbrError   error = OTBR_ERROR_NONE;
-    std::string errorCode;
-    otJoinerInfo joiner;
-    const otExtAddress *addrPtr = nullptr;
-    const uint8_t emptyArray[OT_EXT_ADDRESS_SIZE] = {0};
+    otbrError           error = OTBR_ERROR_NONE;
+    std::string         errorCode;
+    otJoinerInfo        joiner;
+    const otExtAddress *addrPtr                         = nullptr;
+    const uint8_t       emptyArray[OT_EXT_ADDRESS_SIZE] = {0};
 
     VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_ACTIVE, error = OTBR_ERROR_INVALID_STATE);
 
-    VerifyOrExit(Json::JsonJoinerInfoString2JoinerInfo(aRequest.GetBody(), joiner),
-                    error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(Json::JsonJoinerInfoString2JoinerInfo(aRequest.GetBody(), joiner), error = OTBR_ERROR_INVALID_ARGS);
 
     addrPtr = &joiner.mSharedId.mEui64;
-    if (memcmp(&joiner.mSharedId.mEui64, emptyArray, OT_EXT_ADDRESS_SIZE) == 0) {
+    if (memcmp(&joiner.mSharedId.mEui64, emptyArray, OT_EXT_ADDRESS_SIZE) == 0)
+    {
         addrPtr = nullptr;
     }
 
-    if (joiner.mType == OT_JOINER_INFO_TYPE_DISCERNER) {
-        VerifyOrExit(otCommissionerAddJoinerWithDiscerner(mInstance, &joiner.mSharedId.mDiscerner, joiner.mPskd.m8, joiner.mExpirationTime) == OT_ERROR_NONE, 
-                        error = OTBR_ERROR_OPENTHREAD);
-    } else {
-        VerifyOrExit(otCommissionerAddJoiner(mInstance, addrPtr, joiner.mPskd.m8, joiner.mExpirationTime) == OT_ERROR_NONE, 
-                        error = OTBR_ERROR_OPENTHREAD);
+    if (joiner.mType == OT_JOINER_INFO_TYPE_DISCERNER)
+    {
+        VerifyOrExit(otCommissionerAddJoinerWithDiscerner(mInstance, &joiner.mSharedId.mDiscerner, joiner.mPskd.m8,
+                                                          joiner.mExpirationTime) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_OPENTHREAD);
+    }
+    else
+    {
+        VerifyOrExit(otCommissionerAddJoiner(mInstance, addrPtr, joiner.mPskd.m8, joiner.mExpirationTime) ==
+                         OT_ERROR_NONE,
+                     error = OTBR_ERROR_OPENTHREAD);
     }
 
     errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
@@ -949,14 +957,14 @@ exit:
     }
 }
 
-void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const 
+void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const
 {
-    otbrError   error = OTBR_ERROR_NONE;
-    std::string errorCode;
-    otExtAddress eui64;
-    otExtAddress *addrPtr = nullptr;
+    otbrError         error = OTBR_ERROR_NONE;
+    std::string       errorCode;
+    otExtAddress      eui64;
+    otExtAddress     *addrPtr   = nullptr;
     otJoinerDiscerner discerner = {
-        .mValue = 0,
+        .mValue  = 0,
         .mLength = 0,
     };
     std::string body;
@@ -964,29 +972,31 @@ void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const
     VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_ACTIVE, error = OTBR_ERROR_INVALID_STATE);
 
     VerifyOrExit(Json::JsonString2String(aRequest.GetBody(), body), error = OTBR_ERROR_INVALID_ARGS);
-    if (body != "*") {
+    if (body != "*")
+    {
         error = Json::StringDiscerner2Discerner(const_cast<char *>(body.c_str()), discerner);
-        if (error == OTBR_ERROR_NOT_FOUND) 
+        if (error == OTBR_ERROR_NOT_FOUND)
         {
             error = OTBR_ERROR_NONE;
-            VerifyOrExit(Json::Hex2BytesJsonString(body, eui64.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE, 
-                            error = OTBR_ERROR_INVALID_ARGS);
+            VerifyOrExit(Json::Hex2BytesJsonString(body, eui64.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE,
+                         error = OTBR_ERROR_INVALID_ARGS);
             addrPtr = &eui64;
-        } 
-        else if (error != OTBR_ERROR_NONE) 
+        }
+        else if (error != OTBR_ERROR_NONE)
         {
             ExitNow(error = OTBR_ERROR_INVALID_ARGS);
         }
-    } 
-
-    if (discerner.mLength == 0) {
-        VerifyOrExit(otCommissionerRemoveJoiner(mInstance, addrPtr) == OT_ERROR_NONE, 
-                        error = OTBR_ERROR_NOT_FOUND);
-    } else {
-        VerifyOrExit(otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner) == OT_ERROR_NONE, 
-                        error = OTBR_ERROR_NOT_FOUND);
     }
 
+    if (discerner.mLength == 0)
+    {
+        VerifyOrExit(otCommissionerRemoveJoiner(mInstance, addrPtr) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
+    }
+    else
+    {
+        VerifyOrExit(otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_NOT_FOUND);
+    }
 
     errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
     aResponse.SetResponsCode(errorCode);
@@ -1025,7 +1035,7 @@ void Resource::CommissionerJoiner(const Request &aRequest, Response &aResponse) 
     case HttpMethod::kDelete:
         RemoveJoiner(aRequest, aResponse);
         break;
-    
+
     case HttpMethod::kOptions:
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -912,7 +912,7 @@ void Resource::GetJoiners(Response &aResponse) const
 void Resource::AddJoiner(const Request &aRequest, Response &aResponse) const
 {
     otbrError           error   = OTBR_ERROR_NONE;
-    otError             otError = OT_ERROR_NONE;
+    otError             errorOt = OT_ERROR_NONE;
     std::string         errorCode;
     otJoinerInfo        joiner;
     const otExtAddress *addrPtr                         = nullptr;
@@ -930,14 +930,14 @@ void Resource::AddJoiner(const Request &aRequest, Response &aResponse) const
 
     if (joiner.mType == OT_JOINER_INFO_TYPE_DISCERNER)
     {
-        otError = otCommissionerAddJoinerWithDiscerner(mInstance, &joiner.mSharedId.mDiscerner, joiner.mPskd.m8,
+        errorOt = otCommissionerAddJoinerWithDiscerner(mInstance, &joiner.mSharedId.mDiscerner, joiner.mPskd.m8,
                                                        joiner.mExpirationTime);
     }
     else
     {
-        otError = otCommissionerAddJoiner(mInstance, addrPtr, joiner.mPskd.m8, joiner.mExpirationTime);
+        errorOt = otCommissionerAddJoiner(mInstance, addrPtr, joiner.mPskd.m8, joiner.mExpirationTime);
     }
-    VerifyOrExit(otError == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
+    VerifyOrExit(errorOt == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
 
 exit:
     if (error == OTBR_ERROR_NONE)
@@ -955,11 +955,11 @@ exit:
     }
     else if (error == OTBR_ERROR_OPENTHREAD)
     {
-        if (otError == OT_ERROR_INVALID_ARGS)
+        if (errorOt == OT_ERROR_INVALID_ARGS)
         {
             ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
         }
-        else if (otError == OT_ERROR_NO_BUFS)
+        else if (errorOt == OT_ERROR_NO_BUFS)
         {
             ErrorHandler(aResponse, HttpStatusCode::kStatusInsufficientStorage);
         }

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -1003,13 +1003,14 @@ void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const
         }
     }
 
+    // These functions should only return OT_ERROR_NONE or OT_ERROR_NOT_FOUND both treated as successful
     if (discerner.mLength == 0)
     {
-        otCommissionerRemoveJoiner(mInstance, addrPtr);
+        (void)otCommissionerRemoveJoiner(mInstance, addrPtr);
     }
     else
     {
-        otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner);
+        (void)otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner);
     }
 
 exit:

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -846,22 +846,21 @@ void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse
     }
 
 exit:
-    if (error == OTBR_ERROR_NONE)
+    switch (error)
     {
+    case OTBR_ERROR_NONE:
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);
-    }
-    else if (error == OTBR_ERROR_INVALID_STATE)
-    {
+        break;
+    case OTBR_ERROR_INVALID_STATE:
         ErrorHandler(aResponse, HttpStatusCode::kStatusConflict);
-    }
-    else if (error == OTBR_ERROR_INVALID_ARGS)
-    {
+        break;
+    case OTBR_ERROR_INVALID_ARGS:
         ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
-    }
-    else
-    {
+        break;
+    default:
         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+        break;
     }
 }
 
@@ -938,37 +937,35 @@ void Resource::AddJoiner(const Request &aRequest, Response &aResponse) const
     VerifyOrExit(errorOt == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
 
 exit:
-    if (error == OTBR_ERROR_NONE)
+    switch (error)
     {
+    case OTBR_ERROR_NONE:
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);
-    }
-    else if (error == OTBR_ERROR_INVALID_STATE)
-    {
+        break;
+    case OTBR_ERROR_INVALID_STATE:
         ErrorHandler(aResponse, HttpStatusCode::kStatusConflict);
-    }
-    else if (error == OTBR_ERROR_INVALID_ARGS)
-    {
+        break;
+    case OTBR_ERROR_INVALID_ARGS:
         ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
-    }
-    else if (error == OTBR_ERROR_OPENTHREAD)
-    {
-        if (errorOt == OT_ERROR_INVALID_ARGS)
+        break;
+    case OTBR_ERROR_OPENTHREAD:
+        switch (errorOt)
         {
+        case OT_ERROR_INVALID_ARGS:
             ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
-        }
-        else if (errorOt == OT_ERROR_NO_BUFS)
-        {
+            break;
+        case OT_ERROR_NO_BUFS:
             ErrorHandler(aResponse, HttpStatusCode::kStatusInsufficientStorage);
-        }
-        else
-        {
+            break;
+        default:
             ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+            break;
         }
-    }
-    else
-    {
+        break;
+    default:
         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+        break;
     }
 }
 
@@ -1014,22 +1011,21 @@ void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const
     }
 
 exit:
-    if (error == OTBR_ERROR_NONE)
+    switch (error)
     {
+    case OTBR_ERROR_NONE:
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);
-    }
-    else if (error == OTBR_ERROR_INVALID_STATE)
-    {
+        break;
+    case OTBR_ERROR_INVALID_STATE:
         ErrorHandler(aResponse, HttpStatusCode::kStatusConflict);
-    }
-    else if (error == OTBR_ERROR_INVALID_ARGS)
-    {
+        break;
+    case OTBR_ERROR_INVALID_ARGS:
         ErrorHandler(aResponse, HttpStatusCode::kStatusBadRequest);
-    }
-    else
-    {
+        break;
+    default:
         ErrorHandler(aResponse, HttpStatusCode::kStatusInternalServerError);
+        break;
     }
 }
 

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -831,15 +831,13 @@ void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse
     VerifyOrExit(Json::JsonString2String(aRequest.GetBody(), body), error = OTBR_ERROR_INVALID_ARGS);
     if (body == "enable")
     {
-        VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED,
-                     error = OTBR_ERROR_DUPLICATED);
+        VerifyOrExit(otCommissionerGetState(mInstance) == OT_COMMISSIONER_STATE_DISABLED, error = OTBR_ERROR_NONE);
         VerifyOrExit(otCommissionerStart(mInstance, NULL, NULL, NULL) == OT_ERROR_NONE,
                      error = OTBR_ERROR_INVALID_STATE);
     }
     else if (body == "disable")
     {
-        VerifyOrExit(otCommissionerGetState(mInstance) != OT_COMMISSIONER_STATE_DISABLED,
-                     error = OTBR_ERROR_DUPLICATED);
+        VerifyOrExit(otCommissionerGetState(mInstance) != OT_COMMISSIONER_STATE_DISABLED, error = OTBR_ERROR_NONE);
         VerifyOrExit(otCommissionerStop(mInstance) == OT_ERROR_NONE, error = OTBR_ERROR_INVALID_STATE);
     }
     else
@@ -848,7 +846,7 @@ void Resource::SetCommissionerState(const Request &aRequest, Response &aResponse
     }
 
 exit:
-    if (error == OTBR_ERROR_NONE || error == OTBR_ERROR_DUPLICATED)
+    if (error == OTBR_ERROR_NONE)
     {
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);
@@ -1007,16 +1005,15 @@ void Resource::RemoveJoiner(const Request &aRequest, Response &aResponse) const
 
     if (discerner.mLength == 0)
     {
-        VerifyOrExit(otCommissionerRemoveJoiner(mInstance, addrPtr) == OT_ERROR_NONE, error = OTBR_ERROR_NOT_FOUND);
+        otCommissionerRemoveJoiner(mInstance, addrPtr);
     }
     else
     {
-        VerifyOrExit(otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner) == OT_ERROR_NONE,
-                     error = OTBR_ERROR_NOT_FOUND);
+        otCommissionerRemoveJoinerWithDiscerner(mInstance, &discerner);
     }
 
 exit:
-    if (error == OTBR_ERROR_NONE || error == OTBR_ERROR_NOT_FOUND)
+    if (error == OTBR_ERROR_NONE)
     {
         errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
         aResponse.SetResponsCode(errorCode);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -125,6 +125,7 @@ private:
     void Dataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void DatasetActive(const Request &aRequest, Response &aResponse) const;
     void DatasetPending(const Request &aRequest, Response &aResponse) const;
+    void CommissionerState(const Request &aRequest, Response &aResponse) const;
     void Diagnostic(const Request &aRequest, Response &aResponse) const;
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
@@ -142,6 +143,8 @@ private:
     void GetDataRloc(Response &aResponse) const;
     void GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
+    void GetCommissionerState(Response &aResponse) const;
+    void SetCommissionerState(const Request &aRequest, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -126,6 +126,7 @@ private:
     void DatasetActive(const Request &aRequest, Response &aResponse) const;
     void DatasetPending(const Request &aRequest, Response &aResponse) const;
     void CommissionerState(const Request &aRequest, Response &aResponse) const;
+    void CommissionerJoiner(const Request &aRequest, Response &aResponse) const;
     void Diagnostic(const Request &aRequest, Response &aResponse) const;
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
 
@@ -145,6 +146,9 @@ private:
     void SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const;
     void GetCommissionerState(Response &aResponse) const;
     void SetCommissionerState(const Request &aRequest, Response &aResponse) const;
+    void GetJoiners(Response &aResponse) const;
+    void AddJoiner(const Request &aRequest, Response &aResponse) const;
+    void RemoveJoiner(const Request &aRequest, Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -77,6 +77,7 @@ enum class HttpStatusCode : std::uint16_t
     kStatusRequestTimeout      = 408,
     kStatusConflict            = 409,
     kStatusInternalServerError = 500,
+    kStatusInsufficientStorage = 507,
 };
 
 enum class PostError : std::uint8_t

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -92,24 +92,6 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength)
     return static_cast<int>(cur - aBytes);
 }
 
-size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex)
-{
-    uint8_t *buffer = (uint8_t *)&aUint;
-    char     uintHex[3];
-
-    // Make sure strcat appends at the beginning of the output buffer even
-    // if uninitialized.
-    aHex[0] = '\0';
-
-    for (int i = aUintLength; i > 0; i--)
-    {
-        snprintf(uintHex, sizeof(uintHex), "%02X", buffer[i - 1]);
-        strcat(aHex, uintHex);
-    }
-
-    return strlen(aHex);
-}
-
 size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
 {
     char byteHex[3];
@@ -141,19 +123,17 @@ std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength)
 
 size_t Long2Hex(const uint64_t aLong, char *aHex)
 {
-    char     byteHex[3];
-    uint64_t longValue = aLong;
+    char byteHex[3];
 
     // Make sure strcat appends at the beginning of the output buffer even
     // if uninitialized.
     aHex[0] = '\0';
 
-    for (uint8_t i = 0; i < sizeof(uint64_t); i++)
+    for (uint8_t i = 0; i < sizeof(aLong); i++)
     {
-        uint8_t byte = longValue & 0xff;
+        uint8_t byte = (aLong >> (8 * (sizeof(aLong) - i - 1))) & 0xff;
         snprintf(byteHex, sizeof(byteHex), "%02X", byte);
         strcat(aHex, byteHex);
-        longValue = longValue >> 8;
     }
 
     return strlen(aHex);

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -92,6 +92,24 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength)
     return static_cast<int>(cur - aBytes);
 }
 
+size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex)
+{
+    uint8_t *buffer = (uint8_t *) &aUint;
+    char uintHex[3];
+
+    // Make sure strcat appends at the beginning of the output buffer even
+    // if uninitialized.
+    aHex[0] = '\0';
+
+    for (int i = aUintLength; i > 0; i--)
+    {
+        snprintf(uintHex, sizeof(uintHex), "%02X", buffer[i-1]);
+        strcat(aHex, uintHex);
+    }
+
+    return strlen(aHex);
+}
+
 size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
 {
     char byteHex[3];

--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -94,8 +94,8 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength)
 
 size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex)
 {
-    uint8_t *buffer = (uint8_t *) &aUint;
-    char uintHex[3];
+    uint8_t *buffer = (uint8_t *)&aUint;
+    char     uintHex[3];
 
     // Make sure strcat appends at the beginning of the output buffer even
     // if uninitialized.
@@ -103,7 +103,7 @@ size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex)
 
     for (int i = aUintLength; i > 0; i--)
     {
-        snprintf(uintHex, sizeof(uintHex), "%02X", buffer[i-1]);
+        snprintf(uintHex, sizeof(uintHex), "%02X", buffer[i - 1]);
         strcat(aHex, uintHex);
     }
 

--- a/src/utils/hex.hpp
+++ b/src/utils/hex.hpp
@@ -57,17 +57,6 @@ namespace Utils {
 int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
 
 /**
- * @brief Converts a unsinged integer to a hexadecimal string.
- *
- * @param aUint The integer to be converted.
- * @param aUintLength The length of the integer in bytes.
- * @param[out] aHex A character array to store the resulting hexadecimal string.
- *                  Must be at least 2 * @param aUintLength + 1 long.
- * @return size_t
- */
-size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex);
-
-/**
  * @brief Converts a byte array to a hexadecimal string.
  *
  * @param[in]  aBytes A pointer to the byte array to be converted.
@@ -90,7 +79,7 @@ size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
 std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength);
 
 /**
- * @brief Converts a 64-bit integer to a hexadecimal string.
+ * @brief Converts a 64-bit integer to a big endian formatted hexadecimal string.
  *
  * @param[in]  aLong The 64-bit integer to be converted.
  * @param[out] aHex A character array to store the resulting hexadecimal string.

--- a/src/utils/hex.hpp
+++ b/src/utils/hex.hpp
@@ -57,6 +57,17 @@ namespace Utils {
 int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
 
 /**
+ * @brief Converts a unsinged integer to a hexadecimal string.
+ * 
+ * @param aUint The integer to be converted.
+ * @param aUintLength The length of the integer in bytes.
+ * @param[out] aHex A character array to store the resulting hexadecimal string.
+ *                  Must be at least 2 * @param aUintLength + 1 long.
+ * @return size_t 
+ */
+size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex);
+
+/**
  * @brief Converts a byte array to a hexadecimal string.
  *
  * @param[in]  aBytes A pointer to the byte array to be converted.

--- a/src/utils/hex.hpp
+++ b/src/utils/hex.hpp
@@ -58,12 +58,12 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength);
 
 /**
  * @brief Converts a unsinged integer to a hexadecimal string.
- * 
+ *
  * @param aUint The integer to be converted.
  * @param aUintLength The length of the integer in bytes.
  * @param[out] aHex A character array to store the resulting hexadecimal string.
  *                  Must be at least 2 * @param aUintLength + 1 long.
- * @return size_t 
+ * @return size_t
  */
 size_t Uint2Hex(const uint64_t aUint, const uint8_t aUintLength, char *aHex);
 


### PR DESCRIPTION
Added endpoints to the REST server to expose commissioner functionality over the REST API

These changes intend to implement commissioner functionality in the same style as the current rest API offering.
 - The `/node/commissioner/state` endpoint allows the user to get/set the commissioner state using GET and PUT requests respectively.
 - The `/node/commissioner/joiner` allows the user to manage joiners accepted by the commissioner, supporting POST, GET and DELETE request methods to add, get and remove a joiner respectively. 

All added endpoints and their usage have been documented in the openapi.yaml

Example usage:
![image](https://github.com/user-attachments/assets/824a0c41-5185-4775-bf31-13c0bd789458)

Please give me feedback and let me know of any required changes 😄 