### PR TITLE
[bootstrap] for reference devices, install ndisc6

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -126,7 +126,7 @@ EOF
     sudo apt-get install --no-install-recommends -y libjsoncpp-dev
 
     # reference device
-    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils avahi-utils iperf3
+    without REFERENCE_DEVICE || sudo apt-get install --no-install-recommends -y radvd dnsutils avahi-utils iperf3 ndisc6
 
     # backbone-router
     without BACKBONE_ROUTER || sudo apt-get install --no-install-recommends -y libnetfilter-queue1 libnetfilter-queue-dev


### PR DESCRIPTION
1.4 OTBR certification testing requires reference devices to send some ND RA messages via `rdisc6` (eg. test DH_1_7).