### PR TITLE
[thread-host] add common network properties

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -62,6 +62,18 @@ void NcpNetworkProperties::SetDeviceRole(otDeviceRole aRole)
     mDeviceRole = aRole;
 }
 
+bool NcpNetworkProperties::Ip6IsEnabled(void) const
+{
+    // TODO: Implement the method under NCP mode.
+    return false;
+}
+
+uint32_t NcpNetworkProperties::GetPartitionId(void) const
+{
+    // TODO: Implement the method under NCP mode.
+    return 0;
+}
+
 void NcpNetworkProperties::SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs)
 {
     mDatasetActiveTlvs.mLength = aActiveOpDatasetTlvs.mLength;
@@ -72,6 +84,12 @@ void NcpNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatas
 {
     aDatasetTlvs.mLength = mDatasetActiveTlvs.mLength;
     memcpy(aDatasetTlvs.mTlvs, mDatasetActiveTlvs.mTlvs, mDatasetActiveTlvs.mLength);
+}
+
+void NcpNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
+{
+    // TODO: Implement the method under NCP mode.
+    OTBR_UNUSED_VARIABLE(aDatasetTlvs);
 }
 
 // ===================================== NcpHost ======================================

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -58,7 +58,10 @@ public:
 
     // NetworkProperties methods
     otDeviceRole GetDeviceRole(void) const override;
+    bool         Ip6IsEnabled(void) const override;
+    uint32_t     GetPartitionId(void) const override;
     void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
 private:
     // PropsObserver methods

--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -79,9 +79,30 @@ otDeviceRole OtNetworkProperties::GetDeviceRole(void) const
     return otThreadGetDeviceRole(mInstance);
 }
 
+bool OtNetworkProperties::Ip6IsEnabled(void) const
+{
+    return otIp6IsEnabled(mInstance);
+}
+
+uint32_t OtNetworkProperties::GetPartitionId(void) const
+{
+    return otThreadGetPartitionId(mInstance);
+}
+
 void OtNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
 {
     otError error = otDatasetGetActiveTlvs(mInstance, &aDatasetTlvs);
+
+    if (error != OT_ERROR_NONE)
+    {
+        aDatasetTlvs.mLength = 0;
+        memset(aDatasetTlvs.mTlvs, 0, sizeof(aDatasetTlvs.mTlvs));
+    }
+}
+
+void OtNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
+{
+    otError error = otDatasetGetPendingTlvs(mInstance, &aDatasetTlvs);
 
     if (error != OT_ERROR_NONE)
     {

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -73,7 +73,10 @@ public:
 
     // NetworkProperties methods
     otDeviceRole GetDeviceRole(void) const override;
+    bool         Ip6IsEnabled(void) const override;
+    uint32_t     GetPartitionId(void) const override;
     void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
     // Set the otInstance
     void SetInstance(otInstance *aInstance);

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -64,11 +64,33 @@ public:
     virtual otDeviceRole GetDeviceRole(void) const = 0;
 
     /**
+     * Returns whether or not the IPv6 interface is up.
+     *
+     * @retval TRUE   The IPv6 interface is enabled.
+     * @retval FALSE  The IPv6 interface is disabled.
+     */
+    virtual bool Ip6IsEnabled(void) const = 0;
+
+    /**
+     * Returns the Partition ID.
+     *
+     * @returns The Partition ID.
+     */
+    virtual uint32_t GetPartitionId(void) const = 0;
+
+    /**
      * Returns the active operational dataset tlvs.
      *
      * @param[out] aDatasetTlvs  A reference to where the Active Operational Dataset will be placed.
      */
     virtual void GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const = 0;
+
+    /**
+     * Returns the pending operational dataset tlvs.
+     *
+     * @param[out] aDatasetTlvs  A reference to where the Pending Operational Dataset will be placed.
+     */
+    virtual void GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const = 0;
 
     /**
      * The destructor.


### PR DESCRIPTION
This PR adds a few common network properties to `ThreadHost`.

The direct usage of these properties is in Android platform when refreshing the state. With this PR, that process can work for both NCP & RCP. This PR only implements the Get methods for RCP. The NCP version will be implemented later.