### PR TITLE
[dbus] add dbus API to set border agent Id

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -54,6 +54,11 @@ if (OTBR_BORDER_AGENT_MESHCOP_SERVICE)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE=1)
 endif()
 
+option(OTBR_BORDER_AGENT_ID "Enable Border Agent ID support" ON)
+if (OTBR_BORDER_AGENT_ID)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_AGENT_ID=1)
+endif()
+
 option(OTBR_BACKBONE_ROUTER "Enable Backbone Router" ON)
 if (OTBR_BACKBONE_ROUTER)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BACKBONE_ROUTER=1)

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -893,6 +893,11 @@ ClientError ThreadApiDBus::SetBorderAgentEnabled(bool aEnabled)
     return CallDBusMethodSync(OTBR_DBUS_SET_BORDER_AGENT_ENABLED_METHOD, std::tie(aEnabled));
 }
 
+ClientError ThreadApiDBus::SetBorderAgentId(const std::vector<uint8_t> &aBorderAgentId)
+{
+    return SetProperty(OTBR_DBUS_PROPERTY_BORDER_AGENT_ID, aBorderAgentId);
+}
+
 ClientError ThreadApiDBus::UpdateVendorMeshCopTxtEntries(std::vector<TxtEntry> &aUpdate)
 {
     auto args = std::tie(aUpdate);

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -801,6 +801,17 @@ public:
     ClientError SetBorderAgentEnabled(bool aEnabled);
 
     /**
+     * This method sets the 16 byte Border Agent Id.
+     *
+     * @param[in] aBorderAgentId  The Border Agent Id.
+     *
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
+     */
+    ClientError SetBorderAgentId(const std::vector<uint8_t> &aBorderAgentId);
+
+    /**
      * This method sets multiple vendor-specific entries for the TXT record of the MeshCoP service.
      *
      * @note

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -187,6 +187,10 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::SetDnsUpstreamQueryState, this, _1));
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NAT64_CIDR,
                                std::bind(&DBusThreadObjectRcp::SetNat64Cidr, this, _1));
+#if OTBR_ENABLE_BORDER_AGENT_ID
+    RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_BORDER_AGENT_ID,
+                               std::bind(&DBusThreadObjectRcp::SetBorderAgentIdHandler, this, _1));
+#endif
 #if OTBR_ENABLE_EPSKC
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_EPHEMERAL_KEY_ENABLED,
                                std::bind(&DBusThreadObjectRcp::SetEphemeralKeyEnabled, this, _1));
@@ -223,8 +227,10 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::GetRloc16Handler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_EXTENDED_ADDRESS,
                                std::bind(&DBusThreadObjectRcp::GetExtendedAddressHandler, this, _1));
+#if OTBR_ENABLE_BORDER_AGENT_ID
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_BORDER_AGENT_ID,
                                std::bind(&DBusThreadObjectRcp::GetBorderAgentIdHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_ROUTER_ID,
                                std::bind(&DBusThreadObjectRcp::GetRouterIdHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_LEADER_DATA,
@@ -1308,6 +1314,23 @@ exit:
     return error;
 }
 
+#if OTBR_ENABLE_BORDER_AGENT_ID
+otError DBusThreadObjectRcp::SetBorderAgentIdHandler(DBusMessageIter &aIter)
+{
+    otError                                        error = OT_ERROR_NONE;
+    std::array<uint8_t, OT_BORDER_AGENT_ID_LENGTH> data;
+    otBorderAgentId                                borderAgentId;
+
+    VerifyOrExit(DBusMessageExtractFromVariant(&aIter, data) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
+    std::copy(data.begin(), data.end(), borderAgentId.mId);
+
+    error = otBorderAgentSetId(mHost.GetInstance(), &borderAgentId);
+
+exit:
+    return error;
+}
+#endif
+
 #if OTBR_ENABLE_BORDER_AGENT
 void DBusThreadObjectRcp::SetBorderAgentEnabledHandler(DBusRequest &aRequest)
 {
@@ -1664,6 +1687,7 @@ exit:
     return error;
 }
 
+#if OTBR_ENABLE_BORDER_AGENT_ID
 otError DBusThreadObjectRcp::GetBorderAgentIdHandler(DBusMessageIter &aIter)
 {
     otBorderAgentId      id;
@@ -1679,6 +1703,7 @@ otError DBusThreadObjectRcp::GetBorderAgentIdHandler(DBusMessageIter &aIter)
 exit:
     return error;
 }
+#endif
 
 otError DBusThreadObjectRcp::GetOtRcpVersionHandler(DBusMessageIter &aIter)
 {

--- a/src/dbus/server/dbus_thread_object_rcp.hpp
+++ b/src/dbus/server/dbus_thread_object_rcp.hpp
@@ -123,6 +123,9 @@ private:
     otError SetRadioRegionHandler(DBusMessageIter &aIter);
     otError SetDnsUpstreamQueryState(DBusMessageIter &aIter);
     otError SetNat64Cidr(DBusMessageIter &aIter);
+#if OTBR_ENABLE_BORDER_AGENT_ID
+    otError SetBorderAgentIdHandler(DBusMessageIter &aIter);
+#endif
 #if OTBR_ENABLE_EPSKC
     otError SetEphemeralKeyEnabled(DBusMessageIter &aIter);
 #endif
@@ -133,7 +136,9 @@ private:
     otError GetPanIdHandler(DBusMessageIter &aIter);
     otError GetExtPanIdHandler(DBusMessageIter &aIter);
     otError GetEui64Handler(DBusMessageIter &aIter);
+#if OTBR_ENABLE_BORDER_AGENT_ID
     otError GetBorderAgentIdHandler(DBusMessageIter &aIter);
+#endif
     otError GetChannelHandler(DBusMessageIter &aIter);
     otError GetNetworkKeyHandler(DBusMessageIter &aIter);
     otError GetCcaFailureRateHandler(DBusMessageIter &aIter);

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -287,6 +287,18 @@ void CheckBorderAgent(ThreadApiDBus *aApi)
 {
     TEST_ASSERT(aApi->SetBorderAgentEnabled(false) == OTBR_ERROR_NONE);
     TEST_ASSERT(aApi->SetBorderAgentEnabled(true) == OTBR_ERROR_NONE);
+
+#if OTBR_ENABLE_BORDER_AGENT_ID
+    std::vector<uint8_t> borderAgentId        = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    std::vector<uint8_t> invalidBorderAgentId = {0x00};
+    std::vector<uint8_t> responseBorderAgentId;
+
+    TEST_ASSERT(aApi->SetBorderAgentId(invalidBorderAgentId) != OTBR_ERROR_NONE);
+    TEST_ASSERT(aApi->SetBorderAgentId(borderAgentId) == OTBR_ERROR_NONE);
+    TEST_ASSERT(aApi->GetBorderAgentId(responseBorderAgentId) == OTBR_ERROR_NONE);
+    TEST_ASSERT(borderAgentId == responseBorderAgentId);
+#endif
 }
 
 #if OTBR_ENABLE_TELEMETRY_DATA_API

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -32,7 +32,7 @@ set(OT_BACKBONE_ROUTER ${OTBR_BACKBONE_ROUTER} CACHE STRING "Enable Backbone Rou
 set(OT_BACKBONE_ROUTER_DUA_NDPROXYING ${OTBR_DUA_ROUTING} CACHE STRING "Configure DUA ND Proxy feature in OpenThread" FORCE)
 set(OT_BORDER_AGENT ON CACHE STRING "enable border agent" FORCE)
 set(OT_BORDER_AGENT_EPSKC ON CACHE STRING "enable border agent ephemeral PSKc" FORCE)
-set(OT_BORDER_AGENT_ID ON CACHE STRING "enable border agent ID" FORCE)
+set(OT_BORDER_AGENT_ID ${OTBR_BORDER_AGENT_ID} CACHE STRING "enable border agent ID" FORCE)
 set(OT_BORDER_ROUTER ON CACHE STRING "enable border router feature" FORCE)
 set(OT_BORDER_ROUTING ${OTBR_BORDER_ROUTING} CACHE STRING "enable border routing feature" FORCE)
 set(OT_BORDER_ROUTING_COUNTERS ${OTBR_BORDER_ROUTING_COUNTERS} CACHE STRING "enable border routing counters feature" FORCE)


### PR DESCRIPTION
This PR adds a DBUS API to set the Border Agent Id.

This is required for GTBR implementation. The PR also adds a build option `OTBR_BORDER_AGENT_ID` to control whether to enable the Border Agent Id in openthread and the related code in ot-br-posix.