### PR TITLE
[border-agent] remove "rv" key from vendor TXT data

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -327,7 +327,7 @@ exit:
 
 void BorderAgent::EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries)
 {
-    Mdns::Publisher::TxtList txtList{{"rv", "1"}};
+    Mdns::Publisher::TxtList txtList;
 
     if (!mVendorOui.empty())
     {


### PR DESCRIPTION
This commit updates `EncodeVendorTxtData()` to no longer include the "rv" key. This is because the "rv" key is now included as part of the TXT data generated by OpenThread core's Border Agent.

The "rv" key represents the version of the TXT record format, and per the Thread specification, it must be set to "1".


----

Related to 
- https://github.com/openthread/openthread/pull/11504