### PR TITLE
[thread host] add ThreadHost data properties for BorderAgent

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -464,12 +464,12 @@ void AppendBbrTxtEntries(otInstance &aInstance, StateBitmap aState, Mdns::Publis
 }
 #endif
 
-void AppendActiveTimestampTxtEntry(otInstance &aInstance, Mdns::Publisher::TxtList &aTxtList)
+void AppendActiveTimestampTxtEntry(Ncp::ThreadHost &aHost, Mdns::Publisher::TxtList &aTxtList)
 {
     otError              error;
     otOperationalDataset activeDataset;
 
-    if ((error = otDatasetGetActive(&aInstance, &activeDataset)) != OT_ERROR_NONE)
+    if ((error = aHost.GetDatasetActive(activeDataset)) != OT_ERROR_NONE)
     {
         otbrLogWarning("Failed to get active dataset: %s", otThreadErrorToString(error));
     }
@@ -513,9 +513,9 @@ void BorderAgent::PublishMeshCopService(void)
     StateBitmap              state;
     uint32_t                 stateUint32;
     otInstance              *instance    = mHost.GetInstance();
-    const otExtendedPanId   *extPanId    = otThreadGetExtendedPanId(instance);
-    const otExtAddress      *extAddr     = otLinkGetExtendedAddress(instance);
-    const char              *networkName = otThreadGetNetworkName(instance);
+    const otExtendedPanId   *extPanId    = mHost.GetExtendedPanId();
+    const otExtAddress      *extAddr     = mHost.GetExtendedAddress();
+    const char              *networkName = mHost.GetNetworkName();
     Mdns::Publisher::TxtList txtList{{"rv", "1"}};
     Mdns::Publisher::TxtData txtData;
     int                      port;
@@ -569,7 +569,7 @@ void BorderAgent::PublishMeshCopService(void)
     {
         uint32_t partitionId;
 
-        AppendActiveTimestampTxtEntry(*instance, txtList);
+        AppendActiveTimestampTxtEntry(mHost, txtList);
         partitionId = otThreadGetPartitionId(instance);
         txtList.emplace_back("pt", reinterpret_cast<uint8_t *>(&partitionId), sizeof(partitionId));
     }

--- a/src/ncp/ncp_host.cpp
+++ b/src/ncp/ncp_host.cpp
@@ -73,6 +73,24 @@ uint32_t NcpNetworkProperties::GetPartitionId(void) const
     return 0;
 }
 
+const otExtendedPanId *NcpNetworkProperties::GetExtendedPanId(void) const
+{
+    // TODO: Implement the method under NCP mode.
+    return nullptr;
+}
+
+const otExtAddress *NcpNetworkProperties::GetExtendedAddress(void) const
+{
+    // TODO: Implement the method under NCP mode.
+    return nullptr;
+}
+
+const char *NcpNetworkProperties::GetNetworkName(void) const
+{
+    // TODO: Implement the method under NCP mode.
+    return nullptr;
+}
+
 void NcpNetworkProperties::SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs)
 {
     mDatasetActiveTlvs.mLength = aActiveOpDatasetTlvs.mLength;
@@ -89,6 +107,22 @@ void NcpNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aData
 {
     // TODO: Implement the method under NCP mode.
     OTBR_UNUSED_VARIABLE(aDatasetTlvs);
+}
+
+otError NcpNetworkProperties::GetDatasetActive(otOperationalDataset &aDataset) const
+{
+    otError error = OT_ERROR_NONE;
+
+    if (mDatasetActiveTlvs.mLength == 0)
+    {
+        error = OT_ERROR_NOT_FOUND;
+    }
+    else
+    {
+        error = otDatasetParseTlvs(&mDatasetActiveTlvs, &aDataset);
+    }
+
+    return error;
 }
 
 // ===================================== NcpHost ======================================

--- a/src/ncp/ncp_host.hpp
+++ b/src/ncp/ncp_host.hpp
@@ -57,11 +57,15 @@ public:
     explicit NcpNetworkProperties(void);
 
     // NetworkProperties methods
-    otDeviceRole GetDeviceRole(void) const override;
-    bool         Ip6IsEnabled(void) const override;
-    uint32_t     GetPartitionId(void) const override;
-    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
-    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otDeviceRole           GetDeviceRole(void) const override;
+    bool                   Ip6IsEnabled(void) const override;
+    uint32_t               GetPartitionId(void) const override;
+    const otExtendedPanId *GetExtendedPanId(void) const override;
+    const otExtAddress    *GetExtendedAddress(void) const override;
+    const char            *GetNetworkName(void) const override;
+    void                   GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otError                GetDatasetActive(otOperationalDataset &aDataset) const override;
+    void                   GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
 private:
     // PropsObserver methods

--- a/src/ncp/rcp_host.cpp
+++ b/src/ncp/rcp_host.cpp
@@ -89,6 +89,21 @@ uint32_t OtNetworkProperties::GetPartitionId(void) const
     return otThreadGetPartitionId(mInstance);
 }
 
+const otExtendedPanId *OtNetworkProperties::GetExtendedPanId(void) const
+{
+    return otThreadGetExtendedPanId(mInstance);
+}
+
+const otExtAddress *OtNetworkProperties::GetExtendedAddress(void) const
+{
+    return otLinkGetExtendedAddress(mInstance);
+}
+
+const char *OtNetworkProperties::GetNetworkName(void) const
+{
+    return otThreadGetNetworkName(mInstance);
+}
+
 void OtNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
 {
     otError error = otDatasetGetActiveTlvs(mInstance, &aDatasetTlvs);
@@ -98,6 +113,11 @@ void OtNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatase
         aDatasetTlvs.mLength = 0;
         memset(aDatasetTlvs.mTlvs, 0, sizeof(aDatasetTlvs.mTlvs));
     }
+}
+
+otError OtNetworkProperties::GetDatasetActive(otOperationalDataset &aDataset) const
+{
+    return otDatasetGetActive(mInstance, &aDataset);
 }
 
 void OtNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const

--- a/src/ncp/rcp_host.hpp
+++ b/src/ncp/rcp_host.hpp
@@ -72,11 +72,15 @@ public:
     explicit OtNetworkProperties(void);
 
     // NetworkProperties methods
-    otDeviceRole GetDeviceRole(void) const override;
-    bool         Ip6IsEnabled(void) const override;
-    uint32_t     GetPartitionId(void) const override;
-    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
-    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otDeviceRole           GetDeviceRole(void) const override;
+    bool                   Ip6IsEnabled(void) const override;
+    uint32_t               GetPartitionId(void) const override;
+    const otExtendedPanId *GetExtendedPanId(void) const override;
+    const otExtAddress    *GetExtendedAddress(void) const override;
+    const char            *GetNetworkName(void) const override;
+    void                   GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otError                GetDatasetActive(otOperationalDataset &aDataset) const override;
+    void                   GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
 
     // Set the otInstance
     void SetInstance(otInstance *aInstance);

--- a/src/ncp/thread_host.hpp
+++ b/src/ncp/thread_host.hpp
@@ -79,11 +79,42 @@ public:
     virtual uint32_t GetPartitionId(void) const = 0;
 
     /**
+     * Returns the extended Pan ID.
+     *
+     * @returns The extended Pan ID.
+     */
+    virtual const otExtendedPanId *GetExtendedPanId(void) const = 0;
+
+    /**
+     * Returns the extended address.
+     *
+     * @returns The extended address.
+     */
+    virtual const otExtAddress *GetExtendedAddress(void) const = 0;
+
+    /**
+     * Returns the network name.
+     *
+     * @returns The network name.
+     */
+    virtual const char *GetNetworkName(void) const = 0;
+
+    /**
      * Returns the active operational dataset tlvs.
      *
      * @param[out] aDatasetTlvs  A reference to where the Active Operational Dataset will be placed.
      */
     virtual void GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const = 0;
+
+    /**
+     * Returns the active operational dataset.
+     *
+     * @param[out] aDataset  A reference to where the Active Operational Dataset will be placed.
+     *
+     * @retval OT_ERROR_NONE        Successfully retrieved the Active Operational Dataset.
+     * @retval OT_ERROR_NOT_FOUND   No corresponding value in the setting store.
+     */
+    virtual otError GetDatasetActive(otOperationalDataset &aDataset) const = 0;
 
     /**
      * Returns the pending operational dataset tlvs.


### PR DESCRIPTION
This PR adds a few network properties to ThreadHost with the aim of making the co-processor type transparent to the BorderAgent module.

This PR only implements the property get method for RcpHost and adds empty implementation for NcpHost. Currently BorderAgent is not created when it's NCP so the empty implementation is safe. Will implement the methods for NCP later.

The PR also replaces the relevant OT APIs used in BorderAgent with the property get methods.