### PR TITLE
[thread-host] implement join for rcp host

### DIFF
--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -287,6 +287,7 @@ private:
     std::vector<ThreadEnabledStateCallback> mThreadEnabledStateChangedCallbacks;
     bool                                    mEnableAutoAttach = false;
     ThreadEnabledState                      mThreadEnabledState;
+    AsyncResultReceiver                     mJoinReceiver;
     AsyncResultReceiver                     mSetThreadEnabledReceiver;
     AsyncResultReceiver                     mScheduleMigrationReceiver;
     std::vector<DetachGracefullyCallback>   mDetachGracefullyCallbacks;


### PR DESCRIPTION
This PR implements the RcpHost::Join method.

The implementation is exactly the same as Android binder API's implementation. This PR also adds a unit test to check the Join method.