### PR TITLE
[mdns] align preprocessor guard for `NcpHost::SetMdnsPublisher`

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -359,7 +359,7 @@ void Application::InitNcpMode(void)
 #if OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
     mMdnsStateSubject.AddObserver(mBorderAgent);
 #endif
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+#if OTBR_ENABLE_MDNS
     ncpHost.SetMdnsPublisher(mPublisher.get());
     mPublisher->Start();
 #endif

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -307,12 +307,14 @@ void NcpHost::Update(MainloopContext &aMainloop)
     mCliDaemon.UpdateFdSet(aMainloop);
 }
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
 void NcpHost::SetMdnsPublisher(Mdns::Publisher *aPublisher)
 {
     mNcpSpinel.SetMdnsPublisher(aPublisher);
 }
+#endif
 
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
 void NcpHost::HandleMdnsState(Mdns::Publisher::State aState)
 {
     mNcpSpinel.DnssdSetState(aState);

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -307,7 +307,7 @@ void NcpHost::Update(MainloopContext &aMainloop)
     mCliDaemon.UpdateFdSet(aMainloop);
 }
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+#if OTBR_ENABLE_MDNS
 void NcpHost::SetMdnsPublisher(Mdns::Publisher *aPublisher)
 {
     mNcpSpinel.SetMdnsPublisher(aPublisher);

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -140,7 +140,7 @@ public:
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
     void SetMdnsPublisher(Mdns::Publisher *aPublisher);
 #endif
 

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -140,7 +140,7 @@ public:
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+#if OTBR_ENABLE_MDNS
     void SetMdnsPublisher(Mdns::Publisher *aPublisher);
 #endif
 

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -338,14 +338,16 @@ public:
      * @param[in] aState  The dnssd state.
      */
     void DnssdSetState(Mdns::Publisher::State aState);
+#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
 
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
     /**
      * This method sets the mDNS Publisher object.
      *
      * @param[in] aPublisher  A pointer to the mDNS Publisher object.
      */
     void SetMdnsPublisher(otbr::Mdns::Publisher *aPublisher) { mPublisher = aPublisher; }
-#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#endif
 
     /**
      * This method sets a callback that will be invoked when there are any changes on the MeshCoP service from
@@ -513,7 +515,7 @@ private:
     TaskRunner mTaskRunner;
 
     PropsObserver *mPropsObserver;
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
     otbr::Mdns::Publisher *mPublisher;
 #endif
 

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -340,7 +340,7 @@ public:
     void DnssdSetState(Mdns::Publisher::State aState);
 #endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+#if OTBR_ENABLE_MDNS
     /**
      * This method sets the mDNS Publisher object.
      *
@@ -515,7 +515,7 @@ private:
     TaskRunner mTaskRunner;
 
     PropsObserver *mPropsObserver;
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY || (OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE)
+#if OTBR_ENABLE_MDNS
     otbr::Mdns::Publisher *mPublisher;
 #endif
 


### PR DESCRIPTION
This change fixes a build failure in NCP mode that occurs when the Border Agent with MeshCoP service is enabled `OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE` while the SRP advertising proxy `OTBR_ENABLE_SRP_ADVERTISING_PROXY` is disabled.