### PR TITLE
[build] fix the link target of common module

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -47,11 +47,11 @@ add_library(otbr-common
 
 target_link_libraries(otbr-common
     PUBLIC otbr-config
-    openthread-ftd
 )
 
 target_include_directories(otbr-common
     PUBLIC
-        ${OPENTHREAD_PROJECT_DIRECTORY}/src/posix/platform/include
+        ${OPENTHREAD_PROJECT_DIRECTORY}/include
         ${OPENTHREAD_PROJECT_DIRECTORY}/src
+        ${OPENTHREAD_PROJECT_DIRECTORY}/src/posix/platform/include
 )

--- a/src/host/CMakeLists.txt
+++ b/src/host/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(otbr-host
 
 target_link_libraries(otbr-host
     PUBLIC
+        openthread-ftd
         $<$<BOOL:${OTBR_FEATURE_FLAGS}>:otbr-proto>
     PRIVATE
         otbr-common

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -109,6 +109,7 @@ target_include_directories(otbr-posix-gtest-unit
 )
 target_link_libraries(otbr-posix-gtest-unit
     otbr-posix
+    openthread-ftd
     GTest::gmock_main
 )
 gtest_discover_tests(otbr-posix-gtest-unit PROPERTIES LABELS "sudo")


### PR DESCRIPTION
This PR fixes the link dependency of `otbr-common` module.

The common module doesn't use any implementation in OT so it doesn't need to link `openthread-ftd` at all. Instead, the `otbr-host` module needs to link `openthread-ftd`.

Removing the dependency makes `otbr-common` reusable for some unit tests. (The unit test target doesn't link to the whole bunch of stuffs)