### PR TITLE
[dnssd] implement Dnssd Browser/Resolver APIs

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -126,6 +126,11 @@ void Ip6Address::CopyFrom(const struct in6_addr &aIn6Addr)
     memcpy(m8, aIn6Addr.s6_addr, sizeof(aIn6Addr.s6_addr));
 }
 
+void Ip6Address::CopyTo(otIp6Address &aAddress) const
+{
+    memcpy(aAddress.mFields.m8, m8, sizeof(aAddress.mFields.m8));
+}
+
 otbrError Ip6Address::FromString(const char *aStr, Ip6Address &aAddr)
 {
     int ret;

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -311,6 +311,13 @@ public:
      */
     void CopyFrom(const struct in6_addr &aIn6Addr);
 
+    /**
+     * This method copies the Ip6 address to an `otIp6Address` structure.
+     *
+     * @param[out] aAddress  The `otIp6Address` structure to copy the Ip6 address to.
+     */
+    void CopyTo(otIp6Address &aAddress) const;
+
     union
     {
         uint8_t  m8[16];

--- a/src/host/posix/CMakeLists.txt
+++ b/src/host/posix/CMakeLists.txt
@@ -29,6 +29,7 @@
 add_library(otbr-posix
     cli_daemon.hpp
     cli_daemon.cpp
+    dnssd.hpp
     dnssd.cpp
     infra_if.hpp
     infra_if.cpp

--- a/src/host/posix/dnssd.cpp
+++ b/src/host/posix/dnssd.cpp
@@ -36,17 +36,17 @@
 #include "host/posix/dnssd.hpp"
 
 #if OTBR_ENABLE_DNSSD_PLAT
-
 #include <string>
+#include <vector>
 
 #include <openthread/platform/dnssd.h>
 
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/types.hpp"
+#include "utils/dns_utils.hpp"
 
-static otbr::DnssdPlatform::RegisterCallback MakeRegisterCallback(otInstance                 *aInstance,
-                                                                  otPlatDnssdRegisterCallback aCallback)
+otbr::DnssdPlatform::RegisterCallback MakeRegisterCallback(otInstance *aInstance, otPlatDnssdRegisterCallback aCallback)
 {
     return [aInstance, aCallback](otPlatDnssdRequestId aRequestId, otError aError) {
         if (aCallback)
@@ -113,62 +113,62 @@ extern "C" void otPlatDnssdUnregisterKey(otInstance                 *aInstance,
 
 extern "C" void otPlatDnssdStartBrowser(otInstance *aInstance, const otPlatDnssdBrowser *aBrowser)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aBrowser);
+    otbr::DnssdPlatform::Get().StartServiceBrowser(
+        *aBrowser, MakeUnique<otbr::DnssdPlatform::OtBrowseCallback>(aInstance, aBrowser->mCallback));
 }
 
 extern "C" void otPlatDnssdStopBrowser(otInstance *aInstance, const otPlatDnssdBrowser *aBrowser)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aBrowser);
+    otbr::DnssdPlatform::Get().StopServiceBrowser(
+        *aBrowser, otbr::DnssdPlatform::OtBrowseCallback(aInstance, aBrowser->mCallback));
 }
 
 extern "C" void otPlatDnssdStartSrvResolver(otInstance *aInstance, const otPlatDnssdSrvResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StartServiceResolver(
+        *aResolver, MakeUnique<otbr::DnssdPlatform::OtSrvCallback>(aInstance, aResolver->mCallback));
 }
 
 extern "C" void otPlatDnssdStopSrvResolver(otInstance *aInstance, const otPlatDnssdSrvResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StopServiceResolver(*aResolver,
+                                                   otbr::DnssdPlatform::OtSrvCallback(aInstance, aResolver->mCallback));
 }
 
 extern "C" void otPlatDnssdStartTxtResolver(otInstance *aInstance, const otPlatDnssdTxtResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StartTxtResolver(
+        *aResolver, MakeUnique<otbr::DnssdPlatform::OtTxtCallback>(aInstance, aResolver->mCallback));
 }
 
 extern "C" void otPlatDnssdStopTxtResolver(otInstance *aInstance, const otPlatDnssdTxtResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StopTxtResolver(*aResolver,
+                                               otbr::DnssdPlatform::OtTxtCallback(aInstance, aResolver->mCallback));
 }
 
 extern "C" void otPlatDnssdStartIp6AddressResolver(otInstance *aInstance, const otPlatDnssdAddressResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StartIp6AddressResolver(
+        *aResolver, MakeUnique<otbr::DnssdPlatform::OtAddressCallback>(aInstance, aResolver->mCallback));
 }
 
 extern "C" void otPlatDnssdStopIp6AddressResolver(otInstance *aInstance, const otPlatDnssdAddressResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StopIp6AddressResolver(
+        *aResolver, otbr::DnssdPlatform::OtAddressCallback(aInstance, aResolver->mCallback));
 }
 
 void otPlatDnssdStartIp4AddressResolver(otInstance *aInstance, const otPlatDnssdAddressResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StartIp4AddressResolver(
+        *aResolver, MakeUnique<otbr::DnssdPlatform::OtAddressCallback>(aInstance, aResolver->mCallback));
 }
 
 void otPlatDnssdStopIp4AddressResolver(otInstance *aInstance, const otPlatDnssdAddressResolver *aResolver)
 {
-    OTBR_UNUSED_VARIABLE(aInstance);
-    OTBR_UNUSED_VARIABLE(aResolver);
+    otbr::DnssdPlatform::Get().StopIp4AddressResolver(
+        *aResolver, otbr::DnssdPlatform::OtAddressCallback(aInstance, aResolver->mCallback));
 }
 
 void otPlatDnssdStartRecordQuerier(otInstance *aInstance, const otPlatDnssdRecordQuerier *aQuerier)
@@ -187,13 +187,16 @@ void otPlatDnssdStopRecordQuerier(otInstance *aInstance, const otPlatDnssdRecord
 
 namespace otbr {
 
-DnssdPlatform *DnssdPlatform::sDnssdPlatform = nullptr;
+DnssdPlatform            *DnssdPlatform::sDnssdPlatform = nullptr;
+static constexpr uint64_t kInvalidSubscriberId          = 0;
 
 DnssdPlatform::DnssdPlatform(Mdns::Publisher &aPublisher)
     : mPublisher(aPublisher)
     , mState(kStateStopped)
     , mRunning(false)
+    , mInvokingCallbacks(false)
     , mPublisherState(Mdns::Publisher::State::kIdle)
+    , mSubscriberId(kInvalidSubscriberId)
 {
     sDnssdPlatform = this;
 }
@@ -222,13 +225,15 @@ void DnssdPlatform::UpdateState(void)
     {
         VerifyOrExit(mState != kStateReady);
 
-        mState = kStateReady;
+        mState        = kStateReady;
+        mSubscriberId = mPublisher.AddSubscriptionCallbacks(HandleDiscoveredService, HandleDiscoveredHost);
     }
     else
     {
         VerifyOrExit(mState != kStateStopped);
 
         mState = kStateStopped;
+        mPublisher.RemoveSubscriptionCallbacks(mSubscriberId);
     }
 
     if (mStateChangeCallback)
@@ -330,6 +335,160 @@ void DnssdPlatform::UnregisterKey(const Key &aKey, RequestId aRequestId, Registe
     mPublisher.UnpublishKey(KeyNameFor(aKey), MakePublisherCallback(aRequestId, aCallback));
 }
 
+void DnssdPlatform::StartServiceBrowser(const Browser &aBrowser, BrowseCallbackPtr aCallbackPtr)
+{
+    DnsServiceType fullServiceType(aBrowser.mServiceType, aBrowser.mSubTypeLabel);
+    auto          &entryList         = mServiceBrowsersMap[fullServiceType];
+    bool           needsSubscription = !entryList.HasSubscribedOnInfraIf(aBrowser.mInfraIfIndex);
+
+    VerifyOrExit(!mInvokingCallbacks);
+
+    entryList.AddIfAbsent(aBrowser.mInfraIfIndex, std::move(aCallbackPtr));
+
+    if (needsSubscription)
+    {
+        mPublisher.SubscribeService(fullServiceType.ToString(), "");
+    }
+
+exit:
+    return;
+}
+
+void DnssdPlatform::StopServiceBrowser(const Browser &aBrowser, const BrowseCallback &aCallback)
+{
+    DnsServiceType fullServiceType(aBrowser.mServiceType, aBrowser.mSubTypeLabel);
+    auto           iter = mServiceBrowsersMap.find(fullServiceType);
+
+    if (iter != mServiceBrowsersMap.end())
+    {
+        auto &entryList = iter->second;
+
+        entryList.MarkAsDeleted(aBrowser.mInfraIfIndex, aCallback);
+
+        if (!entryList.HasAnyValidCallbacks())
+        {
+            mPublisher.UnsubscribeService(fullServiceType.ToString(), "");
+        }
+
+        if (!mInvokingCallbacks)
+        {
+            entryList.CleanUpDeletedEntries();
+            if (entryList.IsEmpty())
+            {
+                mServiceBrowsersMap.erase(iter);
+            }
+        }
+    }
+}
+
+void DnssdPlatform::StartServiceResolver(const SrvResolver &aSrvResolver, SrvCallbackPtr aCallbackPtr)
+{
+    auto &entryList = mServiceResolversMap[DnsServiceName(aSrvResolver.mServiceInstance, aSrvResolver.mServiceType)];
+    bool  needsSubscription = !entryList.HasSubscribedOnInfraIf(aSrvResolver.mInfraIfIndex);
+
+    VerifyOrExit(!mInvokingCallbacks);
+
+    entryList.AddIfAbsent(aSrvResolver.mInfraIfIndex, std::move(aCallbackPtr));
+
+    if (needsSubscription)
+    {
+        mPublisher.SubscribeService(aSrvResolver.mServiceType, aSrvResolver.mServiceInstance);
+    }
+
+exit:
+    return;
+}
+
+void DnssdPlatform::StopServiceResolver(const SrvResolver &aSrvResolver, const SrvCallback &aCallback)
+{
+    auto iter = mServiceResolversMap.find(DnsServiceName(aSrvResolver.mServiceInstance, aSrvResolver.mServiceType));
+
+    if (iter != mServiceResolversMap.end())
+    {
+        auto &entryList = iter->second;
+
+        entryList.MarkAsDeleted(aSrvResolver.mInfraIfIndex, aCallback);
+
+        if (!entryList.HasAnyValidCallbacks())
+        {
+            mPublisher.UnsubscribeService(aSrvResolver.mServiceType, aSrvResolver.mServiceInstance);
+        }
+
+        if (!mInvokingCallbacks)
+        {
+            entryList.CleanUpDeletedEntries();
+            if (entryList.IsEmpty())
+            {
+                mServiceResolversMap.erase(iter);
+            }
+        }
+    }
+}
+
+void DnssdPlatform::StartTxtResolver(const TxtResolver &aTxtResolver, TxtCallbackPtr aCallbackPtr)
+{
+    auto &entryList = mTxtResolversMap[DnsServiceName(aTxtResolver.mServiceInstance, aTxtResolver.mServiceType)];
+    bool  needsSubscription = !entryList.HasSubscribedOnInfraIf(aTxtResolver.mInfraIfIndex);
+
+    VerifyOrExit(!mInvokingCallbacks);
+
+    entryList.AddIfAbsent(aTxtResolver.mInfraIfIndex, std::move(aCallbackPtr));
+
+    if (needsSubscription)
+    {
+        mPublisher.SubscribeService(aTxtResolver.mServiceType, aTxtResolver.mServiceInstance);
+    }
+
+exit:
+    return;
+}
+
+void DnssdPlatform::StopTxtResolver(const TxtResolver &aTxtResolver, const TxtCallback &aCallback)
+{
+    auto iter = mTxtResolversMap.find(DnsServiceName(aTxtResolver.mServiceInstance, aTxtResolver.mServiceType));
+
+    if (iter != mTxtResolversMap.end())
+    {
+        auto &entryList = iter->second;
+
+        entryList.MarkAsDeleted(aTxtResolver.mInfraIfIndex, aCallback);
+
+        if (!entryList.HasAnyValidCallbacks())
+        {
+            mPublisher.UnsubscribeService(aTxtResolver.mServiceType, aTxtResolver.mServiceInstance);
+        }
+
+        if (!mInvokingCallbacks)
+        {
+            entryList.CleanUpDeletedEntries();
+            if (entryList.IsEmpty())
+            {
+                mTxtResolversMap.erase(iter);
+            }
+        }
+    }
+}
+
+void DnssdPlatform::StartIp6AddressResolver(const AddressResolver &aAddressResolver, AddressCallbackPtr aCallbackPtr)
+{
+    StartAddressResolver(aAddressResolver, std::move(aCallbackPtr), mIp6AddrResolversMap);
+}
+
+void DnssdPlatform::StopIp6AddressResolver(const AddressResolver &aAddressResolver, const AddressCallback &aCallback)
+{
+    StopAddressResolver(aAddressResolver, aCallback, mIp6AddrResolversMap);
+}
+
+void DnssdPlatform::StartIp4AddressResolver(const AddressResolver &aAddressResolver, AddressCallbackPtr aCallbackPtr)
+{
+    StartAddressResolver(aAddressResolver, std::move(aCallbackPtr), mIp4AddrResolversMap);
+}
+
+void DnssdPlatform::StopIp4AddressResolver(const AddressResolver &aAddressResolver, const AddressCallback &aCallback)
+{
+    StopAddressResolver(aAddressResolver, aCallback, mIp4AddrResolversMap);
+}
+
 void DnssdPlatform::HandleMdnsState(Mdns::Publisher::State aState)
 {
     if (mPublisherState != aState)
@@ -337,6 +496,210 @@ void DnssdPlatform::HandleMdnsState(Mdns::Publisher::State aState)
         mPublisherState = aState;
         UpdateState();
     }
+}
+
+void DnssdPlatform::HandleDiscoveredService(const std::string                             &aType,
+                                            const Mdns::Publisher::DiscoveredInstanceInfo &aInfo)
+{
+    otbr::DnssdPlatform::Get().SetInvokingCallbacks(true);
+
+    otbr::DnssdPlatform::Get().ProcessServiceBrowsers(aType, aInfo);
+    otbr::DnssdPlatform::Get().ProcessServiceResolvers(aType, aInfo);
+    otbr::DnssdPlatform::Get().ProcessTxtResolvers(aType, aInfo);
+
+    otbr::DnssdPlatform::Get().SetInvokingCallbacks(false);
+}
+
+void DnssdPlatform::HandleDiscoveredHost(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aInfo)
+{
+    otbr::DnssdPlatform::Get().SetInvokingCallbacks(true);
+
+    otbr::DnssdPlatform::Get().ProcessIp6AddrResolvers(aHostName, aInfo);
+    otbr::DnssdPlatform::Get().ProcessIp4AddrResolvers(aHostName, aInfo);
+
+    otbr::DnssdPlatform::Get().SetInvokingCallbacks(false);
+}
+
+void DnssdPlatform::ProcessServiceBrowsers(const std::string                             &aType,
+                                           const Mdns::Publisher::DiscoveredInstanceInfo &aInfo)
+{
+    std::string  instanceName;
+    BrowseResult result;
+    auto         it = mServiceBrowsersMap.find(DnsServiceType(aType.c_str(), nullptr));
+
+    VerifyOrExit(mState == kStateReady);
+
+    VerifyOrExit(it != mServiceBrowsersMap.end());
+
+    instanceName = DnsUtils::UnescapeInstanceName(aInfo.mName);
+
+    result.mServiceType     = aType.c_str();
+    result.mSubTypeLabel    = nullptr;
+    result.mServiceInstance = instanceName.c_str();
+    result.mTtl             = aInfo.mTtl;
+    result.mInfraIfIndex    = aInfo.mNetifIndex;
+
+    it->second.InvokeAllCallbacks(result.mInfraIfIndex, result);
+
+exit:
+    return;
+}
+
+void DnssdPlatform::ProcessServiceResolvers(const std::string                             &aType,
+                                            const Mdns::Publisher::DiscoveredInstanceInfo &aInfo)
+{
+    std::string    instanceName = DnsUtils::UnescapeInstanceName(aInfo.mName);
+    DnsServiceName serviceName(instanceName, aType);
+    std::string    hostName;
+    std::string    domain;
+    SrvResult      srvResult;
+    auto           it = mServiceResolversMap.find(serviceName);
+
+    VerifyOrExit(mState == kStateReady);
+    VerifyOrExit(it != mServiceResolversMap.end());
+
+    SuccessOrExit(DnsUtils::SplitFullHostName(aInfo.mHostName, hostName, domain));
+    srvResult.mServiceInstance = instanceName.c_str();
+    srvResult.mServiceType     = aType.c_str();
+    srvResult.mHostName        = hostName.c_str();
+    srvResult.mPort            = aInfo.mPort;
+    srvResult.mPriority        = aInfo.mPriority;
+    srvResult.mWeight          = aInfo.mWeight;
+    srvResult.mTtl             = aInfo.mTtl;
+    srvResult.mInfraIfIndex    = aInfo.mNetifIndex;
+
+    it->second.InvokeAllCallbacks(srvResult.mInfraIfIndex, srvResult);
+
+exit:
+    return;
+}
+
+void DnssdPlatform::ProcessTxtResolvers(const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInfo)
+{
+    std::string    instanceName = DnsUtils::UnescapeInstanceName(aInfo.mName);
+    DnsServiceName serviceName(instanceName, aType);
+    TxtResult      txtResult;
+    auto           it = mTxtResolversMap.find(serviceName);
+
+    VerifyOrExit(mState == kStateReady);
+
+    VerifyOrExit(it != mTxtResolversMap.end());
+
+    txtResult.mServiceInstance = instanceName.c_str();
+    txtResult.mServiceType     = aType.c_str();
+    txtResult.mTxtData         = aInfo.mTxtData.data();
+    txtResult.mTxtDataLength   = aInfo.mTxtData.size();
+    txtResult.mTtl             = aInfo.mTtl;
+    txtResult.mInfraIfIndex    = aInfo.mNetifIndex;
+
+    it->second.InvokeAllCallbacks(txtResult.mInfraIfIndex, txtResult);
+
+exit:
+    return;
+}
+
+void DnssdPlatform::ProcessAddrResolvers(const std::string                          &aHostName,
+                                         const Mdns::Publisher::DiscoveredHostInfo  &aInfo,
+                                         std::map<DnsName, EntryList<AddressEntry>> &aResolversMap)
+{
+    std::string                           instanceName;
+    AddressResult                         result;
+    std::vector<otPlatDnssdAddressAndTtl> addressAndTtls;
+    auto                                  it = aResolversMap.find(aHostName);
+
+    VerifyOrExit(mState == kStateReady);
+
+    VerifyOrExit(it != aResolversMap.end());
+
+    result.mHostName = aHostName.c_str();
+    for (const auto &addr : aInfo.mAddresses)
+    {
+        otIp6Address ip6Addr;
+
+        addr.CopyTo(ip6Addr);
+
+        addressAndTtls.push_back({ip6Addr, aInfo.mTtl});
+    }
+    result.mAddresses       = addressAndTtls.data();
+    result.mAddressesLength = addressAndTtls.size();
+    result.mInfraIfIndex    = aInfo.mNetifIndex;
+
+    it->second.InvokeAllCallbacks(result.mInfraIfIndex, result);
+
+exit:
+    return;
+}
+
+void DnssdPlatform::ProcessIp6AddrResolvers(const std::string                         &aHostName,
+                                            const Mdns::Publisher::DiscoveredHostInfo &aInfo)
+{
+    ProcessAddrResolvers(aHostName, aInfo, mIp6AddrResolversMap);
+}
+
+void DnssdPlatform::ProcessIp4AddrResolvers(const std::string                         &aHostName,
+                                            const Mdns::Publisher::DiscoveredHostInfo &aInfo)
+{
+    ProcessAddrResolvers(aHostName, aInfo, mIp4AddrResolversMap);
+}
+
+void DnssdPlatform::StartAddressResolver(const AddressResolver                      &aAddressResolver,
+                                         AddressCallbackPtr                          aCallbackPtr,
+                                         std::map<DnsName, EntryList<AddressEntry>> &aResolversMap)
+{
+    auto &entryList         = aResolversMap[DnsName(aAddressResolver.mHostName)];
+    bool  needsSubscription = !entryList.HasSubscribedOnInfraIf(aAddressResolver.mInfraIfIndex);
+
+    VerifyOrExit(!mInvokingCallbacks);
+
+    entryList.AddIfAbsent(aAddressResolver.mInfraIfIndex, std::move(aCallbackPtr));
+
+    if (needsSubscription)
+    {
+        mPublisher.SubscribeHost(aAddressResolver.mHostName);
+    }
+
+exit:
+    return;
+}
+
+void DnssdPlatform::StopAddressResolver(const AddressResolver                      &aAddressResolver,
+                                        const AddressCallback                      &aCallback,
+                                        std::map<DnsName, EntryList<AddressEntry>> &aResolversMap)
+{
+    auto iter = aResolversMap.find(DnsName(aAddressResolver.mHostName));
+
+    if (iter != aResolversMap.end())
+    {
+        auto &entryList = iter->second;
+
+        entryList.MarkAsDeleted(aAddressResolver.mInfraIfIndex, aCallback);
+
+        if (!entryList.HasAnyValidCallbacks())
+        {
+            mPublisher.UnsubscribeHost(aAddressResolver.mHostName);
+        }
+
+        if (!mInvokingCallbacks)
+        {
+            entryList.CleanUpDeletedEntries();
+            if (entryList.IsEmpty())
+            {
+                aResolversMap.erase(iter);
+            }
+        }
+    }
+}
+
+const std::string DnssdPlatform::DnsServiceType::ToString(void) const
+{
+    std::string serviceType(mType);
+
+    if (!mSubType.empty())
+    {
+        serviceType = std::string(mSubType) + "._sub." + serviceType;
+    }
+
+    return serviceType;
 }
 
 } // namespace otbr

--- a/src/host/posix/dnssd.hpp
+++ b/src/host/posix/dnssd.hpp
@@ -38,16 +38,19 @@
 
 #if OTBR_ENABLE_DNSSD_PLAT
 
+#include <algorithm>
 #include <functional>
+#include <map>
+#include <memory>
 #include <string>
 
 #include <openthread/instance.h>
 #include <openthread/platform/dnssd.h>
 
 #include "common/code_utils.hpp"
-#include "host/thread_host.hpp"
 #include "mdns/mdns.hpp"
 #include "utils/dns_utils.hpp"
+#include "utils/string_utils.hpp"
 
 namespace otbr {
 
@@ -98,12 +101,119 @@ public:
     //-----------------------------------------------------------------------------------------------------------------
     // `otPlatDnssd` APIs (see `openthread/include/openthread/platform/dnssd.h` for detailed documentation).
 
-    typedef otPlatDnssdState                                   State;
-    typedef otPlatDnssdService                                 Service;
-    typedef otPlatDnssdHost                                    Host;
-    typedef otPlatDnssdKey                                     Key;
-    typedef otPlatDnssdRequestId                               RequestId;
+    typedef otPlatDnssdState           State;
+    typedef otPlatDnssdService         Service;
+    typedef otPlatDnssdHost            Host;
+    typedef otPlatDnssdKey             Key;
+    typedef otPlatDnssdRequestId       RequestId;
+    typedef otPlatDnssdBrowser         Browser;
+    typedef otPlatDnssdBrowseResult    BrowseResult;
+    typedef otPlatDnssdSrvResolver     SrvResolver;
+    typedef otPlatDnssdSrvResult       SrvResult;
+    typedef otPlatDnssdTxtResolver     TxtResolver;
+    typedef otPlatDnssdTxtResult       TxtResult;
+    typedef otPlatDnssdAddressResolver AddressResolver;
+    typedef otPlatDnssdAddressResult   AddressResult;
+    typedef otPlatDnssdAddressAndTtl   AddressAndTtl;
+
     typedef std::function<void(otPlatDnssdRequestId, otError)> RegisterCallback;
+
+    typedef enum
+    {
+        kOtCallback,
+        kStdFunc,
+    } CallbackType;
+
+    template <typename DnssdResultType> class DnssdCallback
+    {
+    public:
+        using ResultType = DnssdResultType;
+
+        virtual void InvokeCallback(const DnssdResultType &aDnssdResult) = 0;
+
+        virtual ~DnssdCallback() = default;
+
+        bool operator==(const DnssdCallback &aOther) const
+        {
+            return (GetType() == aOther.GetType()) && IsEqualWhenSameType(aOther);
+        }
+
+    private:
+        virtual CallbackType GetType(void) const                                                     = 0;
+        virtual bool         IsEqualWhenSameType(const DnssdCallback<DnssdResultType> &aOther) const = 0;
+    };
+
+    typedef DnssdCallback<BrowseResult>  BrowseCallback;
+    typedef DnssdCallback<SrvResult>     SrvCallback;
+    typedef DnssdCallback<TxtResult>     TxtCallback;
+    typedef DnssdCallback<AddressResult> AddressCallback;
+
+    template <typename OtDnssdCallbackType, typename DnssdResultType>
+    class OtDnssdCallback : public DnssdCallback<DnssdResultType>
+    {
+    public:
+        OtDnssdCallback(otInstance *aInstance, OtDnssdCallbackType aCallback)
+            : mInstance(aInstance)
+            , mCallback(aCallback)
+        {
+        }
+
+        void InvokeCallback(const DnssdResultType &aResult) override { mCallback(mInstance, &aResult); }
+
+    private:
+        CallbackType GetType(void) const override { return kOtCallback; }
+        bool         IsEqualWhenSameType(const DnssdCallback<DnssdResultType> &aOther) const override
+        {
+            const OtDnssdCallback &other = static_cast<const OtDnssdCallback &>(aOther);
+            return mCallback == other.mCallback;
+        }
+
+        otInstance         *mInstance;
+        OtDnssdCallbackType mCallback;
+    };
+
+    typedef OtDnssdCallback<otPlatDnssdBrowseCallback, BrowseResult>   OtBrowseCallback;
+    typedef OtDnssdCallback<otPlatDnssdSrvCallback, SrvResult>         OtSrvCallback;
+    typedef OtDnssdCallback<otPlatDnssdTxtCallback, TxtResult>         OtTxtCallback;
+    typedef OtDnssdCallback<otPlatDnssdAddressCallback, AddressResult> OtAddressCallback;
+
+    template <typename StdDnssdCallbackType, typename DnssdResultType>
+    class StdDnssdCallback : public DnssdCallback<DnssdResultType>
+    {
+    public:
+        StdDnssdCallback(StdDnssdCallbackType aCallback, uint64_t aId)
+            : mCallback(aCallback)
+            , mId(aId)
+        {
+        }
+
+        void InvokeCallback(const DnssdResultType &aResult) override { mCallback(aResult); }
+
+    private:
+        CallbackType GetType(void) const override { return kStdFunc; }
+        bool         IsEqualWhenSameType(const DnssdCallback<DnssdResultType> &aOther) const override
+        {
+            const StdDnssdCallback &other = static_cast<const StdDnssdCallback &>(aOther);
+            return this->mId == other.mId;
+        }
+
+        StdDnssdCallbackType mCallback;
+        uint64_t             mId;
+    };
+
+    typedef StdDnssdCallback<std::function<void(const BrowseResult &)>, BrowseResult>   StdBrowseCallback;
+    typedef StdDnssdCallback<std::function<void(const SrvResult &)>, SrvResult>         StdSrvCallback;
+    typedef StdDnssdCallback<std::function<void(const TxtResult &)>, TxtResult>         StdTxtCallback;
+    typedef StdDnssdCallback<std::function<void(const AddressResult &)>, AddressResult> StdAddressCallback;
+
+    typedef std::unique_ptr<BrowseCallback>         BrowseCallbackPtr;
+    typedef std::unique_ptr<SrvCallback>            SrvCallbackPtr;
+    typedef std::unique_ptr<TxtCallback>            TxtCallbackPtr;
+    typedef std::unique_ptr<AddressCallback>        AddressCallbackPtr;
+    typedef std::pair<uint64_t, BrowseCallbackPtr>  BrowseEntry;
+    typedef std::pair<uint64_t, SrvCallbackPtr>     SrvEntry;
+    typedef std::pair<uint64_t, TxtCallbackPtr>     TxtEntry;
+    typedef std::pair<uint64_t, AddressCallbackPtr> AddressEntry;
 
     State GetState(void) const { return mState; }
     void  RegisterService(const Service &aService, RequestId aRequestId, RegisterCallback aCallback);
@@ -112,10 +222,182 @@ public:
     void  UnregisterHost(const Host &aHost, RequestId aRequestId, RegisterCallback aCallback);
     void  RegisterKey(const Key &aKey, RequestId aRequestId, RegisterCallback aCallback);
     void  UnregisterKey(const Key &aKey, RequestId aRequestId, RegisterCallback aCallback);
+    void  StartServiceBrowser(const Browser &aBrowser, BrowseCallbackPtr aCallbackPtr);
+    void  StopServiceBrowser(const Browser &aBrowser, const BrowseCallback &aCallback);
+    void  StartServiceResolver(const SrvResolver &aSrvResolver, SrvCallbackPtr aCallbackPtr);
+    void  StopServiceResolver(const SrvResolver &aSrvResolver, const SrvCallback &aCallback);
+    void  StartTxtResolver(const TxtResolver &aTxtResolver, TxtCallbackPtr aCallbackPtr);
+    void  StopTxtResolver(const TxtResolver &aTxtResolver, const TxtCallback &aCallback);
+    void  StartIp6AddressResolver(const AddressResolver &aAddressResolver, AddressCallbackPtr aCallbackPtr);
+    void  StopIp6AddressResolver(const AddressResolver &aAddressResolver, const AddressCallback &aCallback);
+    void  StartIp4AddressResolver(const AddressResolver &aAddressResolver, AddressCallbackPtr aCallbackPtr);
+    void  StopIp4AddressResolver(const AddressResolver &aAddressResolver, const AddressCallback &aCallback);
+
+    void SetInvokingCallbacks(bool aInvokingCallbacks) { mInvokingCallbacks = aInvokingCallbacks; }
 
 private:
     static constexpr State kStateReady   = OT_PLAT_DNSSD_READY;
     static constexpr State kStateStopped = OT_PLAT_DNSSD_STOPPED;
+
+    class DnsName
+    {
+    public:
+        DnsName(std::string aName)
+            : mName(std::move(aName))
+        {
+        }
+
+        bool operator==(const DnsName &aOther) const
+        {
+            return StringUtils::ToLowercase(mName) == StringUtils::ToLowercase(aOther.mName);
+        }
+
+        bool operator<(const DnsName &aOther) const
+        {
+            return StringUtils::ToLowercase(mName) < StringUtils::ToLowercase(aOther.mName);
+        }
+
+    private:
+        std::string mName;
+    };
+
+    class DnsServiceType
+    {
+    public:
+        DnsServiceType(const char *aType, const char *aSubType)
+            : mType(aType ? aType : "")
+            , mSubType(aSubType ? aSubType : "")
+        {
+        }
+
+        bool operator==(const DnsServiceType &aOther) const
+        {
+            return StringUtils::ToLowercase(ToString()) == StringUtils::ToLowercase(aOther.ToString());
+        }
+
+        bool operator<(const DnsServiceType &aOther) const
+        {
+            return StringUtils::ToLowercase(ToString()) < StringUtils::ToLowercase(aOther.ToString());
+        }
+
+        const std::string ToString(void) const;
+
+    private:
+        std::string mType;
+        std::string mSubType;
+    };
+
+    class DnsServiceName
+    {
+    public:
+        DnsServiceName(std::string aInstance, std::string aType)
+            : mInstance(std::move(aInstance))
+            , mType(std::move(aType))
+        {
+        }
+
+        bool operator==(const DnsServiceName &aOther) const
+        {
+            return (mInstance == aOther.mInstance) && (mType == aOther.mType);
+        }
+
+        bool operator<(const DnsServiceName &aOther) const
+        {
+            return (mInstance == aOther.mInstance) ? (mType < aOther.mType) : (mInstance < aOther.mInstance);
+        }
+
+    private:
+        DnsName mInstance;
+        DnsName mType;
+    };
+
+    template <typename T> struct FirstFunctionArg;
+
+    template <typename R, typename Arg, typename... Rest> struct FirstFunctionArg<std::function<R(Arg, Rest...)>>
+    {
+        using Type = Arg;
+    };
+
+    // RequestType MUST be a std::pair<uint64_t, std::unique_ptr<CallbackType>>
+    template <typename RequestType> class EntryList
+    {
+    public:
+        using CallbackType       = typename RequestType::second_type::element_type;
+        using CallbackPtrType    = std::unique_ptr<CallbackType>;
+        using CallbackResultType = typename CallbackType::ResultType;
+
+        bool HasSubscribedOnInfraIf(uint64_t aInfraIfIndex)
+        {
+            return std::find_if(mEntries.begin(), mEntries.end(), [aInfraIfIndex](const RequestType &entry) {
+                       return entry.first == aInfraIfIndex;
+                   }) != mEntries.end();
+        }
+
+        void AddIfAbsent(uint64_t aInfraIfIndex, CallbackPtrType &&aCallbackPtr)
+        {
+            auto iter = FindEntry(aInfraIfIndex, *aCallbackPtr);
+            if (iter == mEntries.end())
+            {
+                mEntries.emplace_back(aInfraIfIndex, std::move(aCallbackPtr));
+            }
+        }
+
+        void MarkAsDeleted(uint64_t aInfraIfIndex, const CallbackType &aCallback)
+        {
+            auto iter = FindEntry(aInfraIfIndex, aCallback);
+            if (iter != mEntries.end())
+            {
+                iter->second = nullptr;
+            }
+        }
+
+        bool IsEmpty(void) { return mEntries.empty(); }
+
+        bool HasAnyValidCallbacks(void)
+        {
+            auto iter = std::find_if(mEntries.begin(), mEntries.end(),
+                                     [](const RequestType &entry) { return entry.second != nullptr; });
+            return iter != mEntries.end();
+        }
+
+        void CleanUpDeletedEntries(void)
+        {
+            for (auto iter = mEntries.begin(); iter != mEntries.end();)
+            {
+                if (!iter->second)
+                {
+                    iter = mEntries.erase(iter);
+                }
+                else
+                {
+                    ++iter;
+                }
+            }
+        }
+
+        void InvokeAllCallbacks(uint64_t aInfraIfIndex, CallbackResultType &aResult)
+        {
+            for (auto &entry : mEntries)
+            {
+                if (entry.first == aInfraIfIndex && entry.second)
+                {
+                    entry.second->InvokeCallback(aResult);
+                }
+            }
+        }
+
+    private:
+        using IteratorType = typename std::vector<RequestType>::iterator;
+
+        IteratorType FindEntry(uint64_t aInfraIfIndex, const CallbackType &aCallback)
+        {
+            return std::find_if(mEntries.begin(), mEntries.end(),
+                                [aInfraIfIndex, &aCallback](const RequestType &entry) {
+                                    return entry.first == aInfraIfIndex && *entry.second == aCallback;
+                                });
+        }
+        std::vector<RequestType> mEntries;
+    };
 
     void HandleMdnsState(Mdns::Publisher::State aState) override;
 
@@ -124,13 +406,39 @@ private:
 
     static std::string KeyNameFor(const Key &aKey);
 
+    static void HandleDiscoveredService(const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInfo);
+    static void HandleDiscoveredHost(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aInfo);
+
+    void ProcessServiceBrowsers(const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInfo);
+    void ProcessServiceResolvers(const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInfo);
+    void ProcessTxtResolvers(const std::string &aType, const Mdns::Publisher::DiscoveredInstanceInfo &aInfo);
+    void ProcessAddrResolvers(const std::string                          &aHostName,
+                              const Mdns::Publisher::DiscoveredHostInfo  &aInfo,
+                              std::map<DnsName, EntryList<AddressEntry>> &aResolversMap);
+    void ProcessIp6AddrResolvers(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aInfo);
+    void ProcessIp4AddrResolvers(const std::string &aHostName, const Mdns::Publisher::DiscoveredHostInfo &aInfo);
+
+    void StartAddressResolver(const AddressResolver                      &aAddressResolver,
+                              AddressCallbackPtr                          aCallbackPtr,
+                              std::map<DnsName, EntryList<AddressEntry>> &aResolversMap);
+    void StopAddressResolver(const AddressResolver                      &aAddressResolver,
+                             const AddressCallback                      &aCallback,
+                             std::map<DnsName, EntryList<AddressEntry>> &aResolversMap);
+
     static DnssdPlatform *sDnssdPlatform;
 
-    Mdns::Publisher         &mPublisher;
-    State                    mState;
-    bool                     mRunning;
-    Mdns::Publisher::State   mPublisherState;
-    DnssdStateChangeCallback mStateChangeCallback;
+    Mdns::Publisher                                 &mPublisher;
+    State                                            mState;
+    bool                                             mRunning;
+    bool                                             mInvokingCallbacks;
+    Mdns::Publisher::State                           mPublisherState;
+    DnssdStateChangeCallback                         mStateChangeCallback;
+    uint64_t                                         mSubscriberId;
+    std::map<DnsServiceType, EntryList<BrowseEntry>> mServiceBrowsersMap;
+    std::map<DnsServiceName, EntryList<SrvEntry>>    mServiceResolversMap;
+    std::map<DnsServiceName, EntryList<TxtEntry>>    mTxtResolversMap;
+    std::map<DnsName, EntryList<AddressEntry>>       mIp6AddrResolversMap;
+    std::map<DnsName, EntryList<AddressEntry>>       mIp4AddrResolversMap;
 };
 
 } // namespace otbr

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -246,7 +246,6 @@ void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aIns
     // service callbacks. We clear it before invoking the callback
     // and restart the iteration over the `mDiscoverCallbacks` list
     // to find the next one to signal, since the list may have changed.
-
     for (DiscoverCallback &callback : mDiscoverCallbacks)
     {
         if (callback.mServiceCallback != nullptr)

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -55,6 +55,31 @@ target_link_libraries(otbr-gtest-unit
 )
 gtest_discover_tests(otbr-gtest-unit)
 
+add_executable(otbr-gtest-unit-dnssd
+    ${OTBR_PROJECT_DIRECTORY}/src/common/types.cpp
+    ${OTBR_PROJECT_DIRECTORY}/src/common/logging.cpp
+    ${OTBR_PROJECT_DIRECTORY}/src/host/posix/dnssd.cpp
+    ${OTBR_PROJECT_DIRECTORY}/src/mdns/mdns.cpp
+    ${OTBR_PROJECT_DIRECTORY}/src/utils/dns_utils.cpp
+    ${OTBR_PROJECT_DIRECTORY}/src/utils/string_utils.cpp
+    test_dnssd.cpp
+)
+target_compile_options(otbr-gtest-unit-dnssd
+    PRIVATE
+        -DOTBR_ENABLE_DNSSD_PLAT=1
+        -DOTBR_ENABLE_MDNS=1
+)
+target_include_directories(otbr-gtest-unit-dnssd
+    PRIVATE
+        ${OTBR_PROJECT_DIRECTORY}/include
+        ${OTBR_PROJECT_DIRECTORY}/src
+        ${OPENTHREAD_PROJECT_DIRECTORY}/include
+)
+target_link_libraries(otbr-gtest-unit-dnssd
+    GTest::gmock_main
+)
+gtest_discover_tests(otbr-gtest-unit-dnssd)
+
 if(OTBR_MDNS AND NOT OTBR_MDNS STREQUAL "openthread")
     add_executable(otbr-gtest-mdns-subscribe
         test_mdns_subscribe.cpp

--- a/tests/gtest/test_dnssd.cpp
+++ b/tests/gtest/test_dnssd.cpp
@@ -1,0 +1,267 @@
+/*
+ *    Copyright (c) 2025, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "common/code_utils.hpp"
+#include "host/posix/dnssd.hpp"
+#include "mdns/mdns.hpp"
+
+#if OTBR_ENABLE_DNSSD_PLAT
+
+using ::testing::_;
+using ::testing::MockFunction;
+using ::testing::SaveArg;
+using ::testing::StrEq;
+
+class MockMdnsPublisher : public otbr::Mdns::Publisher
+{
+public:
+    MockMdnsPublisher(void)           = default;
+    ~MockMdnsPublisher(void) override = default;
+
+    MOCK_METHOD(otbrError,
+                PublishServiceImpl,
+                (const std::string &aHostName,
+                 const std::string &aName,
+                 const std::string &aType,
+                 const SubTypeList &aSubTypeList,
+                 uint16_t           aPort,
+                 const TxtData     &aTxtData,
+                 ResultCallback   &&aCallback),
+                (override));
+    MOCK_METHOD(void,
+                UnpublishService,
+                (const std::string &aName, const std::string &aType, ResultCallback &&aCallback),
+                (override));
+    MOCK_METHOD(otbrError,
+                PublishHostImpl,
+                (const std::string &aName, const AddressList &aAddresses, ResultCallback &&aCallback),
+                (override));
+    MOCK_METHOD(void, UnpublishHost, (const std::string &aName, ResultCallback &&aCallback), (override));
+    MOCK_METHOD(otbrError,
+                PublishKeyImpl,
+                (const std::string &aName, const KeyData &aKey, ResultCallback &&aCallback),
+                (override));
+    MOCK_METHOD(void, UnpublishKey, (const std::string &aName, ResultCallback &&aCallback), (override));
+    MOCK_METHOD(void, SubscribeService, (const std::string &aType, const std::string &aInstanceName), (override));
+    MOCK_METHOD(void, UnsubscribeService, (const std::string &aType, const std::string &aInstanceName), (override));
+    MOCK_METHOD(void, SubscribeHost, (const std::string &aHostName), (override));
+    MOCK_METHOD(void, UnsubscribeHost, (const std::string &aHostName), (override));
+
+    otbrError Start(void) override { return OTBR_ERROR_NONE; }
+    void      Stop(void) override {}
+    bool      IsStarted(void) const override { return true; }
+
+    void OnServiceResolveFailedImpl(const std::string &aType,
+                                    const std::string &aInstanceName,
+                                    int32_t            aErrorCode) override
+    {
+        OTBR_UNUSED_VARIABLE(aType);
+        OTBR_UNUSED_VARIABLE(aInstanceName);
+        OTBR_UNUSED_VARIABLE(aErrorCode);
+    }
+
+    void OnHostResolveFailedImpl(const std::string &aHostName, int32_t aErrorCode) override
+    {
+        OTBR_UNUSED_VARIABLE(aHostName);
+        OTBR_UNUSED_VARIABLE(aErrorCode);
+    }
+
+    otbrError DnsErrorToOtbrError(int32_t aError) override
+    {
+        OTBR_UNUSED_VARIABLE(aError);
+        return OTBR_ERROR_NONE;
+    }
+
+    void TestOnServiceResolved(std::string aType, otbr::Mdns::Publisher::DiscoveredInstanceInfo aInstanceInfo)
+    {
+        OnServiceResolved(std::move(aType), std::move(aInstanceInfo));
+    }
+};
+
+class DnssdTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        mPublisher     = std::make_unique<MockMdnsPublisher>();
+        mDnssdPlatform = std::make_unique<otbr::DnssdPlatform>(*mPublisher);
+
+        mStateSubject.AddObserver(*mDnssdPlatform);
+        mStateSubject.UpdateState(otbr::Mdns::Publisher::State::kReady);
+        mDnssdPlatform->Start();
+    }
+
+    otbr::Mdns::StateSubject             mStateSubject;
+    std::unique_ptr<MockMdnsPublisher>   mPublisher;
+    std::unique_ptr<otbr::DnssdPlatform> mDnssdPlatform;
+};
+
+TEST_F(DnssdTest, TestServiceBrowserCallbackIsCorrectlyInvoked)
+{
+    constexpr uint8_t kInfraIfIndex = 1;
+
+    otbr::DnssdPlatform::Browser                                  browser;
+    otbr::Mdns::Publisher::DiscoveredInstanceInfo                 discoveredInstanceInfo;
+    const char                                                   *serviceType = "_plant._tcp";
+    MockFunction<void(const otbr::DnssdPlatform::BrowseResult &)> mockCallback;
+
+    browser.mServiceType  = serviceType;
+    browser.mSubTypeLabel = nullptr;
+    browser.mInfraIfIndex = kInfraIfIndex;
+    browser.mCallback     = nullptr;
+
+    // 1. A service is resovled and expect the callback is invoked.
+    EXPECT_CALL(*mPublisher, SubscribeService(StrEq(serviceType), StrEq("")));
+
+    mDnssdPlatform->StartServiceBrowser(
+        browser, std::make_unique<otbr::DnssdPlatform::StdBrowseCallback>(mockCallback.AsStdFunction(), 1));
+
+    EXPECT_CALL(mockCallback, Call(_)).WillOnce([&](const otbr::DnssdPlatform::BrowseResult &aResult) {
+        EXPECT_EQ(aResult.mInfraIfIndex, kInfraIfIndex);
+        EXPECT_EQ(aResult.mTtl, 10);
+        EXPECT_EQ(aResult.mSubTypeLabel, nullptr);
+        EXPECT_STREQ(aResult.mServiceType, serviceType);
+        EXPECT_STREQ(aResult.mServiceInstance, "ZGMF-X42S #1");
+    });
+
+    discoveredInstanceInfo.mRemoved    = false;
+    discoveredInstanceInfo.mNetifIndex = kInfraIfIndex;
+    discoveredInstanceInfo.mName       = "ZGMF-X42S #1";
+    discoveredInstanceInfo.mHostName   = "ZGMF-X42S #1._plant._tcp.local.";
+    discoveredInstanceInfo.mTtl        = 10;
+    mPublisher->TestOnServiceResolved(serviceType, discoveredInstanceInfo);
+
+    // 2. Another service is resovled but the callback shouldn't be invoked again.
+    EXPECT_CALL(*mPublisher, UnsubscribeService(StrEq(serviceType), StrEq("")));
+
+    mDnssdPlatform->StopServiceBrowser(browser, otbr::DnssdPlatform::StdBrowseCallback(nullptr, 1));
+
+    discoveredInstanceInfo.mRemoved    = false;
+    discoveredInstanceInfo.mNetifIndex = kInfraIfIndex;
+    discoveredInstanceInfo.mName       = "ZGMF-X666S #1";
+    discoveredInstanceInfo.mHostName   = "ZGMF-X666S #1._plant._tcp.local.";
+    discoveredInstanceInfo.mTtl        = 10;
+    mPublisher->TestOnServiceResolved(serviceType, discoveredInstanceInfo);
+}
+
+TEST_F(DnssdTest, TestServiceResolverStoppedInCallbackOfStartWorksCorrectly)
+{
+    constexpr uint8_t kInfraIfIndex = 1;
+
+    otbr::DnssdPlatform::SrvResolver              resolver1;
+    otbr::DnssdPlatform::SrvResolver              resolver2;
+    const char                                   *serviceType = "_plant._tcp";
+    otbr::Mdns::Publisher::DiscoveredInstanceInfo discoveredInstanceInfo1;
+    otbr::Mdns::Publisher::DiscoveredInstanceInfo discoveredInstanceInfo2;
+    bool                                          invoked = false;
+    uint64_t                                      id1     = 2;
+    uint64_t                                      id2     = 3;
+
+    resolver1.mServiceType     = serviceType;
+    resolver1.mServiceInstance = "ZGMF-X10A #1";
+    resolver1.mInfraIfIndex    = kInfraIfIndex;
+    resolver1.mCallback        = nullptr;
+
+    resolver2.mServiceType     = serviceType;
+    resolver2.mServiceInstance = "ZGMF-X13A #1";
+    resolver2.mInfraIfIndex    = kInfraIfIndex;
+    resolver2.mCallback        = nullptr;
+
+    // 1. Start 2 services resolver. Stop the resolvers in the callbacks.
+    EXPECT_CALL(*mPublisher, SubscribeService(StrEq(serviceType), StrEq(resolver1.mServiceInstance))).Times(1);
+    EXPECT_CALL(*mPublisher, UnsubscribeService(StrEq(serviceType), StrEq(resolver1.mServiceInstance))).Times(1);
+    EXPECT_CALL(*mPublisher, SubscribeService(StrEq(serviceType), StrEq(resolver2.mServiceInstance))).Times(1);
+
+    auto callbackPtr = std::make_unique<otbr::DnssdPlatform::StdSrvCallback>(
+        [this, id1, &resolver1, &discoveredInstanceInfo1, &invoked](const otbr::DnssdPlatform::SrvResult &aResult) {
+            mDnssdPlatform->StopServiceResolver(resolver1, otbr::DnssdPlatform::StdSrvCallback(nullptr, id1));
+
+            EXPECT_EQ(aResult.mInfraIfIndex, resolver1.mInfraIfIndex);
+            EXPECT_EQ(aResult.mTtl, discoveredInstanceInfo1.mTtl);
+            EXPECT_EQ(aResult.mPort, discoveredInstanceInfo1.mPort);
+            EXPECT_EQ(aResult.mPriority, discoveredInstanceInfo1.mPriority);
+            EXPECT_EQ(aResult.mWeight, discoveredInstanceInfo1.mWeight);
+            EXPECT_STREQ(aResult.mServiceInstance, resolver1.mServiceInstance);
+            EXPECT_STREQ(aResult.mServiceType, resolver1.mServiceType);
+            EXPECT_STREQ(aResult.mHostName, "Eternal");
+
+            invoked = true;
+        },
+        id1);
+    mDnssdPlatform->StartServiceResolver(resolver1, std::move(callbackPtr));
+    callbackPtr = std::make_unique<otbr::DnssdPlatform::StdSrvCallback>(
+        [&resolver2, &discoveredInstanceInfo2](const otbr::DnssdPlatform::SrvResult &aResult) {
+            EXPECT_EQ(aResult.mInfraIfIndex, resolver2.mInfraIfIndex);
+            EXPECT_EQ(aResult.mTtl, discoveredInstanceInfo2.mTtl);
+            EXPECT_EQ(aResult.mPort, discoveredInstanceInfo2.mPort);
+            EXPECT_EQ(aResult.mPriority, discoveredInstanceInfo2.mPriority);
+            EXPECT_EQ(aResult.mWeight, discoveredInstanceInfo2.mWeight);
+            EXPECT_STREQ(aResult.mServiceInstance, resolver2.mServiceInstance);
+            EXPECT_STREQ(aResult.mServiceType, resolver2.mServiceType);
+            EXPECT_STREQ(aResult.mHostName, "Genesis");
+        },
+        id2);
+    mDnssdPlatform->StartServiceResolver(resolver2, std::move(callbackPtr));
+
+    // 2. Found an instance for Resolver1.
+    discoveredInstanceInfo1.mRemoved    = false;
+    discoveredInstanceInfo1.mNetifIndex = kInfraIfIndex;
+    discoveredInstanceInfo1.mName       = "ZGMF-X10A #1";
+    discoveredInstanceInfo1.mHostName   = "Eternal.";
+    discoveredInstanceInfo1.mTtl        = 10;
+    discoveredInstanceInfo1.mPort       = 11;
+    discoveredInstanceInfo1.mPriority   = 12;
+    discoveredInstanceInfo1.mWeight     = 13;
+
+    mPublisher->TestOnServiceResolved(serviceType, discoveredInstanceInfo1);
+
+    // 3. Found an instance for Resolver2.
+    discoveredInstanceInfo2.mRemoved    = false;
+    discoveredInstanceInfo2.mNetifIndex = kInfraIfIndex;
+    discoveredInstanceInfo2.mName       = "ZGMF-X13A #1";
+    discoveredInstanceInfo2.mHostName   = "Genesis.";
+    discoveredInstanceInfo2.mTtl        = 13;
+    discoveredInstanceInfo2.mPort       = 14;
+    discoveredInstanceInfo2.mPriority   = 15;
+    discoveredInstanceInfo2.mWeight     = 16;
+
+    mPublisher->TestOnServiceResolved(serviceType, discoveredInstanceInfo2);
+
+    // 4. Updated an instance for Resolver1. Callback shouldn't be invoked.
+    invoked = false;
+
+    discoveredInstanceInfo1.mHostName = "ArchAngel.";
+    mPublisher->TestOnServiceResolved(serviceType, discoveredInstanceInfo1);
+
+    EXPECT_FALSE(invoked);
+}
+
+#endif // OTBR_ENABLE_DNSSD_PLAT


### PR DESCRIPTION
Following https://github.com/openthread/ot-br-posix/pull/2042 and https://github.com/openthread/ot-br-posix/pull/2664, this PR implements other `otPlatDnssd` platform APIs in ot-br-posix. 

The PR implements all the dnssd platform APIs for browse/resolve except for `RecordQuerier` because currently the mdns publisher doesn't support record query. I plan to support this later.

The background for this PR is that I plan to use the natvie OT discovery proxy and remove the current Discovery Proxy module in ot-br-posix. I've noticed that OT now even supports native mDNS. But to support DNSSD runtime selection (OPENTHREAD_CONFIG_PLATFORM_DNSSD_ALLOW_RUN_TIME_SELECTION), we will also need an implementation on the posix platform.

The implementation in this PR basically follows the old PR https://github.com/openthread/ot-br-posix/pull/2042. But there are some major differences in the dnssd platform API definition since then. The core idea of the implementation for browse/resolve is that we maintain a map of query type to a map of netif index to a vector of callback. Whenever the dnssd gets some result, it returns the result to all the callbacks that are interested to it.

```
Map_BrowsersTable
|  DnsName  |  Map_BrowserCallbackTable  |
|  DnsName  |  Map_BrowserCallbackTable  |
|  DnsName  |  Map_BrowserCallbackTable  |

Map_BrowserCallbackTable
|  NetifIndex  |   Vector_Callbacks   |
|  NetifIndex  |   Vector_Callbacks   |
|  NetifIndex  |   Vector_Callbacks   |
```

As a contrast, the old implementation doesn't need a map of map because there is only one callback. But now we have a callback for each browse/resolve action.