### PR TITLE
[ncp] integrate SRP Server and Advertising Proxy for NCP

### DIFF
--- a/.github/workflows/ncp_mode.yml
+++ b/.github/workflows/ncp_mode.yml
@@ -53,7 +53,7 @@ jobs:
         OTBR_MDNS: ${{ matrix.mdns }}
         OTBR_COVERAGE: 1
         OTBR_VERBOSE: 1
-        OTBR_OPTIONS: "-DCMAKE_BUILD_TYPE=Debug -DOT_THREAD_VERSION=1.4 -DOTBR_COVERAGE=ON -DOTBR_DBUS=ON -DOTBR_FEATURE_FLAGS=ON -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_UNSECURE_JOIN=ON -DOTBR_TREL=ON -DBUILD_TESTING=OFF"
+        OTBR_OPTIONS: "-DCMAKE_BUILD_TYPE=Debug -DOT_THREAD_VERSION=1.4 -DOTBR_COVERAGE=ON -DOTBR_DBUS=ON -DOTBR_FEATURE_FLAGS=ON -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_UNSECURE_JOIN=ON -DOTBR_TREL=ON -DOTBR_SRP_ADVERTISING_PROXY=ON -DBUILD_TESTING=OFF"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -76,6 +76,6 @@ jobs:
             --build-arg OTBR_OPTIONS="${OTBR_OPTIONS}"
     - name: Run
       run: |
-       top_builddir="./build/temp" tests/scripts/ncp_mode build_ot_sim expect
+        top_builddir="./build/temp" tests/scripts/ncp_mode build_ot_sim expect
     - name: Codecov
       uses: codecov/codecov-action@v5

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -288,6 +288,12 @@ void Application::DeinitRcpMode(void)
 
 void Application::InitNcpMode(void)
 {
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    otbr::Ncp::NcpHost &ncpHost = static_cast<otbr::Ncp::NcpHost &>(mHost);
+    ncpHost.SetMdnsPublisher(mPublisher.get());
+    mMdnsStateSubject.AddObserver(ncpHost);
+    mPublisher->Start();
+#endif
 #if OTBR_ENABLE_DBUS_SERVER
     mDBusAgent->Init(*mBorderAgent);
 #endif
@@ -295,7 +301,9 @@ void Application::InitNcpMode(void)
 
 void Application::DeinitNcpMode(void)
 {
-    /* empty */
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    mPublisher->Stop();
+#endif
 }
 
 } // namespace otbr

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -44,6 +44,7 @@
 #if OTBR_ENABLE_BORDER_AGENT
 #include "border_agent/border_agent.hpp"
 #endif
+#include "ncp/ncp_host.hpp"
 #include "ncp/rcp_host.hpp"
 #if OTBR_ENABLE_BACKBONE_ROUTER
 #include "backbone_router/backbone_agent.hpp"

--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -38,7 +38,6 @@
 #include <openthread/openthread-system.h>
 
 #include "lib/spinel/spinel_driver.hpp"
-
 #include "ncp/async_task.hpp"
 
 namespace otbr {
@@ -134,6 +133,16 @@ void NcpHost::Init(void)
     {
         mInfraIf.SetInfraIf(mConfig.mBackboneInterfaceName);
     }
+
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_SRP_SERVER_AUTO_ENABLE_MODE
+    // Let SRP server use auto-enable mode. The auto-enable mode delegates the control of SRP server to the Border
+    // Routing Manager. SRP server automatically starts when bi-directional connectivity is ready.
+    mNcpSpinel.SrpServerSetAutoEnableMode(/* aEnabled */ true);
+#else
+    mNcpSpinel.SrpServerSetEnabled(/* aEnabled */ true);
+#endif
+#endif
 }
 
 void NcpHost::Deinit(void)
@@ -254,6 +263,18 @@ void NcpHost::Update(MainloopContext &aMainloop)
 
     mNetif.UpdateFdSet(&aMainloop);
 }
+
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+void NcpHost::SetMdnsPublisher(Mdns::Publisher *aPublisher)
+{
+    mNcpSpinel.SetMdnsPublisher(aPublisher);
+}
+
+void NcpHost::HandleMdnsState(Mdns::Publisher::State aState)
+{
+    mNcpSpinel.DnssdSetState(aState);
+}
+#endif
 
 } // namespace Ncp
 } // namespace otbr

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -72,7 +72,13 @@ private:
     otOperationalDatasetTlvs mDatasetActiveTlvs;
 };
 
-class NcpHost : public MainloopProcessor, public ThreadHost, public NcpNetworkProperties
+class NcpHost : public MainloopProcessor,
+                public ThreadHost,
+                public NcpNetworkProperties
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    ,
+                public Mdns::StateObserver
+#endif
 {
 public:
     /**
@@ -119,7 +125,15 @@ public:
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
 
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    void SetMdnsPublisher(Mdns::Publisher *aPublisher);
+#endif
+
 private:
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    void HandleMdnsState(Mdns::Publisher::State aState) override;
+#endif
+
     ot::Spinel::SpinelDriver &mSpinelDriver;
     otPlatformConfig          mConfig;
     NcpSpinel                 mNcpSpinel;

--- a/src/ncp/ncp_spinel.hpp
+++ b/src/ncp/ncp_spinel.hpp
@@ -37,10 +37,13 @@
 #include <functional>
 #include <memory>
 
+#include <vector>
+
 #include <openthread/dataset.h>
 #include <openthread/error.h>
 #include <openthread/link.h>
 #include <openthread/thread.h>
+#include <openthread/platform/dnssd.h>
 
 #include "lib/spinel/spinel.h"
 #include "lib/spinel/spinel_buffer.hpp"
@@ -49,6 +52,7 @@
 
 #include "common/task_runner.hpp"
 #include "common/types.hpp"
+#include "mdns/mdns.hpp"
 #include "ncp/async_task.hpp"
 #include "ncp/posix/infra_if.hpp"
 #include "ncp/posix/netif.hpp"
@@ -245,10 +249,45 @@ public:
         mInfraIfIcmp6NdCallback = aCallback;
     }
 
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    /**
+     * This method enables/disables the SRP Server on NCP.
+     *
+     * @param[in] aEnable  A boolean to enable/disable the SRP server.
+     */
+    void SrpServerSetEnabled(bool aEnabled);
+
+    /**
+     * This method enables/disables the auto-enable mode on SRP Server on NCP.
+     *
+     * @param[in] aEnable  A boolean to enable/disable the SRP server.
+     */
+    void SrpServerSetAutoEnableMode(bool aEnabled);
+
+    /**
+     * This method sets the dnssd state on NCP.
+     *
+     * @param[in] aState  The dnssd state.
+     */
+    void DnssdSetState(Mdns::Publisher::State aState);
+
+    /**
+     * This method sets the mDNS Publisher object.
+     *
+     * @param[in] aPublisher  A pointer to the mDNS Publisher object.
+     */
+    void SetMdnsPublisher(otbr::Mdns::Publisher *aPublisher)
+    {
+        mPublisher = aPublisher;
+    }
+#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+
 private:
     using FailureHandler = std::function<void(otError)>;
 
-    static constexpr uint8_t kMaxTids = 16;
+    static constexpr uint8_t  kMaxTids             = 16;
+    static constexpr uint16_t kCallbackDataMaxSize = sizeof(uint64_t); // Maximum size of a function pointer.
+    static constexpr uint16_t kMaxSubTypes         = 8;                // Maximum number of sub types in a MDNS service.
 
     template <typename Function, typename... Args> static void SafeInvoke(Function &aFunc, Args &&...aArgs)
     {
@@ -282,6 +321,8 @@ private:
     void      HandleNotification(const uint8_t *aFrame, uint16_t aLength);
     void      HandleResponse(spinel_tid_t aTid, const uint8_t *aFrame, uint16_t aLength);
     void      HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
+    void      HandleValueInserted(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
+    void      HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
     otbrError HandleResponseForPropSet(spinel_tid_t      aTid,
                                        spinel_prop_key_t aKey,
                                        const uint8_t    *aData,
@@ -320,6 +361,7 @@ private:
                                 const otIp6Address *&aAddr,
                                 const uint8_t      *&aData,
                                 uint16_t            &aDataLen);
+    otError SendDnssdResult(otPlatDnssdRequestId aRequestId, const std::vector<uint8_t> &aCallbackData, otError aError);
 
     otbrError SetInfraIf(uint32_t                       aInfraIfIndex,
                          bool                           aIsRunning,
@@ -346,6 +388,9 @@ private:
     TaskRunner mTaskRunner;
 
     PropsObserver *mPropsObserver;
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+    otbr::Mdns::Publisher *mPublisher;
+#endif
 
     AsyncTaskPtr mDatasetSetActiveTask;
     AsyncTaskPtr mDatasetMgmtSetPendingTask;

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -118,6 +118,10 @@ case "$(uname)" in
             configure_network
         fi
 
+        if [ "$BUILD_TARGET" == ncp_mode ]; then
+            sudo apt-get install --no-install-recommends -y avahi-daemon avahi-utils
+        fi
+
         if [ "$BUILD_TARGET" == scan-build ]; then
             pip3 install -U cmake
             sudo apt-get install --no-install-recommends -y clang clang-tools

--- a/tests/scripts/expect/ncp_srp_server.exp
+++ b/tests/scripts/expect/ncp_srp_server.exp
@@ -26,55 +26,52 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-
 source "tests/scripts/expect/_common.exp"
 
-# Dataset of the initial Thread network
+set ptys [create_socat 1]
+set pty1 [lindex $ptys 0]
+set pty2 [lindex $ptys 1]
+set container "otbr-ncp"
+
 set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
 set dataset_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x00,0x00,0x14,0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0x7d,0x61,0xeb,0x42,0xcd,0xc4,0x8d,0x6a,0x07,0x08,0xfd,0x0d,0x07,0xfc,0xa1,0xb9,0xf0,0x50,0x05,0x10,0xba,0x08,0x8f,0xc2,0xbd,0x6c,0x3b,0x38,0x97,0xf7,0xa1,0x0f,0x58,0x26,0x3f,0xf3,0x03,0x0f,0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x35,0x32,0x34,0x66,0x01,0x02,0x52,0x4f,0x04,0x10,0x9d,0xc0,0x23,0xcc,0xd4,0x47,0xb1,0x2b,0x50,0x99,0x7e,0xf6,0x80,0x20,0xf1,0x9e,0x0c,0x04,0x02,0xa0,0xf7,0xf8"
 
-# Dataset of the Thread network to migrate to 
-# (Only updates active timestamp and panid, panid is set to 0x9999)
-set dataset1 "0e080000000000020000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102999904109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
-set dataset1_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x03,0x00,0x00,0x14,0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0x7d,0x61,0xeb,0x42,0xcd,0xc4,0x8d,0x6a,0x07,0x08,0xfd,0x0d,0x07,0xfc,0xa1,0xb9,0xf0,0x50,0x05,0x10,0xba,0x08,0x8f,0xc2,0xbd,0x6c,0x3b,0x38,0x97,0xf7,0xa1,0x0f,0x58,0x26,0x3f,0xf3,0x03,0x0f,0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x35,0x32,0x34,0x66,0x01,0x02,0x99,0x99,0x04,0x10,0x9d,0xc0,0x23,0xcc,0xd4,0x47,0xb1,0x2b,0x50,0x99,0x7e,0xf6,0x80,0x20,0xf1,0x9e,0x0c,0x04,0x02,0xa0,0xf7,0xf8"
+start_otbr_docker $container $::env(EXP_OT_NCP_PATH) 2 $pty1 $pty2
+spawn_node 3 otbr-docker $container
+sleep 5
 
-# Step 1. Start otbr-agent with a NCP and join the network by dbus join method
-spawn_node 1 otbr $::env(EXP_OT_NCP_PATH)
-sleep 1
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
-expect eof
+send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
+expect "app#"
+sleep 20
 
-# Step 2. Wait 10 seconds, check if the otbr-agent has attached successfully
-sleep 10
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {leader} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
-
-# Step 3. Start a Thread node and create a Thread network
-spawn_node 2 cli $::env(EXP_OT_CLI_PATH)
-
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
 send "dataset set active ${dataset}\n"
 expect_line "Done"
-send "mode rn\n"
+send "mode rn\r\n"
 expect_line "Done"
-send "ifconfig up\n"
+send "ifconfig up\r\n"
 expect_line "Done"
-send "thread start\n"
+send "thread start\r\n"
 expect_line "Done"
 wait_for "state" "child"
-expect_line "Done"
+set omr_addr [get_omr_addr]
+sleep 1
 
-# Step 4. Call ScheduleMigration method to migrate to another Thread network after 30s
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.ScheduleMigration "array:byte:${dataset1_dbus}" "uint32:0x7530"
+send "srp client autostart enable\r\n"
+expect_line "Done"
+send "srp client host name otbr-ncp-test\r\n"
+expect_line "Done"
+send "srp client host address $omr_addr\r\n"
+expect_line "Done"
+send "srp client service add ot-service _ipps._tcp 12345\r\n"
+expect_line "Done"
+sleep 1
+
+spawn avahi-browse -r _ipps._tcp
+expect backbone1
+send "\003"
 expect eof
 
-# Step 5. Wait 31 seconds, check if the otbr-agent has migrated successfully by checking child's panid
-sleep 31
-switch_node 2
-send "panid\n"
-expect_line "0x9999"
-expect_line "Done"
+exec sudo docker stop $container
+exec sudo docker rm $container
+dispose_all

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -136,6 +136,7 @@ do_build_ot_simulation()
     OT_CMAKE_BUILD_DIR=${ABS_TOP_OT_BUILDDIR}/ncp "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation \
         -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_CLI=OFF -DOT_APP_RCP=OFF \
         -DOT_BORDER_ROUTING=ON -DOT_NCP_INFRA_IF=ON -DOT_SIMULATION_INFRA_IF=OFF \
+        -DOT_SRP_SERVER=ON -DOT_SRP_ADV_PROXY=ON -DOT_PLATFORM_DNSSD=ON -DOT_SIMULATION_DNSSD=OFF -DOT_NCP_DNSSD=ON \
         -DBUILD_TESTING=OFF
     OT_CMAKE_BUILD_DIR=${ABS_TOP_OT_BUILDDIR}/cli "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation \
         -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
@@ -152,6 +153,7 @@ do_build_otbr_docker()
         "-DOTBR_TELEMETRY_DATA_API=ON"
         "-DOTBR_TREL=ON"
         "-DOTBR_LINK_METRICS_TELEMETRY=ON"
+        "-DOTBR_SRP_ADVERTISING_PROXY=ON"
     )
     sudo docker build -t "${OTBR_DOCKER_IMAGE}" \
         -f ./etc/docker/Dockerfile . \


### PR DESCRIPTION
This PR integrates the mDNS Publisher with NcpHost to make advertising proxy work under NCP mode.

The PR adds an expect test to verify the advertising proxy function under NCP mode. To do the test, `avahi-browser` is used. So it's added into the bootstrap of the CI for ncp_mode.

As an abstraction: 
1. The PR adds `NcpSpinel::SrpServerSetEnabled` and `NcpSpinel::SrpServerSetAutoEnableMode` to control the SRP server on the NCP.
2. The PR adds the handling of `SPINEL_PROP_DNSSD_HOST`, `SPINEL_PROP_DNSSD_SERVICE` and `SPINEL_PROP_DNSSD_KEY_RECORD` to help NCP to publish the dnssd entries (by using the mDNSPublisher on the host).