### PR TITLE
[posix] add posix platform entropy and add entropy source for mbedtls

### DIFF
--- a/src/host/posix/CMakeLists.txt
+++ b/src/host/posix/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(otbr-posix
     cli_daemon.cpp
     dnssd.hpp
     dnssd.cpp
+    entropy.hpp
+    entropy.cpp
     infra_if.hpp
     infra_if.cpp
     multicast_routing_manager.hpp

--- a/src/host/posix/entropy.cpp
+++ b/src/host/posix/entropy.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the posix platform Entropy.
+ */
+
+#include "entropy.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/types.hpp"
+
+namespace otbr {
+
+otbrError Entropy::GetEntropy(uint8_t *aOutput, uint16_t aOutputLength)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    FILE  *file = nullptr;
+    size_t readLength;
+
+    VerifyOrExit(aOutput && aOutputLength, error = OTBR_ERROR_INVALID_ARGS);
+
+    file = fopen("/dev/urandom", "rb");
+    VerifyOrExit(file != nullptr, error = OTBR_ERROR_ERRNO);
+
+    readLength = fread(aOutput, 1, aOutputLength, file);
+    VerifyOrExit(readLength == aOutputLength, error = OTBR_ERROR_ERRNO);
+
+exit:
+
+    if (file != nullptr)
+    {
+        fclose(file);
+    }
+    return error;
+}
+
+} // namespace otbr

--- a/src/host/posix/entropy.hpp
+++ b/src/host/posix/entropy.hpp
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions of the posix Entropy of otbr-agent.
+ */
+
+#ifndef OTBR_AGENT_POSIX_ENTROPY_HPP_
+#define OTBR_AGENT_POSIX_ENTROPY_HPP_
+
+#include <stdint.h>
+
+#include "common/types.hpp"
+
+namespace otbr {
+
+class Entropy
+{
+public:
+    /**
+     * Fill buffer with entropy.
+     *
+     * @param[out]  aOutput              A pointer to where the random values are placed.  Must not be NULL.
+     * @param[in]   aOutputLength        Size of @p aOutput.
+     *
+     * @retval OTBR_ERROR_NONE          Successfully filled @p aOutput with true random values.
+     * @retval OTBR_ERROR_ERRNO         Failed to fill @p aOutput with true random values.
+     * @retval OTBR_ERROR_INVALID_ARGS  @p aOutput was set to NULL or @p aOutputLength is 0.
+     */
+    static otbrError GetEntropy(uint8_t *aOutput, uint16_t aOutputLength);
+};
+
+} // namespace otbr
+
+#endif // OTBR_AGENT_POSIX_ENTROPY_HPP_

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -42,5 +42,6 @@ add_library(otbr-utils
 
 target_link_libraries(otbr-utils PUBLIC
     otbr-common
+    otbr-posix
     mbedtls
 )


### PR DESCRIPTION
This PR fixes an issue in the `Csprng` module.

There is an issue of mbedtls usage in `Csprng` module that `mbedtls_entropy_add_source` isn't called. Thus on some platforms the initialization will fail silently. And this will cause ephemeral key generation to fail.

This PR adds posix platform entropy in ot-br-posix to provide entropy source for mbedtls. The implementation simply mirrors the entropy of openthread posix platform.