### PR TITLE
Implementation of a Time Exceeded Detector functionality for the OpenThread Border Router

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -275,3 +275,15 @@ if(OTBR_MULTI_AIL)
 else()
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_MULTI_AIL=0)
 endif()
+
+# ====================================================================================================
+
+option(OTBR_TIME_EXCEEDED_DETECTION "enable Time Exceeded Detection" OFF)
+if (OTBR_TIME_EXCEEDED_DETECTION)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TIME_EXCEEDED_DETECTION=1)
+else()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_TIME_EXCEEDED_DETECTION=0)
+endif()
+
+# ====================================================================================================
+

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -74,6 +74,9 @@ set(OT_SRP_CLIENT ON CACHE STRING "enable SRP client" FORCE)
 set(OT_SRP_SERVER ON CACHE STRING "enable SRP server")
 set(OT_TARGET_OPENWRT ${OTBR_OPENWRT} CACHE STRING "target on OpenWRT" FORCE)
 set(OT_TCP OFF CACHE STRING "disable TCP")
+# ====================================================================================================
+set(OT_TIME_EXCEEDED_DETECTION ${OTBR_TIME_EXCEEDED_DETECTION} CACHE STRING "enable Time Exceeded Detection" FORCE)
+# ====================================================================================================
 set(OT_TREL ${OTBR_TREL} CACHE STRING "enable TREL" FORCE)
 set(OT_UDP_FORWARD OFF CACHE STRING "disable udp forward" FORCE)
 set(OT_UPTIME ON CACHE STRING "enable uptime" FORCE)


### PR DESCRIPTION
This pull request contains the implementation of a Time Exceeded Detector functionality for the OpenThread Border Router (part: ot-br-posix).
Link for the related openthread pull request : https://github.com/openthread/openthread/pull/12311

This work is done in the context of a Master's Thesis at the University of Liège in Belgium.
Author : Voskertchian Gregory
Supervisor: @evyncke

Sat Jan 17 04:47:59 PM CET 2026