### PR TITLE
[pd] pd daemon service: remove redundant subprocess 'sudo' in python script

### DIFF
--- a/script/reference-device/dhcp6_pd_daemon.py
+++ b/script/reference-device/dhcp6_pd_daemon.py
@@ -54,10 +54,9 @@ def restart_dhcpcd_service(config_path):
         logging.error(f"{config_path} not found. Cannot apply configuration.")
         return
     try:
-        subprocess.run(["sudo", "cp", config_path, DHCP_CONFIG_PATH],
-                       check=True)
-        subprocess.run(["sudo", "systemctl", "daemon-reload"], check=True)
-        subprocess.run(["sudo", "service", "dhcpcd", "restart"], check=True)
+        subprocess.run(["cp", config_path, DHCP_CONFIG_PATH], check=True)
+        subprocess.run(["systemctl", "daemon-reload"], check=True)
+        subprocess.run(["service", "dhcpcd", "restart"], check=True)
         logging.info(
             f"Successfully restarted dhcpcd service with {config_path}.")
     except subprocess.CalledProcessError as e:
@@ -124,8 +123,7 @@ def main():
     # By restarting dhcpcd here, we ensure it runs after network.target is active, allowing
     # radvd to start correctly and dhcpcd to configure the interface.
     try:
-        subprocess.run(["sudo", "systemctl", "reload-or-restart", "dhcpcd"],
-                       check=True)
+        subprocess.run(["systemctl", "reload-or-restart", "dhcpcd"], check=True)
         logging.info("Successfully restarting dhcpcd service.")
     except subprocess.CalledProcessError as e:
         logging.error(f"Error restarting dhcpcd service: {e}")


### PR DESCRIPTION
Removes unnecessary sudo commands from dhcp6_pd_daemon.py.

The script was already running as root due to the `User=root` setting in the `systemd` service file. The internal `sudo` calls were redundant and caused issues with dbus context switching, preventing the script from receiving dbus signals correctly. This change removes the `sudo` calls, ensuring the script operates within a consistent dbus context and resolves the signal handling problems.

This commit addresses the issue where the dhcp6_pd_daemon was not responding to changes in the Dhcp6PdState dbus property.