### PR TITLE
[script] build option to allow configuring dhcpv6 pd minimum lifetime

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -133,7 +133,6 @@ otbr_install()
             "-DOT_DHCP6_CLIENT=ON"
             "-DOT_DHCP6_SERVER=ON"
             "-DOTBR_DUA_ROUTING=ON"
-            "-DOTBR_DHCP6_PD_MIN_LIFETIME=60"
         )
     fi
 


### PR DESCRIPTION
This change introduces a new build option `OTBR_DHCP6_PD_MIN_LIFETIME` to allow configuration of the minimum preferred lifetime for the DHCPv6 PD client.

It is used to set the `OPENTHREAD_CONFIG_BORDER_ROUTING_DHCP6_PD_CLIENT_MIN_LIFETIME` configuration in OT core, which provides flexibility for platforms to adjust the minimum lifetime of a delegated prefix