### PR TITLE
[border-agent] add `OTBR_ENABLE_BORDER_AGENT` guards

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -35,6 +35,8 @@
 
 #include "border_agent/border_agent.hpp"
 
+#if OTBR_ENABLE_BORDER_AGENT
+
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
@@ -570,3 +572,5 @@ std::string BorderAgent::GetAlternativeServiceInstanceName() const
 }
 
 } // namespace otbr
+
+#endif // OTBR_ENABLE_BORDER_AGENT

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-br/config.h"
 
+#if OTBR_ENABLE_BORDER_AGENT
+
 #include <vector>
 
 #include <stdint.h>
@@ -225,5 +227,7 @@ private:
  */
 
 } // namespace otbr
+
+#endif // OTBR_ENABLE_BORDER_AGENT
 
 #endif // OTBR_AGENT_BORDER_AGENT_HPP_


### PR DESCRIPTION
This commit adds `#if OTBR_ENABLE_BORDER_AGENT` guards to `border_agent.hpp` and `border_agent.cpp`. This ensures that definitions within these files are only compiled if the `OTBR_ENABLE_BORDER_AGENT` feature is enabled.