### PR TITLE
[dbus] unregister the dbus object from the dbus library

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -123,6 +123,10 @@ void Application::Init(const std::string &aRestListenAddress, int aRestListenPor
 
 void Application::Deinit(void)
 {
+#if OTBR_ENABLE_DBUS_SERVER
+    mDBusAgent.Deinit();
+#endif
+
     switch (mHost.GetCoprocessorType())
     {
     case OT_COPROCESSOR_RCP:

--- a/src/dbus/server/dbus_agent.cpp
+++ b/src/dbus/server/dbus_agent.cpp
@@ -85,6 +85,15 @@ void DBusAgent::Init(void)
     VerifyOrDie(error == OTBR_ERROR_NONE, "Failed to initialize DBus Agent");
 }
 
+void DBusAgent::Deinit(void)
+{
+    if (mThreadObject != nullptr)
+    {
+        mThreadObject->Deinit();
+        mThreadObject = nullptr;
+    }
+}
+
 DBusAgent::UniqueDBusConnection DBusAgent::PrepareDBusConnection(void)
 {
     DBusError            dbusError;

--- a/src/dbus/server/dbus_agent.hpp
+++ b/src/dbus/server/dbus_agent.hpp
@@ -68,6 +68,8 @@ public:
      */
     void Init(void);
 
+    void Deinit(void);
+
     void Update(MainloopContext &aMainloop) override;
     void Process(const MainloopContext &aMainloop) override;
 

--- a/src/dbus/server/dbus_object.cpp
+++ b/src/dbus/server/dbus_object.cpp
@@ -82,7 +82,28 @@ otbrError DBusObject::Initialize(bool aIsAsyncPropertyHandler)
     }
 
 exit:
+    if (error == OTBR_ERROR_DBUS)
+    {
+        otbrLogCrit("Failed to register d-bus object path: %s", mObjectPath.c_str());
+    }
+
     return error;
+}
+
+void DBusObject::Deinit(void)
+{
+    if ((mConnection != nullptr) && !mMethodHandlers.empty())
+    {
+        if (!dbus_connection_unregister_object_path(mConnection, mObjectPath.c_str()))
+        {
+            otbrLogWarning("Failed to unregister d-bus object path: %s", mObjectPath.c_str());
+        }
+    }
+
+    mMethodHandlers.clear();
+    mGetPropertyHandlers.clear();
+    mSetPropertyHandlers.clear();
+    mAsyncGetPropertyHandlers.clear();
 }
 
 void DBusObject::RegisterMethod(const std::string       &aInterfaceName,

--- a/src/dbus/server/dbus_object.hpp
+++ b/src/dbus/server/dbus_object.hpp
@@ -100,6 +100,13 @@ public:
     virtual otbrError Init(void);
 
     /**
+     * This method de-initializes the d-bus object.
+     *
+     * This method will unregister the object from the d-bus library.
+     */
+    virtual void Deinit(void);
+
+    /**
      * This method registers the method handler.
      *
      * @param[in] aInterfaceName  The interface name.


### PR DESCRIPTION
When running the `factoryreset` command on RaspberryPi, the system generates the following error message: `otbr[2862]: [EMERG]-DBUS----: FAILED src/dbus/server/dbus_agent.cpp:85 - Failed to initialize DBus Agent`

This root cause is that the dbus object was not unregistered from the dbus library when running the `factoryreset` command. When otbr restarts, it registers the dbus object again. So the dbus library generates the error `org.freedesktop.DBus.Error.ObjectPathInUse`.

This commit add `Deinit()` method to unregister the dbus object from the dbus library.