### PR TITLE
[ncp] add meshcop commissioning in NCP mode

### DIFF
--- a/.github/workflows/ncp_mode.yml
+++ b/.github/workflows/ncp_mode.yml
@@ -76,6 +76,6 @@ jobs:
             --build-arg OTBR_OPTIONS="${OTBR_OPTIONS}"
     - name: Run
       run: |
-        top_builddir="./build/temp" tests/scripts/ncp_mode build_ot_sim expect
+        top_builddir="./build/temp" tests/scripts/ncp_mode build_ot_sim build_ot_commissioner expect
     - name: Codecov
       uses: codecov/codecov-action@v5

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -287,6 +287,7 @@ private:
 #endif
 #if OTBR_ENABLE_BORDER_AGENT
     BorderAgent mBorderAgent;
+    UdpProxy    mBorderAgentUdpProxy;
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     std::unique_ptr<BackboneRouter::BackboneAgent> mBackboneAgent;

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -281,6 +281,20 @@ void NcpHost::HandleMdnsState(Mdns::Publisher::State aState)
 }
 #endif
 
+otbrError NcpHost::UdpForward(const uint8_t      *aUdpPayload,
+                              uint16_t            aLength,
+                              const otIp6Address &aRemoteAddr,
+                              uint16_t            aRemotePort,
+                              const UdpProxy     &aUdpProxy)
+{
+    return mNcpSpinel.UdpForward(aUdpPayload, aLength, aRemoteAddr, aRemotePort, aUdpProxy.GetThreadPort());
+}
+
+void NcpHost::SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback)
+{
+    mNcpSpinel.SetUdpForwardSendCallback(aCallback);
+}
+
 void NcpHost::InitNetifCallbacks(Netif &aNetif)
 {
     mNcpSpinel.Ip6SetAddressCallback(

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -112,6 +112,7 @@ public:
     void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
     void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) override;
     void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) override;
+    void SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {
@@ -139,6 +140,11 @@ private:
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     void HandleMdnsState(Mdns::Publisher::State aState) override;
 #endif
+    otbrError UdpForward(const uint8_t      *aUdpPayload,
+                         uint16_t            aLength,
+                         const otIp6Address &aRemoteAddr,
+                         uint16_t            aRemotePort,
+                         const UdpProxy     &aUdpProxy) override;
 
     otbrError Ip6Send(const uint8_t *aData, uint16_t aLength) override;
     otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded) override;

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -84,6 +84,7 @@ void NcpSpinel::Deinit(void)
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     mPublisher = nullptr;
 #endif
+    mUdpForwardSendCallback = nullptr;
 }
 
 otbrError NcpSpinel::SpinelDataUnpack(const uint8_t *aDataIn, spinel_size_t aDataLen, const char *aPackFormat, ...)
@@ -520,6 +521,21 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
         SuccessOrExit(decoder.ReadUint16(port), error = OTBR_ERROR_PARSE);
         SuccessOrExit(decoder.ReadData(data, dataLen), error = OTBR_ERROR_PARSE);
         SafeInvoke(mBorderAgentMeshCoPServiceChangedCallback, isActive, port, data, dataLen);
+        break;
+    }
+
+    case SPINEL_PROP_THREAD_UDP_FORWARD_STREAM:
+    {
+        const uint8_t      *udpPayload;
+        uint16_t            length;
+        const otIp6Address *peerAddress;
+        uint16_t            peerPort;
+        uint16_t            localPort;
+
+        SuccessOrExit(ParseUdpForwardStream(aBuffer, aLength, udpPayload, length, peerAddress, peerPort, localPort),
+                      error = OTBR_ERROR_PARSE);
+        SafeInvoke(mUdpForwardSendCallback, udpPayload, length, *peerAddress, peerPort);
+
         break;
     }
 
@@ -1122,6 +1138,28 @@ exit:
     return error;
 }
 
+otError NcpSpinel::ParseUdpForwardStream(const uint8_t       *aBuf,
+                                         uint16_t             aLen,
+                                         const uint8_t      *&aUdpPayload,
+                                         uint16_t            &aUdpPayloadLen,
+                                         const otIp6Address *&aPeerAddr,
+                                         uint16_t            &aPeerPort,
+                                         uint16_t            &aLocalPort)
+{
+    otError             error = OT_ERROR_NONE;
+    ot::Spinel::Decoder decoder;
+
+    VerifyOrExit(aBuf != nullptr, error = OT_ERROR_INVALID_ARGS);
+    decoder.Init(aBuf, aLen);
+    SuccessOrExit(error = decoder.ReadDataWithLen(aUdpPayload, aUdpPayloadLen));
+    SuccessOrExit(error = decoder.ReadUint16(aPeerPort));
+    SuccessOrExit(error = decoder.ReadIp6Address(aPeerAddr));
+    SuccessOrExit(error = decoder.ReadUint16(aLocalPort));
+
+exit:
+    return error;
+}
+
 otError NcpSpinel::SendDnssdResult(otPlatDnssdRequestId        aRequestId,
                                    const std::vector<uint8_t> &aCallbackData,
                                    otError                     aError)
@@ -1190,6 +1228,36 @@ exit:
     if (error != OTBR_ERROR_NONE)
     {
         otbrLogWarning("Failed to passthrough ICMP6 ND to NCP, %s", otbrErrorString(error));
+    }
+    return error;
+}
+
+otbrError NcpSpinel::UdpForward(const uint8_t      *aUdpPayload,
+                                uint16_t            aLength,
+                                const otIp6Address &aRemoteAddr,
+                                uint16_t            aRemotePort,
+                                uint16_t            aLocalPort)
+{
+    otbrError    error        = OTBR_ERROR_NONE;
+    EncodingFunc encodingFunc = [aUdpPayload, aLength, &aRemoteAddr, aRemotePort,
+                                 aLocalPort](ot::Spinel::Encoder &aEncoder) {
+        otError error = OT_ERROR_NONE;
+
+        SuccessOrExit(error = aEncoder.WriteDataWithLen(aUdpPayload, aLength));
+        SuccessOrExit(error = aEncoder.WriteUint16(aRemotePort));
+        SuccessOrExit(error = aEncoder.WriteIp6Address(aRemoteAddr));
+        SuccessOrExit(error = aEncoder.WriteUint16(aLocalPort));
+
+    exit:
+        return error;
+    };
+
+    SuccessOrExit(SetProperty(SPINEL_PROP_THREAD_UDP_FORWARD_STREAM, encodingFunc), error = OTBR_ERROR_OPENTHREAD);
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to do UDP forwarding to NCP, %s", otbrErrorString(error));
     }
     return error;
 }

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -98,6 +98,7 @@ public:
     using Ip6ReceiveCallback               = std::function<void(const uint8_t *, uint16_t)>;
     using InfraIfSendIcmp6NdCallback = std::function<void(uint32_t, const otIp6Address &, const uint8_t *, uint16_t)>;
     using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
+    using UdpForwardSendCallback = std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t)>;
 
     /**
      * Constructor.
@@ -299,6 +300,31 @@ public:
      */
     void SetBorderAgentMeshCoPServiceChangedCallback(const BorderAgentMeshCoPServiceChangedCallback &aCallback);
 
+    /**
+     * This method forwards a UDP packet to the NCP.
+     *
+     * @param[in] aUdpPayload    The UDP payload.
+     * @param[in] aLength        The length of the UDP payload.
+     * @param[in] aRemoteAddr    The IPv6 address of the remote side.
+     * @param[in] aRemotePort    The UDP port of the remote side.
+     * @param[in] aLocalPort     The UDP port of the local side (in NCP).
+     */
+    otbrError UdpForward(const uint8_t      *aUdpPayload,
+                         uint16_t            aLength,
+                         const otIp6Address &aRemoteAddr,
+                         uint16_t            aRemotePort,
+                         uint16_t            aLocalPort);
+
+    /**
+     * This method sets a callback to send UDP packet received from the NCP side to the remote side.
+     *
+     * @param[in] aCallback    The callback to send the UDP packet to the remote side.
+     */
+    void SetUdpForwardSendCallback(UdpForwardSendCallback aCallback)
+    {
+        mUdpForwardSendCallback = aCallback;
+    }
+
 private:
     using FailureHandler = std::function<void(otError)>;
 
@@ -381,6 +407,13 @@ private:
                                 const otIp6Address *&aAddr,
                                 const uint8_t      *&aData,
                                 uint16_t            &aDataLen);
+    otError ParseUdpForwardStream(const uint8_t       *aBuf,
+                                  uint16_t             aLen,
+                                  const uint8_t      *&aUdpPayload,
+                                  uint16_t            &aUdpPayloadLen,
+                                  const otIp6Address *&aPeerAddr,
+                                  uint16_t            &aPeerPort,
+                                  uint16_t            &aLocalPort);
     otError SendDnssdResult(otPlatDnssdRequestId aRequestId, const std::vector<uint8_t> &aCallbackData, otError aError);
 
     otbrError SetInfraIf(uint32_t                       aInfraIfIndex,
@@ -425,6 +458,7 @@ private:
     NetifStateChangedCallback                mNetifStateChangedCallback;
     InfraIfSendIcmp6NdCallback               mInfraIfIcmp6NdCallback;
     BorderAgentMeshCoPServiceChangedCallback mBorderAgentMeshCoPServiceChangedCallback;
+    UdpForwardSendCallback                   mUdpForwardSendCallback;
 };
 
 } // namespace Host

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -841,9 +841,29 @@ void RcpHost::HandleEpskcStateChanged(void)
     }
 }
 
+otbrError RcpHost::UdpForward(const uint8_t      *aUdpPayload,
+                              uint16_t            aLength,
+                              const otIp6Address &aRemoteAddr,
+                              uint16_t            aRemotePort,
+                              const UdpProxy     &aUdpProxy)
+{
+    OTBR_UNUSED_VARIABLE(aUdpPayload);
+    OTBR_UNUSED_VARIABLE(aLength);
+    OTBR_UNUSED_VARIABLE(aRemoteAddr);
+    OTBR_UNUSED_VARIABLE(aRemotePort);
+    OTBR_UNUSED_VARIABLE(aUdpProxy);
+
+    return OTBR_ERROR_NOT_IMPLEMENTED;
+}
+
 void RcpHost::AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback)
 {
     mEphemeralKeyStateChangedCallbacks.push_back(aCallback);
+}
+
+void RcpHost::SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback)
+{
+    OTBR_UNUSED_VARIABLE(aCallback);
 }
 
 /*

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -213,6 +213,7 @@ public:
     void AddThreadEnabledStateChangedCallback(ThreadEnabledStateCallback aCallback) override;
     void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) override;
     void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) override;
+    void SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback) override;
 
     CoprocessorType GetCoprocessorType(void) override
     {
@@ -260,6 +261,12 @@ private:
     void        HandleMeshCoPServiceChanged(void);
     static void HandleEpskcStateChanged(void *aContext);
     void        HandleEpskcStateChanged(void);
+
+    otbrError UdpForward(const uint8_t      *aUdpPayload,
+                         uint16_t            aLength,
+                         const otIp6Address &aRemoteAddr,
+                         uint16_t            aRemotePort,
+                         const UdpProxy     &aUdpProxy) override;
 
     bool IsAutoAttachEnabled(void);
     void DisableAutoAttach(void);

--- a/src/host/thread_host.hpp
+++ b/src/host/thread_host.hpp
@@ -45,6 +45,7 @@
 #include "lib/spinel/coprocessor_type.h"
 
 #include "common/logging.hpp"
+#include "posix/udp_proxy.hpp"
 
 namespace otbr {
 namespace Host {
@@ -113,7 +114,7 @@ enum ThreadEnabledState
  *
  * The APIs are unified for both NCP and RCP cases.
  */
-class ThreadHost : virtual public NetworkProperties
+class ThreadHost : virtual public NetworkProperties, public UdpProxy::Dependencies
 {
 public:
     using AsyncResultReceiver = std::function<void(otError, const std::string &)>;
@@ -124,6 +125,7 @@ public:
     using ThreadEnabledStateCallback               = std::function<void(ThreadEnabledState)>;
     using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
     using EphemeralKeyStateChangedCallback         = std::function<void(otBorderAgentEphemeralKeyState, uint16_t)>;
+    using UdpForwardToHostCallback = std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t)>;
 
     struct ChannelMaxPower
     {
@@ -266,6 +268,13 @@ public:
      * @param[in] aCallback  The callback function.
      */
     virtual void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) = 0;
+
+    /**
+     * This methods a callback for the Thread stack to forward UDP packet to the host.
+     *
+     * @param[in] aCallback  The callback function.
+     */
+    virtual void SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback) = 0;
 
     /**
      * Returns the co-processor type.

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(otbr-gtest-host-api
     mbedtls
     otbr-common
     otbr-utils
+    otbr-posix
     GTest::gmock_main
 )
 gtest_discover_tests(otbr-gtest-host-api)

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -84,6 +84,10 @@ proc spawn_node {id type sim_app} {
                 timeout { fail "Timed out" }
             }
         }
+        commissioner {
+            spawn $sim_app
+            expect ">"
+        }
         otbr-docker {
             spawn docker exec -it $sim_app bash
             expect "app#"

--- a/tests/scripts/expect/ncp_border_agent.exp
+++ b/tests/scripts/expect/ncp_border_agent.exp
@@ -36,6 +36,7 @@ set container "otbr-ncp"
 set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
 set dataset_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x00,0x00,0x14,0x35,0x06,0x00,0x04,0x00,0x1f,0xff,0xe0,0x02,0x08,0x7d,0x61,0xeb,0x42,0xcd,0xc4,0x8d,0x6a,0x07,0x08,0xfd,0x0d,0x07,0xfc,0xa1,0xb9,0xf0,0x50,0x05,0x10,0xba,0x08,0x8f,0xc2,0xbd,0x6c,0x3b,0x38,0x97,0xf7,0xa1,0x0f,0x58,0x26,0x3f,0xf3,0x03,0x0f,0x4f,0x70,0x65,0x6e,0x54,0x68,0x72,0x65,0x61,0x64,0x2d,0x35,0x32,0x34,0x66,0x01,0x02,0x52,0x4f,0x04,0x10,0x9d,0xc0,0x23,0xcc,0xd4,0x47,0xb1,0x2b,0x50,0x99,0x7e,0xf6,0x80,0x20,0xf1,0x9e,0x0c,0x04,0x02,0xa0,0xf7,0xf8"
 set pskc "9dc023ccd447b12b50997ef68020f19e"
+set joiner_pwd "J01NU5"
 
 proc clean_up {container} {
     puts "Performing cleanup..."
@@ -79,6 +80,39 @@ try {
     check_common_txt $mdns_browse_result
     check_string_contains $mdns_browse_result "pt="
     check_string_contains $mdns_browse_result "at="
+
+    # Get the Border Agent Service IP address and port from mdns record
+    set regex {([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+);([0-9]+);}
+    puts "$mdns_browse_result"
+    if {[regexp $regex $mdns_browse_result match ip_address port]} {
+        puts "IP Address: $ip_address"
+        puts "Port: $port"
+    } else {
+        puts "No IP address and port is found in the mDNS entry!"
+        exit 1
+    }
+
+    # Start commissioner
+    spawn_node 4 commissioner $::env(EXP_OT_COMMISSIONER_PATH)
+    send "config set pskc ${pskc}\n"
+    expect "done"
+    send "active\n"
+    expect "false"
+    expect "done"
+    send "start $ip_address $port\n"
+    expect "done"
+    send "active\n"
+    expect "true"
+    send "joiner enableall meshcop $joiner_pwd\n"
+    expect "done"
+
+    # Join a cli node
+    spawn_node 5 cli $::env(EXP_OT_CLI_PATH)
+    send "ifconfig up\r\n"
+    expect_line "Done"
+    send "joiner start $joiner_pwd\r\n"
+    expect_line "Done"    
+    expect_line "Join success"
 
     clean_up $container
 

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -118,6 +118,10 @@ readonly OTBR_DBUS_CONF
 OTBR_AGENT_PATH="${ABS_TOP_BUILDDIR}/src/agent/${OTBR_AGENT}"
 readonly OTBR_AGENT_PATH
 
+# External commissioner
+OT_COMMISSIONER_PATH=${ABS_TOP_OT_BUILDDIR}/ot-commissioner/build/src/app/cli/commissioner-cli
+readonly OT_COMMISSIONER_PATH
+
 # The node ids
 LEADER_NODE_ID=1
 readonly LEADER_NODE_ID
@@ -143,6 +147,23 @@ do_build_ot_simulation()
         -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
         -DOT_BORDER_ROUTING=OFF \
         -DBUILD_TESTING=OFF
+}
+
+do_build_ot_commissioner()
+{
+    if [[ -x ${OT_COMMISSIONER_PATH} ]]; then
+        return 0
+    fi
+
+    (mkdir -p "${ABS_TOP_OT_BUILDDIR}/ot-commissioner" \
+        && cd "${ABS_TOP_OT_BUILDDIR}/ot-commissioner" \
+        && (git --git-dir=.git rev-parse --is-inside-work-tree || git --git-dir=.git init .) \
+        && git fetch --depth 1 https://github.com/openthread/ot-commissioner.git main \
+        && git checkout FETCH_HEAD \
+        && ./script/bootstrap.sh \
+        && mkdir build && cd build \
+        && cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release .. \
+        && ninja)
 }
 
 do_build_otbr_docker()
@@ -316,6 +337,7 @@ main()
     export EXP_TUN_NAME="${TUN_NAME}"
     export EXP_LEADER_NODE_ID="${LEADER_NODE_ID}"
     export EXP_OTBR_DOCKER_IMAGE="${OTBR_DOCKER_IMAGE}"
+    export EXP_OT_COMMISSIONER_PATH="${OT_COMMISSIONER_PATH}"
 
     while [[ $# != 0 ]]; do
         case "$1" in
@@ -324,6 +346,9 @@ main()
                 ;;
             build_otbr_docker)
                 do_build_otbr_docker
+                ;;
+            build_ot_commissioner)
+                do_build_ot_commissioner
                 ;;
             expect)
                 shift


### PR DESCRIPTION
This PR implements meshcop commissioning in NCP mode.

This PR also introduces ot-commissioner installation in the `ncp_mode` script and extends the expect test of ncp_border_agent to verify the commissioning function in NCP mode.

This PR adds `SetUdpForwardToHostCallback`to `ThreadHost` and let `ThreadHost` implements `UdpProxy::Dependencies`. As of now `RcpHost` has an empty implementation. In later PRs we will implement it for `RcpHost` and repalce the platform UDP.