### PR TITLE
[disc-proxy] fix subscription count check in unsubscribe

### DIFF
--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -157,7 +157,7 @@ void DiscoveryProxy::OnDiscoveryProxyUnsubscribe(const char *aFullName)
 
     otbrLogInfo("Unsubscribe: %s", fullName.c_str());
 
-    if (GetServiceSubscriptionCount(nameInfo) == 1)
+    if (GetServiceSubscriptionCount(nameInfo) <= 1)
     {
         if (nameInfo.mHostName.empty())
         {


### PR DESCRIPTION
This commit fixes `OnDiscoveryProxyUnsubscribe()` by relaxing the `GetServiceSubscriptionCount(nameInfo)` check from `== 1` to `<= 1`.

This addresses an issue where `Unsubscribe` is called after a pending query is resolved, causing the subscription count to be zero. The previous check would fail in this scenario.

By relaxing the check, we ensure that the query is properly canceled in the underlying mDNS library, which stops the discovery proxy from continuing to send prior mDNS queries.