### PR TITLE
[thread-host] make AddThreadStateChangedCallback as a ThreadHost API

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -191,6 +191,12 @@ void NcpHost::SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMa
     mTaskRunner.Post([aReceiver](void) { aReceiver(OT_ERROR_NOT_IMPLEMENTED, "Not implemented!"); });
 }
 
+void NcpHost::AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback)
+{
+    // TODO: Implement AddThreadStateChangedCallback under NCP mode.
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
 void NcpHost::Process(const MainloopContext &aMainloop)
 {
     mSpinelDriver.Process(&aMainloop);

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -95,6 +95,7 @@ public:
     void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
     void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
                              const AsyncResultReceiver          &aReceiver) override;
+    void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
     CoprocessorType GetCoprocessorType(void) override { return OT_COPROCESSOR_NCP; }
     const char     *GetCoprocessorVersion(void) override;
     const char     *GetInterfaceName(void) const override { return mConfig.mInterfaceName; }

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -88,8 +88,6 @@ private:
 class RcpHost : public MainloopProcessor, public ThreadHost, public OtNetworkProperties
 {
 public:
-    using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;
-
     /**
      * This constructor initializes this object.
      *
@@ -153,13 +151,6 @@ public:
     void RegisterResetHandler(std::function<void(void)> aHandler);
 
     /**
-     * This method adds a event listener for Thread state changes.
-     *
-     * @param[in] aCallback  The callback to receive Thread state changed events.
-     */
-    void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback);
-
-    /**
      * This method resets the OpenThread instance.
      */
     void Reset(void);
@@ -213,6 +204,7 @@ public:
     void GetChannelMasks(const ChannelMasksReceiver &aReceiver, const AsyncResultReceiver &aErrReceiver) override;
     void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
                              const AsyncResultReceiver          &aReceiver) override;
+    void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -88,7 +88,8 @@ public:
     using AsyncResultReceiver = std::function<void(otError, const std::string &)>;
     using ChannelMasksReceiver =
         std::function<void(uint32_t /*aSupportedChannelMask*/, uint32_t /*aPreferredChannelMask*/)>;
-    using DeviceRoleHandler = std::function<void(otError, otDeviceRole)>;
+    using DeviceRoleHandler          = std::function<void(otError, otDeviceRole)>;
+    using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;
 
     struct ChannelMaxPower
     {
@@ -200,6 +201,13 @@ public:
      */
     virtual void SetChannelMaxPowers(const std::vector<ChannelMaxPower> &aChannelMaxPowers,
                                      const AsyncResultReceiver          &aReceiver) = 0;
+
+    /**
+     * This method adds a event listener for Thread state changes.
+     *
+     * @param[in] aCallback  The callback to receive Thread state changed events.
+     */
+    virtual void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) = 0;
 
     /**
      * Returns the co-processor type.


### PR DESCRIPTION
This PR adds `AddThreadStateChangedCallback` as a `ThreadHost` API.

Because this method is also needed under NCP mode. The PR doesn't change the implementation in RcpHost and adds an empty implementation in NcpHost.