### PR TITLE
[application] add missing headers

### DIFF
--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -49,6 +49,12 @@
 #if OTBR_ENABLE_BACKBONE_ROUTER
 #include "backbone_router/backbone_agent.hpp"
 #endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#include "sdp_proxy/advertising_proxy.hpp"
+#endif
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
+#include "sdp_proxy/discovery_proxy.hpp"
+#endif
 #if OTBR_ENABLE_REST_SERVER
 #include "rest/rest_web_server.hpp"
 #endif


### PR DESCRIPTION
When setting up OTBR on a Raspberry Pi 4 (`INFRA_IF_NAME=eth1 ./script/setup`), I got this build failure:
```
/home/pi/Documents/git/ot-br-posix/src/agent/application.hpp:205:5: error: ‘Dnssd’ does not name a type
  205 |     Dnssd::DiscoveryProxy &GetDiscoveryProxy(void)
      |     ^~~~~                                                             
compilation terminated due to -Wfatal-errors.
```
I think the issue doesn't happen in CI or linux machine because the two headers are indirectly included in header `border_agent.hpp`. But that doesn't work for the toolchain on my Raspberry Pi 4. Let's still add the headers here. 