### PR TITLE
[dbus] lower the log level in `ReplyOtResult` on error to reduce false alarms 

### DIFF
--- a/src/dbus/server/dbus_request.hpp
+++ b/src/dbus/server/dbus_request.hpp
@@ -142,16 +142,8 @@ public:
     {
         UniqueDBusMessage reply{nullptr};
 
-        if (aError == OT_ERROR_NONE)
-        {
-            otbrLogInfo("Replied to %s.%s with result %s", dbus_message_get_interface(mMessage),
-                        dbus_message_get_member(mMessage), ConvertToDBusErrorName(aError));
-        }
-        else
-        {
-            otbrLogErr("Replied to %s.%s with result %s", dbus_message_get_interface(mMessage),
-                       dbus_message_get_member(mMessage), ConvertToDBusErrorName(aError));
-        }
+        otbrLogInfo("Replied to %s.%s with result %s", dbus_message_get_interface(mMessage),
+                    dbus_message_get_member(mMessage), ConvertToDBusErrorName(aError));
 
         if (aError == OT_ERROR_NONE)
         {


### PR DESCRIPTION
The current behavior of `ReplyOtResult` is that it will print an `ERROR` logging when the error is not `OT_ERROR_NONE`. This may not be appropriate because the error may not indicate a fault in the system. For example, it shouldn't be concerning if `GetActiveDatasetTlvs` returns `NotFound` while the TBR hasn't got any credentials.

This PR lowers the log level to INFO to reduce false alarms. 