### PR TITLE
[utils] add csprng and update ephemeral key generation

### DIFF
--- a/src/border_agent/CMakeLists.txt
+++ b/src/border_agent/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(otbr-border-agent PRIVATE
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     $<$<BOOL:${OTBR_BACKBONE_ROUTER}>:otbr-backbone-router>
     otbr-common
+    otbr-utils
 )

--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -52,8 +52,6 @@
 
 #include <openthread/border_agent.h>
 #include <openthread/border_routing.h>
-#include <openthread/random_crypto.h>
-#include <openthread/random_noncrypto.h>
 #include <openthread/thread.h>
 #include <openthread/thread_ftd.h>
 #include <openthread/verhoeff_checksum.h>
@@ -70,6 +68,7 @@
 #include "common/logging.hpp"
 #include "common/tlv.hpp"
 #include "common/types.hpp"
+#include "utils/csprng.hpp"
 #include "utils/hex.hpp"
 
 #if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
@@ -114,7 +113,7 @@ otbrError BorderAgent::CreateEphemeralKey(std::string &aEphemeralKey)
     {
         while (true)
         {
-            SuccessOrExit(otRandomCryptoFillBuffer(candidateBuffer, 1), error = OTBR_ERROR_ABORTED);
+            SuccessOrExit(Csprng::GetInstance().RandomGet(candidateBuffer, 1), error = OTBR_ERROR_ABORTED);
             // Generates a random number in the range [0, 9] with equal probability.
             if (candidateBuffer[0] < 250)
             {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -28,6 +28,7 @@
 
 add_library(otbr-utils
     crc16.cpp
+    csprng.cpp
     dns_utils.cpp
     hex.cpp
     infra_link_selector.cpp

--- a/src/utils/csprng.cpp
+++ b/src/utils/csprng.cpp
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file includes implementations for cryptographically secure pseudorandom number generator utilities.
+ */
+
+#include "csprng.hpp"
+
+#include <assert.h>
+
+#include <mbedtls/ctr_drbg.h>
+
+#include "common/code_utils.hpp"
+#include "common/types.hpp"
+
+namespace otbr {
+
+Csprng &Csprng::GetInstance(void)
+{
+    static Csprng instance;
+    return instance;
+}
+
+otbrError Csprng::RandomGet(uint8_t *aBuffer, uint16_t aSize)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mInitialized, error = OTBR_ERROR_INVALID_STATE);
+
+    if (mbedtls_ctr_drbg_random(&mCtrDrbgContext, static_cast<unsigned char *>(aBuffer), static_cast<size_t>(aSize)) <
+        0)
+    {
+        error = OTBR_ERROR_INVALID_ARGS;
+    }
+
+exit:
+    return error;
+}
+
+Csprng::Csprng(void)
+    : mInitialized(false)
+{
+    mbedtls_entropy_init(&mEntropyContext);
+    mbedtls_ctr_drbg_init(&mCtrDrbgContext);
+
+    if (mbedtls_ctr_drbg_seed(&mCtrDrbgContext, mbedtls_entropy_func, &mEntropyContext, nullptr, 0) == 0)
+    {
+        mInitialized = true;
+    }
+}
+
+Csprng::~Csprng(void)
+{
+    mbedtls_entropy_free(&mEntropyContext);
+    mbedtls_ctr_drbg_free(&mCtrDrbgContext);
+}
+
+} // namespace otbr

--- a/src/utils/csprng.hpp
+++ b/src/utils/csprng.hpp
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * This file includes definition for cryptographically secure pseudorandom number generator utilities.
+ */
+
+#ifndef OTBR_UTILS_CSPRNG_HPP_
+#define OTBR_UTILS_CSPRNG_HPP_
+
+#include <common/types.hpp>
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+
+namespace otbr {
+
+class Csprng
+{
+public:
+    /**
+     * Gets the singleton instance of the generator.
+     */
+    static Csprng &GetInstance(void);
+
+    /**
+     * Fills a given buffer with cryptographically secure random bytes.
+     *
+     * @param[out] aBuffer  A pointer to a buffer to fill with the random bytes. Must not be NULL.
+     * @param[in]  aSize    Size of buffer (number of bytes to fill).
+     *
+     * @retval OTBR_ERROR_NONE           The bytes are successfully generated.
+     * @retval OTBR_ERROR_INVALID_STATE  The generation failed because of some internal state.
+     * @retval OTBR_ERROR_INVALID_ARGS   @p aBuffer is NULL and @p aSize is not 0.
+     */
+    otbrError RandomGet(uint8_t *aBuffer, uint16_t aSize);
+
+private:
+    Csprng(void);
+    ~Csprng(void);
+
+    mbedtls_entropy_context  mEntropyContext;
+    mbedtls_ctr_drbg_context mCtrDrbgContext;
+
+    bool mInitialized;
+};
+
+} // namespace otbr
+
+#endif // OTBR_UTILS_CSPRNG_HPP_


### PR DESCRIPTION
This PR adds a utils module for cryptographically secure pseudorandom number generation.

The PR updates the implementation of Ephemeral key generation by using the new module and removing the usage of ot platform crypto API. This enables the code to work in both RCP & NCP design.

The underlying implementation is not changed at all, still using mbedtls. 