### PR TITLE
[host] add network property for mesh local prefix

### DIFF
--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -45,10 +45,15 @@ namespace Host {
 
 // =============================== NcpNetworkProperties ===============================
 
+constexpr otMeshLocalPrefix kMeshLocalPrefixInit = {
+    {0xfd, 0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0x00},
+};
+
 NcpNetworkProperties::NcpNetworkProperties(void)
     : mDeviceRole(OT_DEVICE_ROLE_DISABLED)
 {
     memset(&mDatasetActiveTlvs, 0, sizeof(mDatasetActiveTlvs));
+    SetMeshLocalPrefix(kMeshLocalPrefixInit);
 }
 
 otDeviceRole NcpNetworkProperties::GetDeviceRole(void) const
@@ -89,6 +94,16 @@ void NcpNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aData
 {
     // TODO: Implement the method under NCP mode.
     OTBR_UNUSED_VARIABLE(aDatasetTlvs);
+}
+
+void NcpNetworkProperties::SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix)
+{
+    memcpy(mMeshLocalPrefix.m8, aMeshLocalPrefix.m8, sizeof(mMeshLocalPrefix.m8));
+}
+
+const otMeshLocalPrefix *NcpNetworkProperties::GetMeshLocalPrefix(void) const
+{
+    return &mMeshLocalPrefix;
 }
 
 // ===================================== NcpHost ======================================

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -58,19 +58,22 @@ public:
     explicit NcpNetworkProperties(void);
 
     // NetworkProperties methods
-    otDeviceRole GetDeviceRole(void) const override;
-    bool         Ip6IsEnabled(void) const override;
-    uint32_t     GetPartitionId(void) const override;
-    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
-    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otDeviceRole             GetDeviceRole(void) const override;
+    bool                     Ip6IsEnabled(void) const override;
+    uint32_t                 GetPartitionId(void) const override;
+    void                     GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    void                     GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    const otMeshLocalPrefix *GetMeshLocalPrefix(void) const override;
 
 private:
     // PropsObserver methods
     void SetDeviceRole(otDeviceRole aRole) override;
     void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) override;
+    void SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix) override;
 
     otDeviceRole             mDeviceRole;
     otOperationalDatasetTlvs mDatasetActiveTlvs;
+    otMeshLocalPrefix        mMeshLocalPrefix;
 };
 
 class NcpHost : public MainloopProcessor,

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -485,6 +485,19 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
     case SPINEL_PROP_IPV6_LL_ADDR:
         break;
 
+    case SPINEL_PROP_IPV6_ML_ADDR:
+    {
+        const otIp6Address *addr;
+        ot::Spinel::Decoder decoder;
+        otIp6NetworkPrefix  meshLocalPrefix;
+
+        decoder.Init(aBuffer, aLength);
+        SuccessOrExit(decoder.ReadIp6Address(addr), error = OTBR_ERROR_PARSE);
+        memcpy(meshLocalPrefix.m8, addr->mFields.m8, sizeof(meshLocalPrefix.m8));
+        mPropsObserver->SetMeshLocalPrefix(meshLocalPrefix);
+        break;
+    }
+
     case SPINEL_PROP_STREAM_NET:
     {
         const uint8_t *data;

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -81,6 +81,13 @@ public:
     virtual void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) = 0;
 
     /**
+     * Updates the mesh local prefix.
+     *
+     * @param[in] aMeshLocalPrefix  The mesh local prefix.
+     */
+    virtual void SetMeshLocalPrefix(const otIp6NetworkPrefix &aMeshLocalPrefix) = 0;
+
+    /**
      * The destructor.
      */
     virtual ~PropsObserver(void) = default;

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -112,6 +112,11 @@ void OtNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatas
     }
 }
 
+const otMeshLocalPrefix *OtNetworkProperties::GetMeshLocalPrefix(void) const
+{
+    return otThreadGetMeshLocalPrefix(mInstance);
+}
+
 void OtNetworkProperties::SetInstance(otInstance *aInstance)
 {
     mInstance = aInstance;

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -72,11 +72,12 @@ public:
     explicit OtNetworkProperties(void);
 
     // NetworkProperties methods
-    otDeviceRole GetDeviceRole(void) const override;
-    bool         Ip6IsEnabled(void) const override;
-    uint32_t     GetPartitionId(void) const override;
-    void         GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
-    void         GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    otDeviceRole             GetDeviceRole(void) const override;
+    bool                     Ip6IsEnabled(void) const override;
+    uint32_t                 GetPartitionId(void) const override;
+    void                     GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    void                     GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const override;
+    const otMeshLocalPrefix *GetMeshLocalPrefix(void) const override;
 
     // Set the otInstance
     void SetInstance(otInstance *aInstance);

--- a/src/host/thread_host.hpp
+++ b/src/host/thread_host.hpp
@@ -95,6 +95,13 @@ public:
     virtual void GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const = 0;
 
     /**
+     * Returns the meshlocal prefix.
+     *
+     * @returns The mesh local prefix.
+     */
+    virtual const otMeshLocalPrefix *GetMeshLocalPrefix(void) const = 0;
+
+    /**
      * The destructor.
      */
     virtual ~NetworkProperties(void) = default;


### PR DESCRIPTION
This PR adds "otMeshLocalPrefix" to "NetworkProperties" interface.

The intention is to make mesh local prefix available in both NCP & RCP modes. The Multicast Routihng Manager that is under development needs to use the mesh local prefix for check.

In NCP mode, the mesh local prefix is obtained from the notification of `SPINEL_PROP_IPV6_ML_ADDR`. Current NCP alreadys updates this property but it doesn't updates `SPINEL_PROP_IPV6_ML_PREFIX` to the host. So `SPINEL_PROP_IPV6_ML_ADDR` is used.

I've verified locally that in NCP mode the mesh local prefix can be obtained by the interface correctly.