### PR TITLE
[ncp] fix the docker network for ncp integration tests

### DIFF
--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -196,12 +196,14 @@ setup_infraif()
 {
     if ! ip link show backbone1 >/dev/null 2>&1; then
         echo "Creating backbone1 with Docker..."
-        docker network create --driver bridge -o "com.docker.network.bridge.name"="backbone1" backbone1
+        docker network create --driver bridge --ipv6 --subnet 9101::/64 -o "com.docker.network.bridge.name"="backbone1" backbone1
     else
         echo "backbone1 already exists."
     fi
     sudo sysctl -w net.ipv6.conf.backbone1.accept_ra=2
     sudo sysctl -w net.ipv6.conf.backbone1.accept_ra_rt_info_max_plen=64
+    # Delete the 9101::1/ address to ensure ping through backbone1 use an on-link address.
+    sudo ip addr del 9101::1/64 dev backbone1
 }
 
 test_setup()


### PR DESCRIPTION
This PR fixes the CI failure of ncp_border_routing.

I found that after removing `--ipv6` the otbr in docker cannot get the OMR address. But in my local run, it can work without `--ipv6` option.

This PR adds the original `--ipv6` option back and delete the 9101::1/64 address so that the ping tests through backbone1 interface can use the on-link address.