### PR TITLE
Revert "[docker] use `arm64` runner instead of `qemu`"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,37 +59,22 @@ jobs:
       run: tests/scripts/check-docker
 
   buildx:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         include:
           - image_tag: "latest"
-            runner: ubuntu-24.04
             base_image: "ubuntu:bionic"
             build_args: ""
-            platforms: "linux/amd64"
-            push: yes
-          - image_tag: "latest"
-            runner: ubuntu-24.04-arm
-            base_image: "ubuntu:bionic"
-            build_args: ""
-            platforms: "linux/arm/v7,linux/arm64"
+            platforms: "linux/amd64,linux/arm/v7,linux/arm64"
             push: yes
           - image_tag: "focal"
-            runner: ubuntu-24.04
             base_image: "ubuntu:focal"
             build_args: ""
-            platforms: "linux/amd64"
-            push: yes
-          - image_tag: "focal"
-            runner: ubuntu-24.04-arm
-            base_image: "ubuntu:focal"
-            build_args: ""
-            platforms: "linux/arm64"
+            platforms: "linux/amd64,linux/arm64"
             push: yes
           - image_tag: "reference-device"
-            runner: ubuntu-24.04
             base_image: "ubuntu:bionic"
             build_args: >-
               --build-arg REFERENCE_DEVICE=1
@@ -99,40 +84,16 @@ jobs:
               --build-arg WEB_GUI=0
               --build-arg REST_API=0
               --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_MLR=ON'
-            platforms: "linux/amd64"
-            push: yes
-          - image_tag: "reference-device"
-            runner: ubuntu-24.04-arm
-            base_image: "ubuntu:bionic"
-            build_args: >-
-              --build-arg REFERENCE_DEVICE=1
-              --build-arg BORDER_ROUTING=0
-              --build-arg BACKBONE_ROUTER=1
-              --build-arg NAT64=0
-              --build-arg WEB_GUI=0
-              --build-arg REST_API=0
-              --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_MLR=ON'
-            platforms: "linux/arm/v7,linux/arm64"
+            platforms: "linux/amd64,linux/arm/v7,linux/arm64"
             push: yes
           - image_tag: "test"
-            runner: ubuntu-24.04
             base_image: "ubuntu:bionic"
             build_args: >-
               --build-arg OT_BACKBONE_CI=1
               --build-arg REFERENCE_DEVICE=1
               --build-arg BACKBONE_ROUTER=1
               --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_MLR=ON'
-            platforms: "linux/amd64"
-            push: no
-          - image_tag: "test"
-            runner: ubuntu-24.04-arm
-            base_image: "ubuntu:bionic"
-            build_args: >-
-              --build-arg OT_BACKBONE_CI=1
-              --build-arg REFERENCE_DEVICE=1
-              --build-arg BACKBONE_ROUTER=1
-              --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOT_MLR=ON'
-            platforms: "linux/arm/v7,linux/arm64"
+            platforms: "linux/amd64,linux/arm/v7,linux/arm64"
             push: no
     steps:
     - uses: actions/checkout@v4
@@ -157,6 +118,11 @@ jobs:
           --build-arg VCS_REF=${GITHUB_SHA::8} \
           ${{ matrix.build_args }} \
           ${TAGS} --file etc/docker/Dockerfile ." >> $GITHUB_OUTPUT
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:qemu-v8.1.5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -80,6 +80,12 @@ ENV OTBR_BUILD_DEPS apt-utils build-essential psmisc ninja-build cmake wget ca-c
 # Required for OpenThread Backbone CI
 ENV OTBR_OT_BACKBONE_CI_DEPS curl lcov wget build-essential python3-dbus python3-zeroconf socat
 
+# Resolves issue with installing libc-bin
+RUN rm /var/lib/dpkg/info/libc-bin.* \
+  && apt-get clean -y \
+  && apt-get update -y \
+  && apt-get install --no-install-recommends -y libc-bin
+
 RUN apt-get update \
   && apt-get install --no-install-recommends -y $OTBR_DOCKER_REQS $OTBR_DOCKER_DEPS \
   && ([ "${OT_BACKBONE_CI}" != "1" ] || apt-get install --no-install-recommends -y $OTBR_OT_BACKBONE_CI_DEPS) \


### PR DESCRIPTION
Reverts openthread/ot-br-posix#2698

Fixes https://github.com/openthread/openthread/issues/11233