### PR TITLE
[build] allow disabling systemd service unit install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ include(GNUInstallDirs)
 
 pkg_check_modules(SYSTEMD systemd)
 
-if(SYSTEMD_FOUND)
+if(SYSTEMD_FOUND AND (NOT DEFINED INSTALL_SYSTEMD_UNIT OR INSTALL_SYSTEMD_UNIT))
     pkg_get_variable(OTBR_SYSTEMD_UNIT_DIR systemd systemdsystemunitdir)
 endif()
 


### PR DESCRIPTION
Add `INSTALL_SYSTEMD_UNIT` which can explicitly be set to `false` to disable installing the service unit even if systemd is available.

If not defined, it defaults to true, i.e. the systemed service unit is created. As a result, this change is backwards compatible: it's required to _opt-out_ of systemd unit installation.

In particular, this is useful for NixOS, where a systemd unit will be created independently from the CMake build.

See also:
 * https://github.com/NixOS/nixpkgs/pull/332296#pullrequestreview-2523338288