### PR TITLE
[thread host] add support for vendor thread host

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -158,6 +158,11 @@ if (OTBR_VENDOR_SERVER)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_VENDOR_SERVER=1)
 endif()
 
+option(OTBR_VENDOR_THREAD_HOST "Use vendor thread host implementation" OFF)
+if (OTBR_VENDOR_THREAD_HOST)
+    target_compile_definitions(otbr-config OTBR_ENABLE_VENDOR_THREAD_HOST=1)
+endif()
+
 option(OTBR_LINK_METRICS_TELEMETRY "Enable Link Metrics Telemetry Upload" OFF)
 if (OTBR_LINK_METRICS_TELEMETRY)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_LINK_METRICS_TELEMETRY=1)

--- a/src/ncp/thread_host.cpp
+++ b/src/ncp/thread_host.cpp
@@ -41,28 +41,15 @@
 namespace otbr {
 namespace Ncp {
 
+#if !OTBR_ENABLE_VENDOR_THREAD_HOST
 std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *aInterfaceName,
                                                const std::vector<const char *> &aRadioUrls,
                                                const char                      *aBackboneInterfaceName,
                                                bool                             aDryRun,
                                                bool                             aEnableAutoAttach)
 {
-    CoprocessorType             coprocessorType;
-    otPlatformCoprocessorUrls   urls;
+    CoprocessorType             coprocessorType = InitCoprocessor(aRadioUrls);
     std::unique_ptr<ThreadHost> host;
-    otLogLevel                  level = ConvertToOtLogLevel(otbrLogGetLevel());
-
-    VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
-
-    urls.mNum = 0;
-    for (const char *url : aRadioUrls)
-    {
-        urls.mUrls[urls.mNum++] = url;
-    }
-
-    VerifyOrDie(otLoggingSetLevel(level) == OT_ERROR_NONE, "Failed to set OT log Level!");
-
-    coprocessorType = otSysInitCoprocessor(&urls);
 
     switch (coprocessorType)
     {
@@ -80,6 +67,25 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
     }
 
     return host;
+}
+#endif // !OTBR_ENABLE_VENDOR_THREAD_HOST
+
+CoprocessorType ThreadHost::InitCoprocessor(const std::vector<const char *> &aRadioUrls)
+{
+    otPlatformCoprocessorUrls urls;
+    otLogLevel                level = ConvertToOtLogLevel(otbrLogGetLevel());
+
+    VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
+
+    urls.mNum = 0;
+    for (const char *url : aRadioUrls)
+    {
+        urls.mUrls[urls.mNum++] = url;
+    }
+
+    VerifyOrDie(otLoggingSetLevel(level) == OT_ERROR_NONE, "Failed to set OT log Level!");
+
+    return otSysInitCoprocessor(&urls);
 }
 
 } // namespace Ncp

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -232,6 +232,9 @@ public:
      * The destructor.
      */
     virtual ~ThreadHost(void) = default;
+
+protected:
+    static CoprocessorType InitCoprocessor(const std::vector<const char *> &aRadioUrls);
 };
 
 } // namespace Ncp


### PR DESCRIPTION
This PR adds support for vendors to create customized `ThreadHost`.

This allows vendors to provide customized implementation for `ThreadHost` APIs.