### PR TITLE
[cmake] rename the library otbr-ncp to otbr-host

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -47,12 +47,12 @@ target_link_libraries(otbr-agent PRIVATE
     openthread-hdlc
     openthread-posix
     $<$<AND:$<BOOL:${OTBR_MDNS}>,$<NOT:$<STREQUAL:${OTBR_MDNS},openthread>>>:otbr-sdp-proxy>
-    otbr-ncp
+    otbr-host
     otbr-common
     otbr-utils
 )
 
-add_dependencies(otbr-agent ot-ctl print-ot-config otbr-utils otbr-ncp)
+add_dependencies(otbr-agent ot-ctl print-ot-config otbr-utils otbr-host)
 if (OTBR_BORDER_AGENT)
     add_dependencies(otbr-agent otbr-border-agent)
 endif()

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 add_subdirectory(posix)
 
-add_library(otbr-ncp
+add_library(otbr-host
     async_task.cpp
     async_task.hpp
     ncp_host.cpp
@@ -43,7 +43,7 @@ add_library(otbr-ncp
     thread_host.hpp
 )
 
-target_link_libraries(otbr-ncp PRIVATE
+target_link_libraries(otbr-host PRIVATE
     otbr-common
     otbr-posix
     $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(otbr-gtest-unit
 target_link_libraries(otbr-gtest-unit
     mbedtls
     otbr-common
-    otbr-ncp
+    otbr-host
     otbr-utils
     GTest::gmock_main
 )
@@ -105,7 +105,7 @@ target_link_libraries(otbr-gtest-host-api
     otbr-common
     otbr-utils
     otbr-posix
-    otbr-ncp
+    otbr-host
     GTest::gmock_main
 )
 gtest_discover_tests(otbr-gtest-host-api)


### PR DESCRIPTION
This PR renames the cmake library `otbr-ncp` to `otbr-host`.

The name is confusing. It's a legacy name corresponds to the removed class `NcpOpenThreadController`. Since the this library supports both RCP and NCP and its namespace is `Host`, let's rename the library.