### PR TITLE
[host] add IsInitialized method

### DIFF
--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -109,7 +109,8 @@ const otMeshLocalPrefix *NcpNetworkProperties::GetMeshLocalPrefix(void) const
 // ===================================== NcpHost ======================================
 
 NcpHost::NcpHost(const char *aInterfaceName, const char *aBackboneInterfaceName, bool aDryRun)
-    : mSpinelDriver(*static_cast<ot::Spinel::SpinelDriver *>(otSysGetSpinelDriver()))
+    : mIsInitialized(false)
+    , mSpinelDriver(*static_cast<ot::Spinel::SpinelDriver *>(otSysGetSpinelDriver()))
     , mCliDaemon(mNcpSpinel)
 {
     memset(&mConfig, 0, sizeof(mConfig));
@@ -141,10 +142,12 @@ void NcpHost::Init(void)
     mNcpSpinel.SrpServerSetEnabled(/* aEnabled */ true);
 #endif
 #endif
+    mIsInitialized = true;
 }
 
 void NcpHost::Deinit(void)
 {
+    mIsInitialized = false;
     mNcpSpinel.Deinit();
     otSysDeinit();
 }

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -137,6 +137,10 @@ public:
     }
     void Init(void) override;
     void Deinit(void) override;
+    bool IsInitialized(void) const override
+    {
+        return mIsInitialized;
+    }
 
     // MainloopProcessor methods
     void Update(MainloopContext &aMainloop) override;
@@ -169,6 +173,7 @@ private:
                             const uint8_t    *aData,
                             uint16_t          aDataLen) override;
 
+    bool                      mIsInitialized;
     ot::Spinel::SpinelDriver &mSpinelDriver;
     otPlatformConfig          mConfig;
     NcpSpinel                 mNcpSpinel;

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -136,6 +136,7 @@ public:
         return mThreadHelper.get();
     }
 
+    bool IsInitialized(void) const override { return mInstance != nullptr; }
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
 

--- a/src/host/thread_host.hpp
+++ b/src/host/thread_host.hpp
@@ -338,6 +338,16 @@ public:
     virtual void Deinit(void) = 0;
 
     /**
+     * Whether the Thread controller has been initialized.
+     *
+     * All the functional APIs MUST be called when the Thread controller is initialized.
+     *
+     * @retval true   The Thread controller has been initialized.
+     * @retval false  The Thread controller hasn't been initialized.
+     */
+    virtual bool IsInitialized(void) const = 0;
+
+    /**
      * The destructor.
      */
     virtual ~ThreadHost(void) = default;


### PR DESCRIPTION
This PR adds an API 'IsInitialized' to `ThreadHost`.

The intention is to provide a method for the application side to know whether ThreadHost APIs are ready to call. An immediate use case is add checks in Android OtDaemonServer binder methods.