### PR TITLE
[build] provides an option to enable `ot-br-posix-user-config.h` header file

### DIFF
--- a/include/openthread-br/config.h
+++ b/include/openthread-br/config.h
@@ -35,6 +35,10 @@
 
 #if defined(OTBR_CONFIG_FILE)
 #include OTBR_CONFIG_FILE
+#elif defined(OTBR_USER_CONFIG_HEADER_ENABLE) && OTBR_USER_CONFIG_HEADER_ENABLE
+// This configuration header file should be provided by the user when
+// OTBR_USER_CONFIG_HEADER_ENABLE is defined to 1.
+#include "ot-br-posix-user-config.h"
 #endif
 
 /**


### PR DESCRIPTION
This PR introduces a new macro `OTBR_USER_CONFIG_HEADER_ENABLE`. When it's defined and `OTBR_CONFIG_FILE` is not defined, OTBR will use the user-provided header file `ot-br-posix-user-config.h` to configure the build time options.

This is similar to OpenThread's `openthread-core-user-config.h`.