### PR TITLE
[script] remove obsolete dhcpcd ipv6 rs logic from _border_routing

### DIFF
--- a/script/_border_routing
+++ b/script/_border_routing
@@ -36,12 +36,6 @@ readonly INFRA_IF_NAME
 SYSCTL_ACCEPT_RA_FILE="/etc/sysctl.d/60-otbr-accept-ra.conf"
 readonly SYSCTL_ACCEPT_RA_FILE
 
-DHCPCD_CONF_FILE="/etc/dhcpcd.conf"
-readonly DHCPCD_CONF_FILE
-
-DHCPCD_CONF_BACKUP_FILE="$DHCPCD_CONF_FILE.orig"
-readonly DHCPCD_CONF_BACKUP_FILE
-
 accept_ra_install()
 {
     sudo tee $SYSCTL_ACCEPT_RA_FILE <<EOF
@@ -68,45 +62,17 @@ accept_ra_enable()
     fi
 }
 
-# This function disables IPv6 Router Solicitation (RS) in dhcpcd.
-#
-# dhcpcd on raspberry Pi enables IPv6 support by default. The problem with
-# dhcpcd is that it does't support Route Information Option (RIO), so we need
-# to rely on the kernel implementation. dhcpcd will force set accept_ra to 0
-# for all interfaces it is currently running on, if IPv6 RS is enabled. This
-# conflicts with our accept_ra* configurations.
-#
-dhcpcd_disable_ipv6rs()
-{
-    if [ -f $DHCPCD_CONF_FILE ]; then
-        sudo cp $DHCPCD_CONF_FILE $DHCPCD_CONF_BACKUP_FILE
-        sudo tee -a $DHCPCD_CONF_FILE <<EOF
-noipv6rs
-EOF
-    fi
-}
-
-# This function enables IPv6 Router Solicitation (RS) in dhcpcd.
-dhcpcd_enable_ipv6rs()
-{
-    if [ -f $DHCPCD_CONF_BACKUP_FILE ]; then
-        sudo cp $DHCPCD_CONF_BACKUP_FILE $DHCPCD_CONF_FILE
-    fi
-}
-
 border_routing_uninstall()
 {
     with BORDER_ROUTING || return 0
 
     accept_ra_uninstall
-    dhcpcd_enable_ipv6rs
 }
 
 border_routing_install()
 {
     with BORDER_ROUTING || return 0
 
-    dhcpcd_disable_ipv6rs
     accept_ra_install
 
     # /proc/sys/net/ipv6/conf/* files are read-only in docker


### PR DESCRIPTION
This change removes the `dhcpcd_disable_ipv6rs`  from `_border_routing` as it is now obsolete.

The responsibility for managing `dhcpcd.conf` has been consolidated into the `_dhcpcd`. This script already ensures that `noipv6rs` is included in the generated configurations.