### PR TITLE
[tests] propagate `OT_CTL` to restjsonapi test scripts

### DIFF
--- a/tests/restjsonapi/test-restjsonapi-server
+++ b/tests/restjsonapi/test-restjsonapi-server
@@ -33,6 +33,8 @@
 # fail fast on errors
 set -euo pipefail
 
+OT_CTL="${1:-ot-ctl}"
+
 # Check DELETE collections
 bru run actions/Delete_Actions_Collection.bru --env localhost --output results_$LINENO.json
 bru run devices/Delete_Devices_Collection.bru --env localhost --output results_$LINENO.json
@@ -62,7 +64,7 @@ bru run devices/Get_Node_json.bru --env localhost --output results_$LINENO.json
 # GET a non-existing item
 bru run devices/Get_DeviceItem_by_ItemId_404.bru --env localhost --output results_$LINENO.json
 
-./setDUTdestination.sh || true # continue on error, DUT may be configured already
+./setDUTdestination.sh "${OT_CTL}" || true # continue on error, DUT may be configured already
 
 ##############################################################
 ## Actions ##

--- a/tests/scripts/meshcop
+++ b/tests/scripts/meshcop
@@ -615,7 +615,7 @@ test_restapi()
 
     # Run the test-restjsonapi-server.sh script repeatedly.
     for i in {1..3}; do
-        test_result=$(./test-restjsonapi-server 2>&1)
+        test_result=$(./test-restjsonapi-server "${OT_CTL}" 2>&1)
         if grep -qi "error" <<<"${test_result}"; then
             echo "Error found in test-restjsonapi-server on iteration $i"
             echo "${test_result}"


### PR DESCRIPTION
Update `test-restjsonapi-server` to accept an `OT_CTL` argument and pass it to `setDUTdestination.sh`.

Update `meshcop` script to pass the resolved `OT_CTL` path when invoking `test-restjsonapi-server`.

This ensures that the correct `ot-ctl` binary (e.g. the one built locally) is used during the REST API tests, rather than relying on the system-wide `ot-ctl` which may be missing or incompatible.