### PR TITLE
[continuous-integration] fix and clean up macOS.yml

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -49,13 +49,8 @@ jobs:
         submodules: true
     - name: Bootstrap
       run: |
-        rm -f /usr/local/bin/2to3*
-        rm -f /usr/local/bin/idle3*
-        rm -f /usr/local/bin/pydoc3*
-        rm -f /usr/local/bin/python3*
         brew update
-        brew unlink pkg-config
-        brew reinstall boost cmake dbus jsoncpp ninja protobuf@21 pkg-config
+        brew reinstall boost jsoncpp ninja protobuf@21
     - name: Build
       run: |
         OTBR_OPTIONS="-DOTBR_BORDER_AGENT=OFF \


### PR DESCRIPTION
There are macOS workflow failures for new PRs like [this](https://github.com/openthread/ot-br-posix/actions/runs/12006912636/job/33467422370?pr=2618): 
```
Error: No such keg: /opt/homebrew/Cellar/pkg-config
```

I checked [macos-14-Readme.md](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md) and noticed that some dependencies (like `pkg-config`) of the macOS workflow are already satisfied by the image so we don't have to reinstall them again.

Also, this PR removes `dbus` in the macOS workflow because D-BUS is not enabled when building OTBR.