### PR TITLE
[ncp] enforce mDNS dependency for SRP proxy and MeshCoP service

### DIFF
--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -40,6 +40,14 @@
 #include "host/async_task.hpp"
 #include "lib/spinel/spinel_driver.hpp"
 
+#if OTBR_ENABLE_SRP_ADVERTISING_PROXY && !OTBR_ENABLE_MDNS
+#error "OTBR_ENABLE_MDNS is required when OTBR_ENABLE_SRP_ADVERTISING_PROXY is enabled"
+#endif
+
+#if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE && !OTBR_ENABLE_MDNS
+#error "OTBR_ENABLE_MDNS is required when OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE is enabled"
+#endif
+
 namespace otbr {
 namespace Host {
 


### PR DESCRIPTION
Introduce a preprocessor check to ensure build configuration consistency for the NCP host.

The `OTBR_ENABLE_SRP_ADVERTISING_PROXY` and `OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE` rely on the mDNS publisher for service advertisement. If either of these features is enabled without also enabling `OTBR_ENABLE_MDNS`, it results in a compile-time error due to missing dependencies (e.g., `Mdns::Publisher`).

This commit adds a compile-time `#error` directive that fires if an invalid configuration is detected, which provides an immediate and clear error message.