### PR TITLE
[mdns] unify the behavior of `Stop()` between avahi and mDNSResponder

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -519,6 +519,10 @@ bool PublisherAvahi::IsStarted(void) const
 
 void PublisherAvahi::Stop(void)
 {
+    VerifyOrExit(mState == State::kReady);
+
+    mState = State::kIdle;
+
     mServiceRegistrations.clear();
     mHostRegistrations.clear();
 
@@ -531,7 +535,10 @@ void PublisherAvahi::Stop(void)
         mClient = nullptr;
     }
 
-    mState = Mdns::Publisher::State::kIdle;
+    mStateCallback(mState);
+
+exit:
+    return;
 }
 
 void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext)
@@ -664,8 +671,6 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
 
     case AVAHI_CLIENT_FAILURE:
         otbrLogErr("Avahi client failed to start: %s", avahi_strerror(avahi_client_errno(aClient)));
-        mState = State::kIdle;
-        mStateCallback(mState);
         Stop();
         Start();
         break;

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -241,6 +241,8 @@ void PublisherMDnsSd::Stop(StopMode aStopMode)
 {
     VerifyOrExit(mState == State::kReady);
 
+    mState = State::kIdle;
+
     // If we get a `kDNSServiceErr_ServiceNotRunning` and need to
     // restart the `Publisher`, we should immediately de-allocate
     // all `ServiceRef`. Otherwise, we first clear the `Registrations`
@@ -265,7 +267,7 @@ void PublisherMDnsSd::Stop(StopMode aStopMode)
     mSubscribedServices.clear();
     mSubscribedHosts.clear();
 
-    mState = State::kIdle;
+    mStateCallback(mState);
 
 exit:
     return;
@@ -756,7 +758,8 @@ void PublisherMDnsSd::DnssdKeyRegistration::Unregister(void)
 
     VerifyOrExit(serviceRef != nullptr);
 
-    dnsError = DNSServiceRemoveRecord(serviceRef, mRecordRef, /* flags */ 0);
+    dnsError   = DNSServiceRemoveRecord(serviceRef, mRecordRef, /* flags */ 0);
+    mRecordRef = nullptr;
 
     otbrLogInfo("Unregistered key %s: error:%s", mName.c_str(), DNSErrorToString(dnsError));
 

--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -119,7 +119,15 @@ private:
     public:
         using ServiceRegistration::ServiceRegistration; // Inherit base constructor
 
-        ~DnssdServiceRegistration(void) override { Unregister(); }
+        ~DnssdServiceRegistration(void) override
+        {
+            Unregister();
+            if (mServiceRef)
+            {
+                DNSServiceRefDeallocate(mServiceRef);
+                mServiceRef = nullptr;
+            }
+        }
 
         void      Update(MainloopContext &aMainloop) const;
         void      Process(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;


### PR DESCRIPTION
In the `Stop()` method, the `Publisher` will:
1. Early exit if it's already stopped. 
2. Mark the state as stopped.
3. Clear registrations and subscriptions. The destructors will free the mDNS library's client-side objects.
4. Trigger state callbacks.