### PR TITLE
[border agent] refactor dbus meshcop txt update

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -284,18 +284,6 @@ void BorderAgent::Start(void)
 {
     otbrLogInfo("Start Thread Border Agent");
 
-#if OTBR_ENABLE_DBUS_SERVER
-    mHost.GetThreadHelper()->SetUpdateMeshCopTxtHandler([this](std::map<std::string, std::vector<uint8_t>> aUpdate) {
-        HandleUpdateVendorMeshCoPTxtEntries(std::move(aUpdate));
-    });
-    mHost.RegisterResetHandler([this]() {
-        mHost.GetThreadHelper()->SetUpdateMeshCopTxtHandler(
-            [this](std::map<std::string, std::vector<uint8_t>> aUpdate) {
-                HandleUpdateVendorMeshCoPTxtEntries(std::move(aUpdate));
-            });
-    });
-#endif
-
     mServiceInstanceName = GetServiceInstanceNameWithExtAddr(mBaseServiceInstanceName);
     UpdateMeshCopService();
 

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -169,17 +169,26 @@ public:
      */
     void AddEphemeralKeyChangedCallback(EphemeralKeyChangedCallback aCallback);
 
+#if OTBR_ENABLE_DBUS_SERVER
+    /**
+     * This method handles update of vendor MeshCoP TXT entries.
+     *
+     * @param[in] aUpdate  A map of vendor MeshCoP TXT entries.
+     */
+    void HandleUpdateVendorMeshCoPTxtEntries(std::map<std::string, std::vector<uint8_t>> aUpdate);
+#endif
+
 private:
     void ClearState(void);
     void Start(void);
     void Stop(void);
-    bool IsEnabled(void) const { return mIsEnabled; }
+    bool IsEnabled(void) const
+    {
+        return mIsEnabled;
+    }
     void PublishMeshCopService(void);
     void UpdateMeshCopService(void);
     void UnpublishMeshCopService(void);
-#if OTBR_ENABLE_DBUS_SERVER
-    void HandleUpdateVendorMeshCoPTxtEntries(std::map<std::string, std::vector<uint8_t>> aUpdate);
-#endif
 
     void HandleThreadStateChanged(otChangedFlags aFlags);
 

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -1304,8 +1304,7 @@ exit:
 
 void DBusThreadObjectRcp::UpdateMeshCopTxtHandler(DBusRequest &aRequest)
 {
-    auto                                        threadHelper = mHost.GetThreadHelper();
-    otError                                     error        = OT_ERROR_NONE;
+    otError                                     error = OT_ERROR_NONE;
     std::map<std::string, std::vector<uint8_t>> update;
     std::vector<TxtEntry>                       updatedTxtEntries;
     auto                                        args = std::tie(updatedTxtEntries);
@@ -1319,7 +1318,7 @@ void DBusThreadObjectRcp::UpdateMeshCopTxtHandler(DBusRequest &aRequest)
     {
         VerifyOrExit(!update.count(reservedKey), error = OT_ERROR_INVALID_ARGS);
     }
-    threadHelper->OnUpdateMeshCopTxt(std::move(update));
+    mBorderAgent.HandleUpdateVendorMeshCoPTxtEntries(std::move(update));
 
 exit:
     aRequest.ReplyOtResult(error);

--- a/src/utils/thread_helper.cpp
+++ b/src/utils/thread_helper.cpp
@@ -329,20 +329,6 @@ exit:
     }
 }
 
-#if OTBR_ENABLE_DBUS_SERVER
-void ThreadHelper::OnUpdateMeshCopTxt(std::map<std::string, std::vector<uint8_t>> aUpdate)
-{
-    if (mUpdateMeshCopTxtHandler)
-    {
-        mUpdateMeshCopTxtHandler(std::move(aUpdate));
-    }
-    else
-    {
-        otbrLogErr("No UpdateMeshCopTxtHandler");
-    }
-}
-#endif
-
 void ThreadHelper::AddDeviceRoleHandler(DeviceRoleHandler aHandler)
 {
     mDeviceRoleHandlers.emplace_back(aHandler);

--- a/src/utils/thread_helper.hpp
+++ b/src/utils/thread_helper.hpp
@@ -235,25 +235,6 @@ public:
      */
     void StateChangedCallback(otChangedFlags aFlags);
 
-#if OTBR_ENABLE_DBUS_SERVER
-    /**
-     * This method sets a callback for calls of UpdateVendorMeshCopTxtEntries D-Bus API.
-     *
-     * @param[in] aHandler  The handler on MeshCoP TXT changes.
-     */
-    void SetUpdateMeshCopTxtHandler(UpdateMeshCopTxtHandler aHandler)
-    {
-        mUpdateMeshCopTxtHandler = std::move(aHandler);
-    }
-
-    /**
-     * This method handles MeshCoP TXT updates done by UpdateVendorMeshCopTxtEntries D-Bus API.
-     *
-     * @param[in] aUpdate  The key-value pairs to be updated in the TXT record.
-     */
-    void OnUpdateMeshCopTxt(std::map<std::string, std::vector<uint8_t>> aUpdate);
-#endif
-
     void DetachGracefully(ResultHandler aHandler);
 
 #if OTBR_ENABLE_TELEMETRY_DATA_API
@@ -366,10 +347,6 @@ private:
 
 #if OTBR_ENABLE_DHCP6_PD
     Dhcp6PdStateCallback mDhcp6PdCallback;
-#endif
-
-#if OTBR_ENABLE_DBUS_SERVER
-    UpdateMeshCopTxtHandler mUpdateMeshCopTxtHandler;
 #endif
 
 #if OTBR_ENABLE_TELEMETRY_DATA_API && (OTBR_ENABLE_NAT64 || OTBR_ENABLE_DHCP6_PD)


### PR DESCRIPTION
This PR refactors the MeshCoP TXT update method in BorderAgent.

This is a DBUS method for vendors to update their vendor MeshCoP TXT values. The current call stack is:
```
DBus Handler -> ThreadHelper MeshCoP update callback -> BorderAgent Handle MeshCoP update
```
ThreadHelper is totally unnecessary here. So the new stack is simpler:
```
DBus Handler -> BorderAgent Handle MeshCoP update
```

Another intention is to unbind the BorderAgent module from `ThreadHelper` so that it can works in NCP design.