### PR TITLE
[docker] set default vendor name and vendor model

### DIFF
--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -27,6 +27,12 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+OT_VENDOR_NAME="${OT_VENDOR_NAME:-OpenThread}"
+readonly OT_VENDOR_NAME
+
+OT_VENDOR_MODEL="${OT_VENDOR_MODEL:-BorderRouter}"
+readonly OT_VENDOR_MODEL
+
 OT_LOG_LEVEL="${OT_LOG_LEVEL:-7}"
 readonly OT_LOG_LEVEL
 
@@ -84,6 +90,8 @@ echo "Starting otbr-agent..."
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 stdbuf -oL \
      "/usr/sbin/otbr-agent" \
         -d"${OT_LOG_LEVEL}" -v -s \
+        --vendor-name "${OT_VENDOR_NAME}" \
+        --model-name "${OT_VENDOR_MODEL}" \
         -I "${OT_THREAD_IF}" \
         -B "${OT_INFRA_IF}" \
         "${OT_RCP_DEVICE}" \


### PR DESCRIPTION
The `openthread/border-router` docker image now fails to start due to the removal of default vendor name and model name in #3152. 

This PR provides a fallback vendor name (OpenThread) and model name (BorderRouter) in the released docker image for backwards compatibility. In the meantime, users can also override the fallback vendor name and model name through `OT_VENDOR_NAME` and `OT_VENDOR_MODEL`  in their  OTBR configuration file passed when they start the docker image.