### PR TITLE
[ncp] integrate InfraIf module with NcpHost to make border routing work

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -76,14 +76,16 @@ void NcpNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatas
 
 // ===================================== NcpHost ======================================
 
-NcpHost::NcpHost(const char *aInterfaceName, bool aDryRun)
+NcpHost::NcpHost(const char *aInterfaceName, const char *aBackboneInterfaceName, bool aDryRun)
     : mSpinelDriver(*static_cast<ot::Spinel::SpinelDriver *>(otSysGetSpinelDriver()))
     , mNetif(mNcpSpinel)
+    , mInfraIf(mNcpSpinel)
 {
     memset(&mConfig, 0, sizeof(mConfig));
-    mConfig.mInterfaceName = aInterfaceName;
-    mConfig.mDryRun        = aDryRun;
-    mConfig.mSpeedUpFactor = 1;
+    mConfig.mInterfaceName         = aInterfaceName;
+    mConfig.mBackboneInterfaceName = aBackboneInterfaceName;
+    mConfig.mDryRun                = aDryRun;
+    mConfig.mSpeedUpFactor         = 1;
 }
 
 const char *NcpHost::GetCoprocessorVersion(void)
@@ -96,6 +98,7 @@ void NcpHost::Init(void)
     otSysInit(&mConfig);
     mNcpSpinel.Init(mSpinelDriver, *this);
     mNetif.Init(mConfig.mInterfaceName);
+    mInfraIf.Init();
 
     mNcpSpinel.Ip6SetAddressCallback(
         [this](const std::vector<Ip6AddressInfo> &aAddrInfos) { mNetif.UpdateIp6UnicastAddresses(aAddrInfos); });
@@ -104,6 +107,15 @@ void NcpHost::Init(void)
     mNcpSpinel.NetifSetStateChangedCallback([this](bool aState) { mNetif.SetNetifState(aState); });
     mNcpSpinel.Ip6SetReceiveCallback(
         [this](const uint8_t *aData, uint16_t aLength) { mNetif.Ip6Receive(aData, aLength); });
+    mNcpSpinel.InfraIfSetIcmp6NdSendCallback(
+        [this](uint32_t aInfraIfIndex, const otIp6Address &aAddr, const uint8_t *aData, uint16_t aDataLen) {
+            OTBR_UNUSED_VARIABLE(mInfraIf.SendIcmp6Nd(aInfraIfIndex, aAddr, aData, aDataLen));
+        });
+
+    if (mConfig.mBackboneInterfaceName != nullptr && strlen(mConfig.mBackboneInterfaceName) > 0)
+    {
+        mInfraIf.SetInfraIf(mConfig.mBackboneInterfaceName);
+    }
 }
 
 void NcpHost::Deinit(void)

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -75,10 +75,11 @@ public:
     /**
      * Constructor.
      *
-     * @param[in]   aInterfaceName  A string of the NCP interface name.
-     * @param[in]   aDryRun         TRUE to indicate dry-run mode. FALSE otherwise.
+     * @param[in]   aInterfaceName          A string of the NCP interface name.
+     * @param[in]   aBackboneInterfaceName  A string of the backbone interface name.
+     * @param[in]   aDryRun                 TRUE to indicate dry-run mode. FALSE otherwise.
      */
-    NcpHost(const char *aInterfaceName, bool aDryRun);
+    NcpHost(const char *aInterfaceName, const char *aBackboneInterfaceName, bool aDryRun);
 
     /**
      * Destructor.
@@ -111,6 +112,7 @@ private:
     NcpSpinel                 mNcpSpinel;
     TaskRunner                mTaskRunner;
     Netif                     mNetif;
+    InfraIf                   mInfraIf;
 };
 
 } // namespace Ncp

--- a/src/ncp/ncp_spinel.cpp
+++ b/src/ncp/ncp_spinel.cpp
@@ -416,6 +416,18 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
         break;
     }
 
+    case SPINEL_PROP_INFRA_IF_SEND_ICMP6:
+    {
+        uint32_t            infraIfIndex;
+        const otIp6Address *destAddress;
+        const uint8_t      *data;
+        uint16_t            dataLen;
+
+        SuccessOrExit(ParseInfraIfIcmp6Nd(aBuffer, aLength, infraIfIndex, destAddress, data, dataLen));
+        SafeInvoke(mInfraIfIcmp6NdCallback, infraIfIndex, *destAddress, data, dataLen);
+        break;
+    }
+
     default:
         otbrLogWarning("Received uncognized key: %u", aKey);
         break;
@@ -434,7 +446,8 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     OTBR_UNUSED_VARIABLE(aData);
     OTBR_UNUSED_VARIABLE(aLength);
 
-    otbrError error = OTBR_ERROR_NONE;
+    otbrError       error  = OTBR_ERROR_NONE;
+    spinel_status_t status = SPINEL_STATUS_OK;
 
     switch (mWaitingKeyTable[aTid])
     {
@@ -467,8 +480,6 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET_TLVS:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         { // Failed case
-            spinel_status_t status = SPINEL_STATUS_OK;
-
             SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
             CallAndClear(mDatasetMgmtSetPendingTask, ot::Spinel::SpinelStatusToOtError(status));
         }
@@ -479,6 +490,18 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
         break;
 
     case SPINEL_PROP_STREAM_NET:
+        break;
+
+    case SPINEL_PROP_INFRA_IF_STATE:
+        VerifyOrExit(aKey == SPINEL_PROP_LAST_STATUS, error = OTBR_ERROR_INVALID_STATE);
+        SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+        otbrLogInfo("Infra If state update result: %s", spinel_status_to_cstr(status));
+        break;
+
+    case SPINEL_PROP_INFRA_IF_RECV_ICMP6:
+        VerifyOrExit(aKey == SPINEL_PROP_LAST_STATUS, error = OTBR_ERROR_INVALID_STATE);
+        SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+        otbrLogInfo("Infra If handle ICMP6 ND result: %s", spinel_status_to_cstr(status));
         break;
 
     default:
@@ -753,6 +776,72 @@ otError NcpSpinel::ParseOperationalDatasetTlvs(const uint8_t            *aBuf,
     aDatasetTlvs.mLength = datasetTlvsLen;
 
 exit:
+    return error;
+}
+
+otError NcpSpinel::ParseInfraIfIcmp6Nd(const uint8_t       *aBuf,
+                                       uint8_t              aLen,
+                                       uint32_t            &aInfraIfIndex,
+                                       const otIp6Address *&aAddr,
+                                       const uint8_t      *&aData,
+                                       uint16_t            &aDataLen)
+{
+    otError             error = OT_ERROR_NONE;
+    ot::Spinel::Decoder decoder;
+
+    VerifyOrExit(aBuf != nullptr, error = OT_ERROR_INVALID_ARGS);
+
+    decoder.Init(aBuf, aLen);
+    SuccessOrExit(error = decoder.ReadUint32(aInfraIfIndex));
+    SuccessOrExit(error = decoder.ReadIp6Address(aAddr));
+    SuccessOrExit(error = decoder.ReadDataWithLen(aData, aDataLen));
+
+exit:
+    return error;
+}
+
+otbrError NcpSpinel::SetInfraIf(uint32_t aInfraIfIndex, bool aIsRunning, const std::vector<Ip6Address> &aIp6Addresses)
+{
+    otbrError    error        = OTBR_ERROR_NONE;
+    EncodingFunc encodingFunc = [this, aInfraIfIndex, aIsRunning, &aIp6Addresses] {
+        otError error = OT_ERROR_NONE;
+        SuccessOrExit(error = mEncoder.WriteUint32(aInfraIfIndex));
+        SuccessOrExit(error = mEncoder.WriteBool(aIsRunning));
+        for (const Ip6Address &addr : aIp6Addresses)
+        {
+            SuccessOrExit(error = mEncoder.WriteIp6Address(reinterpret_cast<const otIp6Address &>(addr)));
+        }
+    exit:
+        return error;
+    };
+
+    SuccessOrExit(SetProperty(SPINEL_PROP_INFRA_IF_STATE, encodingFunc), error = OTBR_ERROR_OPENTHREAD);
+exit:
+    return error;
+}
+
+otbrError NcpSpinel::HandleIcmp6Nd(uint32_t          aInfraIfIndex,
+                                   const Ip6Address &aIp6Address,
+                                   const uint8_t    *aData,
+                                   uint16_t          aDataLen)
+{
+    otbrError    error        = OTBR_ERROR_NONE;
+    EncodingFunc encodingFunc = [this, aInfraIfIndex, &aIp6Address, aData, aDataLen] {
+        otError error = OT_ERROR_NONE;
+        SuccessOrExit(error = mEncoder.WriteUint32(aInfraIfIndex));
+        SuccessOrExit(error = mEncoder.WriteIp6Address(reinterpret_cast<const otIp6Address &>(aIp6Address)));
+        SuccessOrExit(error = mEncoder.WriteData(aData, aDataLen));
+    exit:
+        return error;
+    };
+
+    SuccessOrExit(SetProperty(SPINEL_PROP_INFRA_IF_RECV_ICMP6, encodingFunc), error = OTBR_ERROR_OPENTHREAD);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to passthrough ICMP6 ND to NCP, %s", otbrErrorString(error));
+    }
     return error;
 }
 

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -239,7 +239,6 @@ public:
      * This method sets the function to send an Icmp6 ND message on the infrastructure link.
      *
      * @param[in] aCallback  The callback to send an Icmp6 ND message on the infrastructure link.
-     *
      */
     void InfraIfSetIcmp6NdSendCallback(const InfraIfSendIcmp6NdCallback &aCallback)
     {

--- a/src/ncp/thread_host.cpp
+++ b/src/ncp/thread_host.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
         break;
 
     case OT_COPROCESSOR_NCP:
-        host = MakeUnique<NcpHost>(aInterfaceName, aDryRun);
+        host = MakeUnique<NcpHost>(aInterfaceName, aBackboneInterfaceName, aDryRun);
         break;
 
     default:

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -68,7 +68,8 @@ install_common_dependencies()
         coreutils \
         git \
         libprotobuf-dev \
-        protobuf-compiler
+        protobuf-compiler \
+        socat
 }
 
 install_openthread_binraries()

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -84,6 +84,10 @@ proc spawn_node {id type sim_app} {
                 timeout { fail "Timed out" }
             }
         }
+        otbr-docker {
+            spawn docker exec -it $sim_app bash
+            expect "app#"
+        }
         otbr {
             spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -d7 "spinel+hdlc+forkpty://${sim_app}?forkpty-arg=${id}"
         }
@@ -94,12 +98,68 @@ proc spawn_node {id type sim_app} {
     return $spawn_id
 }
 
+proc create_socat {id} {
+    global socat_pid
+    spawn socat -d -d pty,raw,echo=0 pty,raw,echo=0
+    set socat_pid [exp_pid]
+    set pty1 ""
+    set pty2 ""
+    expect {
+        -re {PTY is (\S+).*PTY is (\S+)} {
+            set pty1 $expect_out(1,string)
+            set pty2 $expect_out(2,string)
+        }
+        timeout {
+            fail "Timed out"
+        }
+    }
+    set spawn_ids($id) $spawn_id
+    return [list $pty1 $pty2]
+}
+
+proc start_otbr_docker {name sim_app sim_id pty1 pty2} {
+    exec $sim_app $sim_id <$pty1 >$pty1 &
+    exec docker run -d \
+        --name $name \
+        --network backbone1 \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        -v $pty2:/dev/ttyUSB0 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
+}
+
 proc switch_node {id} {
     global spawn_ids
     global spawn_id
 
     send_user "\n# ${id}\n"
     set spawn_id $spawn_ids($id)
+}
+
+proc dispose_node {id} {
+    switch_node $id
+    send "\x04"
+    expect eof
+}
+proc dispose_socat {} {
+    global socat_pid
+    if { [info exists socat_pid] } {
+        exec kill $socat_pid
+    }
+}
+proc dispose_all {} {
+    global spawn_ids
+    set max_node [array size spawn_ids]
+    for {set i 1} {$i <= $max_node} {incr i} {
+        if { [info exists spawn_ids($i)] } {
+            dispose_node $i
+        }
+    }
+    array unset spawn_ids
+    dispose_socat
 }
 
 proc get_ipaddr {type} {
@@ -109,4 +169,10 @@ proc get_ipaddr {type} {
     expect_line "Done"
 
     return $rval
+}
+
+proc get_omr_addr {} {
+    send "ipaddr -v\r\n"
+    expect -re {(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}(?= origin:slaac)}
+    return $expect_out(0,string)
 }

--- a/tests/scripts/expect/ncp_border_routing.exp
+++ b/tests/scripts/expect/ncp_border_routing.exp
@@ -1,0 +1,70 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+set ptys [create_socat 1]
+set pty1 [lindex $ptys 0]
+set pty2 [lindex $ptys 1]
+
+set container "otbr-ncp"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+set dataset_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x00,0x00,0x14,0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0x7d,0x61,0xeb,0x42,0xcd,0xc4,0x8d,0x6a,0x07,0x08,0xfd,0x0d,0x07,0xfc,0xa1,0xb9,0xf0,0x50,0x05,0x10,0xba,0x08,0x8f,0xc2,0xbd,0x6c,0x3b,0x38,0x97,0xf7,0xa1,0x0f,0x58,0x26,0x3f,0xf3,0x03,0x0f,0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x35,0x32,0x34,0x66,0x01,0x02,0x52,0x4f,0x04,0x10,0x9d,0xc0,0x23,0xcc,0xd4,0x47,0xb1,0x2b,0x50,0x99,0x7e,0xf6,0x80,0x20,0xf1,0x9e,0x0c,0x04,0x02,0xa0,0xf7,0xf8"
+
+start_otbr_docker $container $::env(EXP_OT_NCP_PATH) 2 $pty1 $pty2
+
+spawn_node 3 otbr-docker $container
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+
+send "dataset set active ${dataset}\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "leader"
+
+switch_node 3
+send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
+expect "app#"
+sleep 20
+
+switch_node 4
+set omr_addr [get_omr_addr]
+sleep 1
+
+# Test pinging from the host (infrastructure network) to the cli
+set timeout 20
+spawn ping6 -c 10 $omr_addr
+expect -re {10 packets transmitted, 10 received, 0\% packet loss}
+
+exec sudo docker stop $container
+exec sudo docker rm $container
+dispose_all

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -164,6 +164,18 @@ do_build_otbr_docker()
         --build-arg OTBR_OPTIONS="${otbr_docker_options[*]}"
 }
 
+setup_infraif()
+{
+    if ! ip link show backbone1 >/dev/null 2>&1; then
+        echo "Creating backbone1 with Docker..."
+        docker network create --driver bridge --ipv6 --subnet 9101::/64 -o "com.docker.network.bridge.name"="backbone1" backbone1
+    else
+        echo "backbone1 already exists."
+    fi
+    sysctl -w net.ipv6.conf.backbone1.accept_ra=2
+    sysctl -w net.ipv6.conf.backbone1.accept_ra_rt_info_max_plen=64
+}
+
 test_setup()
 {
     executable_or_die "${OTBR_AGENT_PATH}"
@@ -194,6 +206,8 @@ test_setup()
 
     write_syslog "AGENT: kill old"
     sudo killall "${OTBR_AGENT}" || true
+
+    setup_infraif
 
     # From now on - all exits are TRAPPED
     # When they occur, we call the function: output_logs'.


### PR DESCRIPTION
This PR integrates the `InfraIf` module with `NcpHost` to make the border routing function work under NCP mode.

The PR also adds an integration test to test the border routing functionality. To execute this test, docker is used to simulate two devices connected by a infrastructure link (docker network bridge). otbr-agent runs inside the docker and we ping from the host machine to a simulated cli ftd nodes using its OMR address. Some code is added in the test scripts to support testing with docker.