### PR TITLE
[task-runner] only perform read when FD is set

### DIFF
--- a/src/common/task_runner.cpp
+++ b/src/common/task_runner.cpp
@@ -110,9 +110,9 @@ void TaskRunner::Update(MainloopContext &aMainloop)
 
 void TaskRunner::Process(const MainloopContext &aMainloop)
 {
-    OTBR_UNUSED_VARIABLE(aMainloop);
-
     ssize_t rval;
+
+    VerifyOrExit(FD_ISSET(mEventFd[kRead], &aMainloop.mReadFdSet));
 
     // Read any data in the pipe.
     do
@@ -125,6 +125,7 @@ void TaskRunner::Process(const MainloopContext &aMainloop)
     // Critical error happens, simply die.
     VerifyOrDie(errno == EAGAIN || errno == EWOULDBLOCK, strerror(errno));
 
+exit:
     PopTasks();
 }
 


### PR DESCRIPTION
This PR adds a check in TaskRunner::Process so that 'read' is only executed when the eventFd is set.

Currently if we use strace to see the i/o of otbr-agent, we can see many things like this:
```
read(7, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
read(9, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
read(4, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
read(7, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
read(9, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
read(4, 0x7ffc7c0f80ff, 1)              = -1 EAGAIN (Resource temporarily unavailable)
```
Though this is harmless, we should avoid it as possible for easier debugging and reduce overhead.