### PR TITLE
[types] use `ntohs` instead of `bswap_16`

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -70,12 +70,12 @@ Ip6Address Ip6Address::ToSolicitedNodeMulticastAddress(void) const
 
 bool Ip6Address::IsLinkLocal(void) const
 {
-    return (m16[0] & bswap_16(0xffc0)) == bswap_16(0xfe80);
+    return (ntohs(m16[0]) & 0xffc0) == 0xfe80;
 }
 
 bool Ip6Address::IsLoopback(void) const
 {
-    return (m32[0] == 0 && m32[1] == 0 && m32[2] == 0 && m32[3] == htobe32(1));
+    return (m64[0] == 0 && m32[2] == 0 && m32[3] == htonl(1));
 }
 
 uint8_t Ip6Address::GetScope(void) const


### PR DESCRIPTION
Thanks to @michal-markiewicz-ci for raising the issue.