### PR TITLE
[log] set the default log tag to `OTBR`

### DIFF
--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -41,7 +41,7 @@
 #include <openthread/platform/logging.h>
 
 #ifndef OTBR_LOG_TAG
-#define OTBR_LOG_TAG ""
+#define OTBR_LOG_TAG "OTBR"
 #endif
 
 #include "common/types.hpp"

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -41,7 +41,7 @@
 #include <openthread/platform/logging.h>
 
 #ifndef OTBR_LOG_TAG
-#error "OTBR_LOG_TAG is not defined"
+#define OTBR_LOG_TAG ""
 #endif
 
 #include "common/types.hpp"


### PR DESCRIPTION
When compiling the file `src/common/logging.hpp` using the blaze for the Raspberry Pi platform, the compiler reports the following error:

Compiling third_party/ot_posix/src/common/logging.hpp failed: (Exit 1) arm-oe-linux-gnueabi-clang failed: error executing CppCompileHeader command (from cc_library rule target //third_party/ot_posix/src/common:common) arm-oe-linux-gnueabi-clang '--target=arm-oe-linux-gnueabi' '-mcpu=cortex-a7' '-mtune=cortex-a7' -mthumb ... (remaining 211 arguments skipped).  [forge_remote_host=jrbks1] third_party/ot_posix/src/common/logging.hpp:45:2: error: "OTBR_LOG_TAG is not defined"
   45 | #error "OTBR_LOG_TAG is not defined"

This commit sets the default log tag to the string `OTBR` to avoid the build error.