### PR TITLE
[PD] pd daemon service: ensure dhcp6_pd_daemon starts after otbr-agent

### DIFF
--- a/script/_dhcpv6_pd_ref
+++ b/script/_dhcpv6_pd_ref
@@ -78,8 +78,9 @@ create_dhcp6_pd_daemon_service()
     sudo tee ${PD_DAEMON_SERVICE_PATH} <<EOF
 [Unit]
 Description=Daemon to manage dhcpcd based on otbr-agent's PD state change
-After=multi-user.service
 ConditionPathExists=${PD_DAEMON_PATH}
+Requires=otbr-agent.service
+After=otbr-agent.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
The `dhcp6_pd_daemon` occasionally fails to receive dbus messages on initial boot due to a race condition with `otbr-agent`.  This commit fixes the issue by explicitly defining a service dependency on `otbr-agent`.
