### PR TITLE
[github-actions] remove raspbian build for buster

### DIFF
--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -48,7 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         image_url: [
-          "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip",
           "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2025-05-13/2025-05-13-raspios-bookworm-armhf-lite.img.xz"
         ]
     env:


### PR DESCRIPTION
This PR fixes the CI error of raspbian build of buster. Example: https://github.com/openthread/ot-br-posix/actions/runs/20085031921/job/57622996694?pr=3158

This PR removes the CI check for old image `2021-01-11-raspios-buster-armhf-lite.zip` which is too old and causes failure due to stale apt source URL. We still have the check for bookworm image `2025-05-13-raspios-bookworm-armhf-lite.img.xz`.