### PR TITLE
[border-agent] refactor epskc state change handling

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -198,7 +198,7 @@ void Application::CreateRcpMode(const std::string &aRestListenAddress, int aRest
 {
     otbr::Host::RcpHost &rcpHost = static_cast<otbr::Host::RcpHost &>(mHost);
 #if OTBR_ENABLE_BORDER_AGENT
-    mBorderAgent = MakeUnique<BorderAgent>(rcpHost, *mPublisher);
+    mBorderAgent = MakeUnique<BorderAgent>(*mPublisher);
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mBackboneAgent = MakeUnique<BackboneRouter::BackboneAgent>(rcpHost, mInterfaceName, mBackboneInterfaceName);
@@ -260,6 +260,9 @@ void Application::InitRcpMode(void)
             mBorderAgent->HandleBorderAgentMeshCoPServiceChanged(aIsActive, aPort,
                                                                  std::vector<uint8_t>(aTxtData, aTxtData + aLength));
         });
+    mHost.AddEphemeralKeyStateChangedCallback([this](otBorderAgentEphemeralKeyState aEpskcState, uint16_t aPort) {
+        mBorderAgent->HandleEpskcStateChanged(aEpskcState, aPort);
+    });
 // This is for delaying publishing the MeshCoP service until the correct
 // vendor name and OUI etc. are correctly set by BorderAgent::SetMeshCopServiceValues()
 #if OTBR_STOP_BORDER_AGENT_ON_INIT

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -84,10 +84,9 @@ public:
     /**
      * The constructor to initialize the Thread border agent.
      *
-     * @param[in] aHost       A reference to the Thread controller.
      * @param[in] aPublisher  A reference to the mDNS Publisher.
      */
-    BorderAgent(otbr::Host::RcpHost &aHost, Mdns::Publisher &aPublisher);
+    BorderAgent(Mdns::Publisher &aPublisher);
 
     ~BorderAgent(void) = default;
 
@@ -146,6 +145,14 @@ public:
                                                 const std::vector<uint8_t> &aOtMeshCoPTxtValues);
 
     /**
+     * This method handles Epskc state changes.
+     *
+     * @param[in] aEpskcState    The Epskc state.
+     * @param[in] aPort          The UDP port of the Epskc service if it's active.
+     */
+    void HandleEpskcStateChanged(otBorderAgentEphemeralKeyState aEpskcState, uint16_t aPort);
+
+    /**
      * This method creates ephemeral key in the Border Agent.
      *
      * @param[out] aEphemeralKey  The ephemeral key digit string of length 9 with first 8 digits randomly
@@ -155,13 +162,6 @@ public:
      * @returns OTBR_ERROR_NONE          If successfully generate the ePSKc.
      */
     static otbrError CreateEphemeralKey(std::string &aEphemeralKey);
-
-    /**
-     * This method adds a callback for ephemeral key changes.
-     *
-     * @param[in] aCallback  The callback to receive ephemeral key changed events.
-     */
-    void AddEphemeralKeyChangedCallback(EphemeralKeyChangedCallback aCallback);
 
 #if OTBR_ENABLE_DBUS_SERVER
     /**
@@ -187,14 +187,11 @@ private:
     std::string GetServiceInstanceNameWithExtAddr(const std::string &aServiceInstanceName) const;
     std::string GetAlternativeServiceInstanceName() const;
 
-    static void HandleEpskcStateChanged(void *aContext);
-    void        HandleEpskcStateChanged(void);
-    void        PublishEpskcService(void);
-    void        UnpublishEpskcService(void);
+    void PublishEpskcService(uint16_t aPort);
+    void UnpublishEpskcService(void);
 
-    otbr::Host::RcpHost &mHost;
-    Mdns::Publisher     &mPublisher;
-    bool                 mIsEnabled;
+    Mdns::Publisher &mPublisher;
+    bool             mIsEnabled;
 
     std::map<std::string, std::vector<uint8_t>> mMeshCoPTxtUpdate;
 
@@ -213,8 +210,6 @@ private:
     // conflicts. For example, this value can be "OpenThread Border Router #7AC3" or
     // "OpenThread Border Router #7AC3 (14379)".
     std::string mServiceInstanceName;
-
-    std::vector<EphemeralKeyChangedCallback> mEphemeralKeyChangedCallbacks;
 
     // The encoded MeshCoP TXT values from OT core.
     std::vector<uint8_t> mOtMeshCoPTxtValues;

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -258,6 +258,11 @@ void NcpHost::SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServ
     OTBR_UNUSED_VARIABLE(aCallback);
 }
 
+void NcpHost::AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback)
+{
+    OTBR_UNUSED_VARIABLE(aCallback);
+}
+
 void NcpHost::Process(const MainloopContext &aMainloop)
 {
     mSpinelDriver.Process(&aMainloop);

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -110,6 +110,7 @@ public:
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
     void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
     void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) override;
+    void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -212,6 +212,7 @@ public:
     void AddThreadStateChangedCallback(ThreadStateChangedCallback aCallback) override;
     void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
     void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) override;
+    void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {
@@ -257,6 +258,8 @@ private:
 
     static void HandleMeshCoPServiceChanged(void *aContext);
     void        HandleMeshCoPServiceChanged(void);
+    static void HandleEpskcStateChanged(void *aContext);
+    void        HandleEpskcStateChanged(void);
 
     bool IsAutoAttachEnabled(void);
     void DisableAutoAttach(void);
@@ -274,15 +277,16 @@ private:
     std::vector<std::function<void(void)>>     mResetHandlers;
     TaskRunner                                 mTaskRunner;
 
-    std::vector<ThreadStateChangedCallback>  mThreadStateChangedCallbacks;
-    std::vector<ThreadEnabledStateCallback>  mThreadEnabledStateChangedCallbacks;
-    bool                                     mEnableAutoAttach = false;
-    ThreadEnabledState                       mThreadEnabledState;
-    AsyncResultReceiver                      mJoinReceiver;
-    AsyncResultReceiver                      mSetThreadEnabledReceiver;
-    AsyncResultReceiver                      mScheduleMigrationReceiver;
-    std::vector<DetachGracefullyCallback>    mDetachGracefullyCallbacks;
-    BorderAgentMeshCoPServiceChangedCallback mBorderAgentMeshCoPServiceChangedCallback;
+    std::vector<ThreadStateChangedCallback>       mThreadStateChangedCallbacks;
+    std::vector<ThreadEnabledStateCallback>       mThreadEnabledStateChangedCallbacks;
+    bool                                          mEnableAutoAttach = false;
+    ThreadEnabledState                            mThreadEnabledState;
+    AsyncResultReceiver                           mJoinReceiver;
+    AsyncResultReceiver                           mSetThreadEnabledReceiver;
+    AsyncResultReceiver                           mScheduleMigrationReceiver;
+    std::vector<DetachGracefullyCallback>         mDetachGracefullyCallbacks;
+    BorderAgentMeshCoPServiceChangedCallback      mBorderAgentMeshCoPServiceChangedCallback;
+    std::vector<EphemeralKeyStateChangedCallback> mEphemeralKeyStateChangedCallbacks;
 
 #if OTBR_ENABLE_FEATURE_FLAGS
     // The applied FeatureFlagList in ApplyFeatureFlagList call, used for debugging purpose.

--- a/src/host/thread_host.hpp
+++ b/src/host/thread_host.hpp
@@ -37,6 +37,7 @@
 #include <functional>
 #include <memory>
 
+#include <openthread/border_agent.h>
 #include <openthread/dataset.h>
 #include <openthread/error.h>
 #include <openthread/thread.h>
@@ -122,6 +123,7 @@ public:
     using ThreadStateChangedCallback               = std::function<void(otChangedFlags)>;
     using ThreadEnabledStateCallback               = std::function<void(ThreadEnabledState)>;
     using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
+    using EphemeralKeyStateChangedCallback         = std::function<void(otBorderAgentEphemeralKeyState, uint16_t)>;
 
     struct ChannelMaxPower
     {
@@ -257,6 +259,13 @@ public:
      * @param[in] aCallback  The callback function.
      */
     virtual void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) = 0;
+
+    /**
+     * This method adds a callback that will be invoked when there are any changes related to the ephemeral key.
+     *
+     * @param[in] aCallback  The callback function.
+     */
+    virtual void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) = 0;
 
     /**
      * Returns the co-processor type.


### PR DESCRIPTION
This PR refactors the Epskc state change handling in BorderAgent.

The PR adds an API `AddEphemeralKeyStateChangedCallback` in `ThreadHost` to add ephemeral key state callback so that the application rely on this API and unbind `BorderAgent` from OT instance. The intention is to make BorderAgent able to work in NCP mode as well.