### PR TITLE
[dbus] add API to fetch netdiag TLVs

### DIFF
--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -723,6 +723,62 @@ ClientError ThreadApiDBus::GetCapabilities(std::vector<uint8_t> &aCapabilities)
     return GetProperty(OTBR_DBUS_PROPERTY_CAPABILITIES, aCapabilities);
 }
 
+ClientError ThreadApiDBus::GetNetworkDiagnosticTlvs(const Ip6Address               &aDestination,
+                                                    const std::vector<uint8_t>     &aTlvTypes,
+                                                    const NetworkDiagnosticHandler &aHandler,
+                                                    uint32_t                        aTimeoutMs)
+{
+    // Add margin to the timeout for DBus method call to avoid a timeout error
+    // when the method call is close to the timeout value.
+    static constexpr uint32_t kDbusTimeoutMarginMs = 200;
+
+    ClientError ret  = ClientError::ERROR_NONE;
+    auto        args = std::tie(aDestination, aTlvTypes, aTimeoutMs);
+
+    VerifyOrExit(mNetworkDiagnosticHandler == nullptr, ret = ClientError::OT_ERROR_INVALID_STATE);
+    VerifyOrExit(aHandler != nullptr, ret = ClientError::OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aTimeoutMs > 0, ret = ClientError::OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aTimeoutMs <= kMaxNetworkDiagnosticTimeoutMs, ret = ClientError::OT_ERROR_INVALID_ARGS);
+
+    mNetworkDiagnosticHandler = aHandler;
+
+    ret = CallDBusMethodAsync(
+        OTBR_DBUS_GET_NETWORK_DIAGNOSTIC_TLVS_METHOD, args,
+        static_cast<int>(aTimeoutMs + kDbusTimeoutMarginMs),
+        &ThreadApiDBus::sHandleDBusPendingCall<&ThreadApiDBus::NetworkDiagnosticPendingCallHandler>);
+
+    if (ret != ClientError::ERROR_NONE)
+    {
+        mNetworkDiagnosticHandler = nullptr;
+    }
+
+exit:
+    return ret;
+}
+
+void ThreadApiDBus::NetworkDiagnosticPendingCallHandler(DBusPendingCall *aPending)
+{
+    ClientError                           error = ClientError::ERROR_NONE;
+    std::vector<NetworkDiagnosticMessage> responses;
+    UniqueDBusMessage                     message(dbus_pending_call_steal_reply(aPending));
+    DBusMessageIter                       iter;
+    auto                                  handler = mNetworkDiagnosticHandler;
+
+    VerifyOrExit(message != nullptr, error = ClientError::ERROR_DBUS);
+
+    error = DBus::CheckErrorMessage(message.get());
+    SuccessOrExit(error);
+    VerifyOrExit(dbus_message_iter_init(message.get(), &iter), error = ClientError::ERROR_DBUS);
+    VerifyOrExit(DBus::DBusMessageExtract(&iter, responses) == OTBR_ERROR_NONE, error = ClientError::ERROR_DBUS);
+
+exit:
+    mNetworkDiagnosticHandler = nullptr;
+    if (handler != nullptr)
+    {
+        handler(error, responses);
+    }
+}
+
 std::string ThreadApiDBus::GetInterfaceName(void)
 {
     return mInterfaceName;
@@ -796,6 +852,15 @@ ClientError ThreadApiDBus::CallDBusMethodAsync(const std::string            &aMe
                                                const ArgType                &aArgs,
                                                DBusPendingCallNotifyFunction aFunction)
 {
+    return CallDBusMethodAsync(aMethodName, aArgs, DBUS_TIMEOUT_USE_DEFAULT, aFunction);
+}
+
+template <typename ArgType>
+ClientError ThreadApiDBus::CallDBusMethodAsync(const std::string            &aMethodName,
+                                               const ArgType                &aArgs,
+                                               int                           aTimeoutMs,
+                                               DBusPendingCallNotifyFunction aFunction)
+{
     ClientError ret = ClientError::ERROR_NONE;
 
     DBus::UniqueDBusMessage message(dbus_message_new_method_call((OTBR_DBUS_SERVER_PREFIX + mInterfaceName).c_str(),
@@ -805,8 +870,7 @@ ClientError ThreadApiDBus::CallDBusMethodAsync(const std::string            &aMe
 
     VerifyOrExit(message != nullptr, ret = ClientError::ERROR_DBUS);
     VerifyOrExit(DBus::TupleToDBusMessage(*message, aArgs) == OTBR_ERROR_NONE, ret = ClientError::ERROR_DBUS);
-    VerifyOrExit(dbus_connection_send_with_reply(mConnection, message.get(), &pending, DBUS_TIMEOUT_USE_DEFAULT) ==
-                     true,
+    VerifyOrExit(dbus_connection_send_with_reply(mConnection, message.get(), &pending, aTimeoutMs) == true,
                  ret = ClientError::ERROR_DBUS);
 
     VerifyOrExit(dbus_pending_call_set_notify(pending, aFunction, this, &ThreadApiDBus::EmptyFree) == true,

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -53,10 +53,11 @@ bool IsThreadActive(DeviceRole aRole);
 class ThreadApiDBus
 {
 public:
-    using DeviceRoleHandler = std::function<void(DeviceRole)>;
-    using ScanHandler       = std::function<void(const std::vector<ActiveScanResult> &)>;
-    using EnergyScanHandler = std::function<void(const std::vector<EnergyScanResult> &)>;
-    using OtResultHandler   = std::function<void(ClientError)>;
+    using DeviceRoleHandler        = std::function<void(DeviceRole)>;
+    using ScanHandler              = std::function<void(const std::vector<ActiveScanResult> &)>;
+    using EnergyScanHandler        = std::function<void(const std::vector<EnergyScanResult> &)>;
+    using OtResultHandler          = std::function<void(ClientError)>;
+    using NetworkDiagnosticHandler = std::function<void(ClientError, const std::vector<NetworkDiagnosticMessage> &)>;
 
     /**
      * The constructor of a d-bus object.
@@ -875,6 +876,29 @@ public:
     ClientError GetTelemetryData(std::vector<uint8_t> &aTelemetryData);
 
     /**
+     * This method sends a network diagnostic get request and returns the raw payloads received from peers.
+     *
+     * Only one request may be in-flight at a time; concurrent calls return OT_ERROR_BUSY.
+     * Responses are ordered by peer IPv6 address. For peers that split their answer across
+     * multiple CoAP messages (FTD peers with large diagnostic data), the raw payloads are
+     * concatenated, so the caller receives every TLV the peer sent.
+     *
+     * @param[in] aDestination  The IPv6 destination of the diagnostic request.
+     * @param[in] aTlvTypes     The diagnostic TLV type IDs to request.
+     * @param[in] aHandler      The result handler for the final diagnostic response or error.
+     * @param[in] aTimeoutMs    The time to collect responses before replying, in milliseconds.
+     *                          The D-Bus transport timeout is set to aTimeoutMs plus a margin.
+     *
+     * @retval ERROR_NONE  Successfully performed the dbus function call
+     * @retval ERROR_DBUS  dbus encode/decode error
+     * @retval ...         OpenThread defined error value otherwise
+     */
+    ClientError GetNetworkDiagnosticTlvs(const Ip6Address               &aDestination,
+                                         const std::vector<uint8_t>     &aTlvTypes,
+                                         const NetworkDiagnosticHandler &aHandler,
+                                         uint32_t                        aTimeoutMs = 5000);
+
+    /**
      * This method gets the capabilities data proto serialized byte data.
      *
      * @param[out] aCapabilities The capabilities proto serialized byte data
@@ -893,8 +917,20 @@ private:
     template <typename ArgType> ClientError CallDBusMethodSync(const std::string &aMethodName, const ArgType &aArgs);
 
     template <typename ArgType>
+    ClientError CallDBusMethodSync(const std::string &aMethodName,
+                                   const ArgType     &aArgs,
+                                   int                aTimeoutMs,
+                                   DBusMessage      *&aReply);
+
+    template <typename ArgType>
     ClientError CallDBusMethodAsync(const std::string            &aMethodName,
                                     const ArgType                &aArgs,
+                                    DBusPendingCallNotifyFunction aFunction);
+
+    template <typename ArgType>
+    ClientError CallDBusMethodAsync(const std::string            &aMethodName,
+                                    const ArgType                &aArgs,
+                                    int                           aTimeoutMs,
                                     DBusPendingCallNotifyFunction aFunction);
 
     template <typename ValType> ClientError SetProperty(const std::string &aPropertyName, const ValType &aValue);
@@ -915,6 +951,7 @@ private:
     static void sScanPendingCallHandler(DBusPendingCall *aPending, void *aThreadApiDBus);
     void        ScanPendingCallHandler(DBusPendingCall *aPending);
     void        EnergyScanPendingCallHandler(DBusPendingCall *aPending);
+    void        NetworkDiagnosticPendingCallHandler(DBusPendingCall *aPending);
 
     static void EmptyFree(void *) {}
 
@@ -922,12 +959,13 @@ private:
 
     DBusConnection *mConnection;
 
-    ScanHandler       mScanHandler;
-    EnergyScanHandler mEnergyScanHandler;
-    OtResultHandler   mAttachHandler;
-    OtResultHandler   mDetachHandler;
-    OtResultHandler   mFactoryResetHandler;
-    OtResultHandler   mJoinerHandler;
+    ScanHandler              mScanHandler;
+    EnergyScanHandler        mEnergyScanHandler;
+    NetworkDiagnosticHandler mNetworkDiagnosticHandler;
+    OtResultHandler          mAttachHandler;
+    OtResultHandler          mDetachHandler;
+    OtResultHandler          mFactoryResetHandler;
+    OtResultHandler          mJoinerHandler;
 
     std::vector<DeviceRoleHandler> mDeviceRoleHandlers;
 };

--- a/src/dbus/common/constants.hpp
+++ b/src/dbus/common/constants.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_DBUS_CONSTANTS_HPP_
 #define OTBR_DBUS_CONSTANTS_HPP_
 
+#include <stdint.h>
+
 #define DBUS_PROPERTY_GET_METHOD "Get"
 #define DBUS_PROPERTY_SET_METHOD "Set"
 #define DBUS_PROPERTY_GET_ALL_METHOD "GetAll"
@@ -65,6 +67,7 @@
 #define OTBR_DBUS_GET_PROPERTIES_METHOD "GetProperties"
 #define OTBR_DBUS_LEAVE_NETWORK_METHOD "LeaveNetwork"
 #define OTBR_DBUS_SET_NAT64_ENABLED_METHOD "SetNat64Enabled"
+#define OTBR_DBUS_GET_NETWORK_DIAGNOSTIC_TLVS_METHOD "GetNetworkDiagnosticTlvs"
 #define OTBR_DBUS_ACTIVATE_EPHEMERAL_KEY_MODE_METHOD "ActivateEphemeralKeyMode"
 #define OTBR_DBUS_DEACTIVATE_EPHEMERAL_KEY_MODE_METHOD "DeactivateEphemeralKeyMode"
 #define OTBR_DBUS_SCHEDULE_MIGRATION_METHOD "ScheduleMigration"
@@ -137,5 +140,13 @@
 #define OTBR_NAT64_STATE_NAME_ACTIVE "active"
 
 #define OTBR_DBUS_SIGNAL_READY "Ready"
+
+namespace otbr {
+namespace DBus {
+
+static constexpr uint32_t kMaxNetworkDiagnosticTimeoutMs = 300000; // 5 minutes
+
+} // namespace DBus
+} // namespace otbr
 
 #endif // OTBR_DBUS_CONSTANTS_HPP_

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -119,6 +119,8 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const TrelInfo &aTrelInfo);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, TrelInfo &aTrelInfo);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const TrelInfo::TrelPacketCounters &aCounters);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, TrelInfo::TrelPacketCounters &aCounters);
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const NetworkDiagnosticMessage &aMessage);
+otbrError DBusMessageExtract(DBusMessageIter *aIter, NetworkDiagnosticMessage &aMessage);
 
 template <typename T> struct DBusTypeTrait;
 
@@ -407,6 +409,18 @@ template <> struct DBusTypeTrait<InfraLinkInfo>
     static constexpr const char *TYPE_AS_STRING = "(sbbbuuu)";
 };
 
+template <> struct DBusTypeTrait<NetworkDiagnosticMessage>
+{
+    // struct of { array<uint8>, array<uint8> }
+    static constexpr const char *TYPE_AS_STRING = "(ayay)";
+};
+
+template <> struct DBusTypeTrait<std::vector<NetworkDiagnosticMessage>>
+{
+    // array of struct of { array<uint8>, array<uint8> }
+    static constexpr const char *TYPE_AS_STRING = "a(ayay)";
+};
+
 template <> struct DBusTypeTrait<int8_t>
 {
     static constexpr int         TYPE           = DBUS_TYPE_BYTE;
@@ -480,6 +494,8 @@ otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::vector<uint64_t> 
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::vector<int16_t> &aValue);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::vector<int32_t> &aValue);
 otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::vector<int64_t> &aValue);
+template <typename T, size_t SIZE>
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const std::array<T, SIZE> &aValue);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, bool &aValue);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, int8_t &aValue);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, std::string &aValue);
@@ -490,6 +506,7 @@ otbrError DBusMessageExtract(DBusMessageIter *aIter, std::vector<uint64_t> &aVal
 otbrError DBusMessageExtract(DBusMessageIter *aIter, std::vector<int16_t> &aValue);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, std::vector<int32_t> &aValue);
 otbrError DBusMessageExtract(DBusMessageIter *aIter, std::vector<int64_t> &aValue);
+template <typename T, size_t SIZE> otbrError DBusMessageExtract(DBusMessageIter *aIter, std::array<T, SIZE> &aValue);
 
 template <typename T> otbrError DBusMessageExtract(DBusMessageIter *aIter, T &aValue)
 {

--- a/src/dbus/common/dbus_message_helper_openthread.cpp
+++ b/src/dbus/common/dbus_message_helper_openthread.cpp
@@ -1258,5 +1258,33 @@ exit:
     return error;
 }
 
+otbrError DBusMessageEncode(DBusMessageIter *aIter, const NetworkDiagnosticMessage &aMessage)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(dbus_message_iter_open_container(aIter, DBUS_TYPE_STRUCT, nullptr, &sub), error = OTBR_ERROR_DBUS);
+    SuccessOrExit(error = DBusMessageEncode(&sub, aMessage.mPeerAddress));
+    SuccessOrExit(error = DBusMessageEncode(&sub, aMessage.mPayload));
+    VerifyOrExit(dbus_message_iter_close_container(aIter, &sub), error = OTBR_ERROR_DBUS);
+
+exit:
+    return error;
+}
+
+otbrError DBusMessageExtract(DBusMessageIter *aIter, NetworkDiagnosticMessage &aMessage)
+{
+    DBusMessageIter sub;
+    otbrError       error = OTBR_ERROR_NONE;
+
+    SuccessOrExit(error = DbusMessageIterRecurse(aIter, &sub, DBUS_TYPE_STRUCT));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aMessage.mPeerAddress));
+    SuccessOrExit(error = DBusMessageExtract(&sub, aMessage.mPayload));
+    dbus_message_iter_next(aIter);
+
+exit:
+    return error;
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/types.hpp
+++ b/src/dbus/common/types.hpp
@@ -684,6 +684,12 @@ struct TrelInfo
     TrelPacketCounters mTrelCounters; ///< The TREL counters.
 };
 
+struct NetworkDiagnosticMessage
+{
+    Ip6Address           mPeerAddress; ///< The IPv6 address of the responding peer.
+    std::vector<uint8_t> mPayload;     ///< The raw diagnostic message payload as received from OpenThread.
+};
+
 } // namespace DBus
 } // namespace otbr
 

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -27,6 +27,8 @@
  */
 
 #include <assert.h>
+#include <algorithm>
+#include <limits>
 #include <net/if.h>
 #include <string.h>
 
@@ -40,6 +42,7 @@
 #include <openthread/nat64.h>
 #include <openthread/ncp.h>
 #include <openthread/netdata.h>
+#include <openthread/netdiag.h>
 #include <openthread/openthread-system.h>
 #include <openthread/srp_server.h>
 #include <openthread/thread_ftd.h>
@@ -52,6 +55,7 @@
 #include "common/api_strings.hpp"
 #include "common/byteswap.hpp"
 #include "common/code_utils.hpp"
+#include "common/time.hpp"
 #include "dbus/common/constants.hpp"
 #include "dbus/server/dbus_agent.hpp"
 #include "dbus/server/dbus_thread_object_rcp.hpp"
@@ -109,10 +113,19 @@ DBusThreadObjectRcp::DBusThreadObjectRcp(DBusConnection            &aConnection,
 {
 }
 
+DBusThreadObjectRcp::~DBusThreadObjectRcp(void)
+{
+    CancelNetworkDiagnosticRequest();
+
+    mAlive.reset();
+}
+
 otbrError DBusThreadObjectRcp::Init(void)
 {
     otbrError error        = OTBR_ERROR_NONE;
     auto      threadHelper = mHost.GetThreadHelper();
+
+    mAlive = std::make_shared<bool>(true);
 
     SuccessOrExit(error = DBusObject::Initialize(false));
 
@@ -167,6 +180,8 @@ otbrError DBusThreadObjectRcp::Init(void)
                    std::bind(&DBusThreadObjectRcp::LeaveNetworkHandler, this, _1));
     RegisterMethod(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_SET_NAT64_ENABLED_METHOD,
                    std::bind(&DBusThreadObjectRcp::SetNat64Enabled, this, _1));
+    RegisterMethod(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_GET_NETWORK_DIAGNOSTIC_TLVS_METHOD,
+                   std::bind(&DBusThreadObjectRcp::GetNetworkDiagnosticTlvsHandler, this, _1));
 #if OTBR_ENABLE_EPSKC
     RegisterMethod(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_ACTIVATE_EPHEMERAL_KEY_MODE_METHOD,
                    std::bind(&DBusThreadObjectRcp::ActivateEphemeralKeyModeHandler, this, _1));
@@ -338,11 +353,26 @@ void DBusThreadObjectRcp::Dhcp6PdStateHandler(otBorderRoutingDhcp6PdState aDhcp6
 
 void DBusThreadObjectRcp::NcpResetHandler(void)
 {
+    CancelNetworkDiagnosticRequest();
+
     mHost.GetThreadHelper()->AddDeviceRoleHandler(std::bind(&DBusThreadObjectRcp::DeviceRoleHandler, this, _1));
     mHost.GetThreadHelper()->AddActiveDatasetChangeHandler(
         std::bind(&DBusThreadObjectRcp::ActiveDatasetChangeHandler, this, _1));
     SignalPropertyChanged(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DEVICE_ROLE,
                           GetDeviceRoleName(OT_DEVICE_ROLE_DISABLED));
+}
+
+void DBusThreadObjectRcp::CancelNetworkDiagnosticRequest(void)
+{
+    if (mNetworkDiagnosticRequest.mIsActive)
+    {
+        mNetworkDiagnosticRequest.mRequest->ReplyOtResult(OT_ERROR_ABORT);
+        mNetworkDiagnosticRequest.mRequest.reset();
+        mNetworkDiagnosticRequest.mResponses.clear();
+        mNetworkDiagnosticRequest.mIsActive = false;
+        mNetworkDiagnosticRequest.mError = OT_ERROR_NONE;
+        mNetworkDiagnosticRequest.mGeneration++;
+    }
 }
 
 void DBusThreadObjectRcp::ScanHandler(DBusRequest &aRequest)
@@ -458,6 +488,155 @@ void DBusThreadObjectRcp::AttachHandler(DBusRequest &aRequest)
                                  aRequest.ReplyOtResult(aError);
                              });
     }
+}
+
+void DBusThreadObjectRcp::GetNetworkDiagnosticTlvsHandler(DBusRequest &aRequest)
+{
+    otError              error = OT_ERROR_NONE;
+    Ip6Address           destination;
+    std::vector<uint8_t> tlvTypes;
+    uint32_t             timeoutMs;
+    otIp6Address         otDestination;
+    auto                 args = std::tie(destination, tlvTypes, timeoutMs);
+    uint64_t             generation;
+    bool                 requestStarted = false;
+
+    VerifyOrExit(!mNetworkDiagnosticRequest.mIsActive, error = OT_ERROR_BUSY);
+    SuccessOrExit(DBusMessageToTuple(*aRequest.GetMessage(), args), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(!tlvTypes.empty(), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(tlvTypes.size() <= std::numeric_limits<uint8_t>::max(), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(timeoutMs > 0, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(timeoutMs <= kMaxNetworkDiagnosticTimeoutMs, error = OT_ERROR_INVALID_ARGS);
+
+    memcpy(otDestination.mFields.m8, destination.data(), destination.size());
+
+    mNetworkDiagnosticRequest.mIsActive = true;
+    mNetworkDiagnosticRequest.mGeneration++;
+    generation = mNetworkDiagnosticRequest.mGeneration;
+    mNetworkDiagnosticRequest.mRequest.reset(new DBusRequest(aRequest));
+    mNetworkDiagnosticRequest.mResponses.clear();
+    mNetworkDiagnosticRequest.mError = OT_ERROR_NONE;
+    requestStarted = true;
+
+    SuccessOrExit(error = otThreadSendDiagnosticGet(mHost.GetInstance(), &otDestination, tlvTypes.data(),
+                                                    static_cast<uint8_t>(tlvTypes.size()),
+                                                    &DBusThreadObjectRcp::HandleDiagnosticGetResponse, this));
+
+    {
+        std::weak_ptr<bool> weak = mAlive;
+
+        mHost.PostTimerTask(Milliseconds(timeoutMs), [this, generation, weak]() {
+            if (weak.expired())
+            {
+                return;
+            }
+            CompleteNetworkDiagnosticRequest(generation);
+        });
+    }
+
+exit:
+    if (error != OT_ERROR_NONE)
+    {
+        if (requestStarted)
+        {
+            mNetworkDiagnosticRequest.mRequest.reset();
+            mNetworkDiagnosticRequest.mResponses.clear();
+            mNetworkDiagnosticRequest.mIsActive = false;
+            mNetworkDiagnosticRequest.mError = OT_ERROR_NONE;
+            mNetworkDiagnosticRequest.mGeneration++;
+        }
+
+        aRequest.ReplyOtResult(error);
+    }
+}
+
+void DBusThreadObjectRcp::HandleDiagnosticGetResponse(otError              aError,
+                                                      otMessage           *aMessage,
+                                                      const otMessageInfo *aMessageInfo,
+                                                      void                *aContext)
+{
+    static_cast<DBusThreadObjectRcp *>(aContext)->HandleDiagnosticGetResponse(aError, aMessage, aMessageInfo);
+}
+
+void DBusThreadObjectRcp::HandleDiagnosticGetResponse(otError              aError,
+                                                      const otMessage     *aMessage,
+                                                      const otMessageInfo *aMessageInfo)
+{
+    VerifyOrExit(mNetworkDiagnosticRequest.mIsActive);
+
+    if (aError != OT_ERROR_NONE)
+    {
+        // Record the first error encountered
+        if (mNetworkDiagnosticRequest.mError == OT_ERROR_NONE)
+        {
+            mNetworkDiagnosticRequest.mError = aError;
+        }
+        ExitNow();
+    }
+
+    VerifyOrExit(aMessage != nullptr && aMessageInfo != nullptr);
+
+    {
+        Ip6Address peerAddress;
+        uint16_t   offset      = otMessageGetOffset(aMessage);
+        uint16_t   length      = otMessageGetLength(aMessage);
+
+        VerifyOrExit(length >= offset);
+
+        memcpy(peerAddress.data(), aMessageInfo->mPeerAddr.mFields.m8, peerAddress.size());
+
+        if (length > offset)
+        {
+            uint16_t             payloadSize = length - offset;
+            std::vector<uint8_t> payload(payloadSize);
+
+            VerifyOrExit(otMessageRead(aMessage, offset, payload.data(), payloadSize) == payloadSize);
+
+            auto &entry        = mNetworkDiagnosticRequest.mResponses[peerAddress];
+            entry.mPeerAddress = peerAddress;
+            entry.mPayload.insert(entry.mPayload.end(), payload.begin(), payload.end());
+        }
+        else
+        {
+            auto &entry        = mNetworkDiagnosticRequest.mResponses[peerAddress];
+            entry.mPeerAddress = peerAddress;
+        }
+    }
+
+exit:
+    return;
+}
+
+void DBusThreadObjectRcp::CompleteNetworkDiagnosticRequest(uint64_t aGeneration)
+{
+    std::vector<NetworkDiagnosticMessage> responses;
+
+    VerifyOrExit(mNetworkDiagnosticRequest.mIsActive && mNetworkDiagnosticRequest.mRequest != nullptr);
+    VerifyOrExit(mNetworkDiagnosticRequest.mGeneration == aGeneration);
+
+    if (mNetworkDiagnosticRequest.mError != OT_ERROR_NONE)
+    {
+        mNetworkDiagnosticRequest.mRequest->ReplyOtResult(mNetworkDiagnosticRequest.mError);
+    }
+    else
+    {
+        responses.reserve(mNetworkDiagnosticRequest.mResponses.size());
+        for (const auto &entry : mNetworkDiagnosticRequest.mResponses)
+        {
+            responses.emplace_back(entry.second);
+        }
+
+        mNetworkDiagnosticRequest.mRequest->Reply(std::tie(responses));
+    }
+
+    mNetworkDiagnosticRequest.mRequest.reset();
+    mNetworkDiagnosticRequest.mResponses.clear();
+    mNetworkDiagnosticRequest.mIsActive = false;
+    mNetworkDiagnosticRequest.mError = OT_ERROR_NONE;
+    mNetworkDiagnosticRequest.mGeneration++;
+
+exit:
+    return;
 }
 
 void DBusThreadObjectRcp::AttachAllNodesToHandler(DBusRequest &aRequest)

--- a/src/dbus/server/dbus_thread_object_rcp.hpp
+++ b/src/dbus/server/dbus_thread_object_rcp.hpp
@@ -36,7 +36,11 @@
 
 #include "openthread-br/config.h"
 
+#include <array>
+#include <map>
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 #include <openthread/link.h>
 
@@ -72,6 +76,8 @@ public:
                         const std::string         &aInterfaceName,
                         const DependentComponents &aDeps);
 
+    ~DBusThreadObjectRcp(void) override;
+
     otbrError Init(void) override;
 
     void RegisterGetPropertyHandler(const std::string         &aInterfaceName,
@@ -105,6 +111,7 @@ private:
 #endif
     void SetThreadEnabledHandler(DBusRequest &aRequest);
     void JoinHandler(DBusRequest &aRequest);
+    void GetNetworkDiagnosticTlvsHandler(DBusRequest &aRequest);
     void GetPropertiesHandler(DBusRequest &aRequest);
     void LeaveNetworkHandler(DBusRequest &aRequest);
     void SetNat64Enabled(DBusRequest &aRequest);
@@ -190,6 +197,13 @@ private:
 
     void ReplyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otActiveScanResult> &aResult);
     void ReplyEnergyScanResult(DBusRequest &aRequest, otError aError, const std::vector<otEnergyScanResult> &aResult);
+    static void HandleDiagnosticGetResponse(otError              aError,
+                                            otMessage           *aMessage,
+                                            const otMessageInfo *aMessageInfo,
+                                            void                *aContext);
+    void HandleDiagnosticGetResponse(otError aError, const otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    void CompleteNetworkDiagnosticRequest(uint64_t aGeneration);
+    void CancelNetworkDiagnosticRequest(void);
 
     otbr::Host::RcpHost &mHost;
 #if OTBR_ENABLE_TELEMETRY_DATA_API
@@ -201,6 +215,51 @@ private:
 #if OTBR_ENABLE_BORDER_AGENT
     otbr::BorderAgent &mBorderAgent;
 #endif
+
+    // NetworkDiagnosticRequest
+    //
+    // Track in flight requests to fetch network diagnostic TLVs. Only one
+    // request is allowed at a time. Additional requests received while a request
+    // is in flight will be rejected with OT_ERROR_BUSY.
+    //
+    // Responses are keyed by peer address.
+    struct NetworkDiagnosticRequest
+    {
+        // Indication of an active request.
+        //
+        // Used to:
+        // - Reject concurrent callers
+        // - Ignore callbacks when no request is being processed
+        // - Guard completion callbacks
+        bool mIsActive = false;
+
+        // Timer generation count
+        //
+        // Incremented each time a new request is initiated. When a response is
+        // received, the generation count is checked to ensure the response
+        // matches the current request. This prevents a delayed response from a
+        // previous request from being processed after a new request has already
+        // been initiated.
+        uint64_t mGeneration = 0;
+
+        // First error encountered while processing the request.
+        otError mError = OT_ERROR_NONE;
+
+        // The original request object.
+        //
+        // Used to send the reply when all responses have been received.
+        std::unique_ptr<DBusRequest> mRequest;
+
+        // Map of peer address to response message.
+        //
+        // The map is used to track responses received for the current request.
+        std::map<Ip6Address, NetworkDiagnosticMessage> mResponses;
+    };
+
+    NetworkDiagnosticRequest mNetworkDiagnosticRequest;
+
+    // Timer sentinel to ensure timer-task safety.
+    std::shared_ptr<bool> mAlive;
 };
 
 /**

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -235,6 +235,27 @@
       <arg name="enable" type="b" direction="in"/>
     </method>
 
+    <!-- GetNetworkDiagnosticTlvs: Send a network diagnostic get and collect the latest payload from each peer.
+      @destination: The IPv6 destination address of the diagnostic request.
+      @tlv_types: The requested diagnostic TLV type IDs.
+      @timeout_ms: The amount of time to collect responses before replying (1-300000 ms)
+      @response: The diagnostic payload received from each responding peer.
+
+      The response structure is:
+      <literallayout>
+        struct {
+          uint8[] peer_address
+          uint8[] payload
+        }
+      </literallayout>
+    -->
+    <method name="GetNetworkDiagnosticTlvs">
+      <arg name="destination" type="ay" direction="in"/>
+      <arg name="tlv_types" type="ay" direction="in"/>
+      <arg name="timeout_ms" type="u" direction="in"/>
+      <arg name="response" type="a(ayay)" direction="out"/>
+    </method>
+
     <property name="EphemeralKeyEnabled" type="b" access="readwrite">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>

--- a/tests/gtest/test_dbus_message.cpp
+++ b/tests/gtest/test_dbus_message.cpp
@@ -121,6 +121,11 @@ bool operator==(const otbr::DBus::ExternalRoute &aLhs, const otbr::DBus::Externa
            aLhs.mStable == aRhs.mStable && aLhs.mNextHopIsThisDevice == aRhs.mNextHopIsThisDevice;
 }
 
+bool operator==(const NetworkDiagnosticMessage &aLhs, const NetworkDiagnosticMessage &aRhs)
+{
+    return aLhs.mPeerAddress == aRhs.mPeerAddress && aLhs.mPayload == aRhs.mPayload;
+}
+
 inline otbrError DBusMessageEncode(DBusMessageIter *aIter, const TestStruct &aValue)
 {
     otbrError       error = OTBR_ERROR_DBUS;
@@ -258,6 +263,23 @@ TEST(DBusMessage, TestOtbrChildInfo)
     EXPECT_EQ(DBusMessageToTuple(*msg, getVals), OTBR_ERROR_NONE);
 
     EXPECT_EQ(std::get<0>(setVals)[0], std::get<0>(getVals)[0]);
+
+    dbus_message_unref(msg);
+}
+
+TEST(DBusMessage, TestNetworkDiagnosticMessage)
+{
+    DBusMessage                                          *msg = dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_RETURN);
+    tuple<std::vector<otbr::DBus::NetworkDiagnosticMessage>> setVals(
+        {{{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, {0x01, 0x02, 0x03}},
+         {{0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}, {0xaa, 0xbb}}});
+    tuple<std::vector<otbr::DBus::NetworkDiagnosticMessage>> getVals;
+
+    EXPECT_NE(msg, nullptr);
+
+    EXPECT_EQ(TupleToDBusMessage(*msg, setVals), OTBR_ERROR_NONE);
+    EXPECT_EQ(DBusMessageToTuple(*msg, getVals), OTBR_ERROR_NONE);
+    EXPECT_EQ(setVals, getVals);
 
     dbus_message_unref(msg);
 }


### PR DESCRIPTION
Add an API to fetch arbitrary network diagnostic TLVs. This new API mirrors the `ot-ctl` command `networkdiagnostic get`.

A generic approach was preferred over adding individual APIs so that an external application can support fetching future TLVs that OTBR may not support.