### PR TITLE
[posix] refactor the infraif module

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -327,7 +327,8 @@ void Application::CreateNcpMode(void)
 {
     otbr::Host::NcpHost &ncpHost = static_cast<otbr::Host::NcpHost &>(mHost);
 
-    mNetif = MakeUnique<Netif>(mInterfaceName, ncpHost);
+    mNetif   = MakeUnique<Netif>(mInterfaceName, ncpHost);
+    mInfraIf = MakeUnique<InfraIf>(ncpHost);
 }
 
 void Application::InitNcpMode(void)
@@ -336,6 +337,14 @@ void Application::InitNcpMode(void)
 
     SuccessOrDie(mNetif->Init(), "Failed to initialize the Netif!");
     ncpHost.InitNetifCallbacks(*mNetif);
+
+    mInfraIf->Init();
+    if (mBackboneInterfaceName != nullptr && strlen(mBackboneInterfaceName) > 0)
+    {
+        mInfraIf->SetInfraIf(mBackboneInterfaceName);
+    }
+    ncpHost.InitInfraIfCallbacks(*mInfraIf);
+
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     ncpHost.SetMdnsPublisher(mPublisher.get());
     mMdnsStateSubject.AddObserver(ncpHost);
@@ -374,6 +383,7 @@ void Application::DeinitNcpMode(void)
     mPublisher->Stop();
 #endif
     mNetif->Deinit();
+    mInfraIf->Deinit();
 }
 
 #if OTBR_ENABLE_BORDER_AGENT

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -273,10 +273,11 @@ private:
     DBus::DependentComponents MakeDBusDependentComponents(void);
 #endif
 
-    std::string            mInterfaceName;
-    const char            *mBackboneInterfaceName;
-    Host::ThreadHost      &mHost;
-    std::unique_ptr<Netif> mNetif;
+    std::string              mInterfaceName;
+    const char              *mBackboneInterfaceName;
+    Host::ThreadHost        &mHost;
+    std::unique_ptr<Netif>   mNetif;
+    std::unique_ptr<InfraIf> mInfraIf;
 
 #if OTBR_ENABLE_MDNS
     Mdns::StateSubject               mMdnsStateSubject;

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -40,6 +40,7 @@
 #include "common/mainloop.hpp"
 #include "host/ncp_spinel.hpp"
 #include "host/thread_host.hpp"
+#include "posix/infra_if.hpp"
 #include "posix/netif.hpp"
 
 namespace otbr {
@@ -75,7 +76,8 @@ private:
 class NcpHost : public MainloopProcessor,
                 public ThreadHost,
                 public NcpNetworkProperties,
-                public Netif::Dependencies
+                public Netif::Dependencies,
+                public InfraIf::Dependencies
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     ,
                 public Mdns::StateObserver
@@ -135,6 +137,7 @@ public:
 #endif
 
     void InitNetifCallbacks(Netif &aNetif);
+    void InitInfraIfCallbacks(InfraIf &aInfraIf);
 
 private:
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
@@ -148,12 +151,18 @@ private:
 
     otbrError Ip6Send(const uint8_t *aData, uint16_t aLength) override;
     otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded) override;
+    otbrError SetInfraIf(uint32_t                       aInfraIfIndex,
+                         bool                           aIsRunning,
+                         const std::vector<Ip6Address> &aIp6Addresses) override;
+    otbrError HandleIcmp6Nd(uint32_t          aInfraIfIndex,
+                            const Ip6Address &aIp6Address,
+                            const uint8_t    *aData,
+                            uint16_t          aDataLen) override;
 
     ot::Spinel::SpinelDriver &mSpinelDriver;
     otPlatformConfig          mConfig;
     NcpSpinel                 mNcpSpinel;
     TaskRunner                mTaskRunner;
-    InfraIf                   mInfraIf;
 };
 
 } // namespace Host

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -89,7 +89,7 @@ public:
 /**
  * The class provides methods for controlling the Thread stack on the network co-processor (NCP).
  */
-class NcpSpinel : public InfraIf::Dependencies
+class NcpSpinel
 {
 public:
     using Ip6AddressTableCallback          = std::function<void(const std::vector<Ip6AddressInfo> &)>;
@@ -207,6 +207,34 @@ public:
      * @param[in] aIsAdded  `true` to subscribe and `false` to unsubscribe.
      */
     otbrError Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded);
+
+    /**
+     * This method sets the infrastructure link interface information on NCP.
+     *
+     * @param[in] aInfraIfIndex  The index of the infrastructure link interface.
+     * @param[in] aIsRunning     Whether the infrastructure link is running.
+     * @param[in] aIp6Addresses  The IPv6 addresses on of the infrastructure link interface.
+     *
+     * @retval OTBR_ERROR_NONE  The infrastructure link interface is set successfully.
+     * @retval OTBR_ERROR_OPENTHREAD  Failed to encode the spinel message.
+     */
+    otbrError SetInfraIf(uint32_t aInfraIfIndex, bool aIsRunning, const std::vector<Ip6Address> &aIp6Addresses);
+
+    /**
+     * This method passes the recevied ICMPv6 ND message to the NCP.
+     *
+     * @param[in] aInfraIfIndex  The index of the infrastructure link interface.
+     * @param[in] aIp6Address    The source IPv6 address of the received ICMPv6 message.
+     * @param[in] aData          The data payload of the received ICMPv6 message.
+     * @param[in] aDatalen       The length of the data payload.
+     *
+     * @retval OTBR_ERROR_NONE  The infrastructure link interface is set successfully.
+     * @retval OTBR_ERROR_OPENTHREAD  Failed to encode the spinel message.
+     */
+    otbrError HandleIcmp6Nd(uint32_t          aInfraIfIndex,
+                            const Ip6Address &aIp6Address,
+                            const uint8_t    *aData,
+                            uint16_t          aDataLen);
 
     /**
      * This method enableds/disables the Thread network on the NCP.
@@ -415,14 +443,6 @@ private:
                                   uint16_t            &aPeerPort,
                                   uint16_t            &aLocalPort);
     otError SendDnssdResult(otPlatDnssdRequestId aRequestId, const std::vector<uint8_t> &aCallbackData, otError aError);
-
-    otbrError SetInfraIf(uint32_t                       aInfraIfIndex,
-                         bool                           aIsRunning,
-                         const std::vector<Ip6Address> &aIp6Addresses) override;
-    otbrError HandleIcmp6Nd(uint32_t          aInfraIfIndex,
-                            const Ip6Address &aIp6Address,
-                            const uint8_t    *aData,
-                            uint16_t          aDataLen) override;
 
     ot::Spinel::SpinelDriver *mSpinelDriver;
     uint16_t                  mCmdTidsInUse; ///< Used transaction ids.

--- a/src/host/posix/infra_if.cpp
+++ b/src/host/posix/infra_if.cpp
@@ -143,7 +143,7 @@ exit:
     return;
 }
 
-void InfraIf::UpdateFdSet(MainloopContext &aContext)
+void InfraIf::Update(MainloopContext &aContext)
 {
     VerifyOrExit(mInfraIfIcmp6Socket != -1);
 #ifdef __linux__

--- a/src/host/posix/infra_if.hpp
+++ b/src/host/posix/infra_if.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/ip6.h>
 
+#include "common/code_utils.hpp"
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
 
@@ -51,7 +52,7 @@ namespace otbr {
  * The infrastructure network interface MUST be explicitly set by `SetInfraIf` before the InfraIf module can work.
  *
  */
-class InfraIf
+class InfraIf : public MainloopProcessor, private NonCopyable
 {
 public:
     class Dependencies
@@ -72,8 +73,6 @@ public:
 
     void      Init(void);
     void      Deinit(void);
-    void      Process(const MainloopContext &aContext);
-    void      UpdateFdSet(MainloopContext &aContext);
     otbrError SetInfraIf(const char *aIfName);
     otbrError SendIcmp6Nd(uint32_t            aInfraIfIndex,
                           const otIp6Address &aDestAddress,
@@ -90,6 +89,9 @@ private:
 #ifdef __linux__
     void ReceiveNetlinkMessage(void);
 #endif
+
+    void Process(const MainloopContext &aContext) override;
+    void Update(MainloopContext &aContext) override;
 
     Dependencies &mDeps;
     char          mInfraIfName[IFNAMSIZ];

--- a/tests/gtest/test_infra_if.cpp
+++ b/tests/gtest/test_infra_if.cpp
@@ -29,6 +29,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "common/mainloop_manager.hpp"
 #include "host/posix/infra_if.hpp"
 #include "host/posix/netif.hpp"
 
@@ -152,7 +153,7 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
         FD_ZERO(&context.mWriteFdSet);
         FD_ZERO(&context.mErrorFdSet);
 
-        infraIf.UpdateFdSet(context);
+        otbr::MainloopManager::GetInstance().Update(context);
         int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
                           &context.mTimeout);
         if (rval < 0)
@@ -160,7 +161,7 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
             perror("select failed");
             exit(EXIT_FAILURE);
         }
-        infraIf.Process(context);
+        otbr::MainloopManager::GetInstance().Process(context);
     }
     EXPECT_EQ(testInfraIfDep.mIsRunning, true);
 
@@ -175,7 +176,7 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
         FD_ZERO(&context.mWriteFdSet);
         FD_ZERO(&context.mErrorFdSet);
 
-        infraIf.UpdateFdSet(context);
+        otbr::MainloopManager::GetInstance().Update(context);
         int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
                           &context.mTimeout);
         if (rval < 0)
@@ -183,7 +184,7 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
             perror("select failed");
             exit(EXIT_FAILURE);
         }
-        infraIf.Process(context);
+        otbr::MainloopManager::GetInstance().Process(context);
     }
     EXPECT_EQ(testInfraIfDep.mIp6Addresses.size(), 0);
     EXPECT_EQ(testInfraIfDep.mIsRunning, false);
@@ -238,7 +239,7 @@ TEST(InfraIf, DepsHandleIcmp6NdInvokedCorrectly_AfterInfraIfReceivesIcmp6Nd)
         FD_ZERO(&context.mWriteFdSet);
         FD_ZERO(&context.mErrorFdSet);
 
-        infraIf.UpdateFdSet(context);
+        otbr::MainloopManager::GetInstance().Update(context);
         int rval = select(context.mMaxFd + 1, &context.mReadFdSet, &context.mWriteFdSet, &context.mErrorFdSet,
                           &context.mTimeout);
         if (rval < 0)
@@ -246,7 +247,7 @@ TEST(InfraIf, DepsHandleIcmp6NdInvokedCorrectly_AfterInfraIfReceivesIcmp6Nd)
             perror("select failed");
             exit(EXIT_FAILURE);
         }
-        infraIf.Process(context);
+        otbr::MainloopManager::GetInstance().Process(context);
     }
     EXPECT_EQ(testInfraIfDep.mIcmp6NdSrcAddress, otbr::Ip6Address(kPeerLinkLocalAddr));
     EXPECT_EQ(testInfraIfDep.mIcmp6NdDataLen, kTestMsgBodySize);


### PR DESCRIPTION
This PR refactors the otbr::InfraIf module to move it from NcpHost to the Application.

The intention behind the PR is same as https://github.com/openthread/ot-br-posix/pull/2768