### PR TITLE
[infra if] add infra if icmp6 nd receiving

### DIFF
--- a/src/ncp/posix/infra_if.hpp
+++ b/src/ncp/posix/infra_if.hpp
@@ -60,6 +60,10 @@ public:
         virtual otbrError SetInfraIf(unsigned int                   aInfraIfIndex,
                                      bool                           aIsRunning,
                                      const std::vector<Ip6Address> &aIp6Addresses);
+        virtual otbrError HandleIcmp6Nd(uint32_t          aInfraIfIndex,
+                                        const Ip6Address &aSrcAddress,
+                                        const uint8_t    *aData,
+                                        uint16_t          aDataLen);
     };
 
     InfraIf(Dependencies &aDependencies);
@@ -80,6 +84,7 @@ private:
     short                   GetFlags(void) const;
     std::vector<Ip6Address> GetAddresses(void);
     static bool             HasLinkLocalAddress(const std::vector<Ip6Address> &aAddrs);
+    void                    ReceiveIcmp6Message(void);
 #ifdef __linux__
     void ReceiveNetlinkMessage(void);
 #endif


### PR DESCRIPTION
This PR implements Icmp6Nd receiving in the InfraIf module.

The method is used to receive ICMPv6 ND messages (on host) and forward them to the NCP. The implementation of this method is the same as OT posix [implementation](https://github.com/openthread/openthread/blob/main/src/posix/platform/infra_if.cpp#L593). In this PR, the forwarding to NCP hasn't been implemented. It will be later integrated with NcpSpinel. 

This PR also adds a test case to verify that `HandleIcmp6Nd` is called correctly when the infrastructure interface receives an ICMP6 ND message.