### PR TITLE
dbus: handle disabled border agent ID feature

### DIFF
--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -1666,6 +1666,7 @@ exit:
 
 otError DBusThreadObjectRcp::GetBorderAgentIdHandler(DBusMessageIter &aIter)
 {
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
     otBorderAgentId      id;
     std::vector<uint8_t> data;
     otError              error = OT_ERROR_NONE;
@@ -1678,6 +1679,10 @@ otError DBusThreadObjectRcp::GetBorderAgentIdHandler(DBusMessageIter &aIter)
 
 exit:
     return error;
+#else
+    OTBR_UNUSED_VARIABLE(aIter);
+    return OT_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 otError DBusThreadObjectRcp::GetOtRcpVersionHandler(DBusMessageIter &aIter)

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -509,8 +509,10 @@ int main()
                             TEST_ASSERT(api->GetExtPanId(extpanidCheck) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetRloc16(rloc16) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetExtendedAddress(extAddress) == OTBR_ERROR_NONE);
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE
                             TEST_ASSERT(api->GetBorderAgentId(borderAgentId) == OTBR_ERROR_NONE);
                             TEST_ASSERT(borderAgentId.size() == 16);
+#endif
                             TEST_ASSERT(api->GetNetworkData(networkData) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetStableNetworkData(stableNetworkData) == OTBR_ERROR_NONE);
                             TEST_ASSERT(api->GetChildTable(childTable) == OTBR_ERROR_NONE);


### PR DESCRIPTION
This pull request adds conditional support for the Border Agent ID feature based on the `OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE` configuration flag. The main changes ensure that related API calls and handlers behave correctly depending on whether the feature is enabled or not.

Conditional Border Agent ID support:

* Updated `DBusThreadObjectRcp::GetBorderAgentIdHandler` in `dbus_thread_object_rcp.cpp` to only execute Border Agent ID logic if `OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE` is enabled; otherwise, it returns `OT_ERROR_NOT_IMPLEMENTED`. [[1]](diffhunk://#diff-72a8adb55bd6172c3a74e4255b5036b6b034fa90ae74d5589c874591ce8c8343R1669) [[2]](diffhunk://#diff-72a8adb55bd6172c3a74e4255b5036b6b034fa90ae74d5589c874591ce8c8343R1682-R1685)

Test coverage improvements:

* Modified `test_dbus_client.cpp` to add conditional test assertions for Border Agent ID: tests for successful retrieval when enabled, and for proper error handling when disabled.The GetBorderAgentIdHandler now returns OT_ERROR_NOT_IMPLEMENTED if OPENTHREAD_CONFIG_BORDER_AGENT_ID_ENABLE is disabled.

This avoids compilation errors when the otBorderAgentGetId function is not available.