### PR TITLE
[script] add dbus reload in ncp_mode script setup

### DIFF
--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -232,6 +232,8 @@ test_setup()
     # Preparation for otbr-agent
     exists_or_die "${OTBR_DBUS_CONF}"
     sudo cp "${OTBR_DBUS_CONF}" /etc/dbus-1/system.d
+    sudo chmod +r /etc/dbus-1/system.d/otbr-agent.conf
+    sudo systemctl reload dbus
 
     write_syslog "AGENT: kill old"
     sudo killall "${OTBR_AGENT}" || true


### PR DESCRIPTION
This PR fixes the flaky NCP test case in CI.

This PR adds dbus reload step in the test setup.

Sample failure in CI: https://github.com/openthread/ot-br-posix/actions/runs/16924838452/job/47958448701

Luckily the failure is easy to reproduce locally. From the log it turned out that the dbus policy wasn't correctly configured and this caused the cli command to fail. That's why there are some randomness here and sometimes the case can pass because the dbus policy is correctly set.