### PR TITLE
Add multi-AIL detection in telemetry metrics

### DIFF
--- a/src/host/thread_helper.cpp
+++ b/src/host/thread_helper.cpp
@@ -1426,6 +1426,7 @@ otError ThreadHelper::RetrieveTelemetryData(Mdns::Publisher *aPublisher, threadn
 #if OTBR_ENABLE_BORDER_ROUTING
         RetrieveInfraLinkInfo(*wpanBorderRouter->mutable_infra_link_info());
         RetrieveExternalRouteInfo(*wpanBorderRouter->mutable_external_route_info());
+        wpanBorderRouter->set_multi_ail_detected(otBorderRoutingIsMultiAilDetected(mInstance));
 #endif
 
 #if OTBR_ENABLE_SRP_SERVER

--- a/src/proto/thread_telemetry.proto
+++ b/src/proto/thread_telemetry.proto
@@ -636,6 +636,9 @@ message TelemetryData {
 
     // Information about the Border Agent
     optional BorderAgentInfo border_agent_info = 14;
+
+    // Whether multi-AIL (Adjacent Infrastructure Link) scenario is detected
+    optional bool multi_ail_detected = 15;
   }
 
   message RcpStabilityStatistics {

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -363,6 +363,7 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_default_route_added() == false);
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_ula_route_added());
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_others_route_added() == false);
+    TEST_ASSERT(telemetryData.wpan_border_router().multi_ail_detected() == false);
 #endif
 #if !OTBR_ENABLE_MDNS_OPENTHREAD
     TEST_ASSERT(telemetryData.wpan_border_router().mdns().service_registration_responses().success_count() > 0);


### PR DESCRIPTION
This commit adds a new field `multi_ail_detected` to the telemetry data. This field indicates whether the Border Router has detected an adjacent infrastructure link.

The `multi_ail_detected` boolean is retrieved from the OpenThread API `otBorderRoutingIsMultiAilDetected` and included in the `TelemetryData` protobuf message.

The DBus client test is updated to verify the new field.