### PR TITLE
[dbus] add Join and SetThreadEnabled method to Dbus RCP

### DIFF
--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -48,6 +48,7 @@
 #define OTBR_DBUS_ENERGY_SCAN_METHOD "EnergyScan"
 #define OTBR_DBUS_ATTACH_METHOD "Attach"
 #define OTBR_DBUS_DETACH_METHOD "Detach"
+#define OTBR_DBUS_SET_THREAD_ENABLED_METHOD "SetThreadEnabled"
 #define OTBR_DBUS_JOIN_METHOD "Join"
 #define OTBR_DBUS_FACTORY_RESET_METHOD "FactoryReset"
 #define OTBR_DBUS_RESET_METHOD "Reset"

--- a/src/dbus/server/dbus_thread_object_rcp.hpp
+++ b/src/dbus/server/dbus_thread_object_rcp.hpp
@@ -103,6 +103,8 @@ private:
     void AddExternalRouteHandler(DBusRequest &aRequest);
     void RemoveExternalRouteHandler(DBusRequest &aRequest);
     void UpdateMeshCopTxtHandler(DBusRequest &aRequest);
+    void SetThreadEnabledHandler(DBusRequest &aRequest);
+    void JoinHandler(DBusRequest &aRequest);
     void GetPropertiesHandler(DBusRequest &aRequest);
     void LeaveNetworkHandler(DBusRequest &aRequest);
     void SetNat64Enabled(DBusRequest &aRequest);


### PR DESCRIPTION
This PR adds DBus methods 'Join' and 'SetThreadEnabled' under RCP mode.

The background is to support these basic methods for both NCP & RCP mode so that we can write some test scripts that work for both NCP & RCP mode. For the long term, we also try to let NCP & RCP support the same DBus interfaces.