### PR TITLE
[ncp] add handling for NCP reset

### DIFF
--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -442,6 +442,12 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
 
         SuccessOrExit(error = SpinelDataUnpack(aBuffer, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
 
+        if (status >= SPINEL_STATUS_RESET__BEGIN && status <= SPINEL_STATUS_RESET__END)
+        {
+            HandleNcpUnexpectedReset(status);
+            ExitNow();
+        }
+
         otbrLogInfo("NCP last status: %s", spinel_status_to_cstr(status));
         break;
     }
@@ -1037,6 +1043,13 @@ otbrError NcpSpinel::HandleResponseForPropRemove(spinel_tid_t      aTid,
 exit:
     otbrLogResult(error, "HandleResponseForPropRemove, key:%u", mWaitingKeyTable[aTid]);
     return error;
+}
+
+void NcpSpinel::HandleNcpUnexpectedReset(spinel_status_t aStatus)
+{
+    otbrLogCrit("Unexpected NCP reset: %s", spinel_status_to_cstr(aStatus));
+
+    DieNow("NCP reset detected!");
 }
 
 otbrError NcpSpinel::Ip6MulAddrUpdateSubscription(const otIp6Address &aAddress, bool aIsAdded)

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -526,6 +526,7 @@ private:
                                           spinel_prop_key_t aKey,
                                           const uint8_t    *aData,
                                           uint16_t          aLength);
+    void      HandleNcpUnexpectedReset(spinel_status_t aStatus);
 
     spinel_tid_t GetNextTid(void);
     void         FreeTidTableItem(spinel_tid_t aTid);

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -90,7 +90,6 @@ proc spawn_node {id type sim_app} {
         }
         ctl {
             spawn $sim_app
-            send "factoryreset\n"
             wait_for "state" "disabled"
             expect "Done"
 


### PR DESCRIPTION
This PR adds handling for NCP reset.

The currently handling is directly exit the program if NCP resets. For more background: https://github.com/openthread/ot-br-posix/issues/3160