### PR TITLE
[infra-if] use `std::string` for infra network interface names

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -58,7 +58,7 @@ Application::Application(Host::ThreadHost  &aHost,
                          const std::string &aRestListenAddress,
                          int                aRestListenPort)
     : mInterfaceName(aInterfaceName)
-    , mBackboneInterfaceName(aBackboneInterfaceName.c_str())
+    , mBackboneInterfaceName(aBackboneInterfaceName)
     , mHost(aHost)
 #if OTBR_ENABLE_MDNS
     , mPublisher(
@@ -339,7 +339,7 @@ void Application::InitNcpMode(void)
     ncpHost.InitNetifCallbacks(*mNetif);
 
     mInfraIf->Init();
-    if (mBackboneInterfaceName != nullptr && strlen(mBackboneInterfaceName) > 0)
+    if (!mBackboneInterfaceName.empty())
     {
         mInfraIf->SetInfraIf(mBackboneInterfaceName);
     }

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -273,8 +273,8 @@ private:
     DBus::DependentComponents MakeDBusDependentComponents(void);
 #endif
 
-    std::string              mInterfaceName;
-    const char              *mBackboneInterfaceName;
+    const std::string        mInterfaceName;
+    const std::string        mBackboneInterfaceName;
     Host::ThreadHost        &mHost;
     std::unique_ptr<Netif>   mNetif;
     std::unique_ptr<InfraIf> mInfraIf;

--- a/src/host/posix/infra_if.cpp
+++ b/src/host/posix/infra_if.cpp
@@ -161,23 +161,23 @@ exit:
     return;
 }
 
-otbrError InfraIf::SetInfraIf(const char *aIfName)
+otbrError InfraIf::SetInfraIf(std::string aInfraIfName)
 {
     otbrError               error = OTBR_ERROR_NONE;
     std::vector<Ip6Address> addresses;
 
-    VerifyOrExit(aIfName != nullptr && strlen(aIfName) > 0, error = OTBR_ERROR_INVALID_ARGS);
-    VerifyOrExit(strnlen(aIfName, IFNAMSIZ) < IFNAMSIZ, error = OTBR_ERROR_INVALID_ARGS);
-    strcpy(mInfraIfName, aIfName);
+    VerifyOrExit(!aInfraIfName.empty(), error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aInfraIfName.size() < IFNAMSIZ, error = OTBR_ERROR_INVALID_ARGS);
+    mInfraIfName = std::move(aInfraIfName);
 
-    mInfraIfIndex = if_nametoindex(aIfName);
+    mInfraIfIndex = if_nametoindex(mInfraIfName.c_str());
     VerifyOrExit(mInfraIfIndex != 0, error = OTBR_ERROR_INVALID_STATE);
 
     if (mInfraIfIcmp6Socket != -1)
     {
         close(mInfraIfIcmp6Socket);
     }
-    mInfraIfIcmp6Socket = CreateIcmp6Socket(aIfName);
+    mInfraIfIcmp6Socket = CreateIcmp6Socket(mInfraIfName.c_str());
     VerifyOrDie(mInfraIfIcmp6Socket != -1, "Failed to create Icmp6 socket!");
 
     addresses = GetAddresses();
@@ -331,11 +331,11 @@ short InfraIf::GetFlags(void) const
     VerifyOrDie(sock != -1, otbrErrorString(OTBR_ERROR_ERRNO));
 
     memset(&ifReq, 0, sizeof(ifReq));
-    strcpy(ifReq.ifr_name, mInfraIfName);
+    strcpy(ifReq.ifr_name, mInfraIfName.c_str());
 
     if (ioctl(sock, SIOCGIFFLAGS, &ifReq) == -1)
     {
-        otbrLogCrit("The infra link %s may be lost. Exiting.", mInfraIfName);
+        otbrLogCrit("The infra link %s may be lost. Exiting.", mInfraIfName.c_str());
         DieNow(otbrErrorString(OTBR_ERROR_ERRNO));
     }
 
@@ -359,8 +359,7 @@ std::vector<Ip6Address> InfraIf::GetAddresses(void)
     {
         struct sockaddr_in6 *ip6Addr;
 
-        if (strncmp(addr->ifa_name, mInfraIfName, sizeof(mInfraIfName)) != 0 || addr->ifa_addr == nullptr ||
-            addr->ifa_addr->sa_family != AF_INET6)
+        if (mInfraIfName != addr->ifa_name || addr->ifa_addr == nullptr || addr->ifa_addr->sa_family != AF_INET6)
         {
             continue;
         }

--- a/src/host/posix/infra_if.hpp
+++ b/src/host/posix/infra_if.hpp
@@ -73,7 +73,7 @@ public:
 
     void      Init(void);
     void      Deinit(void);
-    otbrError SetInfraIf(const char *aIfName);
+    otbrError SetInfraIf(std::string aInfraIfName);
     otbrError SendIcmp6Nd(uint32_t            aInfraIfIndex,
                           const otIp6Address &aDestAddress,
                           const uint8_t      *aBuffer,
@@ -94,7 +94,7 @@ private:
     void Update(MainloopContext &aContext) override;
 
     Dependencies &mDeps;
-    char          mInfraIfName[IFNAMSIZ];
+    std::string   mInfraIfName;
     unsigned int  mInfraIfIndex;
 #ifdef __linux__
     int mNetlinkSocket;

--- a/tests/gtest/test_infra_if.cpp
+++ b/tests/gtest/test_infra_if.cpp
@@ -104,7 +104,7 @@ TEST(InfraIf, DepsSetInfraIfInvokedCorrectly_AfterSpecifyingInfraIf)
 
     InfraIfDependencyTest testInfraIfDep;
     otbr::InfraIf         infraIf(testInfraIfDep);
-    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf.c_str()), OTBR_ERROR_NONE);
+    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf), OTBR_ERROR_NONE);
 
     EXPECT_NE(testInfraIfDep.mInfraIfIndex, 0);
     EXPECT_EQ(testInfraIfDep.mIsRunning, false);
@@ -137,7 +137,7 @@ TEST(InfraIf, DepsUpdateInfraIfStateInvokedCorrectly_AfterInfraIfStateChange)
     InfraIfDependencyTest testInfraIfDep;
     otbr::InfraIf         infraIf(testInfraIfDep);
     infraIf.Init();
-    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf.c_str()), OTBR_ERROR_NONE);
+    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf), OTBR_ERROR_NONE);
 
     EXPECT_EQ(testInfraIfDep.mIsRunning, false);
     EXPECT_EQ(testInfraIfDep.mIp6Addresses.size(), 2);
@@ -213,7 +213,7 @@ TEST(InfraIf, DepsHandleIcmp6NdInvokedCorrectly_AfterInfraIfReceivesIcmp6Nd)
     InfraIfDependencyTest testInfraIfDep;
     otbr::InfraIf         infraIf(testInfraIfDep);
     infraIf.Init();
-    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf.c_str()), OTBR_ERROR_NONE);
+    EXPECT_EQ(infraIf.SetInfraIf(fakeInfraIf), OTBR_ERROR_NONE);
     netif.SetNetifState(true);
 
     // Let the fake infrastructure interface receive a fake Icmp6 Nd message


### PR DESCRIPTION
This is a minor refactor CL which lets the code prefer `std::string` over C-style strings for convenience and safety.