### PR TITLE
[thread-host] add set channel max power api

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -182,6 +182,15 @@ void NcpHost::GetChannelMasks(const ChannelMasksReceiver &aReceiver, const Async
     mTaskRunner.Post([aErrReceiver](void) { aErrReceiver(OT_ERROR_NOT_IMPLEMENTED, "Not implemented!"); });
 }
 
+void NcpHost::SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
+                                  const AsyncResultReceiver          &aReceiver)
+{
+    OT_UNUSED_VARIABLE(aChannelMaxPowers);
+
+    // TODO: Implement SetChannelMaxPowers under NCP mode.
+    mTaskRunner.Post([aReceiver](void) { aReceiver(OT_ERROR_NOT_IMPLEMENTED, "Not implemented!"); });
+}
+
 void NcpHost::Process(const MainloopContext &aMainloop)
 {
     mSpinelDriver.Process(&aMainloop);

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -93,6 +93,8 @@ public:
     void SetThreadEnabled(bool aEnabled, const AsyncResultReceiver aReceiver) override;
     void SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver) override;
     void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
+    void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
+                             const AsyncResultReceiver          &aReceiver) override;
     CoprocessorType GetCoprocessorType(void) override { return OT_COPROCESSOR_NCP; }
     const char     *GetCoprocessorVersion(void) override;
     const char     *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -211,6 +211,8 @@ public:
     void SetThreadEnabled(bool aEnabled, const AsyncResultReceiver aReceiver) override;
     void SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver) override;
     void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
+    void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
+                             const AsyncResultReceiver          &aReceiver) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -90,6 +90,12 @@ public:
         std::function<void(uint32_t /*aSupportedChannelMask*/, uint32_t /*aPreferredChannelMask*/)>;
     using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
 
+    struct ChannelMaxPower
+    {
+        uint16_t mChannel;
+        int16_t  mMaxPower; // INT16_MAX indicates that the corresponding channel is disabled.
+    };
+
     /**
      * Create a Thread Controller Instance.
      *
@@ -181,6 +187,19 @@ public:
      * @param aErrReceiver  A receiver to get the error if the operation fails.
      */
     virtual void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) = 0;
+
+    /**
+     * Sets the max power of each channel.
+     *
+     * 1. If the host hasn't been initialized, @p aReceiver will be invoked with error OT_ERROR_INVALID_STATE.
+     * 2. If any value in @p aChannelMaxPowers is invalid, @p aReceiver will be invoked with error
+     * OT_ERROR_INVALID_ARGS.
+     *
+     * @param[in] aChannelMaxPowers  A vector of ChannelMaxPower.
+     * @param[in] aReceiver          A receiver to get the async result of this operation.
+     */
+    virtual void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
+                                     const AsyncResultReceiver          &aReceiver) = 0;
 
     /**
      * Returns the co-processor type.


### PR DESCRIPTION
This PR adds the SetChannelMaxPower method to ThreadHost.

The PR implements this method for RcpHost. The implementation for NCP will be added later.