### PR TITLE
[common] move include of byteswap.hpp into source

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <sys/socket.h>
 
+#include "common/byteswap.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/types.hpp"
@@ -65,6 +66,16 @@ Ip6Address Ip6Address::ToSolicitedNodeMulticastAddress(void) const
     ma.m8[15] = m8[15];
 
     return ma;
+}
+
+bool Ip6Address::IsLinkLocal(void) const
+{
+    return (m16[0] & bswap_16(0xffc0)) == bswap_16(0xfe80);
+}
+
+bool Ip6Address::IsLoopback(void) const
+{
+    return (m32[0] == 0 && m32[1] == 0 && m32[2] == 0 && m32[3] == htobe32(1));
 }
 
 uint8_t Ip6Address::GetScope(void) const

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -45,8 +45,6 @@
 #include <openthread/error.h>
 #include <openthread/ip6.h>
 
-#include "common/byteswap.hpp"
-
 #ifndef IN6ADDR_ANY
 /**
  * Any IPv6 address literal.
@@ -233,7 +231,7 @@ public:
      *
      * @returns Whether the Ip6 address is a link-local address.
      */
-    bool IsLinkLocal(void) const { return (m16[0] & bswap_16(0xffc0)) == bswap_16(0xfe80); }
+    bool IsLinkLocal(void) const;
 
     /**
      * This method returns whether or not the Ip6 address is the Loopback Address.
@@ -241,7 +239,7 @@ public:
      * @retval TRUE   If the Ip6 address is the Loopback Address.
      * @retval FALSE  If the Ip6 address is not the Loopback Address.
      */
-    bool IsLoopback(void) const { return (m32[0] == 0 && m32[1] == 0 && m32[2] == 0 && m32[3] == htobe32(1)); }
+    bool IsLoopback(void) const;
 
     /**
      * Returns the IPv6 address scope.

--- a/src/host/thread_helper.cpp
+++ b/src/host/thread_helper.cpp
@@ -65,7 +65,6 @@
 #include <net/if.h>
 #include <openthread/platform/radio.h>
 
-#include "common/byteswap.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 #include "common/tlv.hpp"


### PR DESCRIPTION
This PR moves the include of `byteswap.hpp` from `types.hpp` to `types.cpp`.

Recently I met a build issue on CI on MacOS (with my code change): [Failed Run](https://github.com/openthread/ot-br-posix/actions/runs/16620138139/job/47022300661)
```
FAILED: [code=1] tests/gtest/CMakeFiles/otbr-gtest-telemetry.dir/__/__/src/host/telemetry_retriever_border_agent.cpp.o 
/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DOTBR_ENABLE_BORDER_ROUTING=1 -DOTBR_ENABLE_BORDER_ROUTING_COUNTERS=1 -DOTBR_ENABLE_DHCP6_PD=0 -DOTBR_ENABLE_DNSSD_PLAT=0 -DOTBR_ENABLE_EPSKC=1 -DOTBR_ENABLE_FEATURE_FLAGS=1 -DOTBR_ENABLE_LINK_METRICS_TELEMETRY=1 -DOTBR_ENABLE_NAT64=0 -DOTBR_ENABLE_NOTIFY_UPSTART=1 -DOTBR_ENABLE_POWER_CALIBRATION=1 -DOTBR_ENABLE_PUBLISH_MESHCOP_BA_ID=1 -DOTBR_ENABLE_REST_SERVER=1 -DOTBR_ENABLE_TELEMETRY_DATA_API=1 -DOTBR_ENABLE_UNSECURE_JOIN=1 -DOTBR_ENABLE_VENDOR_INFRA_LINK_SELECT=0 -DOTBR_MESHCOP_SERVICE_INSTANCE_NAME="\"OpenThread BorderRouter\"" -DOTBR_PACKAGE_NAME=\"OpenThread_BorderRouter\" -DOTBR_PACKAGE_VERSION=\"0.3.0-f4c013e\" -DOTBR_PRODUCT_NAME=\"BorderRouter\" -DOTBR_SYSLOG_FACILITY_ID=LOG_USER -DOTBR_VENDOR_NAME=\"OpenThread\" -I/Users/runner/work/ot-br-posix/ot-br-posix/include -I/Users/runner/work/ot-br-posix/ot-br-posix/src -I/Users/runner/work/ot-br-posix/ot-br-posix/third_party/openthread/repo/include -I/Users/runner/work/ot-br-posix/ot-br-posix/third_party/openthread/repo/tests/gtest -I/Users/runner/work/ot-br-posix/ot-br-posix/build/src -isystem /opt/homebrew/opt/protobuf@21/include -isystem /opt/homebrew/include -g -std=c++17 -arch arm64 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk -Wall -Wextra -Werror -Wfatal-errors -Wuninitialized -Wno-missing-braces -DOTBR_ENABLE_TELEMETRY_DATA_API=1 -DOTBR_ENABLE_BORDER_AGENT=1 -MD -MT tests/gtest/CMakeFiles/otbr-gtest-telemetry.dir/__/__/src/host/telemetry_retriever_border_agent.cpp.o -MF tests/gtest/CMakeFiles/otbr-gtest-telemetry.dir/__/__/src/host/telemetry_retriever_border_agent.cpp.o.d -o tests/gtest/CMakeFiles/otbr-gtest-telemetry.dir/__/__/src/host/telemetry_retriever_border_agent.cpp.o -c /Users/runner/work/ot-br-posix/ot-br-posix/src/host/telemetry_retriever_border_agent.cpp
In file included from /Users/runner/work/ot-br-posix/ot-br-posix/src/host/telemetry_retriever_border_agent.cpp:40:
In file included from /Users/runner/work/ot-br-posix/ot-br-posix/src/common/logging.hpp:47:
In file included from /Users/runner/work/ot-br-posix/ot-br-posix/src/common/types.hpp:48:
/Users/runner/work/ot-br-posix/ot-br-posix/src/common/byteswap.hpp:41:9: fatal error: 'bswap_16' macro redefined [-Wmacro-redefined]
#define bswap_16 OSSwapInt16
        ^
/opt/homebrew/opt/protobuf@21/include/google/protobuf/stubs/port.h:247:9: note: previous definition is here
#define bswap_16(x) OSSwapInt16(x)
```

The cause is that the protobuf header and `byteswap.hpp` has re-definition. `types.hpp` is widely included by sources in `otbr-agent` while `byteswap.hpp` is only used by some implementations of `types.hpp`. So we can move the usage of `byteswap.hpp` into `types.cpp` to solve this issue.