### PR TITLE
[host] add active dataset as a network property

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -49,6 +49,7 @@ namespace Ncp {
 NcpNetworkProperties::NcpNetworkProperties(void)
     : mDeviceRole(OT_DEVICE_ROLE_DISABLED)
 {
+    memset(&mDatasetActiveTlvs, 0, sizeof(mDatasetActiveTlvs));
 }
 
 otDeviceRole NcpNetworkProperties::GetDeviceRole(void) const
@@ -59,6 +60,18 @@ otDeviceRole NcpNetworkProperties::GetDeviceRole(void) const
 void NcpNetworkProperties::SetDeviceRole(otDeviceRole aRole)
 {
     mDeviceRole = aRole;
+}
+
+void NcpNetworkProperties::SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs)
+{
+    mDatasetActiveTlvs.mLength = aActiveOpDatasetTlvs.mLength;
+    memcpy(mDatasetActiveTlvs.mTlvs, aActiveOpDatasetTlvs.mTlvs, aActiveOpDatasetTlvs.mLength);
+}
+
+void NcpNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
+{
+    aDatasetTlvs.mLength = mDatasetActiveTlvs.mLength;
+    memcpy(aDatasetTlvs.mTlvs, mDatasetActiveTlvs.mTlvs, mDatasetActiveTlvs.mLength);
 }
 
 // ===================================== NcpHost ======================================

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -58,12 +58,15 @@ public:
 
     // NetworkProperties methods
     otDeviceRole GetDeviceRole(void) const override;
+    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
 private:
     // PropsObserver methods
     void SetDeviceRole(otDeviceRole aRole) override;
+    void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) override;
 
-    otDeviceRole mDeviceRole;
+    otDeviceRole             mDeviceRole;
+    otOperationalDatasetTlvs mDatasetActiveTlvs;
 };
 
 class NcpHost : public MainloopProcessor, public ThreadHost, public NcpNetworkProperties

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -69,6 +69,13 @@ public:
     virtual void SetDeviceRole(otDeviceRole aRole) = 0;
 
     /**
+     * Updates the active dataset.
+     *
+     * @param[in] aActiveOpDatasetTlvs  The active dataset tlvs.
+     */
+    virtual void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) = 0;
+
+    /**
      * The destructor.
      */
     virtual ~PropsObserver(void) = default;
@@ -294,6 +301,7 @@ private:
     otError ParseIp6AddressTable(const uint8_t *aBuf, uint16_t aLength, std::vector<Ip6AddressInfo> &aAddressTable);
     otError ParseIp6MulticastAddresses(const uint8_t *aBuf, uint8_t aLen, std::vector<Ip6Address> &aAddressList);
     otError ParseIp6StreamNet(const uint8_t *aBuf, uint8_t aLen, const uint8_t *&aData, uint16_t &aDataLen);
+    otError ParseOperationalDatasetTlvs(const uint8_t *aBuf, uint8_t aLen, otOperationalDatasetTlvs &aDatasetTlvs);
 
     ot::Spinel::SpinelDriver *mSpinelDriver;
     uint16_t                  mCmdTidsInUse; ///< Used transaction ids.

--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -78,6 +78,17 @@ otDeviceRole OtNetworkProperties::GetDeviceRole(void) const
     return otThreadGetDeviceRole(mInstance);
 }
 
+void OtNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
+{
+    otError error = otDatasetGetActiveTlvs(mInstance, &aDatasetTlvs);
+
+    if (error != OT_ERROR_NONE)
+    {
+        aDatasetTlvs.mLength = 0;
+        memset(aDatasetTlvs.mTlvs, 0, sizeof(aDatasetTlvs.mTlvs));
+    }
+}
+
 void OtNetworkProperties::SetInstance(otInstance *aInstance)
 {
     mInstance = aInstance;

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -73,6 +73,7 @@ public:
 
     // NetworkProperties methods
     otDeviceRole GetDeviceRole(void) const override;
+    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
     // Set the otInstance
     void SetInstance(otInstance *aInstance);

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -64,6 +64,13 @@ public:
     virtual otDeviceRole GetDeviceRole(void) const = 0;
 
     /**
+     * Returns the active operational dataset tlvs.
+     *
+     * @param[out] aDatasetTlvs  A reference to where the Active Operational Dataset will be placed.
+     */
+    virtual void GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const = 0;
+
+    /**
      * The destructor.
      */
     virtual ~NetworkProperties(void) = default;


### PR DESCRIPTION
This PR adds active dataset tlvs to `NetworkProperties` so that for both NCP and RCP active dataset can be accessed directly.

The active dataset is used in many places in the platform code. For example, in android `SetThreadEnabled`, it will only enable Thread when the active dataset is a valid one.

I verified the NCP case locally by log (dumping the active set and see if it's correctly set). If writing a test for it, we need add one more dbus API, which seems unworthy now.