### PR TITLE
[mDNS] fix avahi issue

### DIFF
--- a/.github/workflows/ncp_mode.yml
+++ b/.github/workflows/ncp_mode.yml
@@ -53,7 +53,7 @@ jobs:
         OTBR_MDNS: ${{ matrix.mdns }}
         OTBR_COVERAGE: 1
         OTBR_VERBOSE: 1
-        OTBR_OPTIONS: "-DCMAKE_BUILD_TYPE=Debug -DOT_THREAD_VERSION=1.4 -DOTBR_COVERAGE=ON -DOTBR_DBUS=ON -DOTBR_FEATURE_FLAGS=ON -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_UNSECURE_JOIN=ON -DOTBR_SRP_ADVERTISING_PROXY=ON -DBUILD_TESTING=OFF"
+        OTBR_OPTIONS: "-DCMAKE_BUILD_TYPE=Debug -DOT_THREAD_VERSION=1.4 -DOTBR_MDNS=${{ matrix.mdns }} -DOTBR_COVERAGE=ON -DOTBR_DBUS=ON -DOTBR_FEATURE_FLAGS=ON -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_UNSECURE_JOIN=ON -DOTBR_SRP_ADVERTISING_PROXY=ON -DBUILD_TESTING=OFF"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -71,6 +71,7 @@ jobs:
             --build-arg WEB_GUI=0 \
             --build-arg REST_API=0 \
             --build-arg FIREWALL=0 \
+            --build-arg MDNS=${{ matrix.mdns }} \
             --build-arg OTBR_OPTIONS="${OTBR_OPTIONS}"
     - name: Run
       run: |

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -354,10 +354,16 @@ void Application::InitNcpMode(void)
     ncpHost.InitInfraIfCallbacks(*mInfraIf);
 
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
-    ncpHost.SetMdnsPublisher(mPublisher.get());
     mMdnsStateSubject.AddObserver(ncpHost);
+#endif
+#if OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
+    mMdnsStateSubject.AddObserver(mBorderAgent);
+#endif
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+    ncpHost.SetMdnsPublisher(mPublisher.get());
     mPublisher->Start();
 #endif
+
 #if OTBR_ENABLE_BORDER_AGENT
     mHost.SetBorderAgentMeshCoPServiceChangedCallback(
         [this](bool aIsActive, uint16_t aPort, const uint8_t *aTxtData, uint16_t aLength) {

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -514,7 +514,7 @@ otbrError PublisherAvahi::Start(void)
 
 bool PublisherAvahi::IsStarted(void) const
 {
-    return mClient != nullptr;
+    return mClient != nullptr && mState == Mdns::Publisher::State::kReady;
 }
 
 void PublisherAvahi::Stop(void)


### PR DESCRIPTION
This PR fixes the wrong MDNS options in CI for NCP and 2 bugs in MdnsAvahi.

In the MDNS matrix in CI for NCP, when the MDNS is avahi, the otbr docker image actually still ran with the default MDNS option because the docker image was built in the CI by command so the existing environment variable in CI doesn't affect it. I added a `build-arg` to set the MDNS option for the docker image.

Avahi client has a registering state. Publishing service during this state leads to failure. But currently `IsStarted` method also regards this state as `true`. That's why we failed in the NCP test case. Because the meshcop service was published during this state.

Another issue is that in NCP mode, the BorderAgent isn't added as an observer to the mDNS. mDNSResponder can work because its state becomes ready in an earlier stage. But for avahi whose state becomes ready later than the meshcop service initial publishing, the issue happens.