### PR TITLE
[dnssd-platform] check `OTBR_ENABLE_DNSSD_PLAT` config

### DIFF
--- a/src/host/posix/dnssd.cpp
+++ b/src/host/posix/dnssd.cpp
@@ -35,6 +35,8 @@
 
 #include "host/posix/dnssd.hpp"
 
+#if OTBR_ENABLE_DNSSD_PLAT
+
 #include <string>
 
 #include <openthread/platform/dnssd.h>
@@ -350,3 +352,5 @@ void DnssdPlatform::HandleMdnsState(Mdns::Publisher::State aState)
 }
 
 } // namespace otbr
+
+#endif // OTBR_ENABLE_DNSSD_PLAT

--- a/src/host/posix/dnssd.hpp
+++ b/src/host/posix/dnssd.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-br/config.h"
 
+#if OTBR_ENABLE_DNSSD_PLAT
+
 #include <functional>
 #include <string>
 
@@ -132,5 +134,7 @@ private:
 };
 
 } // namespace otbr
+
+#endif // OTBR_ENABLE_DNSSD_PLAT
 
 #endif // OTBR_AGENT_POSIX_DNSSD_HPP_


### PR DESCRIPTION
This commit adds `#if` checks for `OTBR_ENABLE_DNSSD_PLAT` to the `dnssd` modules, ensuring the `otPlatDnssd` APIs are not provided unless this feature is enabled.

The `OTBR_ENABLE_DNSSD_PLAT` option controls the corresponding OpenThread core `OT_PLATFORM_DNSSD` configuration, which indicates that `otPlatDnssd` APIs are provided by the platform layer.