### PR TITLE
[script] Remove systemctl usage inside Docker

### DIFF
--- a/script/_dhcpv6_pd_ref
+++ b/script/_dhcpv6_pd_ref
@@ -106,7 +106,7 @@ dhcpv6_pd_ref_uninstall()
 {
     with DHCPV6_PD_REF || return 0
 
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl disable ${PD_DAEMON_SERVICE_NAME} || true
         sudo systemctl stop ${PD_DAEMON_SERVICE_NAME} || true
         sudo rm -f ${PD_DAEMON_SERVICE_PATH} || true
@@ -119,7 +119,7 @@ dhcpv6_pd_ref_uninstall()
     sudo rm -f ${DHCPCD_ENTER_HOOK} ${DHCPCD_EXIT_HOOK}
     sudo rm -f ${PD_DAEMON_PATH}
 
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl daemon-reload
 
         if systemctl is-active dhcpcd; then
@@ -154,7 +154,7 @@ dhcpv6_pd_ref_install()
     # TODO: Re-enable and start the daemon when a solution is found
     #       for dhcpcd restarts breaking mDNS.
     #
-    # if have systemctl; then
+    # if have systemctl && without DOCKER; then
     #    sudo systemctl daemon-reload
     #    sudo systemctl enable ${PD_DAEMON_SERVICE_NAME}
     #    sudo systemctl start ${PD_DAEMON_SERVICE_NAME}
@@ -164,7 +164,7 @@ dhcpv6_pd_ref_install()
     # dhcp6_pd_daemon which caused mDNS disruptions.
     sudo cp ${DHCP_CONFIG_PD_PATH} ${DHCP_CONFIG_PATH}
 
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl daemon-reload
 
         # Restart dhcpcd only if it's running. This is unnecessary when the dhcp6_pd_daemon

--- a/script/_firewall
+++ b/script/_firewall
@@ -38,7 +38,7 @@ firewall_uninstall()
     with FIREWALL || return 0
 
     firewall_stop
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl disable otbr-firewall || true
     fi
     # systemctl disable doesn't remove sym-links
@@ -54,7 +54,7 @@ firewall_install()
 
     sudo cp script/otbr-firewall $FIREWALL_SERVICE
     sudo chmod a+x $FIREWALL_SERVICE
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl enable otbr-firewall || die 'Failed to enable firewall service!'
         sudo systemctl start otbr-firewall || die 'Failed to start firewall service!'
     fi

--- a/script/_initrc
+++ b/script/_initrc
@@ -84,7 +84,7 @@ without()
 }
 
 HAVE_SYSTEMCTL=0
-if have systemctl; then
+if have systemctl && without DOCKER; then
     HAVE_SYSTEMCTL=1
 fi
 HAVE_SERVICE=0

--- a/script/_nat64
+++ b/script/_nat64
@@ -107,7 +107,7 @@ EOF
 esac
 EOF
     sudo chmod a+x $NAT44_SERVICE
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl enable otbr-nat44 || die 'Unable to enable nat44 service!'
         sudo systemctl start otbr-nat44 || die 'Failed to start nat44 service!'
     fi
@@ -115,7 +115,7 @@ EOF
 
 nat44_uninstall()
 {
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl disable otbr-nat44 || true
     fi
 

--- a/script/_otbr
+++ b/script/_otbr
@@ -50,7 +50,7 @@ readonly REFERENCE_DEVICE
 
 otbr_uninstall()
 {
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl stop otbr-web || true
         sudo systemctl stop otbr-agent || true
         sudo systemctl disable otbr-web || true
@@ -66,7 +66,7 @@ otbr_uninstall()
             sudo xargs rm <install_manifests.txt || true
         fi
     )
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl daemon-reload
     fi
 }
@@ -151,7 +151,7 @@ otbr_install()
         && ninja \
         && sudo ninja install)
 
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl reload dbus
         sudo systemctl daemon-reload
         without WEB_GUI || sudo systemctl enable otbr-web || true

--- a/script/console
+++ b/script/console
@@ -60,7 +60,7 @@ main()
 {
     # shellcheck source=/dev/null
     . "$BEFORE_HOOK"
-    if have systemctl; then
+    if have systemctl && without DOCKER; then
         sudo systemctl stop otbr-web otbr-agent || true
     fi
     killall_services


### PR DESCRIPTION
While some containers can include the systemctl
package, it is often non-functional or behaves
differently. This commit updates the scripts to
avoid using systemctl inside Docker.