### PR TITLE
[ncp] add TREL support for NCP host

### DIFF
--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -183,6 +183,40 @@ private:
     NcpSpinel                 mNcpSpinel;
     TaskRunner                mTaskRunner;
     CliDaemon                 mCliDaemon;
+
+#if OTBR_ENABLE_MDNS
+    struct MdnsSocket
+    {
+        int  mFd     = -1;
+        bool mActive = false;
+    } mMdnsSocket;
+
+    void OpenMdnsSocket(void);
+    void CloseMdnsSocket(void);
+    void ProcessMdnsSocket(const MainloopContext &aMainloop);
+    void UpdateMdnsSocketFdSet(MainloopContext &aMainloop);
+#endif // OTBR_ENABLE_MDNS
+
+#if OTBR_ENABLE_TREL
+    struct TrelSocket
+    {
+        int      mFd     = -1;
+        uint16_t mPort   = 0;
+        bool     mActive = false;
+    } mTrelSocket;
+
+    void OpenTrelSocket(uint16_t aPort);
+    void CloseTrelSocket(void);
+    void ProcessTrelSocket(const MainloopContext &aMainloop);
+    void UpdateTrelSocketFdSet(MainloopContext &aMainloop);
+    void HandleTrelStateChanged(bool aEnabled, uint16_t aPort);
+#endif // OTBR_ENABLE_TREL
+
+    void HandleUdpForwardSend(const uint8_t      *aUdpPayload,
+                              uint16_t            aLength,
+                              const otIp6Address &aPeerAddr,
+                              uint16_t            aPeerPort,
+                              uint16_t            aLocalPort);
 };
 
 } // namespace Host

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -125,6 +125,8 @@ public:
     using BackboneRouterStateChangedCallback = std::function<void(otBackboneRouterState)>;
     using EphemeralKeyStateChangedCallback   = std::function<void(otBorderAgentEphemeralKeyState, uint16_t)>;
 
+    using TrelStateChangedCallback = std::function<void(bool, uint16_t)>;
+
     /**
      * Constructor.
      */
@@ -467,6 +469,21 @@ public:
     void DeactivateEphemeralKey(bool aRetainActiveSession, AsyncTaskPtr aAsyncTask);
 #endif // OTBR_ENABLE_EPSKC
 
+#if OTBR_ENABLE_TREL
+    void SetTrelStateChangedCallback(TrelStateChangedCallback aCallback);
+
+    /**
+     * This method updates the TREL state on the NCP.
+     *
+     * @param[in] aEnabled  Whether TREL is enabled.
+     * @param[in] aPort     The UDP port number.
+     *
+     * @retval OTBR_ERROR_NONE  Successfully sent the update to NCP.
+     * @retval OTBR_ERROR_OPENTHREAD  Failed to encode or send the property.
+     */
+    otbrError UpdateTrelState(bool aEnabled, uint16_t aPort);
+#endif
+
 private:
     using FailureHandler = std::function<void(otError)>;
 
@@ -600,6 +617,9 @@ private:
     BackboneRouterStateChangedCallback       mBackboneRouterStateChangedCallback;
     BackboneRouterMulticastListenerCallback  mBackboneRouterMulticastListenerCallback;
     EphemeralKeyStateChangedCallback         mEphemeralKeyStateChangedCallback;
+
+    uint16_t                 mTrelPort = 0; // Last observed TREL UDP port (0 = unknown).
+    TrelStateChangedCallback mTrelStateChangedCallback;
 };
 
 } // namespace Host

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -68,6 +68,11 @@ namespace Mdns {
  */
 
 /**
+ * mDNS well-known port number (RFC 6762).
+ */
+static constexpr uint16_t kMdnsPort = 5353;
+
+/**
  * This interface defines the functionality of mDNS publisher.
  */
 class Publisher : private NonCopyable


### PR DESCRIPTION
- Bind to TREL UDP port and publish `_trel._udp` service when TREL is enabled.
- Handle incoming TREL/mDNS packets and forward them to NCP using existing UDP forward mechanism.