### PR TITLE
[ncp] add meshcop service publishing in NCP mode

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -164,7 +164,7 @@ public:
      */
     BorderAgent &GetBorderAgent(void)
     {
-        return *mBorderAgent;
+        return mBorderAgent;
     }
 #endif
 
@@ -266,6 +266,10 @@ private:
     void InitNcpMode(void);
     void DeinitNcpMode(void);
 
+#if OTBR_ENABLE_BORDER_AGENT
+    void SetBorderAgentOnInitState(void);
+#endif
+
     std::string            mInterfaceName;
     const char            *mBackboneInterfaceName;
     Host::ThreadHost      &mHost;
@@ -279,7 +283,7 @@ private:
     DnssdPlatform mDnssdPlatform;
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
-    std::unique_ptr<BorderAgent> mBorderAgent;
+    BorderAgent mBorderAgent;
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     std::unique_ptr<BackboneRouter::BackboneAgent> mBackboneAgent;

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -245,7 +245,7 @@ void NcpHost::AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aC
 
 void NcpHost::SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback)
 {
-    OTBR_UNUSED_VARIABLE(aCallback);
+    mNcpSpinel.SetBorderAgentMeshCoPServiceChangedCallback(aCallback);
 }
 
 void NcpHost::AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback)

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -97,6 +97,7 @@ public:
     using NetifStateChangedCallback        = std::function<void(bool)>;
     using Ip6ReceiveCallback               = std::function<void(const uint8_t *, uint16_t)>;
     using InfraIfSendIcmp6NdCallback = std::function<void(uint32_t, const otIp6Address &, const uint8_t *, uint16_t)>;
+    using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
 
     /**
      * Constructor.
@@ -290,6 +291,14 @@ public:
     }
 #endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
 
+    /**
+     * This method sets a callback that will be invoked when there are any changes on the MeshCoP service from
+     * Thread core.
+     *
+     * @param[in] aCallback  The callback function.
+     */
+    void SetBorderAgentMeshCoPServiceChangedCallback(const BorderAgentMeshCoPServiceChangedCallback &aCallback);
+
 private:
     using FailureHandler = std::function<void(otError)>;
 
@@ -331,6 +340,10 @@ private:
     void      HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
     void      HandleValueInserted(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
     void      HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
+    otbrError HandleResponseForPropGet(spinel_tid_t      aTid,
+                                       spinel_prop_key_t aKey,
+                                       const uint8_t    *aData,
+                                       uint16_t          aLength);
     otbrError HandleResponseForPropSet(spinel_tid_t      aTid,
                                        spinel_prop_key_t aKey,
                                        const uint8_t    *aData,
@@ -351,6 +364,7 @@ private:
 
     using EncodingFunc = std::function<otError(ot::Spinel::Encoder &aEncoder)>;
     otError SendCommand(spinel_command_t aCmd, spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
+    otError GetProperty(spinel_prop_key_t aKey);
     otError SetProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError InsertProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
     otError RemoveProperty(spinel_prop_key_t aKey, const EncodingFunc &aEncodingFunc);
@@ -405,11 +419,12 @@ private:
     AsyncTaskPtr mThreadDetachGracefullyTask;
     AsyncTaskPtr mThreadErasePersistentInfoTask;
 
-    Ip6AddressTableCallback          mIp6AddressTableCallback;
-    Ip6MulticastAddressTableCallback mIp6MulticastAddressTableCallback;
-    Ip6ReceiveCallback               mIp6ReceiveCallback;
-    NetifStateChangedCallback        mNetifStateChangedCallback;
-    InfraIfSendIcmp6NdCallback       mInfraIfIcmp6NdCallback;
+    Ip6AddressTableCallback                  mIp6AddressTableCallback;
+    Ip6MulticastAddressTableCallback         mIp6MulticastAddressTableCallback;
+    Ip6ReceiveCallback                       mIp6ReceiveCallback;
+    NetifStateChangedCallback                mNetifStateChangedCallback;
+    InfraIfSendIcmp6NdCallback               mInfraIfIcmp6NdCallback;
+    BorderAgentMeshCoPServiceChangedCallback mBorderAgentMeshCoPServiceChangedCallback;
 };
 
 } // namespace Host

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -176,3 +176,10 @@ proc get_omr_addr {} {
     expect -re {(?:[0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}(?= origin:slaac)}
     return $expect_out(0,string)
 }
+
+proc check_string_contains {haystack needle} {
+    if {![regexp $needle $haystack]} {
+        puts "Error: '$needle' not found."
+        exit 1
+    }
+}

--- a/tests/scripts/expect/ncp_border_agent.exp
+++ b/tests/scripts/expect/ncp_border_agent.exp
@@ -1,0 +1,89 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2025, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+source "tests/scripts/expect/_common.exp"
+
+set ptys [create_socat 1]
+set pty1 [lindex $ptys 0]
+set pty2 [lindex $ptys 1]
+set container "otbr-ncp"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+set dataset_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x00,0x00,0x14,0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0x7d,0x61,0xeb,0x42,0xcd,0xc4,0x8d,0x6a,0x07,0x08,0xfd,0x0d,0x07,0xfc,0xa1,0xb9,0xf0,0x50,0x05,0x10,0xba,0x08,0x8f,0xc2,0xbd,0x6c,0x3b,0x38,0x97,0xf7,0xa1,0x0f,0x58,0x26,0x3f,0xf3,0x03,0x0f,0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x35,0x32,0x34,0x66,0x01,0x02,0x52,0x4f,0x04,0x10,0x9d,0xc0,0x23,0xcc,0xd4,0x47,0xb1,0x2b,0x50,0x99,0x7e,0xf6,0x80,0x20,0xf1,0x9e,0x0c,0x04,0x02,0xa0,0xf7,0xf8"
+set pskc "9dc023ccd447b12b50997ef68020f19e"
+
+proc clean_up {container} {
+    puts "Performing cleanup..."
+
+    exec sudo docker stop $container
+    exec sudo docker rm $container
+    dispose_all
+}
+
+proc check_common_txt {mdns_browse_result} {
+    check_string_contains $mdns_browse_result "sb="
+    check_string_contains $mdns_browse_result "xa="
+    check_string_contains $mdns_browse_result "tv="
+    check_string_contains $mdns_browse_result "xp="
+    check_string_contains $mdns_browse_result "nn="
+    check_string_contains $mdns_browse_result "id="
+    check_string_contains $mdns_browse_result "mn="
+    check_string_contains $mdns_browse_result "vn="
+    check_string_contains $mdns_browse_result "rv="
+}
+
+try {
+
+    start_otbr_docker $container $::env(EXP_OT_NCP_PATH) 2 $pty1 $pty2
+    spawn_node 3 otbr-docker $container
+    sleep 5
+
+    # Browse when Thread network is not started.
+    set mdns_browse_result [exec avahi-browse -aprt]
+    check_common_txt $mdns_browse_result
+
+    # Join a Thread network.
+    switch_node 3
+    send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
+    expect "dbus-send"
+    expect "app#"
+    sleep 20
+
+    # Browse after Thread network starts.
+    set mdns_browse_result [exec avahi-browse -aprt]
+    check_common_txt $mdns_browse_result
+    check_string_contains $mdns_browse_result "pt="
+    check_string_contains $mdns_browse_result "at="
+
+    clean_up $container
+
+} on error {result} {
+    puts "An error occurred: $result"
+    clean_up $container
+    exit 1
+}

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -137,6 +137,7 @@ do_build_ot_simulation()
         -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_CLI=OFF -DOT_APP_RCP=OFF \
         -DOT_BORDER_ROUTING=ON -DOT_NCP_INFRA_IF=ON -DOT_SIMULATION_INFRA_IF=OFF \
         -DOT_SRP_SERVER=ON -DOT_SRP_ADV_PROXY=ON -DOT_PLATFORM_DNSSD=ON -DOT_SIMULATION_DNSSD=OFF -DOT_NCP_DNSSD=ON \
+        -DOT_BORDER_AGENT=ON \
         -DBUILD_TESTING=OFF
     OT_CMAKE_BUILD_DIR=${ABS_TOP_OT_BUILDDIR}/cli "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation \
         -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
@@ -154,6 +155,7 @@ do_build_otbr_docker()
         "-DOTBR_TREL=ON"
         "-DOTBR_LINK_METRICS_TELEMETRY=ON"
         "-DOTBR_SRP_ADVERTISING_PROXY=ON"
+        "-DOTBR_BORDER_AGENT=ON"
     )
     sudo docker build -t "${OTBR_DOCKER_IMAGE}" \
         -f ./etc/docker/Dockerfile . \
@@ -238,6 +240,13 @@ test_teardown()
     exit ${EXIT_CODE}
 }
 
+restart_avahi_daemon()
+{
+    # Restart the avahi-daemon on the host to remove stale records from previous test runs.
+    sudo service avahi-daemon restart
+    sleep 1
+}
+
 otbr_exec_expect_script()
 {
     local log_file="tmp/log_expect"
@@ -252,6 +261,7 @@ otbr_exec_expect_script()
         sudo killall ot-ncp-mtd || true
         sudo rm -rf tmp
         mkdir tmp
+        restart_avahi_daemon
         {
             sudo -E expect -df "${script}" 2>"${log_file}"
         } || {


### PR DESCRIPTION
This PR adds meshcop service publishing in NCP mode.

A expect test is also added in the PR to verify that the meshcop service is correctly published.