### PR TITLE
[github-actions] fix NCP border routing setup

### DIFF
--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -172,8 +172,8 @@ setup_infraif()
     else
         echo "backbone1 already exists."
     fi
-    sysctl -w net.ipv6.conf.backbone1.accept_ra=2
-    sysctl -w net.ipv6.conf.backbone1.accept_ra_rt_info_max_plen=64
+    sudo sysctl -w net.ipv6.conf.backbone1.accept_ra=2
+    sudo sysctl -w net.ipv6.conf.backbone1.accept_ra_rt_info_max_plen=64
 }
 
 test_setup()


### PR DESCRIPTION
The PR fixes issue in the github action for testing NCP border routing.

Without `sudo` the option cannot be set successfully, and border routing cannot work in the test. Currently the expect script isn't strong enough to detect this problem. I'll enhance the script soon.