### PR TITLE
[script] make rt_tables script robust

### DIFF
--- a/script/_rt_tables
+++ b/script/_rt_tables
@@ -46,7 +46,7 @@ rt_tables_install()
     rt_tables_uninstall
 
     sudo mkdir -p /etc/iproute2
-    sudo sh -c 'grep -qxF "88 openthread" /etc/iproute2/rt_tables || echo "88 openthread" >> /etc/iproute2/rt_tables'
+    sudo sh -c 'grep -qxF "88 openthread" /etc/iproute2/rt_tables 2>/dev/null || echo "88 openthread" >> /etc/iproute2/rt_tables'
 
     # Increase ancillary buffer size to allow for a larger number of multicast groups
     # Required for NdProxyManager::JoinSolicitedNodeMulticastGroup


### PR DESCRIPTION
On some fresh systems where `/etc/iproute2/rt_tables` or `/etc/iproute2` directory does not exist, there might be failures during setup.

This commit introduces the following fixes:

- In `rt_tables_uninstall`, the script now checks if `/etc/iproute2/rt_tables` exists before attempting to modify it.

- In `rt_tables_install`, the script now ensures the `/etc/iproute2` directory exists by using `mkdir -p`.

- The installation logic is also made idempotent by checking if the `88 openthread` rule already exists before appending it.

Fixes #2552 