### PR TITLE
[ci] add raspbian build check for bookworm version

### DIFF
--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -44,8 +44,15 @@ jobs:
 
   raspbian-check:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image_url: [
+          "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip",
+          "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2025-05-13/2025-05-13-raspios-bookworm-armhf-lite.img.xz"
+        ]
     env:
-      IMAGE_URL: https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip
+      IMAGE_URL: ${{ matrix.image_url }}
       BUILD_TARGET: raspbian-gcc
     steps:
     - uses: actions/checkout@v4

--- a/tests/scripts/check-raspbian
+++ b/tests/scripts/check-raspbian
@@ -34,10 +34,20 @@ TOOLS_HOME=$HOME/.cache/tools
 
 main()
 {
-    IMAGE_NAME=$(basename "${IMAGE_URL}" .zip)
+    # Determine the image stem name based on IMAGE_URL suffix
+    if [[ ${IMAGE_URL} == *.zip ]]; then
+        IMAGE_NAME=$(basename "${IMAGE_URL}" .zip)
+    elif [[ ${IMAGE_URL} == *.img.xz ]]; then
+        IMAGE_NAME=$(basename "${IMAGE_URL}" .img.xz)
+    else
+        echo "Unsupported image archive format in IMAGE_URL: ${IMAGE_URL}" >&2
+        echo "Must end in .zip or .img.xz" >&2
+        exit 1
+    fi
+
     STAGE_DIR=/tmp/raspbian
     IMAGE_DIR=/media/rpi
-    IMAGE_FILE="$TOOLS_HOME"/images/"$IMAGE_NAME".img
+    IMAGE_FILE="$TOOLS_HOME/images/${IMAGE_NAME}.img"
 
     [ -d "$STAGE_DIR" ] || mkdir -p "$STAGE_DIR"
     cp -v "$IMAGE_FILE" "$STAGE_DIR"/raspbian.img
@@ -61,11 +71,17 @@ su -c 'RELEASE=1 script/bootstrap' pi
 # Pin CMake version to 3.10.3 for issue https://github.com/openthread/ot-br-posix/issues/728.
 # For more background, see https://gitlab.kitware.com/cmake/cmake/-/issues/20568.
 apt-get purge -y cmake
+apt-get install -y python3-venv
+TEMP_VENV_DIR=$(mktemp -d)
+python3 -m venv "\${TEMP_VENV_DIR}"
+source "\${TEMP_VENV_DIR}/bin/activate"
 pip3 install scikit-build
 pip3 install cmake==3.10.3
 cmake --version
 
 su -c 'RELEASE=1 script/setup' pi
+deactivate
+rm -rf "\${TEMP_VENV_DIR}"
 EOF
 
     (


### PR DESCRIPTION
This PR extends the test scripts so that it can test with the recently raspbian OS versions. The recent raspbian OS can only be downloaded in `.xz` format instead of `.zip` so the current test script doesn't work with it. The PR also adds a test to verify the latest 2025-05-13 version of raspios.