### PR TITLE
 [build] fix minor issues for other build systems

### DIFF
--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -676,7 +676,7 @@ void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aS
         // with the new host name.
         otbrLogErr("Avahi client collision detected: %s", avahi_strerror(avahi_client_errno(aClient)));
 
-        // fall through
+        OT_FALL_THROUGH;
 
     case AVAHI_CLIENT_S_REGISTERING:
         // The server records are now being established. This might be

--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -31,11 +31,11 @@
  *   The file implements the DNS-SD Discovery Proxy.
  */
 
-#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
-
 #define OTBR_LOG_TAG "DPROXY"
 
 #include "sdp_proxy/discovery_proxy.hpp"
+
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
 
 #include <algorithm>
 #include <string>

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -31,11 +31,11 @@
  *   This file includes implementation of TREL DNS-SD over mDNS.
  */
 
-#if OTBR_ENABLE_TREL
-
 #define OTBR_LOG_TAG "TrelDns"
 
 #include "trel_dnssd/trel_dnssd.hpp"
+
+#if OTBR_ENABLE_TREL
 
 #include <inttypes.h>
 #include <net/if.h>


### PR DESCRIPTION
This PR fixes two things:
- For `DiscoveryProxy` and `TrelDnssd`, ensure the header is included before the macro guard.
- Use `OT_FALL_THROUGH` in `mdns_avahi.cpp`.