### PR TITLE
[trel] updates for switching trel interface

### DIFF
--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -91,6 +91,9 @@ TrelDnssd::TrelDnssd(Ncp::RcpHost &aHost, Mdns::Publisher &aPublisher)
 void TrelDnssd::Initialize(std::string aTrelNetif)
 {
     mTrelNetif = std::move(aTrelNetif);
+    // Reset mTrelNetifIndex to 0 so that when this function is called with a different aTrelNetif
+    // than the current mTrelNetif, CheckTrelNetifReady() will update mTrelNetifIndex accordingly.
+    mTrelNetifIndex = 0;
 
     if (IsInitialized())
     {
@@ -190,7 +193,6 @@ exit:
 
 void TrelDnssd::HandleMdnsState(Mdns::Publisher::State aState)
 {
-    VerifyOrExit(IsInitialized());
     VerifyOrExit(aState == Mdns::Publisher::State::kReady);
 
     otbrLogDebug("mDNS Publisher is Ready");
@@ -202,6 +204,7 @@ void TrelDnssd::HandleMdnsState(Mdns::Publisher::State aState)
         mRegisterInfo.mInstanceName = "";
     }
 
+    VerifyOrExit(IsInitialized());
     OnBecomeReady();
 
 exit:


### PR DESCRIPTION
As it's possible to switch network interface for TREL in https://github.com/openthread/openthread/pull/10872, updated trel_dnssd.cpp in 2 places:
1). Initialize() can be called multiple times now, so it should clear the mTrelNetifIndex at the beginning to refresh the index according to the given interface name.
2). HandleMdnsState() may be invoked when TrelDnssd is not initialized, we should still update the mMdnsPublisherReady status, so it's ready to publish a service when TrelDnssd becomes initialized.