### PR TITLE
[build] allow using shared boost libraries

### DIFF
--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -27,7 +27,9 @@
 #
 
 pkg_check_modules(JSONCPP jsoncpp REQUIRED)
-set(Boost_USE_STATIC_LIBS ON)
+if(NOT DEFINED Boost_USE_STATIC_LIBS)
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost REQUIRED COMPONENTS filesystem system)


### PR DESCRIPTION
Do not unconditionally set `Boost_USE_STATIC_LIBS` but instead default it to `true`.

This allows building with shared Boost libraries, which can be useful for OS distribution packaging, for example.

The default is the same if not defined, so this is a backwards compatible change: unless explicitly set to `false`, static Boost libs will still be used.

In particular, this is useful for NixOS, where the static Boost lib will not work.

See also:
 * #2652 
 * https://github.com/NixOS/nixpkgs/pull/332296#pullrequestreview-2523338288