### PR TITLE
[border-agent] add MeshCop `vmail` TXT record to indicate multi-AIL indication

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -297,6 +297,14 @@ void Application::InitRcpMode(const std::string &aRestListenAddress, int aRestLi
     mHost.AddEphemeralKeyStateChangedCallback([this](otBorderAgentEphemeralKeyState aEpskcState, uint16_t aPort) {
         mBorderAgent.HandleEpskcStateChanged(aEpskcState, aPort);
     });
+#if OTBR_ENABLE_MULTI_AIL
+    otBorderRoutingSetMultiAilCallback(
+        rcpHost.GetInstance(),
+        [](bool isDetected, void *aContext) {
+            static_cast<BorderAgent *>(aContext)->HandleMultiAilStateChanged(isDetected);
+        },
+        &mBorderAgent);
+#endif
     SetBorderAgentOnInitState();
 #else
     mBorderAgent.SetVendorTxtDataChangedCallback(

--- a/src/border_agent/border_agent.hpp
+++ b/src/border_agent/border_agent.hpp
@@ -196,12 +196,22 @@ public:
     void UpdateVendorMeshCoPTxtEntries(const VendorTxtEntries &aVendorEntries);
 #endif
 
+#if OTBR_ENABLE_MULTI_AIL
+    /**
+     * This method handles multi-AIL state changes.
+     *
+     * @param[in] aIsDetected  If a multi-AIL is detected.
+     */
+    void HandleMultiAilStateChanged(bool aIsDetected);
+#endif
+
 private:
     void ClearState(void);
     void Start(void);
     void Stop(void);
     bool IsEnabled(void) const { return mIsEnabled; }
 
+    void EncodeVendorTxtData(void);
     void EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries);
 
 #if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
@@ -220,6 +230,9 @@ private:
     Mdns::Publisher &mPublisher;
 #endif
     bool mIsEnabled;
+#if OTBR_ENABLE_MULTI_AIL
+    bool mIsMultiAil;
+#endif
 
     std::vector<uint8_t> mVendorOui;
 
@@ -227,6 +240,7 @@ private:
     std::string mProductName;
 
     TxtData                      mVendorTxtData; // Encoded vendor-specific TXT data.
+    VendorTxtEntries             mVendorTxtEntries;
     VendorTxtDataChangedCallback mVendorTxtDataChangedCallback;
 
 #if OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -339,6 +339,10 @@ void RcpHost::Deinit(void)
 {
     assert(mInstance != nullptr);
 
+#if OTBR_ENABLE_MULTI_AIL
+    otBorderRoutingSetMultiAilCallback(mInstance, nullptr, nullptr);
+#endif
+
     otSysDeinit();
     mInstance = nullptr;
 


### PR DESCRIPTION
This PR introduces a `vmail` (vendor multi-AIL) TXT record to the MeshCoP service advertisement. This boolean record indicates if the BR has detected a multi-AIL condition.

This commit also refactors vendor TXT entry management to persist non-standard vendor specific txt entries during updates.
