### PR TITLE
[dbus-test] remove check for 'nn' (network name) in meshcop service

### DIFF
--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -75,11 +75,6 @@ scan_meshcop_service()
 
 update_meshcop_txt_and_check()
 {
-    sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('nn',[97])]" || true
-    sleep 5
-    service="$(scan_meshcop_service)"
-    grep --binary-files=text "nn=OpenThread" <<<"${service}"
-
     sudo gdbus call --system --dest io.openthread.BorderRouter.wpan0 --method=io.openthread.BorderRouter.UpdateVendorMeshCopTxtEntries --object-path /io/openthread/BorderRouter/wpan0 "[('vn',[118,101,110,100,111,114])]"
     sleep 5
     service="$(scan_meshcop_service)"


### PR DESCRIPTION
This commit removes the test steps that verify the presence of the `nn` (network name) TXT entry in the MeshCoP DNS-SD service.

This change aligns the test with a recent behavior modification in the OpenThread core (PR 11989), which no longer advertises the `nn` entry if a valid network dataset is not available. This prevents a Border Agent from prematurely advertising a default or invalid Network Name or Extended PAN ID during boot-up before it gets valid network information.