### PR TITLE
[ncp] add local port to udp forward callback

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -383,10 +383,13 @@ void Application::InitNcpMode(void)
             OTBR_UNUSED_VARIABLE(aLength);
 #endif
         });
-    mHost.SetUdpForwardToHostCallback(
-        [this](const uint8_t *aUdpPayload, uint16_t aLength, const otIp6Address &aPeerAddr, uint16_t aPeerPort) {
+    mHost.SetUdpForwardToHostCallback([this](const uint8_t *aUdpPayload, uint16_t aLength,
+                                             const otIp6Address &aPeerAddr, uint16_t aPeerPort, uint16_t aLocalPort) {
+        if (aLocalPort == mBorderAgentUdpProxy.GetThreadPort())
+        {
             mBorderAgentUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
-        });
+        }
+    });
     SetBorderAgentOnInitState();
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -577,7 +577,7 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
 
         SuccessOrExit(ParseUdpForwardStream(aBuffer, aLength, udpPayload, length, peerAddress, peerPort, localPort),
                       error = OTBR_ERROR_PARSE);
-        SafeInvoke(mUdpForwardSendCallback, udpPayload, length, *peerAddress, peerPort);
+        SafeInvoke(mUdpForwardSendCallback, udpPayload, length, *peerAddress, peerPort, localPort);
 
         break;
     }

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -108,7 +108,17 @@ public:
     using InfraIfSendIcmp6NdCallback = std::function<void(uint32_t, const otIp6Address &, const uint8_t *, uint16_t)>;
     using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
     using CliDaemonOutputCallback                  = std::function<void(const char *)>;
-    using UdpForwardSendCallback = std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t)>;
+    /**
+     * Callback for forwarding UDP packets to the host.
+     *
+     * @param[in] aPayload         Pointer to the UDP payload.
+     * @param[in] aPayloadLength   Length of the UDP payload.
+     * @param[in] aPeerAddress     IPv6 address of the peer.
+     * @param[in] aPeerPort        UDP port of the peer.
+     * @param[in] aLocalPort       Local UDP port (on the Thread side).
+     */
+    using UdpForwardSendCallback =
+        std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t, uint16_t)>;
     using BackboneRouterMulticastListenerCallback =
         std::function<void(otBackboneRouterMulticastListenerEvent, Ip6Address)>;
     using BackboneRouterStateChangedCallback = std::function<void(otBackboneRouterState)>;

--- a/src/host/thread_host.hpp
+++ b/src/host/thread_host.hpp
@@ -133,7 +133,17 @@ public:
     using ThreadEnabledStateCallback               = std::function<void(ThreadEnabledState)>;
     using BorderAgentMeshCoPServiceChangedCallback = std::function<void(bool, uint16_t, const uint8_t *, uint16_t)>;
     using EphemeralKeyStateChangedCallback         = std::function<void(otBorderAgentEphemeralKeyState, uint16_t)>;
-    using UdpForwardToHostCallback = std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t)>;
+    /**
+     * Callback for forwarding UDP packets to the host.
+     *
+     * @param[in] aPayload         Pointer to the UDP payload.
+     * @param[in] aPayloadLength   Length of the UDP payload.
+     * @param[in] aPeerAddress     IPv6 address of the peer.
+     * @param[in] aPeerPort        UDP port of the peer.
+     * @param[in] aLocalPort       Local UDP port (on the Thread side).
+     */
+    using UdpForwardToHostCallback =
+        std::function<void(const uint8_t *, uint16_t, const otIp6Address &, uint16_t, uint16_t)>;
     using BackboneRouterMulticastListenerCallback =
         std::function<void(otBackboneRouterMulticastListenerEvent, Ip6Address)>;
     using BackboneRouterStateChangedCallback = std::function<void(otBackboneRouterState)>;


### PR DESCRIPTION
This PR adds one more parameter `aLocalPort` to `UdpForwardToHostCallback`.

Currently we only use udp proxy for border agent. As we are going to support Epskc and TREL, more UDP proxies will be required. We need to have the local port to find the right UDP proxy to send the UDP packet.