### PR TITLE
[host] unify the namespace to otbr::Host

### DIFF
--- a/src/dbus/server/dbus_thread_object_ncp.cpp
+++ b/src/dbus/server/dbus_thread_object_ncp.cpp
@@ -148,7 +148,7 @@ void DBusThreadObjectNcp::ScheduleMigrationHandler(DBusRequest &aRequest)
     std::copy(dataset.begin(), dataset.end(), pendingOpDatasetTlvs.mTlvs);
     pendingOpDatasetTlvs.mLength = dataset.size();
 
-    SuccessOrExit(error = agent::ThreadHelper::ProcessDatasetForMigration(pendingOpDatasetTlvs, delayInMilli));
+    SuccessOrExit(error = Host::ThreadHelper::ProcessDatasetForMigration(pendingOpDatasetTlvs, delayInMilli));
 
     mHost.ScheduleMigration(pendingOpDatasetTlvs, [aRequest](otError aError, const std::string &aErrorInfo) mutable {
         OT_UNUSED_VARIABLE(aErrorInfo);

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -248,7 +248,7 @@ void RcpHost::Init(void)
     {
         otError result = otSetStateChangedCallback(mInstance, &RcpHost::HandleStateChanged, this);
 
-        agent::ThreadHelper::LogOpenThreadResult("Set state callback", result);
+        ThreadHelper::LogOpenThreadResult("Set state callback", result);
         VerifyOrExit(result == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
     }
 
@@ -290,7 +290,7 @@ void RcpHost::Init(void)
     otBorderAgentSetMeshCoPServiceChangedCallback(mInstance, RcpHost::HandleMeshCoPServiceChanged, this);
     otBorderAgentEphemeralKeySetCallback(mInstance, RcpHost::HandleEpskcStateChanged, this);
 
-    mThreadHelper = MakeUnique<otbr::agent::ThreadHelper>(mInstance, this);
+    mThreadHelper = MakeUnique<ThreadHelper>(mInstance, this);
 
     OtNetworkProperties::SetInstance(mInstance);
 

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -130,7 +130,7 @@ public:
      *
      * @retval The pointer to the helper object.
      */
-    otbr::agent::ThreadHelper *GetThreadHelper(void)
+    ThreadHelper *GetThreadHelper(void)
     {
         assert(mThreadHelper != nullptr);
         return mThreadHelper.get();
@@ -282,10 +282,10 @@ private:
 
     otInstance *mInstance;
 
-    otPlatformConfig                           mConfig;
-    std::unique_ptr<otbr::agent::ThreadHelper> mThreadHelper;
-    std::vector<std::function<void(void)>>     mResetHandlers;
-    TaskRunner                                 mTaskRunner;
+    otPlatformConfig                       mConfig;
+    std::unique_ptr<ThreadHelper>          mThreadHelper;
+    std::vector<std::function<void(void)>> mResetHandlers;
+    TaskRunner                             mTaskRunner;
 
     std::vector<ThreadStateChangedCallback>       mThreadStateChangedCallbacks;
     std::vector<ThreadEnabledStateCallback>       mThreadEnabledStateChangedCallbacks;

--- a/src/host/thread_helper.cpp
+++ b/src/host/thread_helper.cpp
@@ -51,7 +51,7 @@
 #include "host/rcp_host.hpp"
 
 namespace otbr {
-namespace agent {
+namespace Host {
 namespace {
 const Tlv *FindTlv(uint8_t aTlvType, const uint8_t *aTlvs, int aTlvsSize)
 {
@@ -781,5 +781,5 @@ exit:
     return error;
 }
 
-} // namespace agent
+} // namespace Host
 } // namespace otbr

--- a/src/host/thread_helper.hpp
+++ b/src/host/thread_helper.hpp
@@ -54,12 +54,8 @@
 
 namespace otbr {
 namespace Host {
-class RcpHost;
-}
-} // namespace otbr
 
-namespace otbr {
-namespace agent {
+class RcpHost;
 
 /**
  * This class implements Thread helper.
@@ -314,7 +310,7 @@ private:
 #endif
 };
 
-} // namespace agent
+} // namespace Host
 } // namespace otbr
 
 #endif // OTBR_THREAD_HELPER_HPP_


### PR DESCRIPTION
This PR unifies the namespace for sources under `src/host` to `otbr::Host`.

In particular, chnages `otbr::agent::ThreadHelper` to `otbr::Host::ThreadHelper`.