### PR TITLE
[dbus] refactor dbus module to unbind it with border agent feature

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -70,8 +70,8 @@ Application::Application(Host::ThreadHost  &aHost,
 #if OTBR_ENABLE_BORDER_AGENT
     , mBorderAgent(*mPublisher)
 #endif
-#if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT
-    , mDBusAgent(MakeUnique<DBus::DBusAgent>(mHost, *mPublisher))
+#if OTBR_ENABLE_DBUS_SERVER
+    , mDBusAgent(MakeDBusDependentComponents())
 #endif
 {
     if (mHost.GetCoprocessorType() == OT_COPROCESSOR_RCP)
@@ -104,6 +104,10 @@ void Application::Init(void)
         DieNow("Unknown coprocessor type!");
         break;
     }
+
+#if OTBR_ENABLE_DBUS_SERVER
+    mDBusAgent.Init();
+#endif
 
     otbrLogInfo("Co-processor version: %s", mHost.GetCoprocessorVersion());
 }
@@ -230,8 +234,9 @@ void Application::CreateRcpMode(const std::string &aRestListenAddress, int aRest
     mVendorServer = vendor::VendorServer::newInstance(*this);
 #endif
 
-    OT_UNUSED_VARIABLE(aRestListenAddress);
-    OT_UNUSED_VARIABLE(aRestListenPort);
+    OTBR_UNUSED_VARIABLE(rcpHost);
+    OTBR_UNUSED_VARIABLE(aRestListenAddress);
+    OTBR_UNUSED_VARIABLE(aRestListenPort);
 }
 
 void Application::InitRcpMode(void)
@@ -288,9 +293,6 @@ void Application::InitRcpMode(void)
 #if OTBR_ENABLE_REST_SERVER
     mRestWebServer->Init();
 #endif
-#if OTBR_ENABLE_DBUS_SERVER
-    mDBusAgent->Init(mBorderAgent);
-#endif
 #if OTBR_ENABLE_VENDOR_SERVER
     mVendorServer->Init();
 #endif
@@ -338,9 +340,6 @@ void Application::InitNcpMode(void)
     mMdnsStateSubject.AddObserver(ncpHost);
     mPublisher->Start();
 #endif
-#if OTBR_ENABLE_DBUS_SERVER
-    mDBusAgent->Init(mBorderAgent);
-#endif
 #if OTBR_ENABLE_BORDER_AGENT
     mHost.SetBorderAgentMeshCoPServiceChangedCallback(
         [this](bool aIsActive, uint16_t aPort, const uint8_t *aTxtData, uint16_t aLength) {
@@ -373,6 +372,19 @@ void Application::SetBorderAgentOnInitState(void)
 #else
     mBorderAgent.SetEnabled(true);
 #endif
+}
+#endif
+
+#if OTBR_ENABLE_DBUS_SERVER
+DBus::DependentComponents Application::MakeDBusDependentComponents(void)
+{
+    return DBus::DependentComponents
+    {
+        mHost, *mPublisher,
+#if OTBR_ENABLE_BORDER_AGENT
+            mBorderAgent
+#endif
+    };
 }
 #endif
 

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -248,7 +248,7 @@ public:
      */
     DBus::DBusAgent &GetDBusAgent(void)
     {
-        return *mDBusAgent;
+        return mDBusAgent;
     }
 #endif
 
@@ -268,6 +268,9 @@ private:
 
 #if OTBR_ENABLE_BORDER_AGENT
     void SetBorderAgentOnInitState(void);
+#endif
+#if OTBR_ENABLE_DBUS_SERVER
+    DBus::DependentComponents MakeDBusDependentComponents(void);
 #endif
 
     std::string            mInterfaceName;
@@ -304,7 +307,7 @@ private:
     std::unique_ptr<rest::RestWebServer> mRestWebServer;
 #endif
 #if OTBR_ENABLE_DBUS_SERVER
-    std::unique_ptr<DBus::DBusAgent> mDBusAgent;
+    DBus::DBusAgent mDBusAgent;
 #endif
 #if OTBR_ENABLE_VENDOR_SERVER
     std::shared_ptr<vendor::VendorServer> mVendorServer;

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -46,14 +46,13 @@ namespace DBus {
 const struct timeval           DBusAgent::kPollTimeout = {0, 0};
 constexpr std::chrono::seconds DBusAgent::kDBusWaitAllowance;
 
-DBusAgent::DBusAgent(otbr::Host::ThreadHost &aHost, Mdns::Publisher &aPublisher)
-    : mInterfaceName(aHost.GetInterfaceName())
-    , mHost(aHost)
-    , mPublisher(aPublisher)
+DBusAgent::DBusAgent(const DependentComponents &aDeps)
+    : mInterfaceName(aDeps.mHost.GetInterfaceName())
+    , mDeps(aDeps)
 {
 }
 
-void DBusAgent::Init(otbr::BorderAgent &aBorderAgent)
+void DBusAgent::Init(void)
 {
     otbrError error = OTBR_ERROR_NONE;
 
@@ -67,16 +66,14 @@ void DBusAgent::Init(otbr::BorderAgent &aBorderAgent)
 
     VerifyOrDie(mConnection != nullptr, "Failed to get DBus connection");
 
-    switch (mHost.GetCoprocessorType())
+    switch (mDeps.mHost.GetCoprocessorType())
     {
     case OT_COPROCESSOR_RCP:
-        mThreadObject = MakeUnique<DBusThreadObjectRcp>(*mConnection, mInterfaceName,
-                                                        static_cast<Host::RcpHost &>(mHost), &mPublisher, aBorderAgent);
+        mThreadObject = MakeUnique<DBusThreadObjectRcp>(*mConnection, mInterfaceName, mDeps);
         break;
 
     case OT_COPROCESSOR_NCP:
-        mThreadObject =
-            MakeUnique<DBusThreadObjectNcp>(*mConnection, mInterfaceName, static_cast<Host::NcpHost &>(mHost));
+        mThreadObject = MakeUnique<DBusThreadObjectNcp>(*mConnection, mInterfaceName, mDeps);
         break;
 
     default:

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -59,15 +59,14 @@ public:
     /**
      * The constructor of dbus agent.
      *
-     * @param[in] aHost           A reference to the Thread host.
-     * @param[in] aPublisher      A reference to the MDNS publisher.
+     * @param[in]  aDeps   A reference to the DBus server dependent components.
      */
-    DBusAgent(otbr::Host::ThreadHost &aHost, Mdns::Publisher &aPublisher);
+    DBusAgent(const DependentComponents &aDeps);
 
     /**
      * This method initializes the dbus agent.
      */
-    void Init(otbr::BorderAgent &aBorderAgent);
+    void Init(void);
 
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
@@ -87,8 +86,7 @@ private:
     std::string                 mInterfaceName;
     std::unique_ptr<DBusObject> mThreadObject;
     UniqueDBusConnection        mConnection;
-    otbr::Host::ThreadHost     &mHost;
-    Mdns::Publisher            &mPublisher;
+    DependentComponents         mDeps;
 
     /**
      * This map is used to track DBusWatch-es.

--- a/src/dbus/server/dbus_object.hpp
+++ b/src/dbus/server/dbus_object.hpp
@@ -47,6 +47,7 @@
 
 #include <dbus/dbus.h>
 
+#include "border_agent/border_agent.hpp"
 #include "common/code_utils.hpp"
 #include "common/types.hpp"
 #include "dbus/common/constants.hpp"
@@ -54,9 +55,21 @@
 #include "dbus/common/dbus_message_helper.hpp"
 #include "dbus/common/dbus_resources.hpp"
 #include "dbus/server/dbus_request.hpp"
+#include "host/thread_host.hpp"
+#include "mdns/mdns.hpp"
 
 namespace otbr {
 namespace DBus {
+
+class DependentComponents
+{
+public:
+    Host::ThreadHost &mHost;
+    Mdns::Publisher  &mPublisher;
+#if OTBR_ENABLE_BORDER_AGENT
+    otbr::BorderAgent &mBorderAgent;
+#endif
+};
 
 /**
  * This class is a base class for implementing a d-bus object.

--- a/src/dbus/server/dbus_thread_object_ncp.cpp
+++ b/src/dbus/server/dbus_thread_object_ncp.cpp
@@ -41,11 +41,11 @@ using std::placeholders::_2;
 namespace otbr {
 namespace DBus {
 
-DBusThreadObjectNcp::DBusThreadObjectNcp(DBusConnection      &aConnection,
-                                         const std::string   &aInterfaceName,
-                                         otbr::Host::NcpHost &aHost)
+DBusThreadObjectNcp::DBusThreadObjectNcp(DBusConnection            &aConnection,
+                                         const std::string         &aInterfaceName,
+                                         const DependentComponents &aDeps)
     : DBusObject(&aConnection, OTBR_DBUS_OBJECT_PREFIX + aInterfaceName)
-    , mHost(aHost)
+    , mHost(static_cast<Host::NcpHost &>(aDeps.mHost))
 {
 }
 

--- a/src/dbus/server/dbus_thread_object_ncp.hpp
+++ b/src/dbus/server/dbus_thread_object_ncp.hpp
@@ -65,9 +65,11 @@ public:
      *
      * @param[in] aConnection     The dbus connection.
      * @param[in] aInterfaceName  The dbus interface name.
-     * @param[in] aHost           The Thread controller.
+     * @param[in] aDeps           The dependent components.
      */
-    DBusThreadObjectNcp(DBusConnection &aConnection, const std::string &aInterfaceName, otbr::Host::NcpHost &aHost);
+    DBusThreadObjectNcp(DBusConnection            &aConnection,
+                        const std::string         &aInterfaceName,
+                        const DependentComponents &aDeps);
 
     /**
      * This method initializes the dbus thread object.

--- a/src/dbus/server/dbus_thread_object_rcp.hpp
+++ b/src/dbus/server/dbus_thread_object_rcp.hpp
@@ -65,15 +65,11 @@ public:
      *
      * @param[in] aConnection     The dbus connection.
      * @param[in] aInterfaceName  The dbus interface name.
-     * @param[in] aHost           The Thread controller
-     * @param[in] aPublisher      The Mdns::Publisher
-     * @param[in] aBorderAgent    The Border Agent
+     * @param[in] aDeps           The dependent components.
      */
-    DBusThreadObjectRcp(DBusConnection      &aConnection,
-                        const std::string   &aInterfaceName,
-                        otbr::Host::RcpHost &aHost,
-                        Mdns::Publisher     *aPublisher,
-                        otbr::BorderAgent   &aBorderAgent);
+    DBusThreadObjectRcp(DBusConnection            &aConnection,
+                        const std::string         &aInterfaceName,
+                        const DependentComponents &aDeps);
 
     otbrError Init(void) override;
 
@@ -102,14 +98,18 @@ private:
     void RemoveOnMeshPrefixHandler(DBusRequest &aRequest);
     void AddExternalRouteHandler(DBusRequest &aRequest);
     void RemoveExternalRouteHandler(DBusRequest &aRequest);
+#if OTBR_ENABLE_BORDER_AGENT
     void UpdateMeshCopTxtHandler(DBusRequest &aRequest);
+#endif
     void SetThreadEnabledHandler(DBusRequest &aRequest);
     void JoinHandler(DBusRequest &aRequest);
     void GetPropertiesHandler(DBusRequest &aRequest);
     void LeaveNetworkHandler(DBusRequest &aRequest);
     void SetNat64Enabled(DBusRequest &aRequest);
+#if OTBR_ENABLE_BORDER_AGENT
     void ActivateEphemeralKeyModeHandler(DBusRequest &aRequest);
     void DeactivateEphemeralKeyModeHandler(DBusRequest &aRequest);
+#endif
 
     void IntrospectHandler(DBusRequest &aRequest);
 
@@ -121,7 +121,9 @@ private:
     otError SetRadioRegionHandler(DBusMessageIter &aIter);
     otError SetDnsUpstreamQueryState(DBusMessageIter &aIter);
     otError SetNat64Cidr(DBusMessageIter &aIter);
+#if OTBR_ENABLE_BORDER_AGENT
     otError SetEphemeralKeyEnabled(DBusMessageIter &aIter);
+#endif
 
     otError GetLinkModeHandler(DBusMessageIter &aIter);
     otError GetDeviceRoleHandler(DBusMessageIter &aIter);
@@ -174,7 +176,9 @@ private:
     otError GetNat64Mappings(DBusMessageIter &aIter);
     otError GetNat64ProtocolCounters(DBusMessageIter &aIter);
     otError GetNat64ErrorCounters(DBusMessageIter &aIter);
+#if OTBR_ENABLE_BORDER_AGENT
     otError GetEphemeralKeyEnabled(DBusMessageIter &aIter);
+#endif
     otError GetInfraLinkInfo(DBusMessageIter &aIter);
     otError GetDnsUpstreamQueryState(DBusMessageIter &aIter);
     otError GetTelemetryDataHandler(DBusMessageIter &aIter);
@@ -186,7 +190,9 @@ private:
     otbr::Host::RcpHost                                 &mHost;
     std::unordered_map<std::string, PropertyHandlerType> mGetPropertyHandlers;
     otbr::Mdns::Publisher                               *mPublisher;
-    otbr::BorderAgent                                   &mBorderAgent;
+#if OTBR_ENABLE_BORDER_AGENT
+    otbr::BorderAgent &mBorderAgent;
+#endif
 };
 
 /**


### PR DESCRIPTION
This PR refactors the DBusAgent module to unbind it with the BORDER_AGENT_ENABLE flag as well as simply the code.

Currently the `mDBusAgent` is guarded with `#if OTBR_ENABLE_DBUS_SERVER && OTBR_ENABLE_BORDER_AGENT`. `OTBR_ENABLE_BORDER_AGENT` shouldn't be a precondition to enable the DBus server. 

We have the current code because the DBusAgent relies on the BorderAgent when `OTBR_ENABLE_BORDER_AGENT` is enabled. However the code to inject the `BorderAgent` to DBusAgent is cumbersome: We have to write two versions of constructor or init for many classes. So as of now we only have one constructor which always accepts a `BorderAgent`.

This PR introduces a helper class `DBus::DependentComponents`. The constructor and init method will always accept this class. And we control the fields in this class by using flags like `OTBR_ENABLE_BORDER_AGENT`. Thus we don't need to write two versions of constructors and can enable DBusAgent without having to enable BorderAgent.