### PR TITLE
[tests] remove stale code in test bootstrap script

### DIFF
--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -105,13 +105,6 @@ case "$(uname)" in
             exit 0
         fi
 
-        if [ "$BUILD_TARGET" == otbr-dbus-check ]; then
-            install_openthread_binraries
-            configure_network
-            install_common_dependencies
-            exit 0
-        fi
-
         if [ "$BUILD_TARGET" == check ] || [ "$BUILD_TARGET" == meshcop ]; then
             install_openthread_binraries
             sudo apt-get install --no-install-recommends -y avahi-daemon avahi-utils


### PR DESCRIPTION
This PR removes the if branch of BUILD_TARGET of 'otbr-dbus-check' in the bootstrap script.

In our CI, there is no such target now. All the targets:
```
➜  ot-br-posix git:(clean_up_bootstrap) ✗ grep -rnI --exclude-dir={build,third_party} BUILD_TARGET ./.github/
./.github/workflows/openwrt.yml:52:        BUILD_TARGET: "openwrt-check"
./.github/workflows/build.yml:50:      run: BUILD_TARGET=pretty-check tests/scripts/bootstrap.sh
./.github/workflows/build.yml:62:      BUILD_TARGET: check
./.github/workflows/build.yml:85:      BUILD_TARGET: check
./.github/workflows/build.yml:104:      BUILD_TARGET: script-check
./.github/workflows/build.yml:120:      BUILD_TARGET: scan-build
./.github/workflows/build.yml:135:      BUILD_TARGET: package
./.github/workflows/build.yml:152:      BUILD_TARGET: check
./.github/workflows/meshcop.yml:57:        BUILD_TARGET: "meshcop"
./.github/workflows/docker.yml:56:        BUILD_TARGET: "docker-check"
./.github/workflows/raspbian.yml:49:      BUILD_TARGET: raspbian-gcc
./.github/workflows/documentation.yml:44:      BUILD_TARGET: check
./.github/workflows/ncp_mode.yml:52:        BUILD_TARGET: ncp_mode
```