### PR TITLE
[github-actions] fix MacOS build error: unlink pkg-config before reinstalling

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -54,6 +54,7 @@ jobs:
         rm -f /usr/local/bin/pydoc3*
         rm -f /usr/local/bin/python3*
         brew update
+        brew unlink pkg-config
         brew reinstall boost cmake dbus jsoncpp ninja protobuf@21 pkg-config
     - name: Build
       run: |


### PR DESCRIPTION
Fix macOS build issue caused by pkg-config conflicts.

Unlinking pkg-config before reinstalling it in the MacOS build workflow. This resolves issues arising from stale or conflicting installations of pkg-config, which can lead to build failures.