### PR TITLE
[telemetry] fix missing multi_ail_detected field

### DIFF
--- a/src/host/telemetry/telemetry.cpp
+++ b/src/host/telemetry/telemetry.cpp
@@ -565,6 +565,7 @@ otError TelemetryRetriever::RetrieveTelemetryData(Mdns::Publisher              *
 #if OTBR_ENABLE_BORDER_ROUTING
         RetrieveInfraLinkInfo(*wpanBorderRouter->mutable_infra_link_info());
         RetrieveExternalRouteInfo(*wpanBorderRouter->mutable_external_route_info());
+        wpanBorderRouter->set_multi_ail_detected(otBorderRoutingIsMultiAilDetected(mInstance));
 #endif
 
 #if OTBR_ENABLE_SRP_SERVER

--- a/tests/dbus/test_dbus_client.cpp
+++ b/tests/dbus/test_dbus_client.cpp
@@ -367,6 +367,7 @@ void CheckTelemetryData(ThreadApiDBus *aApi)
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_default_route_added() == false);
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_ula_route_added());
     TEST_ASSERT(telemetryData.wpan_border_router().external_route_info().has_others_route_added() == false);
+    TEST_ASSERT(telemetryData.wpan_border_router().has_multi_ail_detected());
     TEST_ASSERT(telemetryData.wpan_border_router().multi_ail_detected() == false);
 #endif
 #if !OTBR_ENABLE_MDNS_OPENTHREAD


### PR DESCRIPTION
multi_ail_detected is added in https://github.com/openthread/ot-br-posix/pull/3001 but was accidentally removed in https://github.com/openthread/ot-br-posix/pull/3006 

This pull request introduces support for tracking and testing the detection of multiple AILs (Address Independent Links) in the Border Routing telemetry data. The main changes involve updating the telemetry retrieval logic to include this new field and adding corresponding unit tests to ensure its correct behavior.

**Telemetry Enhancements:**

* Added setting of the `multi_ail_detected` field in the `wpanBorderRouter` telemetry data by calling `otBorderRoutingIsMultiAilDetected(mInstance)` in `telemetry.cpp`.

**Testing Improvements:**

* Added assertions in the `test_dbus_client.cpp` test to check the presence and value of the `multi_ail_detected` field in the telemetry data.