### PR TITLE
[ncp] fix ncp spinel parsing methods

### DIFF
--- a/src/ncp/ncp_spinel.cpp
+++ b/src/ncp/ncp_spinel.cpp
@@ -723,7 +723,7 @@ exit:
     return error;
 }
 
-otError NcpSpinel::ParseIp6MulticastAddresses(const uint8_t *aBuf, uint8_t aLen, std::vector<Ip6Address> &aAddressList)
+otError NcpSpinel::ParseIp6MulticastAddresses(const uint8_t *aBuf, uint16_t aLen, std::vector<Ip6Address> &aAddressList)
 {
     otError             error = OT_ERROR_NONE;
     ot::Spinel::Decoder decoder;
@@ -746,7 +746,7 @@ exit:
     return error;
 }
 
-otError NcpSpinel::ParseIp6StreamNet(const uint8_t *aBuf, uint8_t aLen, const uint8_t *&aData, uint16_t &aDataLen)
+otError NcpSpinel::ParseIp6StreamNet(const uint8_t *aBuf, uint16_t aLen, const uint8_t *&aData, uint16_t &aDataLen)
 {
     otError             error = OT_ERROR_NONE;
     ot::Spinel::Decoder decoder;
@@ -761,7 +761,7 @@ exit:
 }
 
 otError NcpSpinel::ParseOperationalDatasetTlvs(const uint8_t            *aBuf,
-                                               uint8_t                   aLen,
+                                               uint16_t                  aLen,
                                                otOperationalDatasetTlvs &aDatasetTlvs)
 {
     otError             error = OT_ERROR_NONE;

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -311,9 +311,9 @@ private:
     otError SendEncodedFrame(void);
 
     otError ParseIp6AddressTable(const uint8_t *aBuf, uint16_t aLength, std::vector<Ip6AddressInfo> &aAddressTable);
-    otError ParseIp6MulticastAddresses(const uint8_t *aBuf, uint8_t aLen, std::vector<Ip6Address> &aAddressList);
-    otError ParseIp6StreamNet(const uint8_t *aBuf, uint8_t aLen, const uint8_t *&aData, uint16_t &aDataLen);
-    otError ParseOperationalDatasetTlvs(const uint8_t *aBuf, uint8_t aLen, otOperationalDatasetTlvs &aDatasetTlvs);
+    otError ParseIp6MulticastAddresses(const uint8_t *aBuf, uint16_t aLen, std::vector<Ip6Address> &aAddressList);
+    otError ParseIp6StreamNet(const uint8_t *aBuf, uint16_t aLen, const uint8_t *&aData, uint16_t &aDataLen);
+    otError ParseOperationalDatasetTlvs(const uint8_t *aBuf, uint16_t aLen, otOperationalDatasetTlvs &aDatasetTlvs);
     otError ParseInfraIfIcmp6Nd(const uint8_t       *aBuf,
                                 uint8_t              aLen,
                                 uint32_t            &aInfraIfIndex,


### PR DESCRIPTION
This PR fixes a critical issue in NcpSpinel parsing methods.

The parsing methods use `uint8_t` as the length of input frame which is not sufficient for large frame like Ip6StreamNet, which could be at most 1000+ bytes.