### PR TITLE
[posix] refactor netif module

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -64,6 +64,7 @@
 #if OTBR_ENABLE_DNSSD_PLAT
 #include "host/posix/dnssd.hpp"
 #endif
+#include "host/posix/netif.hpp"
 #include "utils/infra_link_selector.hpp"
 
 namespace otbr {
@@ -261,12 +262,15 @@ private:
     void InitRcpMode(void);
     void DeinitRcpMode(void);
 
+    void CreateNcpMode(void);
     void InitNcpMode(void);
     void DeinitNcpMode(void);
 
-    std::string       mInterfaceName;
-    const char       *mBackboneInterfaceName;
-    Host::ThreadHost &mHost;
+    std::string            mInterfaceName;
+    const char            *mBackboneInterfaceName;
+    Host::ThreadHost      &mHost;
+    std::unique_ptr<Netif> mNetif;
+
 #if OTBR_ENABLE_MDNS
     Mdns::StateSubject               mMdnsStateSubject;
     std::unique_ptr<Mdns::Publisher> mPublisher;

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -74,7 +74,8 @@ private:
 
 class NcpHost : public MainloopProcessor,
                 public ThreadHost,
-                public NcpNetworkProperties
+                public NcpNetworkProperties,
+                public Netif::Dependencies
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     ,
                 public Mdns::StateObserver
@@ -132,16 +133,20 @@ public:
     void SetMdnsPublisher(Mdns::Publisher *aPublisher);
 #endif
 
+    void InitNetifCallbacks(Netif &aNetif);
+
 private:
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     void HandleMdnsState(Mdns::Publisher::State aState) override;
 #endif
 
+    otbrError Ip6Send(const uint8_t *aData, uint16_t aLength) override;
+    otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded) override;
+
     ot::Spinel::SpinelDriver &mSpinelDriver;
     otPlatformConfig          mConfig;
     NcpSpinel                 mNcpSpinel;
     TaskRunner                mTaskRunner;
-    Netif                     mNetif;
     InfraIf                   mInfraIf;
 };
 

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -89,7 +89,7 @@ public:
 /**
  * The class provides methods for controlling the Thread stack on the network co-processor (NCP).
  */
-class NcpSpinel : public Netif::Dependencies, public InfraIf::Dependencies
+class NcpSpinel : public InfraIf::Dependencies
 {
 public:
     using Ip6AddressTableCallback          = std::function<void(const std::vector<Ip6AddressInfo> &)>;
@@ -188,7 +188,7 @@ public:
     void Ip6SetReceiveCallback(const Ip6ReceiveCallback &aCallback) { mIp6ReceiveCallback = aCallback; }
 
     /**
-     * This methods sends an IP6 datagram through the NCP.
+     * This method sends an IP6 datagram through the NCP.
      *
      * @param[in] aData      A pointer to the beginning of the IP6 datagram.
      * @param[in] aLength    The length of the datagram.
@@ -196,7 +196,15 @@ public:
      * @retval OTBR_ERROR_NONE  The datagram is sent to NCP successfully.
      * @retval OTBR_ERROR_BUSY  NcpSpinel is busy with other requests.
      */
-    otbrError Ip6Send(const uint8_t *aData, uint16_t aLength) override;
+    otbrError Ip6Send(const uint8_t *aData, uint16_t aLength);
+
+    /**
+     * This method updates the multicast address subscription on NCP.
+     *
+     * @param[in] aAddress  A reference to the multicast address to update subscription.
+     * @param[in] aIsAdded  `true` to subscribe and `false` to unsubscribe.
+     */
+    otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded);
 
     /**
      * This method enableds/disables the Thread network on the NCP.
@@ -337,8 +345,6 @@ private:
                                           spinel_prop_key_t aKey,
                                           const uint8_t    *aData,
                                           uint16_t          aLength);
-
-    otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded) override;
 
     spinel_tid_t GetNextTid(void);
     void         FreeTidTableItem(spinel_tid_t aTid);

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -41,12 +41,13 @@
 
 #include <openthread/ip6.h>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
 
 namespace otbr {
 
-class Netif
+class Netif : public MainloopProcessor, private NonCopyable
 {
 public:
     class Dependencies
@@ -58,13 +59,11 @@ public:
         virtual otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded);
     };
 
-    Netif(Dependencies &aDependencies);
+    Netif(const std::string &aInterfaceName, Dependencies &aDependencies);
 
-    otbrError Init(const std::string &aInterfaceName);
+    otbrError Init(void);
     void      Deinit(void);
 
-    void      Process(const MainloopContext *aContext);
-    void      UpdateFdSet(MainloopContext *aContext);
     void      UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos);
     otbrError UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs);
     void      SetNetifState(bool aState);
@@ -87,6 +86,9 @@ private:
     otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
     void      ProcessIp6Send(void);
     void      ProcessMldEvent(void);
+
+    void Update(MainloopContext &aContext) override;
+    void Process(const MainloopContext &aContext) override;
 
     int      mTunFd;           ///< Used to exchange IPv6 packets.
     int      mIpFd;            ///< Used to manage IPv6 stack on the network interface.

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -273,6 +273,8 @@ void CheckEphemeralKey(ThreadApiDBus *aApi)
     TEST_ASSERT(enabled == true);
 }
 
+#if OTBR_ENABLE_TELEMETRY_DATA_API
+
 void CheckBorderAgentInfo(const threadnetwork::TelemetryData_BorderAgentInfo &aBorderAgentInfo)
 {
     TEST_ASSERT(aBorderAgentInfo.border_agent_counters().epskc_activations() == 0);
@@ -293,7 +295,6 @@ void CheckBorderAgentInfo(const threadnetwork::TelemetryData_BorderAgentInfo &aB
     TEST_ASSERT(aBorderAgentInfo.border_agent_counters().mgmt_pending_get_reqs() == 0);
 }
 
-#if OTBR_ENABLE_TELEMETRY_DATA_API
 void CheckTelemetryData(ThreadApiDBus *aApi)
 {
     std::vector<uint8_t>         responseTelemetryDataBytes;

--- a/tests/gtest/test_infra_if.cpp
+++ b/tests/gtest/test_infra_if.cpp
@@ -91,8 +91,8 @@ TEST(InfraIf, DepsSetInfraIfInvokedCorrectly_AfterSpecifyingInfraIf)
 
     // Utilize the Netif module to create a network interface as the fake infrastructure interface.
     otbr::Netif::Dependencies defaultNetifDep;
-    otbr::Netif               netif(defaultNetifDep);
-    EXPECT_EQ(netif.Init(fakeInfraIf), OTBR_ERROR_NONE);
+    otbr::Netif               netif(fakeInfraIf, defaultNetifDep);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
 
     const otIp6Address kTestAddr = {
         {0xfd, 0x35, 0x7a, 0x7d, 0x0f, 0x16, 0xe7, 0xe3, 0x73, 0xf3, 0x09, 0x00, 0x8e, 0xbe, 0x1b, 0x65}};
@@ -120,8 +120,8 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
 
     // Utilize the Netif module to create a network interface as the fake infrastructure interface.
     otbr::Netif::Dependencies defaultNetifDep;
-    otbr::Netif               netif(defaultNetifDep);
-    EXPECT_EQ(netif.Init(fakeInfraIf), OTBR_ERROR_NONE);
+    otbr::Netif               netif(fakeInfraIf, defaultNetifDep);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
 
     const otIp6Address kTestAddr1 = {
         {0xfd, 0x35, 0x7a, 0x7d, 0x0f, 0x16, 0xe7, 0xe3, 0x73, 0xf3, 0x09, 0x00, 0x8e, 0xbe, 0x1b, 0x65}};
@@ -199,8 +199,8 @@ TEST(InfraIf, DepsHandleIcmp6NdInvokedCorrectly_AfterInfraIfReceivesIcmp6Nd)
 
     // Utilize the Netif module to create a network interface as the fake infrastructure interface.
     otbr::Netif::Dependencies defaultNetifDep;
-    otbr::Netif               netif(defaultNetifDep);
-    EXPECT_EQ(netif.Init(fakeInfraIf), OTBR_ERROR_NONE);
+    otbr::Netif               netif(fakeInfraIf, defaultNetifDep);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
 
     const otIp6Address kLinkLocalAddr = {
         {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa8, 0xa5, 0x42, 0xb7, 0x91, 0x80, 0xc3, 0xf8}};

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -56,6 +56,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
+#include "common/mainloop_manager.hpp"
 #include "common/types.hpp"
 #include "host/posix/netif.hpp"
 #include "utils/socket_utils.hpp"
@@ -175,8 +176,8 @@ TEST(Netif, WpanInitWithFullInterfaceName)
     int          sockfd;
     struct ifreq ifr;
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -199,8 +200,8 @@ TEST(Netif, WpanInitWithFormatInterfaceName)
     int          sockfd;
     struct ifreq ifr;
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -222,8 +223,8 @@ TEST(Netif, WpanInitWithEmptyInterfaceName)
     int          sockfd;
     struct ifreq ifr;
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(""), OT_ERROR_NONE);
+    otbr::Netif netif("", sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -243,8 +244,8 @@ TEST(Netif, WpanInitWithInvalidInterfaceName)
 {
     const char *invalid_netif_name = "invalid_netif_name";
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(invalid_netif_name), OTBR_ERROR_INVALID_ARGS);
+    otbr::Netif netif(invalid_netif_name, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_INVALID_ARGS);
 }
 
 TEST(Netif, WpanMtuSize)
@@ -253,8 +254,8 @@ TEST(Netif, WpanMtuSize)
     int          sockfd;
     struct ifreq ifr;
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -276,8 +277,8 @@ TEST(Netif, WpanDeinit)
     int          sockfd;
     struct ifreq ifr;
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
@@ -295,8 +296,8 @@ TEST(Netif, WpanDeinit)
 
 TEST(Netif, WpanAddrGenMode)
 {
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init("wpan0"), OT_ERROR_NONE);
+    otbr::Netif netif("wpan0", sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     std::fstream file("/proc/sys/net/ipv6/conf/wpan0/addr_gen_mode", std::ios::in);
     if (!file.is_open())
@@ -328,8 +329,8 @@ TEST(Netif, WpanIfHasCorrectUnicastAddresses_AfterUpdatingUnicastAddresses)
     const char *kMlRlocStr = "fd0d:7fc:a1b9:f050:0:ff:fe00:b800";
     const char *kMlAlocStr = "fd0d:7fc:a1b9:f050:0:ff:fe00:fc00";
 
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     otbr::Ip6AddressInfo testArray1[] = {
         {kLl, 64, 0, 1, 0},
@@ -372,8 +373,8 @@ TEST(Netif, WpanIfHasCorrectUnicastAddresses_AfterUpdatingUnicastAddresses)
 TEST(Netif, WpanIfHasCorrectMulticastAddresses_AfterUpdatingMulticastAddresses)
 {
     const char *wpan = "wpan0";
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init(wpan), OT_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     otbr::Ip6Address kDefaultMulAddr1 = {
         {0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
@@ -438,9 +439,9 @@ TEST(Netif, WpanIfHasCorrectMulticastAddresses_AfterUpdatingMulticastAddresses)
 
 TEST(Netif, WpanIfStateChangesCorrectly_AfterSettingNetifState)
 {
-    otbr::Netif netif(sDefaultNetifDependencies);
     const char *wpan = "wpan0";
-    EXPECT_EQ(netif.Init(wpan), OTBR_ERROR_NONE);
+    otbr::Netif netif(wpan, sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
 
     int fd = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, kSocketNonBlock);
     if (fd < 0)
@@ -466,8 +467,8 @@ TEST(Netif, WpanIfStateChangesCorrectly_AfterSettingNetifState)
 
 TEST(Netif, WpanIfRecvIp6PacketCorrectly_AfterReceivingFromNetif)
 {
-    otbr::Netif netif(sDefaultNetifDependencies);
-    EXPECT_EQ(netif.Init("wpan0"), OTBR_ERROR_NONE);
+    otbr::Netif netif("wpan0", sDefaultNetifDependencies);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
 
     const otIp6Address kOmr = {
         {0xfd, 0x2a, 0xc3, 0x0c, 0x87, 0xd3, 0x00, 0x01, 0xed, 0x1c, 0x0c, 0x91, 0xcc, 0xb6, 0x57, 0x8b}};
@@ -557,8 +558,8 @@ TEST(Netif, WpanIfSendIp6PacketCorrectly_AfterReceivingOnIf)
     NetifDependencyTestIp6Send netifDependency(received, receivedPayload);
     const char                *hello = "Hello Otbr Netif!";
 
-    otbr::Netif netif(netifDependency);
-    EXPECT_EQ(netif.Init("wpan0"), OT_ERROR_NONE);
+    otbr::Netif netif("wpan0", netifDependency);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     // OMR Prefix: fd76:a5d1:fcb0:1707::/64
     const otIp6Address kOmr = {
@@ -603,7 +604,7 @@ TEST(Netif, WpanIfSendIp6PacketCorrectly_AfterReceivingOnIf)
         FD_ZERO(&context.mWriteFdSet);
         FD_ZERO(&context.mErrorFdSet);
 
-        netif.UpdateFdSet(&context);
+        otbr::MainloopManager::GetInstance().Update(context);
         int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
                           &context.mTimeout);
         if (rval < 0)
@@ -611,7 +612,7 @@ TEST(Netif, WpanIfSendIp6PacketCorrectly_AfterReceivingOnIf)
             perror("select failed");
             exit(EXIT_FAILURE);
         }
-        netif.Process(&context);
+        otbr::MainloopManager::GetInstance().Process(context);
     }
 
     EXPECT_STREQ(receivedPayload.c_str(), hello);
@@ -651,11 +652,11 @@ TEST(Netif, WpanIfUpdateMulAddrSubscription_AfterAppJoiningMulGrp)
     const char               *multicastGroup = "ff99::1";
     const char               *wpan           = "wpan0";
     int                       sockFd;
-    otbr::Netif               netif(dependency);
+    otbr::Netif               netif(wpan, dependency);
     const otIp6Address        expectedMulAddr = {0xff, 0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
-    EXPECT_EQ(netif.Init("wpan0"), OT_ERROR_NONE);
+    EXPECT_EQ(netif.Init(), OT_ERROR_NONE);
 
     const otIp6Address kLl = {
         {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x14, 0x03, 0x32, 0x4c, 0xc2, 0xf8, 0xd0}};
@@ -705,7 +706,7 @@ TEST(Netif, WpanIfUpdateMulAddrSubscription_AfterAppJoiningMulGrp)
         FD_ZERO(&context.mWriteFdSet);
         FD_ZERO(&context.mErrorFdSet);
 
-        netif.UpdateFdSet(&context);
+        otbr::MainloopManager::GetInstance().Update(context);
         int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
                           &context.mTimeout);
         if (rval < 0)
@@ -713,7 +714,7 @@ TEST(Netif, WpanIfUpdateMulAddrSubscription_AfterAppJoiningMulGrp)
             perror("select failed");
             exit(EXIT_FAILURE);
         }
-        netif.Process(&context);
+        otbr::MainloopManager::GetInstance().Process(context);
     }
 
     EXPECT_EQ(otbr::Ip6Address(subscribedMulAddr), otbr::Ip6Address(expectedMulAddr));


### PR DESCRIPTION
This PR refactors the `otbr::Netif` module to move it from `NcpHost` to the `Application`.

The intention behind this PR:
1. We will soon introduce a new module `MulticastRoutingManager` which will need to get the Thread wpan interface index. While we can set a copy to `MulticastRoutingManager`, it's better to have a SSOT. And the `Netif` module will also be able to accessed from other modules in `Application` later.
2. Currently the `Netif` module is only used for NCP. But we will use it for the RCP design as well later and replace the netif module in openthread posix.