### PR TITLE
[test] remove check for `nn` and `xp` in `ncp_border_agent.exp`

### DIFF
--- a/tests/scripts/expect/ncp_border_agent.exp
+++ b/tests/scripts/expect/ncp_border_agent.exp
@@ -50,8 +50,6 @@ proc check_common_txt {mdns_browse_result} {
     check_string_contains $mdns_browse_result "sb="
     check_string_contains $mdns_browse_result "xa="
     check_string_contains $mdns_browse_result "tv="
-    check_string_contains $mdns_browse_result "xp="
-    check_string_contains $mdns_browse_result "nn="
     check_string_contains $mdns_browse_result "id="
     check_string_contains $mdns_browse_result "mn="
     check_string_contains $mdns_browse_result "vn="


### PR DESCRIPTION
This commit removes the test steps that verify the presence of the `nn` (network name) and `xp` (Extended PAN ID) TXT entry in the `ncp_border_agent.exp`

This change aligns the test with a recent behavior modification in the OpenThread core, which no longer advertises the `nn` entry if a valid network dataset is not available. This prevents a Border Agent from prematurely advertising a default or invalid Network Name or Extended PAN ID during boot-up before it gets valid network information.