### PR TITLE
[border-agent] add `Init()` and `Deinit()` for `BorderAgent` 

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -255,6 +255,7 @@ void Application::InitRcpMode(void)
     mPublisher->Start();
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
+    mBorderAgent->Init();
 // This is for delaying publishing the MeshCoP service until the correct
 // vendor name and OUI etc. are correctly set by BorderAgent::SetMeshCopServiceValues()
 #if OTBR_STOP_BORDER_AGENT_ON_INIT
@@ -302,6 +303,7 @@ void Application::DeinitRcpMode(void)
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
     mBorderAgent->SetEnabled(false);
+    mBorderAgent->Deinit();
 #endif
 #if OTBR_ENABLE_MDNS
     mMdnsStateSubject.Clear();

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -159,14 +159,19 @@ struct StateBitmap
 BorderAgent::BorderAgent(otbr::Host::RcpHost &aHost, Mdns::Publisher &aPublisher)
     : mHost(aHost)
     , mPublisher(aPublisher)
-    , mIsEnabled(false)
-    , mIsEphemeralKeyEnabled(otThreadGetVersion() >= OT_THREAD_VERSION_1_4)
-    , mVendorName(OTBR_VENDOR_NAME)
-    , mProductName(OTBR_PRODUCT_NAME)
-    , mBaseServiceInstanceName(OTBR_MESHCOP_SERVICE_INSTANCE_NAME)
 {
-    mHost.AddThreadStateChangedCallback([this](otChangedFlags aFlags) { HandleThreadStateChanged(aFlags); });
+    ClearState();
+}
+
+void BorderAgent::Init(void)
+{
     otbrLogInfo("Ephemeral Key is: %s during initialization", (mIsEphemeralKeyEnabled ? "enabled" : "disabled"));
+    mHost.AddThreadStateChangedCallback([this](otChangedFlags aFlags) { HandleThreadStateChanged(aFlags); });
+}
+
+void BorderAgent::Deinit(void)
+{
+    ClearState();
 }
 
 otbrError BorderAgent::CreateEphemeralKey(std::string &aEphemeralKey)
@@ -260,6 +265,19 @@ void BorderAgent::SetEphemeralKeyEnabled(bool aIsEnabled)
 
 exit:
     return;
+}
+
+void BorderAgent::ClearState(void)
+{
+    mIsEnabled             = false;
+    mIsEphemeralKeyEnabled = (otThreadGetVersion() >= OT_THREAD_VERSION_1_4);
+    mMeshCopTxtUpdate.clear();
+    mVendorOui.clear();
+    mVendorName              = OTBR_VENDOR_NAME;
+    mProductName             = OTBR_PRODUCT_NAME;
+    mBaseServiceInstanceName = OTBR_MESHCOP_SERVICE_INSTANCE_NAME;
+    mServiceInstanceName.clear();
+    mEphemeralKeyChangedCallbacks.clear();
 }
 
 void BorderAgent::Start(void)

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -92,6 +92,16 @@ public:
     ~BorderAgent(void) = default;
 
     /**
+     * Initializes the Thread Border Agent.
+     */
+    void Init(void);
+
+    /**
+     * Deinitializes the Thread Border Agent.
+     */
+    void Deinit(void);
+
+    /**
      * Overrides MeshCoP service (i.e. _meshcop._udp) instance name, product name, vendor name and vendor OUI.
      *
      * This method must be called before this BorderAgent is enabled by SetEnabled.
@@ -160,6 +170,7 @@ public:
     void AddEphemeralKeyChangedCallback(EphemeralKeyChangedCallback aCallback);
 
 private:
+    void ClearState(void);
     void Start(void);
     void Stop(void);
     bool IsEnabled(void) const { return mIsEnabled; }


### PR DESCRIPTION
This PR implements `Init()` and `Deinit()` for `BorderAgent`. This is to support the case on Android that we need to properly  re-initialize the `BorderAgent` after leaving a network. Previously the Thread state callback was registered in the constructor so it goes away after `Deinit` of `ThreadHost` and will never get back. 