### PR TITLE
[REST] fix CORS allow origin header

### DIFF
--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1828,6 +1828,7 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
         {
             otbrLogInfo("RestWebServer listening on %s:%u", aRestListenAddress.c_str(), aRestListenPort);
             self->mServer.set_ipv6_v6only(false);
+            self->mServer.set_default_headers({{"Access-Control-Allow-Origin", "*"}});
             if (!self->mServer.listen(aRestListenAddress, aRestListenPort))
             {
                 otbrLogWarning("REST server failed to start on %s:%d", aRestListenAddress.c_str(), aRestListenPort);


### PR DESCRIPTION
The [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin) header is mandatory for browsers.
Since the refactoring of the rest server this header is missing, hence the front-end is currently broken.