### PR TITLE
[mdns-avahi] utilize Avahi events for complete result handling

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -766,7 +766,12 @@ void Publisher::UpdateHostResolutionEmaLatency(const std::string &aHostName, otb
 
 void Publisher::AddAddress(AddressList &aAddressList, const Ip6Address &aAddress)
 {
-    aAddressList.push_back(aAddress);
+    auto it = std::find(aAddressList.begin(), aAddressList.end(), aAddress);
+
+    if (it == aAddressList.end())
+    {
+        aAddressList.push_back(aAddress);
+    }
 }
 
 void Publisher::RemoveAddress(AddressList &aAddressList, const Ip6Address &aAddress)

--- a/src/mdns/mdns_avahi.hpp
+++ b/src/mdns/mdns_avahi.hpp
@@ -196,6 +196,7 @@ private:
             : Subscription(aAvahiPublisher)
             , mHostName(std::move(aHostName))
             , mRecordBrowser(nullptr)
+            , mResolved(false)
         {
         }
 
@@ -229,6 +230,7 @@ private:
         std::string         mHostName;
         DiscoveredHostInfo  mHostInfo;
         AvahiRecordBrowser *mRecordBrowser;
+        bool                mResolved;
     };
 
     struct ServiceResolver
@@ -300,6 +302,7 @@ private:
         AvahiServiceResolver  *mServiceResolver = nullptr;
         AvahiRecordBrowser    *mRecordBrowser   = nullptr;
         DiscoveredInstanceInfo mInstanceInfo;
+        bool                   mResolved = false;
     };
     struct ServiceSubscription : public Subscription
     {


### PR DESCRIPTION
This commit enhances `Mdns::Publisher` using Avahi to utilize the events `AVAHI_BROWSER_ALL_FOR_NOW` which notify that all records have been processed and no further results are expected in the near future.

This improvement prevents premature "resolved" callbacks after receiving only the initial IPv6 address, thereby improving host and service address resolution. The `Publisher` now waits for these events to ensure it gathers all available addresses from the cache and query responses before signaling resolved callback. 

---

Resolves #2711