### PR TITLE
[infra if] implement infra if state update

### DIFF
--- a/src/ncp/posix/infra_if.hpp
+++ b/src/ncp/posix/infra_if.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/ip6.h>
 
+#include "common/mainloop.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
@@ -65,6 +66,8 @@ public:
 
     void      Init(void);
     void      Deinit(void);
+    void      Process(const MainloopContext &aContext);
+    void      UpdateFdSet(MainloopContext &aContext);
     otbrError SetInfraIf(const char *aIfName);
 
 private:
@@ -72,10 +75,16 @@ private:
     short                   GetFlags(void) const;
     std::vector<Ip6Address> GetAddresses(void);
     static bool             HasLinkLocalAddress(const std::vector<Ip6Address> &aAddrs);
+#ifdef __linux__
+    void ReceiveNetlinkMessage(void);
+#endif
 
     Dependencies &mDeps;
     char          mInfraIfName[IFNAMSIZ];
     unsigned int  mInfraIfIndex;
+#ifdef __linux__
+    int mNetlinkSocket;
+#endif
 };
 
 } // namespace otbr

--- a/tests/gtest/test_infra_if.cpp
+++ b/tests/gtest/test_infra_if.cpp
@@ -41,6 +41,7 @@ public:
     InfraIfDependencyTest(void)
         : mInfraIfIndex(0)
         , mIsRunning(false)
+        , mSetInfraIfInvoked(false)
     {
     }
 
@@ -48,9 +49,10 @@ public:
                          bool                                 aIsRunning,
                          const std::vector<otbr::Ip6Address> &aIp6Addresses) override
     {
-        mInfraIfIndex = aInfraIfIndex;
-        mIsRunning    = aIsRunning;
-        mIp6Addresses = aIp6Addresses;
+        mInfraIfIndex      = aInfraIfIndex;
+        mIsRunning         = aIsRunning;
+        mIp6Addresses      = aIp6Addresses;
+        mSetInfraIfInvoked = true;
 
         return OTBR_ERROR_NONE;
     }
@@ -58,6 +60,7 @@ public:
     unsigned int                  mInfraIfIndex;
     bool                          mIsRunning;
     std::vector<otbr::Ip6Address> mIp6Addresses;
+    bool                          mSetInfraIfInvoked;
 };
 
 TEST(InfraIf, DepsSetInfraIfInvokedCorrectly_AfterSpecifyingInfraIf)
@@ -84,6 +87,87 @@ TEST(InfraIf, DepsSetInfraIfInvokedCorrectly_AfterSpecifyingInfraIf)
     EXPECT_EQ(testInfraIfDep.mIsRunning, false);
     EXPECT_EQ(testInfraIfDep.mIp6Addresses.size(), 1);
     EXPECT_THAT(testInfraIfDep.mIp6Addresses, ::testing::Contains(otbr::Ip6Address(kTestAddr)));
+
+    netif.Deinit();
+}
+
+TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
+{
+    const std::string     fakeInfraIf = "wlx123";
+    otbr::MainloopContext context;
+
+    // Utilize the Netif module to create a network interface as the fake infrastructure interface.
+    otbr::Netif::Dependencies defaultNetifDep;
+    otbr::Netif               netif(defaultNetifDep);
+    EXPECT_EQ(netif.Init(fakeInfraIf), OTBR_ERROR_NONE);
+
+    const otIp6Address kTestAddr1 = {
+        {0xfd, 0x35, 0x7a, 0x7d, 0x0f, 0x16, 0xe7, 0xe3, 0x73, 0xf3, 0x09, 0x00, 0x8e, 0xbe, 0x1b, 0x65}};
+    const otIp6Address kTestAddr2 = {
+        {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa8, 0xa5, 0x42, 0xb7, 0x91, 0x80, 0xc3, 0xf8}};
+    std::vector<otbr::Ip6AddressInfo> addrs = {
+        {kTestAddr1, 64, 0, 1, 0},
+        {kTestAddr2, 64, 0, 1, 0},
+    };
+    netif.UpdateIp6UnicastAddresses(addrs);
+
+    InfraIfDependencyTest testInfraIfDep;
+    otbr::InfraIf         infraIf(testInfraIfDep);
+    infraIf.Init();
+    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf.c_str()), OTBR_ERROR_NONE);
+
+    EXPECT_EQ(testInfraIfDep.mIsRunning, false);
+    EXPECT_EQ(testInfraIfDep.mIp6Addresses.size(), 2);
+
+    netif.SetNetifState(true);
+    testInfraIfDep.mSetInfraIfInvoked = false;
+
+    while (!testInfraIfDep.mSetInfraIfInvoked)
+    {
+        context.mMaxFd   = -1;
+        context.mTimeout = {100, 0};
+        FD_ZERO(&context.mReadFdSet);
+        FD_ZERO(&context.mWriteFdSet);
+        FD_ZERO(&context.mErrorFdSet);
+
+        infraIf.UpdateFdSet(context);
+        int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
+                          &context.mTimeout);
+        if (rval < 0)
+        {
+            perror("select failed");
+            exit(EXIT_FAILURE);
+        }
+        infraIf.Process(context);
+    }
+    EXPECT_EQ(testInfraIfDep.mIsRunning, true);
+
+    addrs.clear();
+    netif.UpdateIp6UnicastAddresses(addrs);
+    testInfraIfDep.mSetInfraIfInvoked = false;
+    while (!testInfraIfDep.mSetInfraIfInvoked)
+    {
+        context.mMaxFd   = -1;
+        context.mTimeout = {100, 0};
+        FD_ZERO(&context.mReadFdSet);
+        FD_ZERO(&context.mWriteFdSet);
+        FD_ZERO(&context.mErrorFdSet);
+
+        infraIf.UpdateFdSet(context);
+        int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
+                          &context.mTimeout);
+        if (rval < 0)
+        {
+            perror("select failed");
+            exit(EXIT_FAILURE);
+        }
+        infraIf.Process(context);
+    }
+    EXPECT_EQ(testInfraIfDep.mIp6Addresses.size(), 0);
+    EXPECT_EQ(testInfraIfDep.mIsRunning, false);
+
+    infraIf.Deinit();
+    netif.Deinit();
 }
 
 #endif // __linux__


### PR DESCRIPTION
This PR implements Infra If state update in the InfraIf module.

This PR enables the `InfraIf` module to listen to the state change of the infrastructure interface and then notify the change to the NCP. This is achieved by listening to netlink events. The implementation is basically the same as OT posix InfraIf.

This PR adds a unit test case to verify `InfraIfDependency::SetInfraIf` is called correctly when the InfraIf state changes.