### PR TITLE
[dbus] fix crash during shutdown due to early deinitialization

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -123,10 +123,6 @@ void Application::Init(const std::string &aRestListenAddress, int aRestListenPor
 
 void Application::Deinit(void)
 {
-#if OTBR_ENABLE_DBUS_SERVER
-    mDBusAgent.Deinit();
-#endif
-
     switch (mHost.GetCoprocessorType())
     {
     case OT_COPROCESSOR_RCP:
@@ -141,6 +137,10 @@ void Application::Deinit(void)
     }
 
     mHost.Deinit();
+
+#if OTBR_ENABLE_DBUS_SERVER
+    mDBusAgent.Deinit();
+#endif
 }
 
 otbrError Application::Run(void)


### PR DESCRIPTION
This commit addresses a regression introduced in #3170 where the DBus agent was deinitialized before the OpenThread `RcpHost`, leading to a possible crash during teardown.

When `Application::Deinit()` is called, the following sequence can occur:

1. `mHost.Deinit()` triggers `ot::Posix::InfraNetif::TearDown()`.
2. This disables Border Routing, causing the `RoutingManager` to update the DHCPv6 PD state.
3. The state change triggers `ThreadHelper::BorderRoutingDhcp6PdCallback`.
4. The callback attempts to notify DBus via `DBusThreadObjectRcp`.

If the DBus agent is already deinitialized, this notification causes a crash. This change ensures `mDBusAgent` is deinitialized last to maintain valid references during the teardown sequence.

----

Should help resolve 
- #3226.