### PR TITLE
[docker] correct radio URL in docker_entrypoint.sh

### DIFF
--- a/etc/docker/docker_entrypoint.sh
+++ b/etc/docker/docker_entrypoint.sh
@@ -81,7 +81,7 @@ trap shutdown TERM INT
 
 parse_args "$@"
 
-[ -n "$RADIO_URL" ] || RADIO_URL="spinel+hdlc+uart:///dev/ttyUSB0"
+[ -n "$RADIO_URL" ] || RADIO_URL="spinel+hdlc:///dev/ttyUSB0"
 [ -n "$TREL_URL" ] || TREL_URL=""
 [ -n "$TUN_INTERFACE_NAME" ] || TUN_INTERFACE_NAME="wpan0"
 [ -n "$BACKBONE_INTERFACE" ] || BACKBONE_INTERFACE="eth0"


### PR DESCRIPTION
OT platform driver compares the radio URL with `spinel+hdlc`. `+uart` is not needed.