### PR TITLE
[thread-host] add get channel mask

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -174,6 +174,14 @@ void NcpHost::SetCountryCode(const std::string &aCountryCode, const AsyncResultR
     mTaskRunner.Post([aReceiver](void) { aReceiver(OT_ERROR_NOT_IMPLEMENTED, "Not implemented!"); });
 }
 
+void NcpHost::GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver)
+{
+    OT_UNUSED_VARIABLE(aReceiver);
+
+    // TODO: Implement GetChannelMasks under NCP mode.
+    mTaskRunner.Post([aErrReceiver](void) { aErrReceiver(OT_ERROR_NOT_IMPLEMENTED, "Not implemented!"); });
+}
+
 void NcpHost::Process(const MainloopContext &aMainloop)
 {
     mSpinelDriver.Process(&aMainloop);

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -92,6 +92,7 @@ public:
                            const AsyncResultReceiver       aReceiver) override;
     void SetThreadEnabled(bool aEnabled, const AsyncResultReceiver aReceiver) override;
     void SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver) override;
+    void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
     CoprocessorType GetCoprocessorType(void) override { return OT_COPROCESSOR_NCP; }
     const char     *GetCoprocessorVersion(void) override;
     const char     *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }

--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -463,6 +463,30 @@ exit:
     }
 }
 
+void RcpHost::GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver)
+{
+    otError  error = OT_ERROR_NONE;
+    uint32_t supportedChannelMask;
+    uint32_t preferredChannelMask;
+
+    VerifyOrExit(mInstance != nullptr, error = OT_ERROR_INVALID_STATE);
+
+    supportedChannelMask = otLinkGetSupportedChannelMask(mInstance);
+    preferredChannelMask = otPlatRadioGetPreferredChannelMask(mInstance);
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        mTaskRunner.Post([aReceiver, supportedChannelMask, preferredChannelMask](void) {
+            aReceiver(supportedChannelMask, preferredChannelMask);
+        });
+    }
+    else
+    {
+        mTaskRunner.Post([aErrReceiver, error](void) { aErrReceiver(error, "OT is not initialized"); });
+    }
+}
+
 void RcpHost::DisableThreadAfterDetach(void *aContext)
 {
     static_cast<RcpHost *>(aContext)->DisableThreadAfterDetach();

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -210,6 +210,7 @@ public:
                            const AsyncResultReceiver       aReceiver) override;
     void SetThreadEnabled(bool aEnabled, const AsyncResultReceiver aReceiver) override;
     void SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver) override;
+    void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -86,7 +86,9 @@ class ThreadHost : virtual public NetworkProperties
 {
 public:
     using AsyncResultReceiver = std::function<void(otError, const std::string &)>;
-    using DeviceRoleHandler   = std::function<void(otError, otDeviceRole)>;
+    using ChannelMasksReceiver =
+        std::function<void(uint32_t /*aSupportedChannelMask*/, uint32_t /*aPreferredChannelMask*/)>;
+    using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
 
     /**
      * Create a Thread Controller Instance.
@@ -168,6 +170,17 @@ public:
      * @param[in] aCountryCode  The country code.
      */
     virtual void SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver) = 0;
+
+    /**
+     * Gets the supported and preferred channel masks.
+     *
+     * If the operation succeeded, @p aReceiver will be invoked with the supported and preferred channel masks.
+     * Otherwise, @p aErrReceiver will be invoked with the error and @p aReceiver won't be invoked in this case.
+     *
+     * @param aReceiver     A receiver to get the channel masks.
+     * @param aErrReceiver  A receiver to get the error if the operation fails.
+     */
+    virtual void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) = 0;
 
     /**
      * Returns the co-processor type.


### PR DESCRIPTION
This PR adds the GetChannelMask method to ThreadHost.

The PR implements this method for RcpHost. The implementation for NCP will be added later.