### PR TITLE
[tests] restart mDNSResponder service in ncp_mode test setup

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -513,6 +513,10 @@ otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
 
     VerifyOrExit(GetPublisher().IsStarted(), dnsError = kDNSServiceErr_ServiceNotRunning);
 
+    // Note: If the mDNSResponder service is in some bad state, `DNSServiceRegister` may block here for 60 seconds at
+    // most.
+    // TODO: Abort on `Timeout` error, as it indicates an unresponsive mDNSResponder. This may require removing
+    // `kDNSServiceErr_Timeout` from `IsRetryableError` and adding specific handling for it.
     dnsError = DNSServiceRegister(&mServiceRef, kDNSServiceFlagsNoAutoRename, kDNSServiceInterfaceIndexAny,
                                   serviceNameCString, regType.c_str(),
                                   /* domain */ nullptr, hostNameCString, htons(mPort), mTxtData.size(), mTxtData.data(),

--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -49,6 +49,9 @@ readonly OT_NCP
 OTBR_DOCKER_IMAGE="${OTBR_DOCKER_IMAGE:-otbr-ncp}"
 readonly OTBR_DOCKER_IMAGE
 
+OTBR_MDNS="${OTBR_MDNS:-avahi}"
+readonly OTBR_MDNS
+
 ABS_TOP_BUILDDIR="$(cd "${top_builddir:-"${SCRIPT_DIR}"/../../}" && pwd)"
 readonly ABS_TOP_BUILDDIR
 
@@ -234,6 +237,9 @@ test_setup()
     sudo cp "${OTBR_DBUS_CONF}" /etc/dbus-1/system.d
     sudo chmod +r /etc/dbus-1/system.d/otbr-agent.conf
     sudo systemctl reload dbus
+    if [[ ${OTBR_MDNS} == "mDNSResponder" ]]; then
+        sudo systemctl restart mdns
+    fi
 
     write_syslog "AGENT: kill old"
     sudo killall "${OTBR_AGENT}" || true
@@ -289,6 +295,7 @@ otbr_exec_expect_script()
         sudo killall ot-ncp-mtd || true
         sudo rm -rf tmp
         mkdir tmp
+        # avahi-browser is used to discover the service and verify in the test cases no matter what OTBR_MDNS is.
         restart_avahi_daemon
         {
             sudo -E expect -df "${script}" 2>"${log_file}"


### PR DESCRIPTION
This PR tries to fix the frequent CI failure of ncp_mode.

For example: https://github.com/openthread/ot-br-posix/actions/runs/16956074962/job/48058480421

I believe this time I find the true cause. I can reproduce this issue in CI environment **occasionally**. And I found when the issue occurred:
```
Aug 14 07:22:43 pkrvm0wrmc9nc7o otbr-agent[30503]: [INFO]-MDNS----: Registering service OpenThread BorderRouter #8D4B._meshcop._udp
Aug 14 07:23:44 pkrvm0wrmc9nc7o otbr-agent[30503]: dnssd_clientstub set_waitlimit:_daemon timed out (60 secs) without any response: Socket 21
Aug 14 07:23:44 pkrvm0wrmc9nc7o otbr-agent[30503]: [INFO]-MDNS----: After DNSServiceRegister
Aug 14 07:23:44 pkrvm0wrmc9nc7o otbr-agent[30503]: [INFO]-MDNS----: HandleRegisterResult with dnsError
Aug 14 07:23:44 pkrvm0wrmc9nc7o otbr-agent[30503]: [INFO]-MDNS----: Will re-register service OpenThread BorderRouter #8D4B._meshcop._udp on the retryable error: Timeout
```
This indicates that the `DNSServiceRegister` blocks in the function for 60 seconds and thus the otbr-agent main processor cannot handle anything else.

`DNSServiceRegister` blocking here means the mDNSResponder is somehow in a bad state. So the PR restarts the mDNSResponder before running the tests to ensure it's in a good state. I verified that this can work on CI (keep failing first, restart mdns, then it works).

On the other hand, potential blocking for such a long time in otbr-agent is risky. But considering that basically means the mDNSResponder is not responding, we should probably handle this error by aborting the entire process. I added a note in the code.