### PR TITLE
[mdns] bump mDNSResponder from 2881.0.25 to 2881.40.18

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -90,7 +90,7 @@ install_packages_apt()
     # Thread Certification tests require mDNSResponder ('dns-sd') to publish records for testing. Since the
     # same image is used for reference OTBRs and for reference Linux hosts, this needs to be installed here.
     if [[ ${OTBR_MDNS} == "mDNSResponder" || ${OT_BACKBONE_CI} == 1 || ${REFERENCE_DEVICE} == 1 ]]; then
-        (MDNS_RESPONDER_SOURCE_NAME=mDNSResponder-2881.0.25 \
+        (MDNS_RESPONDER_SOURCE_NAME=mDNSResponder-2881.40.18 \
             && cd /tmp \
             && wget -c --tries=3 --no-check-certificate -O "$MDNS_RESPONDER_SOURCE_NAME.tar.gz" \
                 "https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$MDNS_RESPONDER_SOURCE_NAME.tar.gz" \

--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -125,7 +125,7 @@ case "$(uname)" in
         fi
 
         if [ "${OTBR_MDNS-}" == 'mDNSResponder' ]; then
-            SOURCE_NAME=mDNSResponder-2881.0.25
+            SOURCE_NAME=mDNSResponder-2881.40.18
             (cd /tmp \
                 && wget -c --tries=3 --no-check-certificate -O "$SOURCE_NAME.tar.gz" \
                     "https://github.com/apple-oss-distributions/mDNSResponder/archive/refs/tags/$SOURCE_NAME.tar.gz" \


### PR DESCRIPTION
This commit updates the mDNSResponder version to mDNSResponder-2881.40.18.