### PR TITLE
[pd] configure dhcpcd ia_pd:sla_id for wpan0 to resolve /64 routing conflict

### DIFF
--- a/script/_dhcpv6_pd_ref
+++ b/script/_dhcpv6_pd_ref
@@ -32,6 +32,7 @@
 
 # TODO: set the upstream interface according to the environment variables of `script/setup`.
 UPSTREAM_INTERFACE="eth0"
+WPAN_INTERFACE="wpan0"
 
 DHCPCD_ENTER_HOOK="/etc/dhcpcd.enter-hook"
 DHCPCD_EXIT_HOOK="/etc/dhcpcd.exit-hook"
@@ -53,7 +54,7 @@ create_dhcpcd_conf_pd()
 noipv6rs # disable router solicitation
 interface ${UPSTREAM_INTERFACE}
   iaid 1
-  ia_pd 2/::/64 -
+  ia_pd 2/::/64 ${WPAN_INTERFACE}/0/64
 release
 # Disable Router Solicitations (RS) again, specifically for ${UPSTREAM_INTERFACE}.
 # This ensures that accept_ra is prevented from being set to 0, allowing


### PR DESCRIPTION
When BR receives a /64 IPv6 prefix via prefix delefation, dhcpcd's default behavior can lead to a routing conflict. Specifically:

- If the delegated /64 is not explicitly assigned via ia_pd using sla_id 0, dhcpcd installs an "unreachable" route for the prefix.

- This "unreachable" route then conflicts with the active route for the same /64 prefix on wpan0 which is configured by OT, as kernel prefers dhcpcd's "unreachable" route due to its better (lower) metric.

- This issue is specific to /64 PDs. For larger PDs (e.g., /56), the longest prefix match rule correctly prioritizes OT's active /64.

This PR modifies the /etc/dhcpcd.conf file. Within the configuration block for the WAN interface, the ia_pd directive is changed to explicitly assign the received /64 delegated prefix to wpan0 using sla_id 0 and a /64 prefix length.

This change leverages dhcpcd's documented behavior for ia_pd assignments. As dhcpcd.conf(5) man states:

"Unless a sla_id of 0 is assigned with the same resultant prefix length as the delegation, a reject route is installed for the Delegated Prefix..."

Side effect:
dhcpcd will also assign an IP address from the delegated prefix to wpan0. This address will coexist with the IP address configured by OT. 

While multiple GUAs from the same prefix on an IPv6 interface are valid, this is acceptable.