### PR TITLE
[infra if] implement infra if send icmp6 nd

### DIFF
--- a/src/ncp/posix/infra_if.hpp
+++ b/src/ncp/posix/infra_if.hpp
@@ -69,8 +69,13 @@ public:
     void      Process(const MainloopContext &aContext);
     void      UpdateFdSet(MainloopContext &aContext);
     otbrError SetInfraIf(const char *aIfName);
+    otbrError SendIcmp6Nd(uint32_t            aInfraIfIndex,
+                          const otIp6Address &aDestAddress,
+                          const uint8_t      *aBuffer,
+                          uint16_t            aBufferLength);
 
 private:
+    static int              CreateIcmp6Socket(const char *aInfraIfName);
     bool                    IsRunning(const std::vector<Ip6Address> &aAddrs) const;
     short                   GetFlags(void) const;
     std::vector<Ip6Address> GetAddresses(void);
@@ -85,6 +90,7 @@ private:
 #ifdef __linux__
     int mNetlinkSocket;
 #endif
+    int mInfraIfIcmp6Socket;
 };
 
 } // namespace otbr


### PR DESCRIPTION
This PR implements `SendIcmp6Nd` in the `InfraIf` module.

The method is used to send an ICMPv6 ND message (on host) when NCP calls `otPlatInfraIfSendIcmp6Nd`. In this PR, the method hasn't been called. It will be later integrated with `NcpSpinel`. The implementation of this method is the same as OT posix [implementation](https://github.com/openthread/openthread/blob/main/src/posix/platform/infra_if.cpp#L214).