### PR TITLE
[thread-host] add ThreadEnabled state callback

### DIFF
--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -229,6 +229,12 @@ void NcpHost::AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback
     OT_UNUSED_VARIABLE(aCallback);
 }
 
+void NcpHost::AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback)
+{
+    // TODO: Implement AddThreadEnabledStateChangedCallback under NCP mode.
+    OT_UNUSED_VARIABLE(aCallback);
+}
+
 void NcpHost::Process(const MainloopContext &aMainloop)
 {
     mSpinelDriver.Process(&aMainloop);

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -102,6 +102,7 @@ public:
                              const AsyncResultReceiver          &aReceiver) override;
 #endif
     void            AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
+    void            AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
     CoprocessorType GetCoprocessorType(void) override
     {
         return OT_COPROCESSOR_NCP;

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -210,6 +210,7 @@ public:
                              const AsyncResultReceiver          &aReceiver) override;
 #endif
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
+    void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {
@@ -260,6 +261,8 @@ private:
 
     bool IsAttached(void);
 
+    void UpdateThreadEnabledState(ThreadEnabledState aState);
+
     otError SetOtbrAndOtLogLevel(otbrLogLevel aLevel);
 
     otInstance *mInstance;
@@ -268,11 +271,13 @@ private:
     std::unique_ptr<otbr::agent::ThreadHelper> mThreadHelper;
     std::vector<std::function<void(void)>>     mResetHandlers;
     TaskRunner                                 mTaskRunner;
-    std::vector<ThreadStateChangedCallback>    mThreadStateChangedCallbacks;
-    bool                                       mEnableAutoAttach = false;
 
-    AsyncResultReceiver mSetThreadEnabledReceiver;
-    AsyncResultReceiver mScheduleMigrationReceiver;
+    std::vector<ThreadStateChangedCallback> mThreadStateChangedCallbacks;
+    std::vector<ThreadEnabledStateCallback> mThreadEnabledStateChangedCallbacks;
+    bool                                    mEnableAutoAttach = false;
+    ThreadEnabledState                      mThreadEnabledState;
+    AsyncResultReceiver                     mSetThreadEnabledReceiver;
+    AsyncResultReceiver                     mScheduleMigrationReceiver;
 
 #if OTBR_ENABLE_FEATURE_FLAGS
     // The applied FeatureFlagList in ApplyFeatureFlagList call, used for debugging purpose.

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -98,6 +98,14 @@ public:
     virtual ~NetworkProperties(void) = default;
 };
 
+enum ThreadEnabledState
+{
+    kStateDisabled  = 0,
+    kStateEnabled   = 1,
+    kStateDisabling = 2,
+    kStateInvalid   = 255,
+};
+
 /**
  * This class is an interface which provides a set of async APIs to control the
  * Thread network.
@@ -112,6 +120,7 @@ public:
         std::function<void(uint32_t /*aSupportedChannelMask*/, uint32_t /*aPreferredChannelMask*/)>;
     using DeviceRoleHandler          = std::function<void(otError, otDeviceRole)>;
     using ThreadStateChangedCallback = std::function<void(otChangedFlags aFlags)>;
+    using ThreadEnabledStateCallback = std::function<void(ThreadEnabledState aState)>;
 
     struct ChannelMaxPower
     {
@@ -232,6 +241,13 @@ public:
      * @param[in] aCallback  The callback to receive Thread state changed events.
      */
     virtual void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) = 0;
+
+    /**
+     * This method adds a event listener for Thread Enabled state changes.
+     *
+     * @param[in] aCallback  The callback to receive Thread Enabled state changed events.
+     */
+    virtual void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) = 0;
 
     /**
      * Returns the co-processor type.


### PR DESCRIPTION
This PR adds `AddThreadEnabledStateChangedCallback` to `ThreadHost` and implements it for RcpHost.

Since the `ThreadEnabledState` is subscribed by some platform services, (for example, on Android) and this state is also required to implement `Join`, `Leave`, `ScheduleMigration` and `SetThreadEnabled`, this PR adds the `ThreadEnabledState` to `RcpHost` and provide an API to allow other components to subscribe to this state.

This PR makes the behavior of `ScheduleMigration` and `SetThreadEnabled` same as the Android binder API. And the unit test is updated accordingly.