### PR TITLE
[bootstrap] Improve Robustness of mDNSResponder Download and Extraction

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,6 +41,8 @@ OTBR_MDNS="${OTBR_MDNS:-mDNSResponder}"
 OT_BACKBONE_CI="${OT_BACKBONE_CI:-0}"
 REFERENCE_DEVICE="${REFERENCE_DEVICE:-0}"
 
+MDNS_RESPONDER_PATCH_PATH=$(realpath "$(dirname "$0")"/../third_party/mDNSResponder)
+
 install_packages_apt()
 {
     sudo apt-get update
@@ -68,20 +70,7 @@ install_packages_apt()
         sudo apt-get install --no-install-recommends -y avahi-daemon
     fi
 
-    (MDNS_RESPONDER_SOURCE_NAME=mDNSResponder-1790.80.10 \
-        && MDNS_RESPONDER_PATCH_PATH=$(realpath "$(dirname "$0")"/../third_party/mDNSResponder) \
-        && cd /tmp \
-        && wget --no-check-certificate https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$MDNS_RESPONDER_SOURCE_NAME.tar.gz \
-        && mkdir -p $MDNS_RESPONDER_SOURCE_NAME \
-        && tar xvf $MDNS_RESPONDER_SOURCE_NAME.tar.gz -C $MDNS_RESPONDER_SOURCE_NAME --strip-components=1 \
-        && cd /tmp/"$MDNS_RESPONDER_SOURCE_NAME" \
-        && (
-            for patch in "$MDNS_RESPONDER_PATCH_PATH"/*.patch; do
-                patch -p1 <"$patch"
-            done
-        ) \
-        && cd mDNSPosix \
-        && make os=linux tls=no && sudo make install os=linux tls=no)
+    . script/setup-mdns-responder "${MDNS_RESPONDER_PATCH_PATH}"
 
     # nat64
     without NAT64 || {

--- a/script/setup-mdns-responder
+++ b/script/setup-mdns-responder
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -euxo pipefail
+
+MDNS_RESPONDER_SOURCE_NAME="mDNSResponder-1790.80.10"
+MDNS_RESPONDER_URL="https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/${MDNS_RESPONDER_SOURCE_NAME}.tar.gz"
+MDNS_RESPONDER_BUILD_DIR="/tmp/${MDNS_RESPONDER_SOURCE_NAME}"
+
+MDNS_RESPONDER_PATCH_PATH="${1}"
+
+mdns_responder_install()
+{
+    wget --no-check-certificate -O "${MDNS_RESPONDER_SOURCE_NAME}.tar.gz" "${MDNS_RESPONDER_URL}"
+    mkdir -p "${MDNS_RESPONDER_BUILD_DIR}"
+    tar xvf "${MDNS_RESPONDER_SOURCE_NAME}.tar.gz" -C "${MDNS_RESPONDER_BUILD_DIR}" --overwrite --strip-components=1
+
+    cd "${MDNS_RESPONDER_BUILD_DIR}"
+    for patch in "${MDNS_RESPONDER_PATCH_PATH}"/*.patch; do
+        patch -p1 <"${patch}"
+    done
+
+    # Build and install
+    cd mDNSPosix
+    make os=linux tls=no
+    sudo make install os=linux tls=no
+}
+
+mdns_responder_install

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -32,7 +32,7 @@ set -euxo pipefail
 TOOLS_HOME="$HOME"/.cache/tools
 [[ -d $TOOLS_HOME ]] || mkdir -p "$TOOLS_HOME"
 
-MDNSRESPONDER_PATCH_PATH=$(realpath "$(dirname "$0")"/../../third_party/mDNSResponder)
+MDNS_RESPONDER_PATCH_PATH=$(realpath "$(dirname "$0")"/../../third_party/mDNSResponder)
 
 disable_install_recommends()
 {
@@ -123,18 +123,7 @@ case "$(uname)" in
         fi
 
         if [ "${OTBR_MDNS-}" == 'mDNSResponder' ]; then
-            SOURCE_NAME=mDNSResponder-1790.80.10
-            wget https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$SOURCE_NAME.tar.gz \
-                && mkdir -p $SOURCE_NAME \
-                && tar xvf $SOURCE_NAME.tar.gz -C $SOURCE_NAME --strip-components=1 \
-                && cd "$SOURCE_NAME" \
-                && (
-                    for patch in "$MDNSRESPONDER_PATCH_PATH"/*.patch; do
-                        patch -p1 <"$patch"
-                    done
-                ) \
-                && cd mDNSPosix \
-                && make os=linux tls=no && sudo make install os=linux tls=no
+            . "../../script/setup-mdns-responder" "${MDNS_RESPONDER_PATCH_PATH}"
         fi
 
         # Enable IPv6


### PR DESCRIPTION
The previous implementation of the mDNSResponder download and build process was susceptible to several issues:

1.  **Incomplete or Corrupted Downloads:** If the `wget` command failed to download the entire mDNSResponder archive, or if the download was corrupted, the script might continue with an invalid archive.
2.   **Pre-existing Files:** If the `/tmp/mDNSResponder-1790.80.10` directory or `mDNSResponder.tar.gz` file already existed from a previous run, the `tar` command would fail to extract the archive correctly, leading to a mix of old and new files.

The PR addresses the two issues with:
    *   The `tar --overwrite ` command is to overwrite existing files when extracting.
    *   The `wget -O mDNSResponder.tar.gz` command is used to explicitly specify the output file name and overwrite the old one
