### PR TITLE
[bbr] add multicast routing manager

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -67,6 +67,30 @@ Ip6Address Ip6Address::ToSolicitedNodeMulticastAddress(void) const
     return ma;
 }
 
+uint8_t Ip6Address::GetScope(void) const
+{
+    uint8_t rval;
+
+    if (IsMulticast())
+    {
+        rval = m8[1] & 0xf;
+    }
+    else if (IsLinkLocal())
+    {
+        rval = kLinkLocalScope;
+    }
+    else if (IsLoopback())
+    {
+        rval = kNodeLocalScope;
+    }
+    else
+    {
+        rval = kGlobalScope;
+    }
+
+    return rval;
+}
+
 void Ip6Address::CopyTo(struct sockaddr_in6 &aSockAddr) const
 {
     memset(&aSockAddr, 0, sizeof(aSockAddr));

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -109,6 +109,18 @@ static constexpr char kLinkLocalAllNodesMulticastAddress[] = "ff02::01";
 class Ip6Address
 {
 public:
+    // IPv6 Address Scopes
+    static constexpr uint8_t kNodeLocalScope      = 0;  ///< Node-Local scope
+    static constexpr uint8_t kInterfaceLocalScope = 1;  ///< Interface-Local scope
+    static constexpr uint8_t kLinkLocalScope      = 2;  ///< Link-Local scope
+    static constexpr uint8_t kRealmLocalScope     = 3;  ///< Realm-Local scope
+    static constexpr uint8_t kAdminLocalScope     = 4;  ///< Admin-Local scope
+    static constexpr uint8_t kSiteLocalScope      = 5;  ///< Site-Local scope
+    static constexpr uint8_t kOrgLocalScope       = 8;  ///< Organization-Local scope
+    static constexpr uint8_t kGlobalScope         = 14; ///< Global scope
+
+    static constexpr uint8_t kBitsPerByte = 8;
+
     /**
      * Default constructor.
      */
@@ -230,6 +242,13 @@ public:
      * @retval FALSE  If the Ip6 address is not the Loopback Address.
      */
     bool IsLoopback(void) const { return (m32[0] == 0 && m32[1] == 0 && m32[2] == 0 && m32[3] == htobe32(1)); }
+
+    /**
+     * Returns the IPv6 address scope.
+     *
+     * @returns The IPv6 address scope.
+     */
+    uint8_t GetScope(void) const;
 
     /**
      * This function returns the wellknown Link Local All Nodes Multicast Address (ff02::1).

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -305,6 +305,11 @@ void NcpHost::SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback)
     mNcpSpinel.SetUdpForwardSendCallback(aCallback);
 }
 
+const otMeshLocalPrefix *NcpHost::GetMeshLocalPrefix(void) const
+{
+    return NcpNetworkProperties::GetMeshLocalPrefix();
+}
+
 void NcpHost::InitNetifCallbacks(Netif &aNetif)
 {
     mNcpSpinel.Ip6SetAddressCallback(

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -119,6 +119,7 @@ public:
     void SetBorderAgentMeshCoPServiceChangedCallback(BorderAgentMeshCoPServiceChangedCallback aCallback) override;
     void AddEphemeralKeyStateChangedCallback(EphemeralKeyStateChangedCallback aCallback) override;
     void SetUdpForwardToHostCallback(UdpForwardToHostCallback aCallback) override;
+    const otMeshLocalPrefix *GetMeshLocalPrefix(void) const override;
 
     CoprocessorType GetCoprocessorType(void) override
     {

--- a/src/host/posix/CMakeLists.txt
+++ b/src/host/posix/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(otbr-posix
     dnssd.cpp
     infra_if.hpp
     infra_if.cpp
+    multicast_routing_manager.hpp
+    multicast_routing_manager.cpp
     netif.cpp
     netif_linux.cpp
     netif_unix.cpp

--- a/src/host/posix/infra_if.hpp
+++ b/src/host/posix/infra_if.hpp
@@ -79,6 +79,8 @@ public:
                           const uint8_t      *aBuffer,
                           uint16_t            aBufferLength);
 
+    unsigned int GetIfIndex(void) const { return mInfraIfIndex; }
+
 private:
     static int              CreateIcmp6Socket(const char *aInfraIfName);
     bool                    IsRunning(const std::vector<Ip6Address> &aAddrs) const;

--- a/src/host/posix/multicast_routing_manager.cpp
+++ b/src/host/posix/multicast_routing_manager.cpp
@@ -1,0 +1,583 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "multicast_routing_manager.hpp"
+
+#include <assert.h>
+#include <net/if.h>
+#include <netinet/icmp6.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#ifdef __linux__
+#include <linux/mroute6.h>
+#endif
+
+#include <openthread/ip6.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/types.hpp"
+#include "utils/socket_utils.hpp"
+
+#ifdef __linux__
+#if OTBR_ENABLE_BACKBONE_ROUTER
+
+namespace otbr {
+
+MulticastRoutingManager::MulticastRoutingManager(const Netif                   &aNetif,
+                                                 const InfraIf                 &aInfraIf,
+                                                 const Host::NetworkProperties &aNetworkProperties)
+    : mNetif(aNetif)
+    , mInfraIf(aInfraIf)
+    , mNetworkProperties(aNetworkProperties)
+    , mLastExpireTime(otbr::Timepoint::min())
+    , mMulticastRouterSock(-1)
+{
+}
+
+void MulticastRoutingManager::HandleStateChange(otBackboneRouterState aState)
+{
+    otbrLogInfo("State Change:%u", aState);
+
+    switch (aState)
+    {
+    case OT_BACKBONE_ROUTER_STATE_DISABLED:
+    case OT_BACKBONE_ROUTER_STATE_SECONDARY:
+        Disable();
+        break;
+    case OT_BACKBONE_ROUTER_STATE_PRIMARY:
+        Enable();
+        break;
+    }
+}
+
+void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                                   const Ip6Address                      &aAddress)
+{
+    switch (aEvent)
+    {
+    case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED:
+        mMulticastListeners.insert(aAddress);
+        Add(aAddress);
+        break;
+    case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED:
+        mMulticastListeners.erase(aAddress);
+        Remove(aAddress);
+        break;
+    }
+}
+
+void MulticastRoutingManager::Update(MainloopContext &aContext)
+{
+    VerifyOrExit(IsEnabled());
+
+    aContext.AddFdToReadSet(mMulticastRouterSock);
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::Process(const MainloopContext &aContext)
+{
+    VerifyOrExit(IsEnabled());
+
+    ExpireMulticastForwardingCache();
+
+    if (FD_ISSET(mMulticastRouterSock, &aContext.mReadFdSet))
+    {
+        ProcessMulticastRouterMessages();
+    }
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::Enable(void)
+{
+    VerifyOrExit(!IsEnabled());
+
+    InitMulticastRouterSock();
+
+    otbrLogResult(OTBR_ERROR_NONE, "%s", __FUNCTION__);
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::Disable(void)
+{
+    FinalizeMulticastRouterSock();
+
+    otbrLogResult(OTBR_ERROR_NONE, "%s", __FUNCTION__);
+}
+
+void MulticastRoutingManager::Add(const Ip6Address &aAddress)
+{
+    VerifyOrExit(IsEnabled());
+
+    UnblockInboundMulticastForwardingCache(aAddress);
+    UpdateMldReport(aAddress, true);
+
+    otbrLogResult(OTBR_ERROR_NONE, "%s: %s", __FUNCTION__, aAddress.ToString().c_str());
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::Remove(const Ip6Address &aAddress)
+{
+    VerifyOrExit(IsEnabled());
+
+    RemoveInboundMulticastForwardingCache(aAddress);
+    UpdateMldReport(aAddress, false);
+
+    otbrLogResult(OTBR_ERROR_NONE, "%s: %s", __FUNCTION__, aAddress.ToString().c_str());
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::UpdateMldReport(const Ip6Address &aAddress, bool isAdd)
+{
+    struct ipv6_mreq ipv6mr;
+    otbrError        error = OTBR_ERROR_NONE;
+
+    ipv6mr.ipv6mr_interface = mInfraIf.GetIfIndex();
+    aAddress.CopyTo(ipv6mr.ipv6mr_multiaddr);
+    if (setsockopt(mMulticastRouterSock, IPPROTO_IPV6, (isAdd ? IPV6_JOIN_GROUP : IPV6_LEAVE_GROUP), (void *)&ipv6mr,
+                   sizeof(ipv6mr)) != 0)
+    {
+        error = OTBR_ERROR_ERRNO;
+    }
+
+    otbrLogResult(error, "%s: address %s %s", __FUNCTION__, aAddress.ToString().c_str(), (isAdd ? "Added" : "Removed"));
+}
+
+bool MulticastRoutingManager::HasMulticastListener(const Ip6Address &aAddress) const
+{
+    return mMulticastListeners.find(aAddress) != mMulticastListeners.end();
+}
+
+void MulticastRoutingManager::InitMulticastRouterSock(void)
+{
+    int                 one = 1;
+    struct icmp6_filter filter;
+    struct mif6ctl      mif6ctl;
+
+    // Create a Multicast Routing socket
+    mMulticastRouterSock = SocketWithCloseExec(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, kSocketBlock);
+    VerifyOrDie(mMulticastRouterSock != -1, "Failed to create socket");
+
+    // Enable Multicast Forwarding in Kernel
+    VerifyOrDie(0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_INIT, &one, sizeof(one)),
+                "Failed to enable multicast forwarding");
+
+    // Filter all ICMPv6 messages
+    ICMP6_FILTER_SETBLOCKALL(&filter);
+    VerifyOrDie(0 == setsockopt(mMulticastRouterSock, IPPROTO_ICMPV6, ICMP6_FILTER, (void *)&filter, sizeof(filter)),
+                "Failed to set filter");
+
+    memset(&mif6ctl, 0, sizeof(mif6ctl));
+    mif6ctl.mif6c_flags     = 0;
+    mif6ctl.vifc_threshold  = 1;
+    mif6ctl.vifc_rate_limit = 0;
+
+    // Add Thread network interface to MIF
+    mif6ctl.mif6c_mifi = kMifIndexThread;
+    mif6ctl.mif6c_pifi = mNetif.GetIfIndex();
+    VerifyOrDie(mif6ctl.mif6c_pifi > 0, "Thread interface index is invalid");
+    VerifyOrDie(0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_ADD_MIF, &mif6ctl, sizeof(mif6ctl)),
+                "Failed to add Thread network interface to MIF");
+
+    // Add Backbone network interface to MIF
+    mif6ctl.mif6c_mifi = kMifIndexBackbone;
+    mif6ctl.mif6c_pifi = mInfraIf.GetIfIndex();
+    VerifyOrDie(mif6ctl.mif6c_pifi > 0, "Backbone interface index is invalid");
+    VerifyOrDie(0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_ADD_MIF, &mif6ctl, sizeof(mif6ctl)),
+                "Failed to add Backbone interface to MIF");
+}
+
+void MulticastRoutingManager::FinalizeMulticastRouterSock(void)
+{
+    VerifyOrExit(IsEnabled());
+
+    close(mMulticastRouterSock);
+    mMulticastRouterSock = -1;
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::ProcessMulticastRouterMessages(void)
+{
+    otbrError       error = OTBR_ERROR_NONE;
+    char            buf[sizeof(struct mrt6msg)];
+    int             nr;
+    struct mrt6msg *mrt6msg;
+    Ip6Address      src, dst;
+
+    nr = read(mMulticastRouterSock, buf, sizeof(buf));
+
+    VerifyOrExit(nr >= static_cast<int>(sizeof(struct mrt6msg)), error = OTBR_ERROR_ERRNO);
+
+    mrt6msg = reinterpret_cast<struct mrt6msg *>(buf);
+
+    VerifyOrExit(mrt6msg->im6_mbz == 0);
+    VerifyOrExit(mrt6msg->im6_msgtype == MRT6MSG_NOCACHE);
+
+    src.CopyFrom(mrt6msg->im6_src);
+    dst.CopyFrom(mrt6msg->im6_dst);
+
+    error = AddMulticastForwardingCache(src, dst, static_cast<MifIndex>(mrt6msg->im6_mif));
+
+exit:
+    otbrLogResult(error, "%s", __FUNCTION__);
+}
+
+otbrError MulticastRoutingManager::AddMulticastForwardingCache(const Ip6Address &aSrcAddr,
+                                                               const Ip6Address &aGroupAddr,
+                                                               MifIndex          aIif)
+{
+    otbrError      error = OTBR_ERROR_NONE;
+    struct mf6cctl mf6cctl;
+    MifIndex       forwardMif = kMifIndexNone;
+
+    VerifyOrExit(aIif == kMifIndexThread || aIif == kMifIndexBackbone, error = OTBR_ERROR_INVALID_ARGS);
+
+    ExpireMulticastForwardingCache();
+
+    if (aIif == kMifIndexBackbone)
+    {
+        // Forward multicast traffic from Backbone to Thread if the group address is subscribed by any Thread device via
+        // MLR.
+        if (HasMulticastListener(aGroupAddr))
+        {
+            forwardMif = kMifIndexThread;
+        }
+    }
+    else
+    {
+        VerifyOrExit(!aSrcAddr.IsLinkLocal(), error = OTBR_ERROR_NONE);
+        VerifyOrExit(!MatchesMeshLocalPrefix(aSrcAddr, *mNetworkProperties.GetMeshLocalPrefix()),
+                     error = OTBR_ERROR_NONE);
+
+        // Forward multicast traffic from Thread to Backbone if multicast scope > kRealmLocalScope
+        // TODO: (MLR) allow scope configuration of outbound multicast routing
+        if (aGroupAddr.GetScope() > Ip6Address::kRealmLocalScope)
+        {
+            forwardMif = kMifIndexBackbone;
+        }
+    }
+
+    memset(&mf6cctl, 0, sizeof(mf6cctl));
+
+    aSrcAddr.CopyTo(mf6cctl.mf6cc_origin.sin6_addr);
+    aGroupAddr.CopyTo(mf6cctl.mf6cc_mcastgrp.sin6_addr);
+    mf6cctl.mf6cc_parent = aIif;
+
+    if (forwardMif != kMifIndexNone)
+    {
+        IF_SET(forwardMif, &mf6cctl.mf6cc_ifset);
+    }
+
+    // Note that kernel reports repetitive `MRT6MSG_NOCACHE` upcalls with a rate limit (e.g. once per 10s for Linux).
+    // Because of it, we need to add a "blocking" MFC even if there is no forwarding for this group address.
+    // When a  Multicast Listener is later added, the "blocking" MFC will be altered to be a "forwarding" MFC so that
+    // corresponding multicast traffic can be forwarded instantly.
+    VerifyOrExit(0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_ADD_MFC, &mf6cctl, sizeof(mf6cctl)),
+                 error = OTBR_ERROR_ERRNO);
+
+    SaveMulticastForwardingCache(aSrcAddr, aGroupAddr, aIif, forwardMif);
+exit:
+    otbrLogResult(error, "%s: add dynamic route: %s %s => %s %s", __FUNCTION__, MifIndexToString(aIif),
+                  aSrcAddr.ToString().c_str(), aGroupAddr.ToString().c_str(), MifIndexToString(forwardMif));
+
+    return error;
+}
+
+void MulticastRoutingManager::UnblockInboundMulticastForwardingCache(const Ip6Address &aGroupAddr)
+{
+    struct mf6cctl mf6cctl;
+
+    memset(&mf6cctl, 0, sizeof(mf6cctl));
+    aGroupAddr.CopyTo(mf6cctl.mf6cc_mcastgrp.sin6_addr);
+    mf6cctl.mf6cc_parent = kMifIndexBackbone;
+    IF_SET(kMifIndexThread, &mf6cctl.mf6cc_ifset);
+
+    for (MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
+    {
+        otbrError error;
+
+        if (!mfc.IsValid() || mfc.mIif != kMifIndexBackbone || mfc.mOif == kMifIndexThread ||
+            mfc.mGroupAddr != aGroupAddr)
+        {
+            continue;
+        }
+
+        // Unblock this inbound route
+        mfc.mSrcAddr.CopyTo(mf6cctl.mf6cc_origin.sin6_addr);
+
+        error = (0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_ADD_MFC, &mf6cctl, sizeof(mf6cctl)))
+                    ? OTBR_ERROR_NONE
+                    : OTBR_ERROR_ERRNO;
+
+        mfc.Set(kMifIndexBackbone, kMifIndexThread);
+
+        otbrLogResult(error, "%s: %s %s => %s %s", __FUNCTION__, MifIndexToString(mfc.mIif),
+                      mfc.mSrcAddr.ToString().c_str(), mfc.mGroupAddr.ToString().c_str(),
+                      MifIndexToString(kMifIndexThread));
+    }
+}
+
+void MulticastRoutingManager::RemoveInboundMulticastForwardingCache(const Ip6Address &aGroupAddr)
+{
+    for (MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
+    {
+        if (mfc.IsValid() && mfc.mIif == kMifIndexBackbone && mfc.mGroupAddr == aGroupAddr)
+        {
+            RemoveMulticastForwardingCache(mfc);
+        }
+    }
+}
+
+void MulticastRoutingManager::ExpireMulticastForwardingCache(void)
+{
+    struct sioc_sg_req6 sioc_sg_req6;
+    Timepoint           now = Clock::now();
+    struct mf6cctl      mf6cctl;
+
+    VerifyOrExit(now >= mLastExpireTime + Microseconds(kMulticastForwardingCacheExpiringInterval * kUsPerSecond));
+
+    mLastExpireTime = now;
+
+    memset(&mf6cctl, 0, sizeof(mf6cctl));
+    memset(&sioc_sg_req6, 0, sizeof(sioc_sg_req6));
+
+    for (MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
+    {
+        if (mfc.IsValid() &&
+            mfc.mLastUseTime + Microseconds(kMulticastForwardingCacheExpireTimeout * kUsPerSecond) < now)
+        {
+            if (!UpdateMulticastRouteInfo(mfc))
+            {
+                // The multicast route is expired
+                RemoveMulticastForwardingCache(mfc);
+            }
+        }
+    }
+
+    DumpMulticastForwardingCache();
+
+exit:
+    return;
+}
+
+bool MulticastRoutingManager::UpdateMulticastRouteInfo(MulticastForwardingCache &aMfc) const
+{
+    bool                updated = false;
+    struct sioc_sg_req6 sioc_sg_req6;
+
+    memset(&sioc_sg_req6, 0, sizeof(sioc_sg_req6));
+
+    aMfc.mSrcAddr.CopyTo(sioc_sg_req6.src.sin6_addr);
+    aMfc.mGroupAddr.CopyTo(sioc_sg_req6.grp.sin6_addr);
+
+    if (ioctl(mMulticastRouterSock, SIOCGETSGCNT_IN6, &sioc_sg_req6) != -1)
+    {
+        unsigned long validPktCnt;
+
+        otbrLogDebug("%s: SIOCGETSGCNT_IN6 %s => %s: bytecnt=%lu, pktcnt=%lu, wrong_if=%lu", __FUNCTION__,
+                     aMfc.mSrcAddr.ToString().c_str(), aMfc.mGroupAddr.ToString().c_str(), sioc_sg_req6.bytecnt,
+                     sioc_sg_req6.pktcnt, sioc_sg_req6.wrong_if);
+
+        validPktCnt = sioc_sg_req6.pktcnt - sioc_sg_req6.wrong_if;
+        if (validPktCnt != aMfc.mValidPktCnt)
+        {
+            aMfc.SetValidPktCnt(validPktCnt);
+
+            updated = true;
+        }
+    }
+    else
+    {
+        otbrLogDebug("%s: SIOCGETSGCNT_IN6 %s => %s failed: %s", __FUNCTION__, aMfc.mSrcAddr.ToString().c_str(),
+                     aMfc.mGroupAddr.ToString().c_str(), strerror(errno));
+    }
+
+    return updated;
+}
+
+const char *MulticastRoutingManager::MifIndexToString(MifIndex aMif)
+{
+    const char *string = "Unknown";
+
+    switch (aMif)
+    {
+    case kMifIndexNone:
+        string = "None";
+        break;
+    case kMifIndexThread:
+        string = "Thread";
+        break;
+    case kMifIndexBackbone:
+        string = "Backbone";
+        break;
+    }
+
+    return string;
+}
+
+void MulticastRoutingManager::DumpMulticastForwardingCache(void) const
+{
+    VerifyOrExit(otbrLogGetLevel() == OTBR_LOG_DEBUG);
+
+    otbrLogDebug("==================== MFC ENTRIES ====================");
+
+    for (const MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
+    {
+        if (mfc.IsValid())
+        {
+            otbrLogDebug("%s %s => %s %s", MifIndexToString(mfc.mIif), mfc.mSrcAddr.ToString().c_str(),
+                         mfc.mGroupAddr.ToString().c_str(), MifIndexToString(mfc.mOif));
+        }
+    }
+
+    otbrLogDebug("=====================================================");
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::MulticastForwardingCache::Set(MulticastRoutingManager::MifIndex aIif,
+                                                            MulticastRoutingManager::MifIndex aOif)
+{
+    mIif         = aIif;
+    mOif         = aOif;
+    mValidPktCnt = 0;
+    mLastUseTime = Clock::now();
+}
+
+void MulticastRoutingManager::MulticastForwardingCache::Set(const Ip6Address &aSrcAddr,
+                                                            const Ip6Address &aGroupAddr,
+                                                            MifIndex          aIif,
+                                                            MifIndex          aOif)
+{
+    mSrcAddr   = aSrcAddr;
+    mGroupAddr = aGroupAddr;
+    Set(aIif, aOif);
+}
+
+void MulticastRoutingManager::MulticastForwardingCache::SetValidPktCnt(unsigned long aValidPktCnt)
+{
+    mValidPktCnt = aValidPktCnt;
+    mLastUseTime = Clock::now();
+}
+
+void MulticastRoutingManager::SaveMulticastForwardingCache(const Ip6Address                 &aSrcAddr,
+                                                           const Ip6Address                 &aGroupAddr,
+                                                           MulticastRoutingManager::MifIndex aIif,
+                                                           MulticastRoutingManager::MifIndex aOif)
+{
+    MulticastForwardingCache *invalid = nullptr;
+    MulticastForwardingCache *oldest  = nullptr;
+
+    for (MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)
+    {
+        if (mfc.IsValid())
+        {
+            if (mfc.mSrcAddr == aSrcAddr && mfc.mGroupAddr == aGroupAddr)
+            {
+                mfc.Set(aIif, aOif);
+                ExitNow();
+            }
+
+            if (oldest == nullptr || mfc.mLastUseTime < oldest->mLastUseTime)
+            {
+                oldest = &mfc;
+            }
+        }
+        else if (invalid == nullptr)
+        {
+            invalid = &mfc;
+        }
+    }
+
+    if (invalid != nullptr)
+    {
+        invalid->Set(aSrcAddr, aGroupAddr, aIif, aOif);
+    }
+    else
+    {
+        RemoveMulticastForwardingCache(*oldest);
+        oldest->Set(aSrcAddr, aGroupAddr, aIif, aOif);
+    }
+
+exit:
+    return;
+}
+
+void MulticastRoutingManager::RemoveMulticastForwardingCache(
+    MulticastRoutingManager::MulticastForwardingCache &aMfc) const
+{
+    otbrError      error;
+    struct mf6cctl mf6cctl;
+
+    memset(&mf6cctl, 0, sizeof(mf6cctl));
+
+    aMfc.mSrcAddr.CopyTo(mf6cctl.mf6cc_origin.sin6_addr);
+    aMfc.mGroupAddr.CopyTo(mf6cctl.mf6cc_mcastgrp.sin6_addr);
+
+    mf6cctl.mf6cc_parent = aMfc.mIif;
+
+    error = (0 == setsockopt(mMulticastRouterSock, IPPROTO_IPV6, MRT6_DEL_MFC, &mf6cctl, sizeof(mf6cctl)))
+                ? OTBR_ERROR_NONE
+                : OTBR_ERROR_ERRNO;
+
+    otbrLogResult(error, "%s: %s %s => %s %s", __FUNCTION__, MifIndexToString(aMfc.mIif),
+                  aMfc.mSrcAddr.ToString().c_str(), aMfc.mGroupAddr.ToString().c_str(), MifIndexToString(aMfc.mOif));
+
+    aMfc.Erase();
+}
+
+bool MulticastRoutingManager::MatchesMeshLocalPrefix(const Ip6Address        &aAddress,
+                                                     const otMeshLocalPrefix &aMeshLocalPrefix)
+{
+    otIp6Address matcher{};
+    memcpy(matcher.mFields.m8, aMeshLocalPrefix.m8, sizeof(otMeshLocalPrefix));
+
+    return otIp6PrefixMatch(reinterpret_cast<const otIp6Address *>(aAddress.m8), &matcher) >= OT_IP6_PREFIX_BITSIZE;
+}
+
+} // namespace otbr
+
+#endif // OTBR_ENABLE_BACKBONE_ROUTER
+#endif // __linux__

--- a/src/host/posix/multicast_routing_manager.hpp
+++ b/src/host/posix/multicast_routing_manager.hpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BACKBONE_ROUTER_MULTICAST_ROUTING_MANAGER_HPP_
+#define BACKBONE_ROUTER_MULTICAST_ROUTING_MANAGER_HPP_
+
+#include "openthread-br/config.h"
+
+#include <set>
+
+#include <openthread/backbone_router_ftd.h>
+#include <openthread/dataset.h>
+
+#include "common/code_utils.hpp"
+#include "common/mainloop.hpp"
+#include "common/time.hpp"
+#include "common/types.hpp"
+#include "host/posix/infra_if.hpp"
+#include "host/posix/netif.hpp"
+#include "host/thread_host.hpp"
+
+namespace otbr {
+
+class MulticastRoutingManager : public MainloopProcessor, private NonCopyable
+{
+public:
+    explicit MulticastRoutingManager(const Netif                   &aNetif,
+                                     const InfraIf                 &aInfraIf,
+                                     const Host::NetworkProperties &aNetworkProperties);
+
+    void Deinit(void) { FinalizeMulticastRouterSock(); }
+    bool IsEnabled(void) const { return mMulticastRouterSock >= 0; }
+    void HandleStateChange(otBackboneRouterState aState);
+    void HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                              const Ip6Address                      &aAddress);
+
+private:
+    static constexpr uint32_t kUsPerSecond = 1000000; //< Microseconds per second.
+    static constexpr uint32_t kMulticastForwardingCacheExpireTimeout =
+        300; //< Expire timeout of Multicast Forwarding Cache (in seconds)
+    static constexpr uint32_t kMulticastForwardingCacheExpiringInterval =
+        60; //< Expire interval of Multicast Forwarding Cache (in seconds)
+    static constexpr uint32_t kMulticastMaxListeners = 75; //< The max number of Multicast listeners
+    static constexpr uint32_t kMulticastForwardingCacheTableSize =
+        kMulticastMaxListeners * 10; //< The max size of MFC table.
+
+    enum MifIndex : uint8_t
+    {
+        kMifIndexNone     = 0xff,
+        kMifIndexThread   = 0,
+        kMifIndexBackbone = 1,
+    };
+
+    class MulticastForwardingCache
+    {
+        friend class MulticastRoutingManager;
+
+    private:
+        MulticastForwardingCache()
+            : mIif(kMifIndexNone)
+        {
+        }
+
+        bool IsValid() const { return mIif != kMifIndexNone; }
+        void Set(MifIndex aIif, MifIndex aOif);
+        void Set(const Ip6Address &aSrcAddr, const Ip6Address &aGroupAddr, MifIndex aIif, MifIndex aOif);
+        void Erase(void) { mIif = kMifIndexNone; }
+        void SetValidPktCnt(unsigned long aValidPktCnt);
+
+        Ip6Address    mSrcAddr;
+        Ip6Address    mGroupAddr;
+        Timepoint     mLastUseTime;
+        unsigned long mValidPktCnt;
+        MifIndex      mIif;
+        MifIndex      mOif;
+    };
+
+    void Update(MainloopContext &aContext) override;
+    void Process(const MainloopContext &aContext) override;
+
+    void      Enable(void);
+    void      Disable(void);
+    void      Add(const Ip6Address &aAddress);
+    void      Remove(const Ip6Address &aAddress);
+    void      UpdateMldReport(const Ip6Address &aAddress, bool isAdd);
+    bool      HasMulticastListener(const Ip6Address &aAddress) const;
+    void      InitMulticastRouterSock(void);
+    void      FinalizeMulticastRouterSock(void);
+    void      ProcessMulticastRouterMessages(void);
+    otbrError AddMulticastForwardingCache(const Ip6Address &aSrcAddr, const Ip6Address &aGroupAddr, MifIndex aIif);
+    void      SaveMulticastForwardingCache(const Ip6Address &aSrcAddr,
+                                           const Ip6Address &aGroupAddr,
+                                           MifIndex          aIif,
+                                           MifIndex          aOif);
+    void      UnblockInboundMulticastForwardingCache(const Ip6Address &aGroupAddr);
+    void      RemoveInboundMulticastForwardingCache(const Ip6Address &aGroupAddr);
+    void      ExpireMulticastForwardingCache(void);
+    bool      UpdateMulticastRouteInfo(MulticastForwardingCache &aMfc) const;
+    void      RemoveMulticastForwardingCache(MulticastForwardingCache &aMfc) const;
+    static const char *MifIndexToString(MifIndex aMif);
+    void               DumpMulticastForwardingCache(void) const;
+
+    static bool MatchesMeshLocalPrefix(const Ip6Address &aAddress, const otMeshLocalPrefix &aMeshLocalPrefix);
+
+    const Netif                   &mNetif;
+    const InfraIf                 &mInfraIf;
+    const Host::NetworkProperties &mNetworkProperties;
+    MulticastForwardingCache       mMulticastForwardingCacheTable[kMulticastForwardingCacheTableSize];
+    otbr::Timepoint                mLastExpireTime;
+    int                            mMulticastRouterSock;
+    std::set<Ip6Address>           mMulticastListeners;
+};
+
+} // namespace otbr
+
+#endif // BACKBONE_ROUTER_MULTICAST_ROUTING_MANAGER_HPP_

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -70,6 +70,8 @@ public:
 
     void Ip6Receive(const uint8_t *aBuf, uint16_t aLen);
 
+    unsigned int GetIfIndex(void) const { return mNetifIndex; }
+
 private:
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
     static constexpr size_t kIp6Mtu = 1280;

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -75,10 +75,19 @@ if(OTBR_MDNS)
 endif()
 
 add_executable(otbr-posix-gtest-unit
+    ${OPENTHREAD_PROJECT_DIRECTORY}/tests/gtest/fake_platform.cpp
+    fake_posix_platform.cpp
+    test_backbone_multicast_routing.cpp
     test_cli_daemon.cpp
     test_infra_if.cpp
     test_netif.cpp
     test_udp_proxy.cpp
+)
+target_include_directories(otbr-posix-gtest-unit
+    PRIVATE
+        ${OTBR_PROJECT_DIRECTORY}/src
+        ${OPENTHREAD_PROJECT_DIRECTORY}/src/core
+        ${OPENTHREAD_PROJECT_DIRECTORY}/tests/gtest
 )
 target_link_libraries(otbr-posix-gtest-unit
     otbr-posix

--- a/tests/gtest/test_backbone_multicast_routing.cpp
+++ b/tests/gtest/test_backbone_multicast_routing.cpp
@@ -1,0 +1,210 @@
+/*
+ *    Copyright (c) 2025, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <sys/time.h>
+#include <vector>
+
+#include "common/mainloop.hpp"
+#include "common/mainloop_manager.hpp"
+#include "common/types.hpp"
+#include "host/posix/infra_if.hpp"
+#include "host/posix/multicast_routing_manager.hpp"
+#include "host/posix/netif.hpp"
+#include "host/thread_host.hpp"
+#include "utils/socket_utils.hpp"
+
+// Only Test on linux platform for now.
+#ifdef __linux__
+#if OTBR_ENABLE_BACKBONE_ROUTER
+
+std::string Exec(const char *aCmd)
+{
+    std::array<char, 128>                  buffer;
+    std::string                            result;
+    std::unique_ptr<FILE, int (*)(FILE *)> pipe(popen(aCmd, "r"), pclose);
+    if (!pipe)
+    {
+        perror("Failed to open pipe!");
+        exit(EXIT_FAILURE);
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
+    {
+        result += buffer.data();
+    }
+    return result;
+}
+
+std::vector<std::string> GetMulticastRoutingTable(void)
+{
+    std::vector<std::string> lines;
+    std::stringstream        ss(Exec("ip -6 mroute"));
+    std::string              line;
+
+    while (std::getline(ss, line))
+    {
+        lines.push_back(line);
+    }
+
+    return lines;
+}
+
+static void MainloopProcess(uint32_t aTimeoutMs)
+{
+    otbr::MainloopContext mainloop;
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    while (true)
+    {
+        FD_ZERO(&mainloop.mReadFdSet);
+        FD_ZERO(&mainloop.mWriteFdSet);
+        FD_ZERO(&mainloop.mErrorFdSet);
+        otbr::MainloopManager::GetInstance().Update(mainloop);
+
+        int rval =
+            select(mainloop.mMaxFd + 1, &mainloop.mReadFdSet, &mainloop.mWriteFdSet, &mainloop.mErrorFdSet, nullptr);
+
+        if (rval >= 0)
+        {
+            otbr::MainloopManager::GetInstance().Process(mainloop);
+        }
+        else
+        {
+            perror("select()");
+            exit(EXIT_FAILURE);
+        }
+
+        auto elapsedTime = std::chrono::high_resolution_clock::now() - start;
+        if (elapsedTime > std::chrono::milliseconds(aTimeoutMs))
+        {
+            break;
+        }
+    }
+}
+
+class DummyNetworkProperties : public otbr::Host::NetworkProperties
+{
+public:
+    otDeviceRole GetDeviceRole(void) const override { return OT_DEVICE_ROLE_DISABLED; }
+    bool         Ip6IsEnabled(void) const override { return false; }
+    uint32_t     GetPartitionId(void) const override { return 0; }
+    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override
+    {
+        OTBR_UNUSED_VARIABLE(aDatasetTlvs);
+    }
+    void GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override
+    {
+        OTBR_UNUSED_VARIABLE(aDatasetTlvs);
+    }
+    const otMeshLocalPrefix *GetMeshLocalPrefix(void) const override { return &mMeshLocalPrefix; }
+
+    otMeshLocalPrefix mMeshLocalPrefix = {0};
+};
+
+TEST(BbrMcastRouting, MulticastRoutingTableSetCorrectlyAfterHandlingMlrEvents)
+{
+    otbr::Netif::Dependencies defaultNetifDep;
+    otbr::Netif               netif("wpan0", defaultNetifDep);
+    otbr::Netif               fakeInfraIf("wlx123", defaultNetifDep);
+    EXPECT_EQ(netif.Init(), OTBR_ERROR_NONE);
+    EXPECT_EQ(fakeInfraIf.Init(), OTBR_ERROR_NONE);
+
+    const otIp6Address kInfraIfAddr = {
+        {0x91, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}};
+    std::vector<otbr::Ip6AddressInfo> addrs = {
+        {kInfraIfAddr, 64, 0, 1, 0},
+    };
+    fakeInfraIf.UpdateIp6UnicastAddresses(addrs);
+    fakeInfraIf.SetNetifState(true);
+
+    otbr::InfraIf::Dependencies defaultInfraIfDep;
+    otbr::InfraIf               infraIf(defaultInfraIfDep);
+    EXPECT_EQ(infraIf.SetInfraIf("wlx123"), OTBR_ERROR_NONE);
+
+    DummyNetworkProperties        dummyNetworkProperties;
+    otbr::MulticastRoutingManager mcastRtMgr(netif, infraIf, dummyNetworkProperties);
+    mcastRtMgr.HandleStateChange(OT_BACKBONE_ROUTER_STATE_PRIMARY);
+
+    /*
+     * IP6 9101::1 > ff05::abcd: ICMP6, echo request, id 8, seq 1, length 64
+     *   0x0000:  6003 742b 0040 3a05 9101 0000 0000 0000
+     *   0x0010:  0000 0000 0000 0001 ff05 0000 0000 0000
+     *   0x0020:  0000 0000 0000 abcd 8000 f9ae 0008 0001
+     *   0x0030:  49b3 f867 0000 0000 4809 0100 0000 0000
+     *   0x0040:  1011 1213 1415 1617 1819 1a1b 1c1d 1e1f
+     *   0x0050:  2021 2223 2425 2627 2829 2a2b 2c2d 2e2f
+     *   0x0060:  3031 3233 3435 3637
+     */
+    const uint8_t icmp6Packet[] = {
+        0x60, 0x03, 0x74, 0x2b, 0x00, 0x40, 0x3a, 0x05, 0x91, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0xab, 0xcd, 0x80, 0x00, 0xf9, 0xae, 0x00, 0x08, 0x00, 0x01, 0x49, 0xb3, 0xf8, 0x67, 0x00, 0x00,
+        0x00, 0x00, 0x48, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
+        0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    };
+    fakeInfraIf.Ip6Receive(icmp6Packet, sizeof(icmp6Packet));
+
+    MainloopProcess(10);
+
+    const std::string kAddressPair   = "(9101::1,ff05::abcd)";
+    const std::string kIif           = "Iif: wlx123";
+    const std::string kOifs          = "Oifs: wpan0";
+    const std::string kStateResolved = "State: resolved";
+
+    auto lines = GetMulticastRoutingTable();
+    EXPECT_EQ(lines.size(), 1);
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kAddressPair));
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kIif));
+    EXPECT_THAT(lines.front(), ::testing::Not(::testing::HasSubstr(kOifs)));
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kStateResolved));
+
+    otbr::Ip6Address kMulAddr1 = {
+        {0xff, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xab, 0xcd}};
+    mcastRtMgr.HandleBackboneMulticastListenerEvent(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED, kMulAddr1);
+
+    MainloopProcess(10);
+    lines = GetMulticastRoutingTable();
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kAddressPair));
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kIif));
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kOifs));
+    EXPECT_THAT(lines.front(), ::testing::HasSubstr(kStateResolved));
+}
+
+#endif // OTBR_ENABLE_BACKBONE_ROUTER
+#endif // __linux__


### PR DESCRIPTION
This PR adds the MulticastRoutingManager module for backbone router multicast forwarding feature.

The implementation follows the [multicast module](https://github.com/openthread/openthread/blob/main/src/posix/platform/multicast_routing.hpp) in Openthread posix.

In this PR the module isn't integrated into application. A unit test is added to test it. It will then be first used for NCP mode to enable the multicast forwarding feature.