### PR TITLE
[test] add unit test framework for ThreadHost APIs (RCP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,8 @@ if(SYSTEMD_FOUND)
     pkg_get_variable(OTBR_SYSTEMD_UNIT_DIR systemd systemdsystemunitdir)
 endif()
 
+set(OPENTHREAD_PROJECT_DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/openthread/repo)
+set(OTBR_PROJECT_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 add_subdirectory(src)

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -40,12 +40,12 @@ target_link_libraries(otbr-agent PRIVATE
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     $<$<BOOL:${OTBR_OPENWRT}>:otbr-ubus>
     $<$<BOOL:${OTBR_REST}>:otbr-rest>
-    openthread-posix
     openthread-cli-ftd
     openthread-ftd
     openthread-spinel-rcp
     openthread-radio-spinel
     openthread-hdlc
+    openthread-posix
     otbr-sdp-proxy
     otbr-ncp
     otbr-common

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,7 +49,12 @@ add_library(otbr-common
 target_link_libraries(otbr-common
     PUBLIC otbr-config
     openthread-ftd
-    openthread-posix
     $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
     $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
+)
+
+target_include_directories(otbr-common
+    PUBLIC
+        ${OPENTHREAD_PROJECT_DIRECTORY}/src/posix/platform/include
+        ${OPENTHREAD_PROJECT_DIRECTORY}/src
 )

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -297,3 +297,33 @@ void otbrLogDeinit(void)
 {
     closelog();
 }
+
+otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel)
+{
+    otLogLevel level;
+
+    switch (aLevel)
+    {
+    case OTBR_LOG_EMERG:
+    case OTBR_LOG_ALERT:
+    case OTBR_LOG_CRIT:
+        level = OT_LOG_LEVEL_CRIT;
+        break;
+    case OTBR_LOG_ERR:
+    case OTBR_LOG_WARNING:
+        level = OT_LOG_LEVEL_WARN;
+        break;
+    case OTBR_LOG_NOTICE:
+        level = OT_LOG_LEVEL_NOTE;
+        break;
+    case OTBR_LOG_INFO:
+        level = OT_LOG_LEVEL_INFO;
+        break;
+    case OTBR_LOG_DEBUG:
+    default:
+        level = OT_LOG_LEVEL_DEBG;
+        break;
+    }
+
+    return level;
+}

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -233,4 +233,13 @@ void otbrLogDeinit(void);
 #define otbrLogInfo(...) otbrLog(OTBR_LOG_INFO, OTBR_LOG_TAG, __VA_ARGS__)
 #define otbrLogDebug(...) otbrLog(OTBR_LOG_DEBUG, OTBR_LOG_TAG, __VA_ARGS__)
 
+/**
+ * Convert otbrLogLevel to otLogLevel.
+ *
+ * @param[in] aLevel  The otbrLogLevel to convert.
+ *
+ * @return the corresponding OT log level.
+ */
+otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel);
+
 #endif // OTBR_COMMON_LOGGING_HPP_

--- a/src/ncp/thread_host.cpp
+++ b/src/ncp/thread_host.cpp
@@ -82,35 +82,5 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
     return host;
 }
 
-otLogLevel ThreadHost::ConvertToOtLogLevel(otbrLogLevel aLevel)
-{
-    otLogLevel level;
-
-    switch (aLevel)
-    {
-    case OTBR_LOG_EMERG:
-    case OTBR_LOG_ALERT:
-    case OTBR_LOG_CRIT:
-        level = OT_LOG_LEVEL_CRIT;
-        break;
-    case OTBR_LOG_ERR:
-    case OTBR_LOG_WARNING:
-        level = OT_LOG_LEVEL_WARN;
-        break;
-    case OTBR_LOG_NOTICE:
-        level = OT_LOG_LEVEL_NOTE;
-        break;
-    case OTBR_LOG_INFO:
-        level = OT_LOG_LEVEL_INFO;
-        break;
-    case OTBR_LOG_DEBUG:
-    default:
-        level = OT_LOG_LEVEL_DEBG;
-        break;
-    }
-
-    return level;
-}
-
 } // namespace Ncp
 } // namespace otbr

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -188,9 +188,6 @@ public:
      * The destructor.
      */
     virtual ~ThreadHost(void) = default;
-
-protected:
-    static otLogLevel ConvertToOtLogLevel(otbrLogLevel aLevel);
 };
 
 } // namespace Ncp

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -83,3 +83,23 @@ target_link_libraries(otbr-posix-gtest-unit
     GTest::gmock_main
 )
 gtest_discover_tests(otbr-posix-gtest-unit PROPERTIES LABELS "sudo")
+
+add_executable(otbr-gtest-host-api
+    ${OTBR_PROJECT_DIRECTORY}/src/ncp/rcp_host.cpp
+    ${OPENTHREAD_PROJECT_DIRECTORY}/tests/gtest/fake_platform.cpp
+    fake_posix_platform.cpp
+    test_rcp_host_api.cpp
+)
+target_include_directories(otbr-gtest-host-api
+    PRIVATE
+        ${OTBR_PROJECT_DIRECTORY}/src
+        ${OPENTHREAD_PROJECT_DIRECTORY}/src/core
+        ${OPENTHREAD_PROJECT_DIRECTORY}/tests/gtest
+)
+target_link_libraries(otbr-gtest-host-api
+    mbedtls
+    otbr-common
+    otbr-utils
+    GTest::gmock_main
+)
+gtest_discover_tests(otbr-gtest-host-api)

--- a/tests/gtest/fake_posix_platform.cpp
+++ b/tests/gtest/fake_posix_platform.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2024, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fake_platform.hpp"
+
+#include "openthread/openthread-system.h"
+
+otPlatResetReason       gPlatResetReason = OT_PLAT_RESET_REASON_POWER_ON;
+static ot::FakePlatform sFakePlatform;
+
+const otRadioSpinelMetrics *otSysGetRadioSpinelMetrics(void)
+{
+    return nullptr;
+}
+const otRcpInterfaceMetrics *otSysGetRcpInterfaceMetrics(void)
+{
+    return nullptr;
+}
+
+uint32_t otSysGetInfraNetifFlags(void)
+{
+    return 0;
+}
+
+void otSysCountInfraNetifAddresses(otSysInfraNetIfAddressCounters *)
+{
+}
+
+const char *otSysGetInfraNetifName(void)
+{
+    return nullptr;
+}
+
+otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
+{
+    OT_UNUSED_VARIABLE(aPlatformConfig);
+
+    return sFakePlatform.CurrentInstance();
+}
+
+void otSysDeinit(void)
+{
+}
+
+void otSysMainloopUpdate(otInstance *, otSysMainloopContext *)
+{
+}
+
+void otSysMainloopProcess(otInstance *, const otSysMainloopContext *)
+{
+    sFakePlatform.Run(/* microseconds */ 1000);
+}

--- a/tests/gtest/test_rcp_host_api.cpp
+++ b/tests/gtest/test_rcp_host_api.cpp
@@ -1,0 +1,131 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sys/time.h>
+
+#include <openthread/dataset.h>
+#include <openthread/dataset_ftd.h>
+
+#include "common/mainloop.hpp"
+#include "common/mainloop_manager.hpp"
+#include "ncp/rcp_host.hpp"
+
+#include "fake_platform.hpp"
+
+static void MainloopProcessUntil(otbr::MainloopContext    &aMainloop,
+                                 uint32_t                  aTimeoutSec,
+                                 std::function<bool(void)> aCondition)
+{
+    timeval startTime;
+    timeval now;
+    gettimeofday(&startTime, nullptr);
+
+    while (!aCondition())
+    {
+        gettimeofday(&now, nullptr);
+        // Simply compare the second. We don't need high precision here.
+        if (now.tv_sec - startTime.tv_sec > aTimeoutSec)
+        {
+            break;
+        }
+
+        otbr::MainloopManager::GetInstance().Update(aMainloop);
+        otbr::MainloopManager::GetInstance().Process(aMainloop);
+    }
+}
+
+TEST(RcpHostApi, DeviceRoleChangesCorrectlyAfterSetThreadEnabled)
+{
+    otError                                    error          = OT_ERROR_FAILED;
+    bool                                       resultReceived = false;
+    otbr::MainloopContext                      mainloop;
+    otbr::Ncp::ThreadHost::AsyncResultReceiver receiver = [&resultReceived, &error](otError            aError,
+                                                                                    const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        resultReceived = true;
+        error          = aError;
+    };
+    otbr::Ncp::RcpHost host("wpan0", std::vector<const char *>(), /* aBackboneInterfaceName */ "", /* aDryRun */ false,
+                            /* aEnableAutoAttach */ false);
+
+    host.Init();
+
+    // 1. Active dataset hasn't been set, should succeed with device role still being disabled.
+    host.SetThreadEnabled(true, receiver);
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 1, [&resultReceived]() { return resultReceived; });
+    EXPECT_EQ(error, OT_ERROR_NONE);
+    EXPECT_EQ(host.GetDeviceRole(), OT_DEVICE_ROLE_DISABLED);
+
+    // 2. Set active dataset and enable it
+    {
+        otOperationalDataset     dataset;
+        otOperationalDatasetTlvs datasetTlvs;
+        OT_UNUSED_VARIABLE(otDatasetCreateNewNetwork(ot::FakePlatform::CurrentInstance(), &dataset));
+        otDatasetConvertToTlvs(&dataset, &datasetTlvs);
+        OT_UNUSED_VARIABLE(otDatasetSetActiveTlvs(ot::FakePlatform::CurrentInstance(), &datasetTlvs));
+    }
+    error          = OT_ERROR_FAILED;
+    resultReceived = false;
+    host.SetThreadEnabled(true, receiver);
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 1, [&resultReceived]() { return resultReceived; });
+    EXPECT_EQ(error, OT_ERROR_NONE);
+    EXPECT_EQ(host.GetDeviceRole(), OT_DEVICE_ROLE_DETACHED);
+
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 1,
+                         [&host]() { return host.GetDeviceRole() != OT_DEVICE_ROLE_DETACHED; });
+    EXPECT_EQ(host.GetDeviceRole(), OT_DEVICE_ROLE_LEADER);
+
+    // 3. Disable it
+    error          = OT_ERROR_FAILED;
+    resultReceived = false;
+    host.SetThreadEnabled(false, receiver);
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 1, [&resultReceived]() { return resultReceived; });
+    EXPECT_EQ(error, OT_ERROR_NONE);
+    EXPECT_EQ(host.GetDeviceRole(), OT_DEVICE_ROLE_DISABLED);
+
+    // 4. Duplicate call, should get OT_ERROR_BUSY
+    error                   = OT_ERROR_FAILED;
+    resultReceived          = false;
+    otError error2          = OT_ERROR_FAILED;
+    bool    resultReceived2 = false;
+    host.SetThreadEnabled(false, receiver);
+    host.SetThreadEnabled(false, [&resultReceived2, &error2](otError aError, const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        error2          = aError;
+        resultReceived2 = true;
+    });
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 1,
+                         [&resultReceived, &resultReceived2]() { return resultReceived && resultReceived2; });
+    EXPECT_EQ(error, OT_ERROR_NONE);
+    EXPECT_EQ(error2, OT_ERROR_BUSY);
+
+    host.Deinit();
+}


### PR DESCRIPTION
This PR adds a unit test framework for testing ThreadHost APIs (RCP).

It's implemeneted by building `rcp_host.cpp` with `FakePlatform` in OT. A few small changes are done to make this work:
* implement openthread posix system APIs in  `fake_posix_platform.cpp`. (like `otSysInit`, `otSysMainloopProcess `) `ot::FakePlatform` doesn't include these things and I think it's better to put it here.
* Remove the fixed build dependency of `otbr-common` on `openthread-posix` so that the unit test executable can link to the fake system API implementation instead those in `openthread-posix`.
* Move `ThreadHost::ConvertToOtLogLevel` to `logging.hpp`. Because otherwise we have to build `thread_host.cpp` into the test executable and then have more dependencies on NcpHost.

This PR also implements the first unit test case to test the `RcpHost::SetThreadEnabled` method.