### PR TITLE
[border-agent] add UDP Proxy module for Thread commissioning

### DIFF
--- a/src/host/posix/CMakeLists.txt
+++ b/src/host/posix/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(otbr-posix
     netif_linux.cpp
     netif_unix.cpp
     netif.hpp
+    udp_proxy.cpp
+    udp_proxy.hpp
 )
 
 target_link_libraries(otbr-posix

--- a/src/host/posix/udp_proxy.cpp
+++ b/src/host/posix/udp_proxy.cpp
@@ -1,0 +1,277 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "UDPProxy"
+
+#ifdef __APPLE__
+#define __APPLE_USE_RFC_3542
+#endif
+
+#include "host/posix/udp_proxy.hpp"
+
+#include <assert.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <unistd.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "host/posix/dnssd.hpp"
+#include "utils/socket_utils.hpp"
+
+namespace otbr {
+
+otbrError UdpProxy::Dependencies::UdpForward(const uint8_t      *aUdpPayload,
+                                             uint16_t            aLength,
+                                             const otIp6Address &aRemoteAddr,
+                                             uint16_t            aRemotePort,
+                                             const UdpProxy     &aUdpProxy)
+{
+    OTBR_UNUSED_VARIABLE(aUdpPayload);
+    OTBR_UNUSED_VARIABLE(aLength);
+    OTBR_UNUSED_VARIABLE(aRemoteAddr);
+    OTBR_UNUSED_VARIABLE(aRemotePort);
+    OTBR_UNUSED_VARIABLE(aUdpProxy);
+
+    return OTBR_ERROR_NONE;
+}
+
+UdpProxy::UdpProxy(Dependencies &aDeps)
+    : mFd(-1)
+    , mHostPort(0)
+    , mThreadPort(0)
+    , mDeps(aDeps)
+{
+}
+
+void UdpProxy::Start(uint16_t aPort)
+{
+    VerifyOrExit(!IsStarted());
+
+    BindToEphemeralPort();
+    mThreadPort = aPort;
+
+exit:
+    return;
+}
+
+void UdpProxy::Stop(void)
+{
+    VerifyOrExit(IsStarted());
+
+    mHostPort = 0;
+
+    if (mFd >= 0)
+    {
+        close(mFd);
+        mFd = -1;
+    }
+
+exit:
+    return;
+}
+
+void UdpProxy::Process(const MainloopContext &aContext)
+{
+    constexpr size_t kMaxUdpSize = 1280;
+
+    uint8_t      payload[kMaxUdpSize];
+    uint16_t     length = sizeof(payload);
+    otIp6Address remoteAddr;
+    uint16_t     remotePort;
+
+    VerifyOrExit(mFd != -1 && IsStarted());
+    VerifyOrExit(FD_ISSET(mFd, &aContext.mReadFdSet));
+
+    SuccessOrExit(ReceivePacket(payload, length, remoteAddr, remotePort));
+
+    // UDP Forward to NCPq
+    mDeps.UdpForward(payload, length, remoteAddr, remotePort, *this);
+
+exit:
+    return;
+}
+
+void UdpProxy::Update(MainloopContext &aContext)
+{
+    VerifyOrExit(mFd != -1);
+    VerifyOrExit(IsStarted());
+
+    aContext.AddFdToReadSet(mFd);
+
+exit:
+    return;
+}
+
+void UdpProxy::SendToPeer(const uint8_t      *aUdpPayload,
+                          uint16_t            aLength,
+                          const otIp6Address &aPeerAddr,
+                          uint16_t            aPeerPort)
+{
+#ifdef __APPLE__
+    // use fixed value for CMSG_SPACE is not a constant expression on macOS
+    constexpr size_t kBufferSize = 128;
+#else
+    constexpr size_t kBufferSize = CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(int));
+#endif
+    struct sockaddr_in6 peerAddr;
+    uint8_t             control[kBufferSize];
+    size_t              controlLength = 0;
+    struct iovec        iov;
+    struct msghdr       msg;
+    struct cmsghdr     *cmsg;
+    ssize_t             rval;
+
+    memset(&peerAddr, 0, sizeof(peerAddr));
+    peerAddr.sin6_port   = htons(aPeerPort);
+    peerAddr.sin6_family = AF_INET6;
+    memcpy(&peerAddr.sin6_addr, &aPeerAddr, sizeof(aPeerAddr));
+    memset(control, 0, sizeof(control));
+
+    iov.iov_base = reinterpret_cast<void *>(const_cast<uint8_t *>(aUdpPayload));
+    iov.iov_len  = aLength;
+
+    msg.msg_name       = &peerAddr;
+    msg.msg_namelen    = sizeof(peerAddr);
+    msg.msg_control    = control;
+    msg.msg_controllen = static_cast<decltype(msg.msg_controllen)>(sizeof(control));
+    msg.msg_iov        = &iov;
+    msg.msg_iovlen     = 1;
+    msg.msg_flags      = 0;
+
+    {
+        constexpr int kIp6HopLimit = 64;
+
+        int hopLimit = kIp6HopLimit;
+
+        cmsg             = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_level = IPPROTO_IPV6;
+        cmsg->cmsg_type  = IPV6_HOPLIMIT;
+        cmsg->cmsg_len   = CMSG_LEN(sizeof(int));
+
+        memcpy(CMSG_DATA(cmsg), &hopLimit, sizeof(int));
+
+        controlLength += CMSG_SPACE(sizeof(int));
+    }
+
+#ifdef __APPLE__
+    msg.msg_controllen = static_cast<socklen_t>(controlLength);
+#else
+    msg.msg_controllen           = controlLength;
+#endif
+
+    rval = sendmsg(mFd, &msg, 0);
+
+    if (rval == -1)
+    {
+        otbrLogWarning("Failed to sendmsg: %s", strerror(errno));
+    }
+}
+
+otbrError UdpProxy::BindToEphemeralPort(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+    mFd             = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_UDP, kSocketNonBlock);
+
+    VerifyOrExit(mFd != 0, error = OTBR_ERROR_ERRNO);
+
+    {
+        struct sockaddr_in6 sin6;
+
+        memset(&sin6, 0, sizeof(sin6));
+        sin6.sin6_family = AF_INET6;
+        sin6.sin6_addr   = in6addr_any;
+        sin6.sin6_port   = 0;
+
+        VerifyOrExit(0 == bind(mFd, reinterpret_cast<struct sockaddr *>(&sin6), sizeof(sin6)),
+                     error = OTBR_ERROR_ERRNO);
+    }
+
+    {
+        int on = 1;
+        VerifyOrExit(0 == setsockopt(mFd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &on, sizeof(on)), error = OTBR_ERROR_ERRNO);
+        VerifyOrExit(0 == setsockopt(mFd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)), error = OTBR_ERROR_ERRNO);
+    }
+
+    {
+        struct sockaddr_in bound_addr;
+        socklen_t          addr_len = sizeof(bound_addr);
+        getsockname(mFd, (struct sockaddr *)&bound_addr, &addr_len);
+
+        mHostPort = ntohs(bound_addr.sin_port);
+        otbrLogInfo("Ephemeral port: %u", mHostPort);
+    }
+
+exit:
+    otbrLogResult(error, "Bind to ephemeral port");
+    if (error != OTBR_ERROR_NONE)
+    {
+        Stop();
+    }
+    return error;
+}
+
+otbrError UdpProxy::ReceivePacket(uint8_t      *aPayload,
+                                  uint16_t     &aLength,
+                                  otIp6Address &aRemoteAddr,
+                                  uint16_t     &aRemotePort)
+{
+    constexpr size_t kMaxUdpSize = 1280;
+
+    struct sockaddr_in6 peerAddr;
+    uint8_t             control[kMaxUdpSize];
+    struct iovec        iov;
+    struct msghdr       msg;
+    ssize_t             rval;
+
+    iov.iov_base = aPayload;
+    iov.iov_len  = aLength;
+
+    msg.msg_name       = &peerAddr;
+    msg.msg_namelen    = sizeof(peerAddr);
+    msg.msg_control    = control;
+    msg.msg_controllen = sizeof(control);
+    msg.msg_iov        = &iov;
+    msg.msg_iovlen     = 1;
+    msg.msg_flags      = 0;
+
+    rval = recvmsg(mFd, &msg, 0);
+    VerifyOrExit(rval > 0, perror("recvmsg"));
+    aLength = static_cast<uint16_t>(rval);
+
+    aRemotePort = ntohs(peerAddr.sin6_port);
+    memcpy(&aRemoteAddr, &peerAddr.sin6_addr, sizeof(otIp6Address));
+
+    otbrLogDebug("Receive a packet, remote address:%s, remote port:%d", Ip6Address(aRemoteAddr).ToString().c_str(),
+                 aRemotePort);
+
+exit:
+    return rval > 0 ? OTBR_ERROR_NONE : OTBR_ERROR_ERRNO;
+}
+
+} // namespace otbr

--- a/src/host/posix/udp_proxy.hpp
+++ b/src/host/posix/udp_proxy.hpp
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @brief
+ *   This module includes definition for Thread UDP Proxy.
+ */
+
+#ifndef OTBR_AGENT_POSIX_UDP_PROXY_HPP_
+#define OTBR_AGENT_POSIX_UDP_PROXY_HPP_
+
+#include <openthread/error.h>
+#include <openthread/ip6.h>
+
+#include "common/mainloop.hpp"
+#include "common/types.hpp"
+
+namespace otbr {
+
+class UdpProxy : public MainloopProcessor
+{
+public:
+    class Dependencies
+    {
+    public:
+        virtual ~Dependencies(void) = default;
+
+        virtual otbrError UdpForward(const uint8_t      *aUdpPayload,
+                                     uint16_t            aLength,
+                                     const otIp6Address &aRemoteAddr,
+                                     uint16_t            aRemotePort,
+                                     const UdpProxy     &aUdpProxy);
+    };
+
+    /**
+     * The constructor to initialize the Thread Border Agent UDP Proxy.
+     */
+    explicit UdpProxy(Dependencies &aDeps);
+
+    ~UdpProxy(void) = default;
+
+    /**
+     * Start the UDP Proxy for Thread UDP port @p aPort.
+     *
+     * The UDP Proxy will bind to an ephemeral port and set a mapping between the ephemeral port and @p aPort.
+     *
+     * @param[in] aPort  The UDP port to be proxied in Thread stack.
+     */
+    void Start(uint16_t aPort);
+
+    /**
+     * Stop the UDP Proxy if started.
+     */
+    void Stop(void);
+
+    /**
+     * Get the ephemeral UDP port bound on host.
+     *
+     * @returns The UDP port bound on the host. If the proxy isn't running, `0` will be returned.
+     */
+    uint16_t GetHostPort(void) const { return mHostPort; }
+
+    /**
+     * Get the UDP port on the Thread side.
+     *
+     * @returns The UDP port on the Thread side. If the proxy isn't running, `0` will be returned.
+     */
+    uint16_t GetThreadPort(void) const { return mThreadPort; }
+
+    /**
+     * Sends a UDP packet to the peer.
+     *
+     * @param[in] aUdpPlayload  The UDP payload.
+     * @param[in] aLength       Then length of the UDP payload.
+     * @param[in] aPeerAddr     The address of the peer.
+     * @param[in] aPeerPort     The UDP of the peer.
+     */
+    void SendToPeer(const uint8_t *aUdpPayload, uint16_t aLength, const otIp6Address &aPeerAddr, uint16_t aPeerPort);
+
+private:
+    // MainloopProcessor methods
+    void Process(const MainloopContext &aMainloop) override;
+    void Update(MainloopContext &aMainloop) override;
+
+    bool      IsStarted(void) const { return mHostPort != 0; }
+    otbrError BindToEphemeralPort(void);
+    otbrError ReceivePacket(uint8_t *aPayload, uint16_t &aLength, otIp6Address &aRemoteAddr, uint16_t &aRemotePort);
+
+    int      mFd; ///< Used to proxy UDP packets in Thread network.
+    uint16_t mHostPort;
+    uint16_t mThreadPort;
+
+    Dependencies &mDeps;
+};
+
+} // namespace otbr
+
+#endif // OTBR_AGENT_POSIX_UDP_PROXY_HPP_

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(otbr-posix-gtest-unit
     test_cli_daemon.cpp
     test_infra_if.cpp
     test_netif.cpp
+    test_udp_proxy.cpp
 )
 target_link_libraries(otbr-posix-gtest-unit
     otbr-posix

--- a/tests/gtest/test_udp_proxy.cpp
+++ b/tests/gtest/test_udp_proxy.cpp
@@ -1,0 +1,182 @@
+/*
+ *    Copyright (c) 2025, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "common/mainloop_manager.hpp"
+#include "common/types.hpp"
+#include "host/posix/udp_proxy.hpp"
+
+static constexpr size_t   kMaxUdpSize       = 1280;
+static constexpr uint16_t kTestThreadBaPort = 49191;
+const std::string         kHello            = "Hello UdpProxy!";
+
+class UdpProxyTest : public otbr::UdpProxy::Dependencies
+{
+public:
+    UdpProxyTest(void)
+        : mForwarded(false)
+    {
+    }
+
+    otbrError UdpForward(const uint8_t        *aUdpPayload,
+                         uint16_t              aLength,
+                         const otIp6Address   &aRemoteAddr,
+                         uint16_t              aRemotePort,
+                         const otbr::UdpProxy &aUdpProxy) override
+    {
+        mForwarded = true;
+        assert(aLength < kMaxUdpSize);
+
+        memcpy(mPayload, aUdpPayload, aLength);
+        mLength = aLength;
+        memcpy(mRemoteAddress.mFields.m8, aRemoteAddr.mFields.m8, sizeof(mRemoteAddress));
+        mRemotePort = aRemotePort;
+        mLocalPort  = aUdpProxy.GetThreadPort();
+
+        return OTBR_ERROR_NONE;
+    }
+
+    bool         mForwarded;
+    uint8_t      mPayload[kMaxUdpSize];
+    uint16_t     mLength;
+    otIp6Address mRemoteAddress;
+    uint16_t     mRemotePort;
+    uint16_t     mLocalPort;
+};
+
+TEST(UdpProxy, UdpProxyForwardCorrectlyWhenActive)
+{
+    UdpProxyTest   tester;
+    otbr::UdpProxy udpProxy(tester);
+
+    udpProxy.Start(kTestThreadBaPort);
+    EXPECT_NE(udpProxy.GetHostPort(), 0);
+
+    // Send a UDP packet destined to loopback address.
+    {
+        int                sockFd;
+        struct sockaddr_in destAddr;
+
+        if ((sockFd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+        {
+            perror("socket creation failed");
+            exit(EXIT_FAILURE);
+        }
+
+        memset(&destAddr, 0, sizeof(destAddr));
+        destAddr.sin_family      = AF_INET;
+        destAddr.sin_port        = htons(udpProxy.GetHostPort());
+        destAddr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Loopback address
+
+        if (sendto(sockFd, kHello.c_str(), kHello.size(), 0, (const struct sockaddr *)&destAddr, sizeof(destAddr)) < 0)
+        {
+            perror("Failed to send UDP packet through loopback interface");
+            exit(EXIT_FAILURE);
+        }
+        close(sockFd);
+    }
+
+    otbr::MainloopContext context;
+    while (!tester.mForwarded)
+    {
+        context.mMaxFd   = -1;
+        context.mTimeout = {100, 0};
+        FD_ZERO(&context.mReadFdSet);
+        FD_ZERO(&context.mWriteFdSet);
+        FD_ZERO(&context.mErrorFdSet);
+
+        otbr::MainloopManager::GetInstance().Update(context);
+        int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
+                          &context.mTimeout);
+        if (rval < 0)
+        {
+            perror("select failed");
+            exit(EXIT_FAILURE);
+        }
+        otbr::MainloopManager::GetInstance().Process(context);
+    }
+
+    std::string udpPayload(reinterpret_cast<const char *>(tester.mPayload), tester.mLength);
+    EXPECT_EQ(udpPayload, kHello);
+    EXPECT_EQ(tester.mLength, kHello.size());
+    EXPECT_EQ(tester.mLocalPort, kTestThreadBaPort);
+
+    udpProxy.Stop();
+}
+
+TEST(UdpProxy, UdpProxySendToPeerCorrectlyWhenActive)
+{
+    UdpProxyTest   tester;
+    otbr::UdpProxy udpProxy(tester);
+
+    udpProxy.Start(kTestThreadBaPort);
+
+    // Receive UDP packets on loopback address with specified port
+    int                sockFd;
+    const uint16_t     port = 12345;
+    struct sockaddr_in listenAddr;
+    uint8_t            recvBuf[kMaxUdpSize];
+
+    if ((sockFd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+    {
+        perror("socket creation failed");
+        exit(EXIT_FAILURE);
+    }
+
+    memset(&listenAddr, 0, sizeof(listenAddr));
+    listenAddr.sin_family      = AF_INET;
+    listenAddr.sin_port        = htons(port);
+    listenAddr.sin_addr.s_addr = inet_addr("127.0.0.1"); // Loopback address
+
+    if (bind(sockFd, (const struct sockaddr *)&listenAddr, sizeof(listenAddr)) < 0)
+    {
+        perror("bind failed");
+        exit(EXIT_FAILURE);
+    }
+
+    // Send a UDP packet through UDP Proxy
+    otIp6Address peerAddress = {
+        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x01}};
+    udpProxy.SendToPeer(reinterpret_cast<const uint8_t *>(kHello.c_str()), kHello.size(), peerAddress, port);
+
+    // Receive the UDP packet
+    socklen_t   len = sizeof(listenAddr);
+    int         n   = recvfrom(sockFd, (char *)recvBuf, kMaxUdpSize, MSG_WAITALL, (struct sockaddr *)&listenAddr, &len);
+    std::string udpPayload(reinterpret_cast<const char *>(recvBuf), n);
+    EXPECT_EQ(udpPayload, kHello);
+
+    close(sockFd);
+
+    udpProxy.Stop();
+}


### PR DESCRIPTION
This PR adds a UDP Proxy module to do Thread commissioning under NCP architecture.

This PR is one of sub-task to support Border Agent under NCP mode. The UDP Proxy will also be used to do Thread commisssioning under RCP architecture and replace `OT_PLATFORM_UDP`.

Based on the OT border agent state changes (HandleBorderAgentStateChange), the module simply starts/stops listening on an UDP ephemeral port and if starts, sets a mapping between OT border agent UDP port and the port on host. And then it does bidrectional UDP forwarding:
* `Dependencies::UdpForward` will be implemented as OT UDP forwarding to OT core.
* `SendToPeer` will send a UDP packet to the remote peer using the local host port (that maps to OT border agent port) as the source port.

The module hasn't been integrated with the application and put in use. This PR adds a unit test for the module.

This module can also be used for other cases.