### PR TITLE
[mdns] handle retryable mDNSResponder errors

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -353,7 +353,7 @@ std::string Publisher::MakeFullName(const std::string &aName)
     return aName + ".local";
 }
 
-void Publisher::AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg)
+void Publisher::AddServiceRegistration(ServiceRegistrationPtr aServiceReg)
 {
     mServiceRegistrations.emplace(MakeFullServiceName(aServiceReg->mName, aServiceReg->mType), std::move(aServiceReg));
 }
@@ -469,7 +469,7 @@ exit:
     return std::move(aCallback);
 }
 
-void Publisher::AddHostRegistration(HostRegistrationPtr &&aHostReg)
+void Publisher::AddHostRegistration(HostRegistrationPtr aHostReg)
 {
     mHostRegistrations.emplace(MakeFullHostName(aHostReg->mName), std::move(aHostReg));
 }
@@ -538,7 +538,7 @@ exit:
     return std::move(aCallback);
 }
 
-void Publisher::AddKeyRegistration(KeyRegistrationPtr &&aKeyReg)
+void Publisher::AddKeyRegistration(KeyRegistrationPtr aKeyReg)
 {
     mKeyRegistrations.emplace(MakeFullKeyName(aKeyReg->mName), std::move(aKeyReg));
 }

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -534,11 +534,11 @@ protected:
         void OnComplete(otbrError aError);
     };
 
-    using ServiceRegistrationPtr = std::unique_ptr<ServiceRegistration>;
+    using ServiceRegistrationPtr = std::shared_ptr<ServiceRegistration>;
     using ServiceRegistrationMap = std::map<std::string, ServiceRegistrationPtr>;
-    using HostRegistrationPtr    = std::unique_ptr<HostRegistration>;
+    using HostRegistrationPtr    = std::shared_ptr<HostRegistration>;
     using HostRegistrationMap    = std::map<std::string, HostRegistrationPtr>;
-    using KeyRegistrationPtr     = std::unique_ptr<KeyRegistration>;
+    using KeyRegistrationPtr     = std::shared_ptr<KeyRegistration>;
     using KeyRegistrationMap     = std::map<std::string, KeyRegistrationPtr>;
 
     static SubTypeList SortSubTypeList(SubTypeList aSubTypeList);
@@ -570,7 +570,7 @@ protected:
 
     virtual otbrError DnsErrorToOtbrError(int32_t aError) = 0;
 
-    void AddServiceRegistration(ServiceRegistrationPtr &&aServiceReg);
+    void AddServiceRegistration(ServiceRegistrationPtr aServiceReg);
     void RemoveServiceRegistration(const std::string &aName, const std::string &aType, otbrError aError);
     ServiceRegistration *FindServiceRegistration(const std::string &aName, const std::string &aType);
     ServiceRegistration *FindServiceRegistration(const std::string &aNameAndType);
@@ -600,11 +600,11 @@ protected:
                                                   const KeyData     &aKeyData,
                                                   ResultCallback   &&aCallback);
 
-    void              AddHostRegistration(HostRegistrationPtr &&aHostReg);
+    void              AddHostRegistration(HostRegistrationPtr aHostReg);
     void              RemoveHostRegistration(const std::string &aName, otbrError aError);
     HostRegistration *FindHostRegistration(const std::string &aName);
 
-    void             AddKeyRegistration(KeyRegistrationPtr &&aKeyReg);
+    void             AddKeyRegistration(KeyRegistrationPtr aKeyReg);
     void             RemoveKeyRegistration(const std::string &aName, otbrError aError);
     KeyRegistration *FindKeyRegistration(const std::string &aName);
     KeyRegistration *FindKeyRegistration(const std::string &aName, const std::string &aType);

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -749,8 +749,8 @@ otbrError PublisherAvahi::PublishServiceImpl(const std::string &aHostName,
     avahiError = avahi_entry_group_commit(group);
     VerifyOrExit(avahiError == AVAHI_OK);
 
-    AddServiceRegistration(std::unique_ptr<AvahiServiceRegistration>(new AvahiServiceRegistration(
-        aHostName, serviceName, aType, sortedSubTypeList, aPort, aTxtData, std::move(aCallback), group, this)));
+    AddServiceRegistration(std::make_shared<AvahiServiceRegistration>(
+        aHostName, serviceName, aType, sortedSubTypeList, aPort, aTxtData, std::move(aCallback), group, this));
 
 exit:
     if (avahiError != AVAHI_OK || error != OTBR_ERROR_NONE)
@@ -815,8 +815,7 @@ otbrError PublisherAvahi::PublishHostImpl(const std::string &aName,
     avahiError = avahi_entry_group_commit(group);
     VerifyOrExit(avahiError == AVAHI_OK);
 
-    AddHostRegistration(std::unique_ptr<AvahiHostRegistration>(
-        new AvahiHostRegistration(aName, aAddresses, std::move(aCallback), group, this)));
+    AddHostRegistration(std::make_shared<AvahiHostRegistration>(aName, aAddresses, std::move(aCallback), group, this));
 
 exit:
     if (avahiError != AVAHI_OK || error != OTBR_ERROR_NONE)
@@ -873,8 +872,7 @@ otbrError PublisherAvahi::PublishKeyImpl(const std::string &aName, const KeyData
     avahiError = avahi_entry_group_commit(group);
     VerifyOrExit(avahiError == AVAHI_OK);
 
-    AddKeyRegistration(std::unique_ptr<AvahiKeyRegistration>(
-        new AvahiKeyRegistration(aName, aKeyData, std::move(aCallback), group, this)));
+    AddKeyRegistration(std::make_shared<AvahiKeyRegistration>(aName, aKeyData, std::move(aCallback), group, this));
 
 exit:
     if (avahiError != AVAHI_OK || error != OTBR_ERROR_NONE)


### PR DESCRIPTION
This PR adds handling for the retryable mDNSResponder errors.

For example, on `kDNSServiceErr_DefunctConnection` we need to redo the registration or the query instead of giving up. Currently the retry interval is 5 seconds.