### PR TITLE
[ncp] pass necessary encoder to encoding func

### DIFF
--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -290,7 +290,7 @@ private:
     spinel_tid_t GetNextTid(void);
     void         FreeTidTableItem(spinel_tid_t aTid);
 
-    using EncodingFunc = std::function<otError(void)>;
+    using EncodingFunc = std::function<otError(ot::Spinel::Encoder &aEncoder)>;
     otError SendCommand(spinel_command_t aCmd, spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError SetProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError InsertProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);


### PR DESCRIPTION
Only the encoder is needed for the encoding functions. This commit voids passing unnecessary context to them.