### PR TITLE
[ncp] add handling for unused properties to avoid warning logs

### DIFF
--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -464,6 +464,13 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
         break;
     }
 
+    case SPINEL_PROP_THREAD_CHILD_TABLE:
+    case SPINEL_PROP_THREAD_ON_MESH_NETS:
+    case SPINEL_PROP_THREAD_OFF_MESH_ROUTES:
+    case SPINEL_PROP_THREAD_LEADER_NETWORK_DATA:
+    case SPINEL_PROP_IPV6_LL_ADDR:
+        break;
+
     case SPINEL_PROP_STREAM_NET:
     {
         const uint8_t *data;
@@ -739,6 +746,12 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
         VerifyOrExit(aKey == SPINEL_PROP_LAST_STATUS, error = OTBR_ERROR_INVALID_STATE);
         SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
         otbrLogInfo("Infra If handle ICMP6 ND result: %s", spinel_status_to_cstr(status));
+        break;
+
+    case SPINEL_PROP_DNSSD_STATE:
+        VerifyOrExit(aKey == SPINEL_PROP_LAST_STATUS, error = OTBR_ERROR_INVALID_STATE);
+        SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+        otbrLogInfo("Update dnssd state result: %s", spinel_status_to_cstr(status));
         break;
 
     default:


### PR DESCRIPTION
This PR adds handling for some NCP properites.

Currently theere are some logs like:
```
2025-02-27T10:57:03.981495+08:00 otbr-agent[424273]: [CRIT]-NcpSpin-: Received unexpected response with (cmd:6, key:0), waiting (cmd:3, key:2353) for tid:3

2025-02-27T02:38:29.478937+00:00 rpi-4 otbr-agent[6900]: [WARN]-NcpSpin-: Received uncognized key: 5389
2025-02-27T02:38:29.479525+00:00 rpi-4 otbr-agent[6900]: [WARN]-NcpSpin-: Received uncognized key: 90
2025-02-27T02:38:29.480519+00:00 rpi-4 otbr-agent[6900]: [WARN]-NcpSpin-: Received uncognized key: 91
```

This PR adds handling for these properties to avoid these warning logs. For unsolicited notification cases, add `case` for these properties to avoid that they go to the default case and emit warnings.