### PR TITLE
[border-agent] add `OTBR_BORDER_AGENT_MESHCOP_SERVICE` CMake option

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -98,7 +98,7 @@ jobs:
             cert_scripts: ./tests/scripts/thread-cert/backbone/*.py
             packet_verification: 1
           - name: "Border Router with OT Core Advertising Proxy (avahi)"
-            otbr_options: "-DOT_DUA=ON -DOT_ECDSA=ON -DOT_MLR=ON -DOT_SERVICE=ON -DOT_SRP_SERVER=ON -DOTBR_COVERAGE=ON -DOTBR_DUA_ROUTING=ON -DOTBR_TREL=OFF -DOTBR_DNS_UPSTREAM_QUERY=ON"
+            otbr_options: "-DOT_DUA=ON -DOT_ECDSA=ON -DOT_MLR=ON -DOT_SERVICE=ON -DOT_SRP_SERVER=ON -DOTBR_COVERAGE=ON -DOTBR_DUA_ROUTING=ON -DOTBR_TREL=OFF -DOTBR_DNS_UPSTREAM_QUERY=ON -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF"
             border_routing: 1
             internet: 0
             ot_srp_adv_proxy: 1
@@ -106,7 +106,7 @@ jobs:
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router with OT Core Advertising Proxy (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOT_ECDSA=ON -DOT_MLR=ON -DOT_SERVICE=ON -DOT_SRP_SERVER=ON -DOTBR_COVERAGE=ON -DOTBR_DUA_ROUTING=ON -DOTBR_TREL=OFF -DOTBR_DNS_UPSTREAM_QUERY=ON"
+            otbr_options: "-DOT_DUA=ON -DOT_ECDSA=ON -DOT_MLR=ON -DOT_SERVICE=ON -DOT_SRP_SERVER=ON -DOTBR_COVERAGE=ON -DOTBR_DUA_ROUTING=ON -DOTBR_TREL=OFF -DOTBR_DNS_UPSTREAM_QUERY=ON -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF"
             border_routing: 1
             internet: 0
             ot_srp_adv_proxy: 1

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -36,6 +36,11 @@ if (OTBR_BORDER_AGENT)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_AGENT=1)
 endif()
 
+option(OTBR_BORDER_AGENT_MESHCOP_SERVICE "Enable Border Agent to register MeshCoP mDNS service" ${OTBR_BORDER_AGENT})
+if (OTBR_BORDER_AGENT_MESHCOP_SERVICE)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE=1)
+endif()
+
 option(OTBR_BACKBONE_ROUTER "Enable Backbone Router" OFF)
 if (OTBR_BACKBONE_ROUTER)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BACKBONE_ROUTER=1)

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -245,7 +245,7 @@ void Application::InitRcpMode(void)
     Host::RcpHost &rcpHost = static_cast<otbr::Host::RcpHost &>(mHost);
     OTBR_UNUSED_VARIABLE(rcpHost);
 
-#if OTBR_ENABLE_BORDER_AGENT
+#if OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     mMdnsStateSubject.AddObserver(mBorderAgent);
 #endif
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
@@ -268,7 +268,7 @@ void Application::InitRcpMode(void)
 #if OTBR_ENABLE_MDNS
     mPublisher->Start();
 #endif
-#if OTBR_ENABLE_BORDER_AGENT
+#if OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     mHost.SetBorderAgentMeshCoPServiceChangedCallback(
         [this](bool aIsActive, uint16_t aPort, const uint8_t *aTxtData, uint16_t aLength) {
             mBorderAgent.HandleBorderAgentMeshCoPServiceChanged(aIsActive, aPort,
@@ -364,8 +364,13 @@ void Application::InitNcpMode(void)
             {
                 mBorderAgentUdpProxy.Start(aPort);
             }
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
             mBorderAgent.HandleBorderAgentMeshCoPServiceChanged(aIsActive, mBorderAgentUdpProxy.GetHostPort(),
                                                                 std::vector<uint8_t>(aTxtData, aTxtData + aLength));
+#else
+            OTBR_UNUSED_VARIABLE(aTxtData);
+            OTBR_UNUSED_VARIABLE(aLength);
+#endif
         });
     mHost.SetUdpForwardToHostCallback(
         [this](const uint8_t *aUdpPayload, uint16_t aLength, const otIp6Address &aPeerAddr, uint16_t aPeerPort) {

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -72,16 +72,21 @@
 #include "common/types.hpp"
 #include "utils/hex.hpp"
 
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 #if !(OTBR_ENABLE_MDNS_AVAHI || OTBR_ENABLE_MDNS_MDNSSD || OTBR_ENABLE_MDNS_MOJO)
-#error "Border Agent feature requires at least one `OTBR_MDNS` implementation"
+#error "Border Agent meshcop service feature requires at least one `OTBR_MDNS` implementation"
+#endif
 #endif
 
 namespace otbr {
 
-static const char    kBorderAgentServiceType[]      = "_meshcop._udp";   ///< Border agent service type of mDNS
-static const char    kBorderAgentEpskcServiceType[] = "_meshcop-e._udp"; ///< Border agent ePSKc service
-static constexpr int kBorderAgentServiceDummyPort   = 49152;
-static constexpr int kEpskcRandomGenLen             = 8;
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+static const char kBorderAgentServiceType[]      = "_meshcop._udp";   ///< Border agent service type of mDNS
+static const char kBorderAgentEpskcServiceType[] = "_meshcop-e._udp"; ///< Border agent ePSKc service
+#endif
+
+static constexpr int kBorderAgentServiceDummyPort = 49152;
+static constexpr int kEpskcRandomGenLen           = 8;
 
 BorderAgent::BorderAgent(Mdns::Publisher &aPublisher)
     : mPublisher(aPublisher)
@@ -177,22 +182,30 @@ void BorderAgent::ClearState(void)
     mProductName = OTBR_PRODUCT_NAME;
     EncodeVendorTxtData(emptyTxtEntries);
     mBaseServiceInstanceName = OTBR_MESHCOP_SERVICE_INSTANCE_NAME;
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     mServiceInstanceName.clear();
+#endif
 }
 
 void BorderAgent::Start(void)
 {
     otbrLogInfo("Start Thread Border Agent");
 
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     mServiceInstanceName = GetServiceInstanceName();
     UpdateMeshCoPService();
+#endif
 }
 
 void BorderAgent::Stop(void)
 {
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     otbrLogInfo("Stop Thread Border Agent");
     UnpublishMeshCoPService();
+#endif
 }
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 
 void BorderAgent::HandleEpskcStateChanged(otBorderAgentEphemeralKeyState aEpskcState, uint16_t aPort)
 {
@@ -310,6 +323,8 @@ exit:
     UpdateMeshCoPService();
 }
 
+#endif // OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+
 void BorderAgent::EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries)
 {
     Mdns::Publisher::TxtList txtList{{"rv", "1"}};
@@ -362,6 +377,8 @@ void BorderAgent::EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries)
         OTBR_UNUSED_VARIABLE(error);
     }
 }
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 
 void BorderAgent::PublishMeshCoPService(void)
 {
@@ -427,13 +444,19 @@ exit:
     return;
 }
 
+#endif
+
 #if OTBR_ENABLE_DBUS_SERVER
 void BorderAgent::UpdateVendorMeshCoPTxtEntries(const VendorTxtEntries &aVendorEntries)
 {
     EncodeVendorTxtData(aVendorEntries);
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     UpdateMeshCoPService();
+#endif
 }
 #endif
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 
 std::string BorderAgent::GetServiceInstanceName(void) const
 {
@@ -457,6 +480,8 @@ std::string BorderAgent::GetAlternativeServiceInstanceName(void) const
     ss << GetServiceInstanceName() << " (" << rand << ")";
     return ss.str();
 }
+
+#endif // OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 
 } // namespace otbr
 

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -77,7 +77,11 @@ namespace otbr {
 /**
  * This class implements Thread border agent functionality.
  */
-class BorderAgent : public Mdns::StateObserver, private NonCopyable
+class BorderAgent : private NonCopyable
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+    ,
+                    public Mdns::StateObserver
+#endif
 {
 public:
     typedef std::map<std::string, std::vector<uint8_t>> VendorTxtEntries; ///< Vendor TXT entry map.
@@ -130,6 +134,8 @@ public:
      */
     void SetEnabled(bool aIsEnabled);
 
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+
     /**
      * This method handles mDNS publisher's state changes.
      *
@@ -153,6 +159,8 @@ public:
      * @param[in] aPort          The UDP port of the Epskc service if it's active.
      */
     void HandleEpskcStateChanged(otBorderAgentEphemeralKeyState aEpskcState, uint16_t aPort);
+
+#endif // OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
 
     /**
      * This method creates ephemeral key in the Border Agent.
@@ -182,17 +190,20 @@ private:
     {
         return mIsEnabled;
     }
+
+    void EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries);
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     void PublishMeshCoPService(void);
     void UpdateMeshCoPService(void);
     void UnpublishMeshCoPService(void);
-
-    void EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries);
 
     std::string GetServiceInstanceName(void) const;
     std::string GetAlternativeServiceInstanceName(void) const;
 
     void PublishEpskcService(uint16_t aPort);
     void UnpublishEpskcService(void);
+#endif
 
     Mdns::Publisher &mPublisher;
     bool             mIsEnabled;
@@ -203,13 +214,17 @@ private:
     std::string mProductName;
 
     std::vector<uint8_t> mVendorTxtData; // Encoded vendor-specific TXT data.
-    std::vector<uint8_t> mOtTxtData;     // Encoded TXT data from OpenThread core Border Agent module
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+    std::vector<uint8_t> mOtTxtData; // Encoded TXT data from OpenThread core Border Agent module
+#endif
 
     // The base service instance name typically consists of the vendor and product name. But it can
     // also be overridden by `OTBR_MESHCOP_SERVICE_INSTANCE_NAME` or method `SetMeshCoPServiceValues()`.
     // For example, this value can be "OpenThread Border Router".
     std::string mBaseServiceInstanceName;
 
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     // The actual instance name advertised in the mDNS service. This is usually the value of
     // `mBaseServiceInstanceName` plus the Extended Address and optional random number for avoiding
     // conflicts. For example, this value can be "OpenThread Border Router #7AC3" or
@@ -220,6 +235,7 @@ private:
     otExtAddress mExtAddress;
     uint16_t     mMeshCoPUdpPort;
     bool         mBaIsActive;
+#endif
 };
 
 /**


### PR DESCRIPTION
This commit adds the `OTBR_BORDER_AGENT_MESHCOP_SERVICE` CMake option, which maps to the `OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE` macro.

This new configuration controls whether the OTBR platform's `BorderAgent` module publishes the `_meshcop._udp` mDNS service (including the ePSKc service). It can be used to disable platform layer service registration so to enable/allow OpenThread core's Border Agent module to handle this responsibility.

This configuration is enabled by default. It is explicitly disabled in GitHub workflows, specifically in `border_router.yml`, where OpenThread core mDNS/DNS-SD support (along with use of the native SRP advertising proxy) is enabled.
