### PR TITLE
[TrelDnssd] fix build dependency

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(otbr-agent PRIVATE
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     $<$<BOOL:${OTBR_OPENWRT}>:otbr-ubus>
     $<$<BOOL:${OTBR_REST}>:otbr-rest>
+    $<$<BOOL:${OTBR_TREL_DNSSD}>:otbr-trel-dnssd>
     openthread-cli-ftd
     openthread-ftd
     openthread-spinel-rcp

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -70,6 +70,9 @@
 #if OTBR_ENABLE_DNSSD_PLAT
 #include "host/posix/dnssd.hpp"
 #endif
+#if OTBR_ENABLE_TREL_DNSSD
+#include "trel_dnssd/trel_dnssd.hpp"
+#endif
 #include "host/posix/multicast_routing_manager.hpp"
 #include "host/posix/netif.hpp"
 #include "utils/infra_link_selector.hpp"

--- a/src/border_agent/CMakeLists.txt
+++ b/src/border_agent/CMakeLists.txt
@@ -34,6 +34,5 @@ add_library(otbr-border-agent
 target_link_libraries(otbr-border-agent PRIVATE
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     $<$<BOOL:${OTBR_BACKBONE_ROUTER}>:otbr-backbone-router>
-    $<$<BOOL:${OTBR_TREL_DNSSD}>:otbr-trel-dnssd>
     otbr-common
 )


### PR DESCRIPTION
This PR fixes the unnecessary dependency of border-agent on trel-dnssd.

BorderAgent doesn't have any dependency on TrelDnssd. With current code, we got an build error if we build with `-DOTBR_BORDER_AGENT=OFF`:
```
In file included from /usr/local/google/home/irvingcl/Documents/git/ot-br-posix/src/agent/application.cpp:40:
/usr/local/google/home/irvingcl/Documents/git/ot-br-posix/src/agent/application.hpp:203:5: error: ‘TrelDnssd’ does not name a type
  203 |     TrelDnssd::TrelDnssd &GetTrelDnssd(void) { return *mTrelDnssd; }
      |     ^~~~~~~~~
compilation terminated due to -Wfatal-errors.
[538/570] Building CXX object src/agent/CMakeFiles/otbr-agent.dir/main.cpp.o
FAILED: src/agent/CMakeFiles/otbr-agent.dir/main.cpp.o 
```

This is caused by a missing header. This PR adds the missing header. But even we added the header, the TrelDnssd won't be built and there will be a link issue because it's dependent by agent module instead of the BorderAgent module.