### PR TITLE
[pd] support of multiple prefixes publishing and deprecating

### DIFF
--- a/script/reference-device/dhcpcd.enter-hook
+++ b/script/reference-device/dhcpcd.enter-hook
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Copyright (c) 2024, The OpenThread Authors.
 #  All rights reserved.
@@ -36,22 +36,7 @@ LOG_TAG="dhcpcd.enter.hook:"
 
 config_ra()
 {
-    local old_prefix="$1"
-    local old_prefix_len="$2"
-    local new_prefix="$3"
-    local new_prefix_len="$4"
-    local new_pltime="$5"
-    local new_vltime="$6"
-
-    local deprecate_old_prefix=false
-    if [ -n "$old_prefix" ] && [ "$old_prefix/$old_prefix_len" != "$new_prefix/$new_prefix_len" ]; then
-        deprecate_old_prefix=true
-    fi
-
-    local publish_new_prefix=false
-    if [ -n "$new_prefix" ] && [ -n "$new_prefix_len" ] && [ -n "$new_pltime" ] && [ -n "$new_vltime" ]; then
-        publish_new_prefix=true
-    fi
+    prefixes="$1"
 
     logger "$LOG_TAG $reason start config radvd"
 
@@ -62,33 +47,29 @@ interface ${WPAN_INTERFACE}
     AdvSendAdvert on;
 EOF
 
-    if "$deprecate_old_prefix"; then
-        logger "$LOG_TAG Deprecating old prefix $old_prefix/$old_prefix_len"
+    set -- $prefixes
+    while [ $# -ge 4 ]; do
+        prefix=$1
+        length=$2
+        vltime=$3
+        pltime=$4
+        if [ -z "$vltime" ] && [ -z "$pltime" ]; then
+            logger "$LOG_TAG Deprecating prefix: $prefix/$length"
+        else
+            logger "$LOG_TAG Publishing prefix: $prefix/$length vltime: $vltime pltime: $pltime"
+        fi
 sudo tee -a "${RADVD_CONF}" > /dev/null <<EOF
-    prefix ${old_prefix}/${old_prefix_len}
+    prefix ${prefix}/${length}
     {
         AdvOnLink on;
         AdvAutonomous on;
         AdvRouterAddr off;
-        AdvPreferredLifetime 0;
-        AdvValidLifetime 0;
+        AdvPreferredLifetime ${pltime};
+        AdvValidLifetime ${vltime};
     };
 EOF
-    fi
-
-    if $publish_new_prefix; then
-        logger "$LOG_TAG Publishing new prefix $new_prefix/$new_prefix_len  PLTime: $new_pltime  VLTime: $new_vltime"
-sudo tee -a "${RADVD_CONF}" > /dev/null <<EOF
-    prefix ${new_prefix}/${new_prefix_len}
-    {
-        AdvOnLink on;
-        AdvAutonomous on;
-        AdvRouterAddr off;
-        AdvPreferredLifetime ${new_pltime};
-        AdvValidLifetime ${new_vltime};
-    };
-EOF
-    fi
+        shift 4
+    done
 
 sudo tee -a "${RADVD_CONF}" > /dev/null <<EOF
 };
@@ -98,26 +79,33 @@ EOF
 
 
 if [ ${interface} = ${UPSTREAM_INTERFACE} ]; then
-
-    for var in $(env); do
-        # Split the variable into name and value
-        name="${var%%=*}"
-        value="${var#*=}"
-        logger "$LOG_TAG $reason sysenv: $name=$value"
-    done
+    prefixes=""
 
     case $reason in
         DELEGATED6 | REBIND6 | RENEW6 | BOUND6 )
-            # TODO: Handle multiple IA_PD prefixes (new_dhcp6_ia_pd{i}_prefix{j}, new_dhcp6_ia_pd{i}_prefix{j}_length, etc.)
-            #       and deprecate old prefixes properly for each.  Currently, only one prefix is handled.
-            if { [ -n "$new_dhcp6_ia_pd1_prefix1" ] && [ -n "$new_dhcp6_ia_pd1_prefix1_length" ]; } || \
-               { [ -n "$old_dhcp6_ia_pd1_prefix1" ] && [ -n "$old_dhcp6_ia_pd1_prefix1_length" ]; }; then
-                config_ra "$old_dhcp6_ia_pd1_prefix1" "$old_dhcp6_ia_pd1_prefix1_length" \
-                    "$new_dhcp6_ia_pd1_prefix1" "$new_dhcp6_ia_pd1_prefix1_length" "$new_dhcp6_ia_pd1_prefix1_pltime"  "$new_dhcp6_ia_pd1_prefix1_vltime"
-                if systemctl is-active network.target; then
-                    sudo systemctl reload-or-restart radvd || logger "$LOG_TAG Failed to reload radvd"
-                fi
-            fi
+            for name in $(env | cut -d'=' -f1); do
+                case "$name" in
+                    new_dhcp6_ia_pd*_prefix*)
+                    if echo "$name" | grep -q "[0-9]$"; then
+                        eval prefix="\$${name}"
+                        eval length="\$${name}_length"
+                        eval vltime="\$${name}_vltime"
+                        eval pltime="\$${name}_pltime"
+
+                        if [ -n "$prefix" ] && [ -n "$length" ] && [ -n "$vltime" ] && [ -n $pltime ]; then
+                            prefixes="$prefixes $prefix $length $vltime $pltime"
+                        fi
+                    fi
+                    ;;
+                esac
+            done
             ;;
     esac
+
+    if [ -n "$prefixes" ]; then
+        config_ra "$prefixes"
+        if systemctl is-active network.target; then
+            sudo systemctl reload-or-restart radvd || logger "$LOG_TAG Failed to reload radvd"
+        fi
+    fi
 fi

--- a/script/reference-device/dhcpcd.exit-hook
+++ b/script/reference-device/dhcpcd.exit-hook
@@ -36,46 +36,68 @@ LOG_TAG="dhcpcd.exit.hook:"
 
 config_ra()
 {
+    prefixes="$1"
+
     logger "$LOG_TAG $reason start config radvd"
 
 sudo tee "${RADVD_CONF}" > /dev/null <<EOF
 interface ${WPAN_INTERFACE}
 {
+    IgnoreIfMissing on;
     AdvSendAdvert on;
-    prefix ${1}/${2}
+EOF
+
+    set -- $prefixes
+    while [ $# -ge 2 ]; do
+        prefix=$1
+        length=$2
+        logger "$LOG_TAG Deprecating prefix: $prefix/$length"
+sudo tee -a "${RADVD_CONF}" > /dev/null <<EOF
+    prefix ${prefix}/${length}
     {
         AdvOnLink on;
         AdvAutonomous on;
         AdvRouterAddr off;
-        AdvPreferredLifetime ${3};
-        AdvValidLifetime ${4};
+        AdvPreferredLifetime 0;
+        AdvValidLifetime 0;
     };
+EOF
+        shift 2
+    done
+
+sudo tee -a "${RADVD_CONF}" > /dev/null <<EOF
 };
 EOF
+
 }
 
 
 if [ ${interface} = ${UPSTREAM_INTERFACE} ]; then
-
-    for var in $(env); do
-        # Split the variable into name and value
-        name="${var%%=*}"
-        value="${var#*=}"
-        logger -t "$LOG_TAG $reason sysenv: " "$name=$value"
-    done
+    prefixes=""
 
     case $reason in
-        EXPIRE6 | STOP6 | RELEASE6 )
-            # TODO: Handle multiple IA_PD prefixes (new_dhcp6_ia_pd{i}_prefix{j}, new_dhcp6_ia_pd{i}_prefix{j}_length, etc.)
-            #       and deprecate old prefixes properly for each.  Currently, only one prefix is handled.)
-            if [ -z "$old_dhcp6_ia_pd1_prefix1" ] || [ -z "$old_dhcp6_ia_pd1_prefix1_length" ]; then
-                logger "$LOG_TAG WARNING: Missing DHCPv6 prefix information. Skipping radvd configuration."
-            else
-                config_ra $old_dhcp6_ia_pd1_prefix1 $old_dhcp6_ia_pd1_prefix1_length 0 0
-                if systemctl is-active network.target; then
-                    sudo systemctl reload-or-restart radvd
-                fi
-            fi
+        RELEASE6 | EXPIRE6 | STOP6 )
+            for name in $(env | cut -d'=' -f1); do
+                case "$name" in
+                    old_dhcp6_ia_pd*_prefix*)
+                    if echo "$name" | grep -q "[0-9]$"; then
+                        eval prefix="\$${name}"
+                        eval length="\$${name}_length"
+
+                        if [ -n $prefix ] && [ -n $length ]; then
+                            prefixes="$prefixes $prefix $length"
+                        fi
+                    fi
+                    ;;
+                esac
+            done
             ;;
     esac
+
+    if [ -n "$prefixes" ]; then
+        config_ra "$prefixes"
+        if systemctl is-active network.target; then
+            sudo systemctl reload-or-restart radvd || logger "$LOG_TAG Failed to reload radvd"
+        fi
+    fi
 fi


### PR DESCRIPTION
Add support of multiple prefixes handling in both 

- dhcpcd.enter-hook (Publishing Prefixes):

  - This script is triggered when dhcpcd gets new or updated IPv6 PD information.
  - It now iterates through multiple new_dhcp6_ia_pd*_prefix* environment variables (where * is a number), allowing for multiple prefixes.
  - For each prefix, it extracts the prefix, length, valid lifetime (vltime), and preferred lifetime (pltime). If lifetime is zero, it means the prefix is deprecated.
  - It then constructs a radvd.conf file that includes multiple prefix blocks, each with its own lifetimes.
  - It reloads or restarts radvd to apply the new configuration.

- dhcpcd.exit-hook (Deprecating Prefixes):

  - This script is triggered when dhcpcd releases or expires IPv6 PD information.
  - It now iterates through multiple old_dhcp6_ia_pd*_prefix* environment variables to find prefixes that are no longer valid.
  - For each deprecated prefix, it sets the AdvPreferredLifetime and AdvValidLifetime to 0 in radvd.conf.
  - It reloads or restarts radvd to apply the updated configuration.