### PR TITLE
[mdns] fix ServiceInstanceResolutions leak in mdnssd

### DIFF
--- a/src/mdns/mdns_mdnssd.hpp
+++ b/src/mdns/mdns_mdnssd.hpp
@@ -230,6 +230,10 @@ private:
         {
         }
 
+        bool      Matches(uint32_t           aInterfaceIndex,
+                          const std::string &aInstanceName,
+                          const std::string &aType,
+                          const std::string &aDomain) const;
         void      Release(void);
         void      Resolve(void);
         otbrError GetAddrInfo(uint32_t aInterfaceIndex);
@@ -293,6 +297,10 @@ private:
                      const std::string &aInstanceName,
                      const std::string &aType,
                      const std::string &aDomain);
+        void Remove(uint32_t           aNetifIndex,
+                    const std::string &aInstanceName,
+                    const std::string &aType,
+                    const std::string &aDomain);
         void UpdateAll(MainloopContext &aMainloop) const;
         void ProcessAll(const MainloopContext &aMainloop, std::vector<DNSServiceRef> &aReadyServices) const;
 


### PR DESCRIPTION
### Background 

While testing TREL in our BR implementation we started seeing forced exits due to "too many open files".
Closer investigation showed a file descriptor leak that was growing by `n` descriptors every five minutes
where `n` is equal to the number of discoverable `_trel._udp` services on the network. These file descriptors
were found to be open sockets to `mdnsResponder` at `/var/run/mdnsd`. 

The root cause is due to accumulation of `ServiceInstanceResolution` objects in the `mResolvingInstances`
vector in `PublisherMDnsSd::ServiceSubscription` that are never removed. As a result the `DNSServiceRef`
handles owned by the `ServiceInstanceResolution` are never deallocated. I believe this issue may have
been introduced in [this PR](https://github.com/openthread/ot-br-posix/pull/2148) when the
`RemoveInstanceResolution` was taken out. In this fix we simply take ownership of the object after removing
it from the vector and keep it in scope so downstream handlers can reference it if needed.

### Steps to reproduce

- Linux system with `dns-sd` and `mdnsResponder` on board.
- At least one other Border Router on the network with TREL enabled (advertising `_trel._udp`)
- Relevant CMake config used:
    ```
    -DOTBR_TREL:BOOL=ON
   -DOTBR_NAT64:BOOL=ON
   -DOTBR_DUA_ROUTING:BOOL=ON
   -DOTBR_DHCP6_PD:BOOL=ON
   -DOTBR_MDNS:STRING=mDNSResponder
  ```
 - Every 5 minutes:
   ```
   ls /proc/$(pidof otbr-agent)/fd | wc -l
   ....
   netstat | grep /var/run/mdnsd | wc -l
   ```
- Observe counts from above commands increasing by the number of discoverable `_trel._udp` services.

### Testing
I and some colleagues have tested this patch on several systems and have found it prevents the leak.
   
   