### PR TITLE
[posix] add virtual destructor for InfraIf::Dependencies

### DIFF
--- a/src/ncp/posix/infra_if.hpp
+++ b/src/ncp/posix/infra_if.hpp
@@ -57,6 +57,8 @@ public:
     class Dependencies
     {
     public:
+        virtual ~Dependencies(void) = default;
+
         virtual otbrError SetInfraIf(unsigned int                   aInfraIfIndex,
                                      bool                           aIsRunning,
                                      const std::vector<Ip6Address> &aIp6Addresses);


### PR DESCRIPTION
This PR adds virtual destructor for InfraIf::Dependencies.

On some platforms this will cause build warnings and errors.