### PR TITLE
[tests-dbus] remove assertion on `trelInfo.mEnabled` 

### DIFF
--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -198,7 +198,6 @@ void CheckTrelInfo(ThreadApiDBus *aApi)
     otbr::DBus::TrelInfo trelInfo;
 
     TEST_ASSERT(aApi->GetTrelInfo(trelInfo) == OTBR_ERROR_NONE);
-    TEST_ASSERT(trelInfo.mEnabled);
     TEST_ASSERT(trelInfo.mNumTrelPeers == 0);
     TEST_ASSERT(trelInfo.mTrelCounters.mTxPackets == 0);
     TEST_ASSERT(trelInfo.mTrelCounters.mTxBytes == 0);
@@ -346,7 +345,6 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_border_router().dns_server().response_counters().server_failure_count() == 0);
 #endif
 #if OTBR_ENABLE_TREL
-    TEST_ASSERT(telemetryData.wpan_border_router().trel_info().is_trel_enabled());
     TEST_ASSERT(telemetryData.wpan_border_router().trel_info().has_counters());
     TEST_ASSERT(telemetryData.wpan_border_router().trel_info().counters().trel_tx_packets() == 0);
     TEST_ASSERT(telemetryData.wpan_border_router().trel_info().counters().trel_tx_bytes() == 0);


### PR DESCRIPTION
The TREL state may not always be enabled when `CheckTrelInfo()` or `CheckTelemetryData()` are called, and assuming this state  makes the test brittle. This change removes theses assertions.

These checks were always flawed. Previously, `ot-br-posix` feature flags would disable TREL upon stack initialization, but then bringing the Thread netif up would re-enable all radio links, including TREL. The `test-dbus-client` was unintentionally validating this incorrect behavior.

Recent changes in OpenThread PR #11944 enhanced this behavior to distinguish between user and stack TREL enable requests. A key change is that a user's request to disable TREL is now persistent. If the user explicitly disables TREL, it remains disabled regardless of Thread stack state changes and other API calls. The user must explicitly re-enable TREL via `otTrelSetEnabled(true)` to allow it to operate again.

---

This should help address failures like https://github.com/openthread/ot-br-posix/actions/runs/17823619992/job/50701129434?pr=3056#step:4:1635