### PR TITLE
[mdns] refactor mDNS State subscription

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -66,7 +66,8 @@ Application::Application(const std::string               &aInterfaceName,
                                     /* aDryRun */ false,
                                     aEnableAutoAttach))
 #if OTBR_ENABLE_MDNS
-    , mPublisher(Mdns::Publisher::Create([this](Mdns::Publisher::State aState) { this->HandleMdnsState(aState); }))
+    , mPublisher(
+          Mdns::Publisher::Create([this](Mdns::Publisher::State aState) { mMdnsStateSubject.UpdateState(aState); }))
 #endif
 #if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
     , mDBusAgent(MakeUnique<DBus::DBusAgent>(*mHost, *mPublisher))
@@ -191,24 +192,6 @@ otbrError Application::Run(void)
     return error;
 }
 
-void Application::HandleMdnsState(Mdns::Publisher::State aState)
-{
-    OTBR_UNUSED_VARIABLE(aState);
-
-#if OTBR_ENABLE_BORDER_AGENT
-    mBorderAgent->HandleMdnsState(aState);
-#endif
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    mAdvertisingProxy->HandleMdnsState(aState);
-#endif
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-    mDiscoveryProxy->HandleMdnsState(aState);
-#endif
-#if OTBR_ENABLE_TREL
-    mTrelDnssd->HandleMdnsState(aState);
-#endif
-}
-
 void Application::HandleSignal(int aSignal)
 {
     sShouldTerminate = true;
@@ -249,6 +232,19 @@ void Application::CreateRcpMode(const std::string &aRestListenAddress, int aRest
 
 void Application::InitRcpMode(void)
 {
+#if OTBR_ENABLE_BORDER_AGENT
+    mMdnsStateSubject.AddObserver(*mBorderAgent);
+#endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mMdnsStateSubject.AddObserver(*mAdvertisingProxy);
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+    mMdnsStateSubject.AddObserver(*mDiscoveryProxy);
+#endif
+#if OTBR_ENABLE_TREL
+    mMdnsStateSubject.AddObserver(*mTrelDnssd);
+#endif
+
 #if OTBR_ENABLE_MDNS
     mPublisher->Start();
 #endif
@@ -296,6 +292,7 @@ void Application::DeinitRcpMode(void)
     mBorderAgent->SetEnabled(false);
 #endif
 #if OTBR_ENABLE_MDNS
+    mMdnsStateSubject.Clear();
     mPublisher->Stop();
 #endif
 }

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -237,13 +237,6 @@ public:
     }
 #endif
 
-    /**
-     * This method handles mDNS publisher's state changes.
-     *
-     * @param[in] aState  The state of mDNS publisher.
-     */
-    void HandleMdnsState(Mdns::Publisher::State aState);
-
 private:
     // Default poll timeout.
     static const struct timeval kPollTimeout;
@@ -264,6 +257,7 @@ private:
     const char                      *mBackboneInterfaceName;
     std::unique_ptr<Ncp::ThreadHost> mHost;
 #if OTBR_ENABLE_MDNS
+    Mdns::StateSubject               mMdnsStateSubject;
     std::unique_ptr<Mdns::Publisher> mPublisher;
 #endif
 #if OTBR_ENABLE_BORDER_AGENT

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -75,7 +75,7 @@ namespace otbr {
 /**
  * This class implements Thread border agent functionality.
  */
-class BorderAgent : private NonCopyable
+class BorderAgent : public Mdns::StateObserver, private NonCopyable
 {
 public:
     /** The callback for receiving ephemeral key changes. */
@@ -139,7 +139,7 @@ public:
      *
      * @param[in] aState  The state of mDNS publisher.
      */
-    void HandleMdnsState(Mdns::Publisher::State aState);
+    void HandleMdnsState(Mdns::Publisher::State aState) override;
 
     /**
      * This method creates ephemeral key in the Border Agent.

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -779,6 +779,24 @@ void Publisher::RemoveAddress(AddressList &aAddressList, const Ip6Address &aAddr
     }
 }
 
+void StateSubject::AddObserver(StateObserver &aObserver)
+{
+    mObservers.push_back(&aObserver);
+}
+
+void StateSubject::UpdateState(Publisher::State aState)
+{
+    for (StateObserver *observer : mObservers)
+    {
+        observer->HandleMdnsState(aState);
+    }
+}
+
+void StateSubject::Clear(void)
+{
+    mObservers.clear();
+}
+
 } // namespace Mdns
 } // namespace otbr
 

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -666,6 +666,64 @@ protected:
 };
 
 /**
+ * This interface is a mDNS State Observer.
+ */
+class StateObserver
+{
+public:
+    /**
+     * This method notifies the mDNS state to the observer.
+     *
+     * @param[in] aState  The mDNS State.
+     */
+    virtual void HandleMdnsState(Publisher::State aState) = 0;
+
+    /**
+     * The destructor.
+     */
+    virtual ~StateObserver(void) = default;
+};
+
+/**
+ * This class defines a mDNS State Subject.
+ */
+class StateSubject
+{
+public:
+    /**
+     * Constructor.
+     */
+    StateSubject(void) = default;
+
+    /**
+     * Destructor.
+     */
+    ~StateSubject(void) = default;
+
+    /**
+     * This method adds an mDNS State Observer to this subject.
+     *
+     * @param[in] aObserver  A reference to the observer. If it's nullptr, it won't be added.
+     */
+    void AddObserver(StateObserver &aObserver);
+
+    /**
+     * This method updates the mDNS State.
+     *
+     * @param[in] aState  The mDNS State.
+     */
+    void UpdateState(Publisher::State aState);
+
+    /**
+     * This method removes all the observers.
+     */
+    void Clear(void);
+
+private:
+    std::vector<StateObserver *> mObservers;
+};
+
+/**
  * @}
  */
 

--- a/src/sdp_proxy/advertising_proxy.hpp
+++ b/src/sdp_proxy/advertising_proxy.hpp
@@ -52,7 +52,7 @@ namespace otbr {
 /**
  * This class implements the Advertising Proxy.
  */
-class AdvertisingProxy : private NonCopyable
+class AdvertisingProxy : public Mdns::StateObserver, private NonCopyable
 {
 public:
     /**
@@ -80,7 +80,7 @@ public:
      *
      * @param[in] aState  The state of mDNS publisher.
      */
-    void HandleMdnsState(Mdns::Publisher::State aState);
+    void HandleMdnsState(Mdns::Publisher::State aState) override;
 
 private:
     struct OutstandingUpdate

--- a/src/sdp_proxy/discovery_proxy.hpp
+++ b/src/sdp_proxy/discovery_proxy.hpp
@@ -56,7 +56,7 @@ namespace Dnssd {
 /**
  * This class implements the DNS-SD Discovery Proxy.
  */
-class DiscoveryProxy : private NonCopyable
+class DiscoveryProxy : public Mdns::StateObserver, private NonCopyable
 {
 public:
     /**

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -60,7 +60,7 @@ namespace TrelDnssd {
  * @{
  */
 
-class TrelDnssd
+class TrelDnssd : public Mdns::StateObserver
 {
 public:
     /**
@@ -107,7 +107,7 @@ public:
      *
      * @param[in] aState  The state of mDNS publisher.
      */
-    void HandleMdnsState(Mdns::Publisher::State aState);
+    void HandleMdnsState(Mdns::Publisher::State aState) override;
 
 private:
     static constexpr size_t   kPeerCacheSize             = 256;


### PR DESCRIPTION
This PR refactors the mDNS State subscription using the Subject-Observer pattern.

The PR makes the state subscription more flexible. Currently the mDNS state is published in `Application::HandleMdnsState`. Now we have both NCP and RCP case. This function will be difficult to implement. With this new pattern, we can register different observers during NCP/RCP initialization.