### PR TITLE
[host] add detach gracefully method

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -114,6 +114,16 @@ void NcpHost::Join(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs, const A
     task->Run();
 }
 
+void NcpHost::DetachGracefully(const AsyncResultReceiver &aReceiver)
+{
+    AsyncTaskPtr task;
+    auto errorHandler = [aReceiver](otError aError, const std::string &aErrorInfo) { aReceiver(aError, aErrorInfo); };
+
+    task = std::make_shared<AsyncTask>(errorHandler);
+    task->First([this](AsyncTaskPtr aNext) { mNcpSpinel.ThreadDetachGracefully(std::move(aNext)); });
+    task->Run();
+}
+
 void NcpHost::Leave(const AsyncResultReceiver &aReceiver)
 {
     AsyncTaskPtr task;

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -84,6 +84,7 @@ public:
 
     // ThreadHost methods
     void Join(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs, const AsyncResultReceiver &aReceiver) override;
+    void DetachGracefully(const AsyncResultReceiver &aRecevier) override;
     void Leave(const AsyncResultReceiver &aReceiver) override;
     void ScheduleMigration(const otOperationalDatasetTlvs &aPendingOpDatasetTlvs,
                            const AsyncResultReceiver       aReceiver) override;

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -204,6 +204,7 @@ public:
 
     // Thread Control virtual methods
     void Join(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs, const AsyncResultReceiver &aRecevier) override;
+    void DetachGracefully(const AsyncResultReceiver &aRecevier) override;
     void Leave(const AsyncResultReceiver &aRecevier) override;
     void ScheduleMigration(const otOperationalDatasetTlvs &aPendingOpDatasetTlvs,
                            const AsyncResultReceiver       aReceiver) override;
@@ -238,6 +239,11 @@ private:
     void        HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aAddress);
 #endif
 
+    static void DetachGracefullyCallback(void *aContext);
+    void        DetachGracefullyCallback(void);
+    static void DetachGracefullyCallbackForLeave(void *aContext);
+    void        DetachGracefullyCallbackForLeave(void);
+
     bool IsAutoAttachEnabled(void);
     void DisableAutoAttach(void);
 
@@ -251,6 +257,8 @@ private:
     TaskRunner                                 mTaskRunner;
     std::vector<ThreadStateChangedCallback>    mThreadStateChangedCallbacks;
     bool                                       mEnableAutoAttach = false;
+    AsyncResultReceiver                        mDetachGracefullyResultReceiver;
+    AsyncResultReceiver                        mLeaveResultReceiver;
 
 #if OTBR_ENABLE_FEATURE_FLAGS
     // The applied FeatureFlagList in ApplyFeatureFlagList call, used for debugging purpose.

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -112,7 +112,19 @@ public:
     virtual void Join(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs, const AsyncResultReceiver &aRecevier) = 0;
 
     /**
-     * This method instructs the device to leave the current network gracefully.
+     * This method instructs the device to detach from the current network gracefully without erasing the persistent
+     * network credentials.
+     *
+     * If there is an ongoing 'DetachGracefully' operation, @p aReceiver will be called with OT_ERROR_BUSY.
+     * Otherwise, @p aReceiver will be invoked after the detach is completed with its error code.
+     *
+     * @param[in] aReceiver  A receiver to get the async result of this operation.
+     */
+    virtual void DetachGracefully(const AsyncResultReceiver &aRecevier) = 0;
+
+    /**
+     * This method instructs the device to detach from the current network gracefully and then erase the persistent
+     * network credentials.
      *
      * 1. If there is already an ongoing 'Leave' operation, no action will be taken and @p aReceiver
      *    will be called after the previous request is completed. The previous @p aReceiver will also


### PR DESCRIPTION
This PR adds a method `DetachGracefully` in the `ThreadHost` APIs.

This method instructs the device to detach from the network gracefully without erasing the persistent network info. The method is required in `SetThreadEnabled` on Android platform where detachGracefully is called first and then disable the ifconfig and Thread stack.

This PR also implements the `Leave` method for `RcpHost` for it to be called in Android source code.