### PR TITLE
[log] add Android log system support

### DIFF
--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -55,6 +55,7 @@
 #include "ncp/thread_host.hpp"
 
 #ifdef OTBR_ENABLE_PLATFORM_ANDROID
+#include <log/log.h>
 #ifndef __ANDROID__
 #error "OTBR_ENABLE_PLATFORM_ANDROID can be enabled for only Android devices"
 #endif
@@ -177,16 +178,21 @@ static void OnAllocateFailed(void)
 
 static otbrLogLevel GetDefaultLogLevel(void)
 {
-    otbrLogLevel level = OTBR_LOG_INFO;
-
 #if OTBR_ENABLE_PLATFORM_ANDROID
-    char value[PROPERTY_VALUE_MAX];
+    // The log level is set to DEBUG by default, the final output log will be filtered by Android log system.
+    otbrLogLevel level = OTBR_LOG_DEBUG;
+    char         value[PROPERTY_VALUE_MAX];
+
+    // Set the Android log level to INFO by default.
+    __android_log_set_minimum_priority(ANDROID_LOG_INFO);
 
     property_get("ro.build.type", value, "user");
     if (!strcmp(value, "user"))
     {
         level = OTBR_LOG_WARNING;
     }
+#else
+    otbrLogLevel level = OTBR_LOG_INFO;
 #endif
 
     return level;


### PR DESCRIPTION
Developers can use the command `ot-ctl log level 5` to change the default log level to DEBUG. Sometimes, the `ot-daemon` crashes before developers can run the ot-ctl command on Android.

This commit adds the Android log system support, so that developers can run the command `setprop log.tag.ot-daemon DEBUG` to change the log level before the ot-daemon runs. The log output format is the same with using the Linux log system.