### PR TITLE
[host] remove unused methods in RcpHost

### DIFF
--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -245,19 +245,6 @@ private:
     }
     void HandleStateChanged(otChangedFlags aFlags);
 
-    static void HandleBackboneRouterDomainPrefixEvent(void                             *aContext,
-                                                      otBackboneRouterDomainPrefixEvent aEvent,
-                                                      const otIp6Prefix                *aDomainPrefix);
-    void        HandleBackboneRouterDomainPrefixEvent(otBackboneRouterDomainPrefixEvent aEvent,
-                                                      const otIp6Prefix                *aDomainPrefix);
-
-#if OTBR_ENABLE_DUA_ROUTING
-    static void HandleBackboneRouterNdProxyEvent(void                        *aContext,
-                                                 otBackboneRouterNdProxyEvent aEvent,
-                                                 const otIp6Address          *aAddress);
-    void        HandleBackboneRouterNdProxyEvent(otBackboneRouterNdProxyEvent aEvent, const otIp6Address *aAddress);
-#endif
-
     using DetachGracefullyCallback = std::function<void()>;
     void        ThreadDetachGracefully(const DetachGracefullyCallback &aCallback);
     static void ThreadDetachGracefullyCallback(void *aContext);


### PR DESCRIPTION
These methods are already moved to the 'BackboneRouter' class and has no implementation in 'RcpHost'.