### PR TITLE
[rest] add coprocessor version string API

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -389,6 +389,21 @@ paths:
           description: Invalid request body.
         "409":
           description: request rejected because commissioner is not active.
+  /node/coprocessor/version:
+    get:
+      tags:
+        - node
+      summary: Get the coprocessor version
+      description: Retrieves the NCP or RCP coprocessor version string.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Coprocessor version string
+                example: "OPENTHREAD/20210309-00615-g9836b6f18; NRF52840; Mar 9 2021 13:30:04"
 
 components:
   schemas:

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -393,8 +393,8 @@ paths:
     get:
       tags:
         - node
-      summary: Get the coprocessor version
-      description: Retrieves the NCP or RCP coprocessor version string.
+      summary: Get the coprocessor firmware version
+      description: Retrieves the NCP or RCP coprocessor firmware version string.
       responses:
         "200":
           description: Successful operation
@@ -403,7 +403,7 @@ paths:
               schema:
                 type: string
                 description: Coprocessor version string
-                example: "OPENTHREAD/20210309-00615-g9836b6f18; NRF52840; Mar 9 2021 13:30:04"
+                example: "OPENTHREAD/thread-reference-20200818-1740-g33cc75ed3; NRF52840; Jun  2 2022 14:25:49"
 
 components:
   schemas:

--- a/src/rest/resource.cpp
+++ b/src/rest/resource.cpp
@@ -49,6 +49,8 @@
 #define OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING "/node/dataset/pending"
 #define OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE "/node/commissioner/state"
 #define OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER "/node/commissioner/joiner"
+#define OT_REST_RESOURCE_PATH_NODE_COPROCESSOR "/node/coprocessor"
+#define OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION "/node/coprocessor/version"
 #define OT_REST_RESOURCE_PATH_NETWORK "/networks"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT "/networks/current"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_COMMISSION "/networks/commission"
@@ -148,6 +150,7 @@ Resource::Resource(RcpHost *aHost)
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, &Resource::DatasetPending);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, &Resource::CommissionerState);
     mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, &Resource::CommissionerJoiner);
+    mResourceMap.emplace(OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION, &Resource::CoprocessorVersion);
 
     // Resource callback handler
     mResourceCallbackMap.emplace(OT_REST_RESOURCE_PATH_DIAGNOSTICS, &Resource::HandleDiagnosticCallback);
@@ -1053,6 +1056,33 @@ void Resource::CommissionerJoiner(const Request &aRequest, Response &aResponse) 
     default:
         ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
         break;
+    }
+}
+
+void Resource::GetCoprocessorVersion(Response &aResponse) const
+{
+    std::string coprocessorVersion;
+    std::string errorCode;
+
+    coprocessorVersion = mHost->GetCoprocessorVersion();
+    coprocessorVersion = Json::String2JsonString(coprocessorVersion);
+
+    aResponse.SetBody(coprocessorVersion);
+    errorCode = GetHttpStatus(HttpStatusCode::kStatusOk);
+    aResponse.SetResponsCode(errorCode);
+}
+
+void Resource::CoprocessorVersion(const Request &aRequest, Response &aResponse) const
+{
+    std::string errorCode;
+
+    if (aRequest.GetMethod() == HttpMethod::kGet)
+    {
+        GetCoprocessorVersion(aResponse);
+    }
+    else
+    {
+        ErrorHandler(aResponse, HttpStatusCode::kStatusMethodNotAllowed);
     }
 }
 

--- a/src/rest/resource.hpp
+++ b/src/rest/resource.hpp
@@ -129,6 +129,7 @@ private:
     void CommissionerJoiner(const Request &aRequest, Response &aResponse) const;
     void Diagnostic(const Request &aRequest, Response &aResponse) const;
     void HandleDiagnosticCallback(const Request &aRequest, Response &aResponse);
+    void CoprocessorVersion(const Request &aRequest, Response &aResponse) const;
 
     void GetNodeInfo(Response &aResponse) const;
     void DeleteNodeInfo(Response &aResponse) const;
@@ -149,6 +150,7 @@ private:
     void GetJoiners(Response &aResponse) const;
     void AddJoiner(const Request &aRequest, Response &aResponse) const;
     void RemoveJoiner(const Request &aRequest, Response &aResponse) const;
+    void GetCoprocessorVersion(Response &aResponse) const;
 
     void DeleteOutDatedDiagnostic(void);
     void UpdateDiag(std::string aKey, std::vector<otNetworkDiagTlv> &aDiag);

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -296,6 +296,14 @@ def node_ext_panid_check(data):
     return True
 
 
+def node_coprocessor_version_check(data):
+    assert data is not None
+
+    assert (type(data) == str)
+
+    return True
+
+
 def node_test(thread_num):
     url = rest_api_addr + "/node"
 
@@ -406,6 +414,18 @@ def node_ext_panid_test(thread_num):
     print(" /node/ext-panid : all {}, valid {} ".format(thread_num, valid))
 
 
+def node_coprocessor_version_test(thread_num):
+    url = rest_api_addr + "/node/coprocessor/version"
+
+    response_data = [None] * thread_num
+
+    create_multi_thread(get_data_from_url, url, thread_num, response_data)
+
+    valid = [node_coprocessor_version_check(data) for data in response_data].count(True)
+
+    print(" /node/coprocessor/version : all {}, valid {} ".format(thread_num, valid))
+
+
 def diagnostics_test(thread_num):
     url = rest_api_addr + "/diagnostics"
 
@@ -450,6 +470,7 @@ def main():
     node_leader_data_test(200)
     node_num_of_router_test(200)
     node_ext_panid_test(200)
+    node_coprocessor_version_test(200)
     diagnostics_test(20)
     error_test(10)
 


### PR DESCRIPTION
We'd like to access the current NCP/RCP coprocessor firmware version string from the REST API. I've added a new API endpoint under `/node/coprocessor/version` that fetches it with `GetCoprocessorVersion()`.