### PR TITLE
[build] remove unnecessary link to otbr-proto

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -48,8 +48,6 @@ add_library(otbr-common
 target_link_libraries(otbr-common
     PUBLIC otbr-config
     openthread-ftd
-    $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
-    $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
 )
 
 target_include_directories(otbr-common

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -44,9 +44,10 @@ add_library(otbr-host
     thread_host.hpp
 )
 
-target_link_libraries(otbr-host PRIVATE
-    otbr-common
-    otbr-posix
-    $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
-    $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
+target_link_libraries(otbr-host
+    PUBLIC
+        $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
+    PRIVATE
+        otbr-common
+        otbr-posix
 )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -41,7 +41,5 @@ add_library(otbr-utils
 
 target_link_libraries(otbr-utils PUBLIC
     otbr-common
-    $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
-    $<$<BOOL:${OTBR_TELEMETRY_DATA_API}>:otbr-proto>
     mbedtls
 )


### PR DESCRIPTION
This PR removes some unnecessary dependencies on `otbr-proto`