### PR TITLE
[mdns] handle timeout as terminal for registration retries

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -252,6 +252,12 @@ bool IsRetryableError(DNSServiceErrorType aError)
     return ret;
 }
 
+bool IsRetryableRegistrationError(DNSServiceErrorType aError)
+{
+    // Timeout indicates an unresponsive mDNSResponder during registration and should fail fast.
+    return aError != kDNSServiceErr_Timeout && IsRetryableError(aError);
+}
+
 PublisherMDnsSd::PublisherMDnsSd(StateCallback aCallback)
     : mHostsRef(nullptr)
     , mState(State::kIdle)
@@ -516,8 +522,7 @@ otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
 
     // Note: If the mDNSResponder service is in some bad state, `DNSServiceRegister` may block here for 60 seconds at
     // most.
-    // TODO: Abort on `Timeout` error, as it indicates an unresponsive mDNSResponder. This may require removing
-    // `kDNSServiceErr_Timeout` from `IsRetryableError` and adding specific handling for it.
+    // Timeout is treated as non-retryable in registration callbacks to fail fast.
     dnsError = DNSServiceRegister(&mServiceRef, kDNSServiceFlagsNoAutoRename, kDNSServiceInterfaceIndexAny,
                                   serviceNameCString, regType.c_str(),
                                   /* domain */ nullptr, hostNameCString, htons(mPort), mTxtData.size(), mTxtData.data(),
@@ -598,7 +603,7 @@ void PublisherMDnsSd::DnssdServiceRegistration::HandleRegisterResult(DNSServiceF
         otbrLogInfo("Successfully registered service %s.%s", mName.c_str(), mType.c_str());
         Complete(OTBR_ERROR_NONE);
     }
-    else if (IsRetryableError(aError))
+    else if (IsRetryableRegistrationError(aError))
     {
         otbrLogInfo("Will re-register service %s.%s on the retryable error: %s", mName.c_str(), mType.c_str(),
                     DNSErrorToString(aError));
@@ -698,7 +703,7 @@ void PublisherMDnsSd::DnssdHostRegistration::HandleRegisterResult(DNSServiceRef 
 
 void PublisherMDnsSd::DnssdHostRegistration::HandleRegisterResult(DNSRecordRef aRecordRef, DNSServiceErrorType aError)
 {
-    if (IsRetryableError(aError))
+    if (IsRetryableRegistrationError(aError))
     {
         otbrLogInfo("Will re-register host %s on the retryable error: %s", mName.c_str(), DNSErrorToString(aError));
         GetPublisher().ScheduleRetry<DnssdHostRegistration>(this, [](DnssdHostRegistration *aHostReg) {
@@ -848,7 +853,7 @@ void PublisherMDnsSd::DnssdKeyRegistration::HandleRegisterResult(DNSServiceError
         otbrLogInfo("Successfully registered key %s", mName.c_str());
         Complete(OTBR_ERROR_NONE);
     }
-    else if (IsRetryableError(aError))
+    else if (IsRetryableRegistrationError(aError))
     {
         otbrLogInfo("Will re-register key %s on the retryable error: %s", mName.c_str(), DNSErrorToString(aError));
         GetPublisher().ScheduleRetry<DnssdKeyRegistration>(this, [](DnssdKeyRegistration *aKeyReg) {

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(otbr-gtest-unit-dnssd
     ${OTBR_PROJECT_DIRECTORY}/src/utils/dns_utils.cpp
     ${OTBR_PROJECT_DIRECTORY}/src/utils/string_utils.cpp
     test_dnssd.cpp
+    test_mdns_mdnssd.cpp
 )
 target_compile_options(otbr-gtest-unit-dnssd
     PRIVATE

--- a/tests/gtest/test_mdns_mdnssd.cpp
+++ b/tests/gtest/test_mdns_mdnssd.cpp
@@ -65,3 +65,21 @@ TEST(MdnsSd, TestDNSErrorToString)
     EXPECT_NE(otbr::Mdns::DNSErrorToString(kDNSServiceErr_PollingMode), nullptr);
     EXPECT_NE(otbr::Mdns::DNSErrorToString(kDNSServiceErr_Timeout), nullptr);
 }
+
+TEST(MdnsSd, TestIsRetryableError)
+{
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_Transient));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_ServiceNotRunning));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_Timeout));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_DefunctConnection));
+}
+
+TEST(MdnsSd, TestIsRetryableRegistrationError)
+{
+    EXPECT_TRUE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_Transient));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_ServiceNotRunning));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_DefunctConnection));
+
+    // Timeout is treated as terminal for registration operations.
+    EXPECT_FALSE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_Timeout));
+}

--- a/tests/gtest/test_mdns_mdnssd.cpp
+++ b/tests/gtest/test_mdns_mdnssd.cpp
@@ -72,6 +72,7 @@ TEST(MdnsSd, TestIsRetryableError)
     EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_ServiceNotRunning));
     EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_Timeout));
     EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_DefunctConnection));
+    EXPECT_FALSE(otbr::Mdns::IsRetryableError(kDNSServiceErr_BadParam));
 }
 
 TEST(MdnsSd, TestIsRetryableRegistrationError)
@@ -82,4 +83,5 @@ TEST(MdnsSd, TestIsRetryableRegistrationError)
 
     // Timeout is treated as terminal for registration operations.
     EXPECT_FALSE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_Timeout));
+    EXPECT_FALSE(otbr::Mdns::IsRetryableRegistrationError(kDNSServiceErr_BadParam));
 }


### PR DESCRIPTION
## Summary

Handle `kDNSServiceErr_Timeout` as non-retryable for mDNS **registration** flows in `mdns_mdnssd`.

This keeps existing generic retry behavior intact for browse/resolve paths, while making registration fail fast when mDNSResponder is unresponsive.

## Changes

1. Added a registration-specific helper:
   - `IsRetryableRegistrationError(DNSServiceErrorType aError)`
   - Returns false for `kDNSServiceErr_Timeout`, otherwise delegates to `IsRetryableError(...)`.
2. Updated registration callbacks to use the new helper:
   - `DnssdServiceRegistration::HandleRegisterResult`
   - `DnssdHostRegistration::HandleRegisterResult`
   - `DnssdKeyRegistration::HandleRegisterResult`
3. Updated nearby comment in `DnssdServiceRegistration::Register` to reflect this behavior.
4. Added tests:
   - `TestIsRetryableError` (confirms generic retry policy, including timeout)
   - `TestIsRetryableRegistrationError` (confirms timeout is terminal for registration policy)

## Why

There is an existing TODO near `DNSServiceRegister` indicating timeout should be handled as terminal for unresponsive mDNSResponder. This change addresses that concern without broadening behavior changes to unrelated resolution/subscription paths.

## Validation

- Unit tests updated in `tests/gtest/test_mdns_mdnssd.cpp`.
- Local full build/test could not be executed in this environment because required toolchain components are missing (`cmake`, clang-format 19.1.7).

## Related

- Fixes #3242
