### PR TITLE
[dbus] add TrelInfo to introspect.xml

### DIFF
--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -960,6 +960,25 @@
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
+    <!-- TrelInfo: Information about the TREL link
+    <literallayout>
+        struct {
+          bool   enabled          // Whether TREL is enabled.
+          uint16 num_trel_peers   // The number of TREL peers.
+          struct {
+            uint64 tx_packets     // Number of packets transmitted through TREL.
+            uint64 tx_bytes       // Sum of size of packets transmitted through TREL.
+            uint64 tx_failure     // Number of packet transmission failures through TREL.
+            uint64 rx_packets     // Number of packets received through TREL.
+            uint64 rx_bytes       // Sum of size of packets received through TREL.
+          }
+        }
+    </literallayout>
+    -->
+    <property name="TrelInfo" type="(bq(ttttt))" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
     <!-- DnsUpstreamQueryState: Whether the server will / should forward DNS queries platform
     specified upstream DNS servers. -->
     <property name="DnsUpstreamQueryState" type="b" access="readwrite">


### PR DESCRIPTION
There is currently a handler for TrelInfo, but no introspect entry.

Example fetching information structure:
```
dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:TrelInfo
method return time=1744738821.325205 sender=:1.76 -> destination=:1.81 serial=19 reply_serial=2
   variant       struct {
         boolean true
         uint16 0
         struct {
            uint64 0
            uint64 0
            uint64 0
            uint64 0
            uint64 0
         }
      }
```