### PR TITLE
[dnssd-platform] fix registering services for local host

### DIFF
--- a/src/host/posix/dnssd.cpp
+++ b/src/host/posix/dnssd.cpp
@@ -267,6 +267,7 @@ void DnssdPlatform::SetDnssdStateChangedCallback(DnssdStateChangeCallback aCallb
 
 void DnssdPlatform::RegisterService(const Service &aService, RequestId aRequestId, RegisterCallback aCallback)
 {
+    const char                  *hostName;
     Mdns::Publisher::SubTypeList subTypeList;
     Mdns::Publisher::TxtData     txtData(aService.mTxtData, aService.mTxtData + aService.mTxtDataLength);
 
@@ -275,8 +276,19 @@ void DnssdPlatform::RegisterService(const Service &aService, RequestId aRequestI
         subTypeList.push_back(aService.mSubTypeLabels[index]);
     }
 
-    mPublisher.PublishService(aService.mHostName, aService.mServiceInstance, aService.mServiceType, subTypeList,
-                              aService.mPort, txtData, MakePublisherCallback(aRequestId, aCallback));
+    // When `aService.mHostName` is `nullptr`, the service is for
+    // the local host. `Mdns::Publisher` expects an empty string
+    // to indicate this.
+
+    hostName = aService.mHostName;
+
+    if (hostName == nullptr)
+    {
+        hostName = "";
+    }
+
+    mPublisher.PublishService(hostName, aService.mServiceInstance, aService.mServiceType, subTypeList, aService.mPort,
+                              txtData, MakePublisherCallback(aRequestId, aCallback));
 }
 
 void DnssdPlatform::UnregisterService(const Service &aService, RequestId aRequestId, RegisterCallback aCallback)


### PR DESCRIPTION
This commit updates `DnssdPlatform::RegisterService()` so it can correctly handle registering a service for the local host. The `otPlatDnssdRegisterService()` indicates this by setting the `mHostName` field in the passed-in `otPlatDnssdService` structure to null. As documented: "The `mHostName` field specifies the host name of the service if it is not NULL. Otherwise, if it is NULL, it indicates that this service is for the device itself and leaves the host name selection to DNS-SD platform."

The `Mdns::Publisher::PublishService()` expects `std::string` as input and assumes an empty host string to indicate the service is for the local host.