### PR TITLE
[github-actions] update runner from `ubuntu-20.04` to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
 
   border-router:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       run: script/make-pretty check
 
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +76,7 @@ jobs:
       uses: codecov/codecov-action@v5
 
   rest-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
       uses: codecov/codecov-action@v5
 
   script-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_TARGET: script-check
       OTBR_COVERAGE: 1
@@ -115,7 +115,7 @@ jobs:
       uses: codecov/codecov-action@v5
 
   scan-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_TARGET: scan-build
       CC: clang
@@ -130,7 +130,7 @@ jobs:
       run: tests/scripts/check-scan-build
 
   package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_TARGET: package
     steps:

--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
 
   raspbian-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip
       BUILD_TARGET: raspbian-gcc


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/