### PR TITLE
[ncp] enhance ncp spinel log

### DIFF
--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -355,7 +355,11 @@ void NcpSpinel::HandleNotification(const uint8_t *aFrame, uint16_t aLength)
     }
 
 exit:
-    otbrLogResult(error, "%s", __FUNCTION__);
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to handle notification: %s", otbrErrorString(error));
+    }
+    return;
 }
 
 void NcpSpinel::HandleResponse(spinel_tid_t aTid, const uint8_t *aFrame, uint16_t aLength)
@@ -588,7 +592,7 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
     }
 
 exit:
-    otbrLogResult(error, "NcpSpinel: %s", __FUNCTION__);
+    otbrLogResult(error, "%s, Property:%s", __FUNCTION__, spinel_prop_key_to_cstr(aKey));
     return;
 }
 


### PR DESCRIPTION
This PR enhances the log in NcpSpinel.

Currently the log is as:
```
2025-10-12T17:33:57.775394+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:57.775433+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.611891+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.612046+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.612143+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.612171+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.612240+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.612277+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.612349+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.612397+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.612485+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.612526+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:58.732385+08:00 otbr-agent[2854087]: [WARN]-NcpSpin-: Received uncognized key: 115
2025-10-12T17:33:58.732418+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:58.732449+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:59.292184+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
2025-10-12T17:33:59.292232+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: HandleNotification: OK
2025-10-12T17:33:59.292326+08:00 otbr-agent[2854087]: [INFO]-NcpSpin-: NcpSpinel: HandleValueIs: OK
```

The `HandleNotification` log isn't useful. This PR removes it. This PR also adds the property name in `HandleValueIs` log and remove redundant `NcpSpinel` since it's already in the log prepender.