### PR TITLE
[netif] verify unicast netlink ACKs and gate cache updates

### DIFF
--- a/src/host/posix/netif.cpp
+++ b/src/host/posix/netif.cpp
@@ -154,29 +154,54 @@ void Netif::Deinit(void)
 
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)
 {
+    std::vector<Ip6AddressInfo> updatedUnicastAddresses = mIp6UnicastAddresses;
+
     // Remove stale addresses
     for (const Ip6AddressInfo &addrInfo : mIp6UnicastAddresses)
     {
         if (std::find(aAddrInfos.begin(), aAddrInfos.end(), addrInfo) == aAddrInfos.end())
         {
+            otbrError error;
+
             otbrLogInfo("Remove address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            // TODO: Verify success of the addition or deletion in Netlink response.
-            ProcessUnicastAddressChange(addrInfo, false);
+            error = ProcessUnicastAddressChange(addrInfo, false);
+            if (error == OTBR_ERROR_NONE)
+            {
+                updatedUnicastAddresses.erase(
+                    std::remove(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(), addrInfo),
+                    updatedUnicastAddresses.end());
+            }
+            else
+            {
+                otbrLogWarning("Failed to remove unicast address %s: %s",
+                               Ip6Address(addrInfo.mAddress).ToString().c_str(), otbrErrorString(error));
+            }
         }
     }
 
     // Add new addresses
     for (const Ip6AddressInfo &addrInfo : aAddrInfos)
     {
-        if (std::find(mIp6UnicastAddresses.begin(), mIp6UnicastAddresses.end(), addrInfo) == mIp6UnicastAddresses.end())
+        if (std::find(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(), addrInfo) ==
+            updatedUnicastAddresses.end())
         {
+            otbrError error;
+
             otbrLogInfo("Add address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            // TODO: Verify success of the addition or deletion in Netlink response.
-            ProcessUnicastAddressChange(addrInfo, true);
+            error = ProcessUnicastAddressChange(addrInfo, true);
+            if (error == OTBR_ERROR_NONE)
+            {
+                updatedUnicastAddresses.push_back(addrInfo);
+            }
+            else
+            {
+                otbrLogWarning("Failed to add unicast address %s: %s", Ip6Address(addrInfo.mAddress).ToString().c_str(),
+                               otbrErrorString(error));
+            }
         }
     }
 
-    mIp6UnicastAddresses.assign(aAddrInfos.begin(), aAddrInfos.end());
+    mIp6UnicastAddresses = std::move(updatedUnicastAddresses);
 }
 
 otbrError Netif::UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs)

--- a/src/host/posix/netif.cpp
+++ b/src/host/posix/netif.cpp
@@ -154,12 +154,18 @@ void Netif::Deinit(void)
 
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)
 {
-    std::vector<Ip6AddressInfo> updatedUnicastAddresses = mIp6UnicastAddresses;
+    std::vector<Ip6AddressInfo> updatedUnicastAddresses;
+
+    updatedUnicastAddresses.reserve(std::max(mIp6UnicastAddresses.size(), aAddrInfos.size()));
 
     // Remove stale addresses
     for (const Ip6AddressInfo &addrInfo : mIp6UnicastAddresses)
     {
-        if (std::find(aAddrInfos.begin(), aAddrInfos.end(), addrInfo) == aAddrInfos.end())
+        if (std::find(aAddrInfos.begin(), aAddrInfos.end(), addrInfo) != aAddrInfos.end())
+        {
+            updatedUnicastAddresses.push_back(addrInfo);
+        }
+        else
         {
             otbrError error;
 
@@ -167,14 +173,12 @@ void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrIn
             error = ProcessUnicastAddressChange(addrInfo, false);
             if (error == OTBR_ERROR_NONE)
             {
-                updatedUnicastAddresses.erase(
-                    std::remove(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(), addrInfo),
-                    updatedUnicastAddresses.end());
             }
             else
             {
                 otbrLogWarning("Failed to remove unicast address %s: %s",
                                Ip6Address(addrInfo.mAddress).ToString().c_str(), otbrErrorString(error));
+                updatedUnicastAddresses.push_back(addrInfo);
             }
         }
     }

--- a/src/host/posix/netif.cpp
+++ b/src/host/posix/netif.cpp
@@ -57,6 +57,15 @@
 
 namespace otbr {
 
+namespace {
+
+bool HasSameIp6Address(const Ip6AddressInfo &aFirst, const Ip6AddressInfo &aSecond)
+{
+    return memcmp(&aFirst.mAddress, &aSecond.mAddress, sizeof(aFirst.mAddress)) == 0;
+}
+
+} // namespace
+
 otbrError Netif::Dependencies::Ip6Send(const uint8_t *aData, uint16_t aLength)
 {
     OTBR_UNUSED_VARIABLE(aData);
@@ -154,14 +163,25 @@ void Netif::Deinit(void)
 
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)
 {
+    mIp6UnicastAddresses = ReconcileIp6UnicastAddresses(
+        mIp6UnicastAddresses, aAddrInfos, [this](const Ip6AddressInfo &aAddrInfo, bool aIsAdded) {
+            return ProcessUnicastAddressChange(aAddrInfo, aIsAdded);
+        });
+}
+
+std::vector<Ip6AddressInfo> Netif::ReconcileIp6UnicastAddresses(
+    const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+    const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+    const UnicastAddressChangeHandler &aChangeHandler)
+{
     std::vector<Ip6AddressInfo> updatedUnicastAddresses;
 
-    updatedUnicastAddresses.reserve(std::max(mIp6UnicastAddresses.size(), aAddrInfos.size()));
+    updatedUnicastAddresses.reserve(std::max(aCachedAddrInfos.size(), aDesiredAddrInfos.size()));
 
     // Remove stale addresses
-    for (const Ip6AddressInfo &addrInfo : mIp6UnicastAddresses)
+    for (const Ip6AddressInfo &addrInfo : aCachedAddrInfos)
     {
-        if (std::find(aAddrInfos.begin(), aAddrInfos.end(), addrInfo) != aAddrInfos.end())
+        if (std::find(aDesiredAddrInfos.begin(), aDesiredAddrInfos.end(), addrInfo) != aDesiredAddrInfos.end())
         {
             updatedUnicastAddresses.push_back(addrInfo);
         }
@@ -170,7 +190,7 @@ void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrIn
             otbrError error;
 
             otbrLogInfo("Remove address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            error = ProcessUnicastAddressChange(addrInfo, false);
+            error = aChangeHandler(addrInfo, false);
             if (error == OTBR_ERROR_NONE)
             {
             }
@@ -184,7 +204,7 @@ void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrIn
     }
 
     // Add new addresses
-    for (const Ip6AddressInfo &addrInfo : aAddrInfos)
+    for (const Ip6AddressInfo &addrInfo : aDesiredAddrInfos)
     {
         if (std::find(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(), addrInfo) ==
             updatedUnicastAddresses.end())
@@ -192,9 +212,15 @@ void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrIn
             otbrError error;
 
             otbrLogInfo("Add address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            error = ProcessUnicastAddressChange(addrInfo, true);
+            error = aChangeHandler(addrInfo, true);
             if (error == OTBR_ERROR_NONE)
             {
+                updatedUnicastAddresses.erase(
+                    std::remove_if(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(),
+                                   [&](const Ip6AddressInfo &aExistingAddrInfo) {
+                                       return HasSameIp6Address(aExistingAddrInfo, addrInfo);
+                                   }),
+                    updatedUnicastAddresses.end());
                 updatedUnicastAddresses.push_back(addrInfo);
             }
             else
@@ -205,7 +231,7 @@ void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrIn
         }
     }
 
-    mIp6UnicastAddresses = std::move(updatedUnicastAddresses);
+    return updatedUnicastAddresses;
 }
 
 otbrError Netif::UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs)

--- a/src/host/posix/netif.cpp
+++ b/src/host/posix/netif.cpp
@@ -164,8 +164,8 @@ void Netif::Deinit(void)
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)
 {
     mIp6UnicastAddresses = ReconcileIp6UnicastAddresses(
-        mIp6UnicastAddresses, aAddrInfos, [this](const Ip6AddressInfo &aAddrInfo, bool aIsAdded) {
-            return ProcessUnicastAddressChange(aAddrInfo, aIsAdded);
+        mIp6UnicastAddresses, aAddrInfos, [this](const std::vector<UnicastAddressChange> &aChanges) {
+            return ProcessUnicastAddressChanges(aChanges);
         });
 }
 
@@ -174,11 +174,15 @@ std::vector<Ip6AddressInfo> Netif::ReconcileIp6UnicastAddresses(
     const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
     const UnicastAddressChangeHandler &aChangeHandler)
 {
+    std::vector<UnicastAddressChange>       changes;
+    std::vector<UnicastAddressChangeResult> results;
     std::vector<Ip6AddressInfo> updatedUnicastAddresses;
+    size_t                      changeIndex = 0;
 
     updatedUnicastAddresses.reserve(std::max(aCachedAddrInfos.size(), aDesiredAddrInfos.size()));
+    changes.reserve(aCachedAddrInfos.size() + aDesiredAddrInfos.size());
 
-    // Remove stale addresses
+    // Keep unchanged addresses and queue stale addresses for removal.
     for (const Ip6AddressInfo &addrInfo : aCachedAddrInfos)
     {
         if (std::find(aDesiredAddrInfos.begin(), aDesiredAddrInfos.end(), addrInfo) != aDesiredAddrInfos.end())
@@ -187,33 +191,62 @@ std::vector<Ip6AddressInfo> Netif::ReconcileIp6UnicastAddresses(
         }
         else
         {
-            otbrError error;
-
             otbrLogInfo("Remove address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            error = aChangeHandler(addrInfo, false);
-            if (error == OTBR_ERROR_NONE)
-            {
-            }
-            else
+            changes.push_back({addrInfo, /* mIsAdded */ false, /* mAllowAlreadyExists */ false});
+        }
+    }
+
+    // Queue new addresses for addition. If the desired address replaces cached metadata for the same IPv6 address,
+    // EEXIST is not considered success because the kernel may still hold the old metadata.
+    for (const Ip6AddressInfo &addrInfo : aDesiredAddrInfos)
+    {
+        bool hasSameCachedAddress = false;
+
+        if (std::find(aCachedAddrInfos.begin(), aCachedAddrInfos.end(), addrInfo) != aCachedAddrInfos.end())
+        {
+            continue;
+        }
+
+        hasSameCachedAddress =
+            std::find_if(aCachedAddrInfos.begin(), aCachedAddrInfos.end(), [&](const Ip6AddressInfo &aCachedAddrInfo) {
+                return HasSameIp6Address(aCachedAddrInfo, addrInfo);
+            }) != aCachedAddrInfos.end();
+
+        otbrLogInfo("Add address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
+        changes.push_back({addrInfo, /* mIsAdded */ true, /* mAllowAlreadyExists */ !hasSameCachedAddress});
+    }
+
+    results = aChangeHandler(changes);
+    if (results.size() != changes.size())
+    {
+        results.assign(changes.size(), {OTBR_ERROR_INVALID_STATE, 0});
+    }
+
+    // Apply removal results.
+    for (const Ip6AddressInfo &addrInfo : aCachedAddrInfos)
+    {
+        if (std::find(aDesiredAddrInfos.begin(), aDesiredAddrInfos.end(), addrInfo) == aDesiredAddrInfos.end())
+        {
+            const UnicastAddressChangeResult &result = results[changeIndex++];
+
+            if (result.mError != OTBR_ERROR_NONE)
             {
                 otbrLogWarning("Failed to remove unicast address %s: %s",
-                               Ip6Address(addrInfo.mAddress).ToString().c_str(), otbrErrorString(error));
+                               Ip6Address(addrInfo.mAddress).ToString().c_str(),
+                               result.mErrno == 0 ? otbrErrorString(result.mError) : strerror(result.mErrno));
                 updatedUnicastAddresses.push_back(addrInfo);
             }
         }
     }
 
-    // Add new addresses
+    // Apply addition results.
     for (const Ip6AddressInfo &addrInfo : aDesiredAddrInfos)
     {
-        if (std::find(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(), addrInfo) ==
-            updatedUnicastAddresses.end())
+        if (std::find(aCachedAddrInfos.begin(), aCachedAddrInfos.end(), addrInfo) == aCachedAddrInfos.end())
         {
-            otbrError error;
+            const UnicastAddressChangeResult &result = results[changeIndex++];
 
-            otbrLogInfo("Add address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            error = aChangeHandler(addrInfo, true);
-            if (error == OTBR_ERROR_NONE)
+            if (result.mError == OTBR_ERROR_NONE)
             {
                 updatedUnicastAddresses.erase(
                     std::remove_if(updatedUnicastAddresses.begin(), updatedUnicastAddresses.end(),
@@ -226,7 +259,7 @@ std::vector<Ip6AddressInfo> Netif::ReconcileIp6UnicastAddresses(
             else
             {
                 otbrLogWarning("Failed to add unicast address %s: %s", Ip6Address(addrInfo.mAddress).ToString().c_str(),
-                               otbrErrorString(error));
+                               result.mErrno == 0 ? otbrErrorString(result.mError) : strerror(result.mErrno));
             }
         }
     }

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -79,8 +79,11 @@ public:
     unsigned int GetIfIndex(void) const { return mNetifIndex; }
 
 private:
+    friend class NetifUnicastAddressCacheTestPeer;
+
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
     static constexpr size_t kIp6Mtu = 1280;
+    using UnicastAddressChangeHandler = std::function<otbrError(const Ip6AddressInfo &, bool)>;
 
     void Clear(void);
 
@@ -90,6 +93,9 @@ private:
 
     void      PlatformSpecificInit(void);
     void      SetAddrGenModeToNone(void);
+    static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+                                                                    const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+                                                                    const UnicastAddressChangeHandler &aChangeHandler);
     otbrError ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
     otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
     void      ProcessIp6Send(void);

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -90,7 +90,7 @@ private:
 
     void      PlatformSpecificInit(void);
     void      SetAddrGenModeToNone(void);
-    void      ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
+    otbrError ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
     otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
     void      ProcessIp6Send(void);
     void      ProcessMldEvent(void);

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -83,7 +83,21 @@ private:
 
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
     static constexpr size_t kIp6Mtu = 1280;
-    using UnicastAddressChangeHandler = std::function<otbrError(const Ip6AddressInfo &, bool)>;
+    struct UnicastAddressChange
+    {
+        Ip6AddressInfo mAddressInfo;
+        bool           mIsAdded;
+        bool           mAllowAlreadyExists;
+    };
+
+    struct UnicastAddressChangeResult
+    {
+        otbrError mError;
+        int       mErrno;
+    };
+
+    using UnicastAddressChangeHandler =
+        std::function<std::vector<UnicastAddressChangeResult>(const std::vector<UnicastAddressChange> &)>;
 
     void Clear(void);
 
@@ -96,7 +110,8 @@ private:
     static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
                                                                     const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
                                                                     const UnicastAddressChangeHandler &aChangeHandler);
-    otbrError ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
+    std::vector<UnicastAddressChangeResult> ProcessUnicastAddressChanges(
+        const std::vector<UnicastAddressChange> &aChanges);
     otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
     void      ProcessIp6Send(void);
     void      ProcessMldEvent(void);

--- a/src/host/posix/netif_linux.cpp
+++ b/src/host/posix/netif_linux.cpp
@@ -41,8 +41,11 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <net/if_arp.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+#include <chrono>
 
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
@@ -196,16 +199,23 @@ void Netif::SetAddrGenModeToNone(void)
     }
 }
 
-void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+otbrError Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
 {
+    constexpr int kNetlinkAckTimeoutMs = 1000;
+
     struct
     {
         nlmsghdr  nh;
         ifaddrmsg ifa;
         char      buf[512];
     } req;
+    uint32_t  seq;
+    otbrError error = OTBR_ERROR_NONE;
+    auto      deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(static_cast<int>(kNetlinkAckTimeoutMs));
 
     assert(mIpFd >= 0);
+    assert(mNetlinkFd >= 0);
     memset(&req, 0, sizeof(req));
 
     req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifaddrmsg));
@@ -213,6 +223,7 @@ void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool
     req.nh.nlmsg_type  = aIsAdded ? RTM_NEWADDR : RTM_DELADDR;
     req.nh.nlmsg_pid   = 0;
     req.nh.nlmsg_seq   = ++mNetlinkSequence;
+    seq                = req.nh.nlmsg_seq;
 
     req.ifa.ifa_family    = AF_INET6;
     req.ifa.ifa_prefixlen = aAddressInfo.mPrefixLength;
@@ -232,16 +243,101 @@ void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool
         AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
     }
 
-    if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1)
+    VerifyOrExit(send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1, error = OTBR_ERROR_ERRNO);
+
+    otbrLogInfo("Sent request#%u to %s %s/%u", seq, (aIsAdded ? "add" : "remove"),
+                Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+
+    for (;;)
     {
-        otbrLogInfo("Sent request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
-                    Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+        struct pollfd pfd;
+        int           pollResult;
+        auto          now = std::chrono::steady_clock::now();
+        int           pollTimeoutMs;
+
+        if (now >= deadline)
+        {
+            errno = ETIMEDOUT;
+            ExitNow(error = OTBR_ERROR_ERRNO);
+        }
+
+        pollTimeoutMs = static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count());
+
+        pfd.fd      = mNetlinkFd;
+        pfd.events  = POLLIN;
+        pfd.revents = 0;
+
+        pollResult = poll(&pfd, 1, pollTimeoutMs);
+        if (pollResult == 0)
+        {
+            errno = ETIMEDOUT;
+            ExitNow(error = OTBR_ERROR_ERRNO);
+        }
+        if (pollResult < 0 && errno == EINTR)
+        {
+            continue;
+        }
+        VerifyOrExit(pollResult >= 0, error = OTBR_ERROR_ERRNO);
+
+        if ((pfd.revents & POLLIN) != 0)
+        {
+            union
+            {
+                nlmsghdr mHeader;
+                uint8_t  mBuffer[2048];
+            } response;
+            ssize_t length;
+
+            length = recv(mNetlinkFd, response.mBuffer, sizeof(response.mBuffer), /* flags */ 0);
+            if (length < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
+            {
+                continue;
+            }
+            VerifyOrExit(length >= 0, error = OTBR_ERROR_ERRNO);
+
+            for (nlmsghdr *header = &response.mHeader; NLMSG_OK(header, static_cast<size_t>(length));
+                 header           = NLMSG_NEXT(header, length))
+            {
+                if (header->nlmsg_seq != seq)
+                {
+                    continue;
+                }
+
+                VerifyOrExit(header->nlmsg_type == NLMSG_ERROR, errno = EPROTO; error = OTBR_ERROR_ERRNO);
+                VerifyOrExit(header->nlmsg_len >= NLMSG_LENGTH(sizeof(nlmsgerr)), errno = EBADMSG;
+                             error = OTBR_ERROR_ERRNO);
+
+                {
+                    nlmsgerr *errMsg    = reinterpret_cast<nlmsgerr *>(NLMSG_DATA(header));
+                    int       kernelErr = (errMsg->error < 0) ? -errMsg->error : errMsg->error;
+
+                    if (kernelErr == 0 || (aIsAdded && kernelErr == EEXIST) ||
+                        (!aIsAdded && (kernelErr == ENOENT || kernelErr == EADDRNOTAVAIL)))
+                    {
+                        ExitNow(error = OTBR_ERROR_NONE);
+                    }
+
+                    errno = kernelErr;
+                    ExitNow(error = OTBR_ERROR_ERRNO);
+                }
+            }
+        }
+        else
+        {
+            errno = EIO;
+            ExitNow(error = OTBR_ERROR_ERRNO);
+        }
     }
-    else
+
+exit:
+    if (error != OTBR_ERROR_NONE)
     {
-        otbrLogWarning("Failed to send request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
-                       Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+        otbrLogWarning("Failed request#%u to %s %s/%u: %s", seq, (aIsAdded ? "add" : "remove"),
+                       Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength,
+                       strerror(errno));
     }
+
+    return error;
 }
 
 } // namespace otbr

--- a/src/host/posix/netif_linux.cpp
+++ b/src/host/posix/netif_linux.cpp
@@ -199,88 +199,140 @@ void Netif::SetAddrGenModeToNone(void)
     }
 }
 
-otbrError Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+std::vector<Netif::UnicastAddressChangeResult> Netif::ProcessUnicastAddressChanges(
+    const std::vector<UnicastAddressChange> &aChanges)
 {
-    constexpr int kNetlinkAckTimeoutMs = 1000;
+    constexpr int kNetlinkAckTimeoutMs = 100;
 
-    struct
+    struct PendingAck
     {
-        nlmsghdr  nh;
-        ifaddrmsg ifa;
-        char      buf[512];
-    } req;
-    uint32_t  seq;
-    otbrError error = OTBR_ERROR_NONE;
-    auto      deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(static_cast<int>(kNetlinkAckTimeoutMs));
+        uint32_t mSequence;
+        size_t   mChangeIndex;
+        bool     mIsDone;
+    };
+
+    std::vector<UnicastAddressChangeResult> results(aChanges.size(), {OTBR_ERROR_NONE, 0});
+    std::vector<PendingAck>                 pendingAcks;
+    size_t                                  pendingAckCount = 0;
 
     assert(mIpFd >= 0);
     assert(mNetlinkFd >= 0);
-    memset(&req, 0, sizeof(req));
 
-    req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifaddrmsg));
-    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | (aIsAdded ? (NLM_F_CREATE | NLM_F_EXCL) : 0);
-    req.nh.nlmsg_type  = aIsAdded ? RTM_NEWADDR : RTM_DELADDR;
-    req.nh.nlmsg_pid   = 0;
-    req.nh.nlmsg_seq   = ++mNetlinkSequence;
-    seq                = req.nh.nlmsg_seq;
+    pendingAcks.reserve(aChanges.size());
 
-    req.ifa.ifa_family    = AF_INET6;
-    req.ifa.ifa_prefixlen = aAddressInfo.mPrefixLength;
-    req.ifa.ifa_flags     = IFA_F_NODAD;
-    req.ifa.ifa_scope     = aAddressInfo.mScope;
-    req.ifa.ifa_index     = mNetifIndex;
-
-    AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, &aAddressInfo.mAddress, sizeof(aAddressInfo.mAddress));
-
-    if (!aAddressInfo.mPreferred || aAddressInfo.mMeshLocal)
+    for (size_t i = 0; i < aChanges.size(); ++i)
     {
-        ifa_cacheinfo cacheinfo;
-
-        memset(&cacheinfo, 0, sizeof(cacheinfo));
-        cacheinfo.ifa_valid = UINT32_MAX;
-
-        AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
-    }
-
-    VerifyOrExit(send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1, error = OTBR_ERROR_ERRNO);
-
-    otbrLogInfo("Sent request#%u to %s %s/%u", seq, (aIsAdded ? "add" : "remove"),
-                Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
-
-    for (;;)
-    {
-        struct pollfd pfd;
-        int           pollResult;
-        auto          now = std::chrono::steady_clock::now();
-        int           pollTimeoutMs;
-
-        if (now >= deadline)
+        const UnicastAddressChange &change = aChanges[i];
+        const Ip6AddressInfo       &addrInfo = change.mAddressInfo;
+        struct
         {
-            errno = ETIMEDOUT;
-            ExitNow(error = OTBR_ERROR_ERRNO);
+            nlmsghdr  nh;
+            ifaddrmsg ifa;
+            char      buf[512];
+        } req;
+
+        memset(&req, 0, sizeof(req));
+
+        req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifaddrmsg));
+        req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | (change.mIsAdded ? (NLM_F_CREATE | NLM_F_EXCL) : 0);
+        req.nh.nlmsg_type  = change.mIsAdded ? RTM_NEWADDR : RTM_DELADDR;
+        req.nh.nlmsg_pid   = 0;
+        req.nh.nlmsg_seq   = ++mNetlinkSequence;
+
+        req.ifa.ifa_family    = AF_INET6;
+        req.ifa.ifa_prefixlen = addrInfo.mPrefixLength;
+        req.ifa.ifa_flags     = IFA_F_NODAD;
+        req.ifa.ifa_scope     = addrInfo.mScope;
+        req.ifa.ifa_index     = mNetifIndex;
+
+        AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, &addrInfo.mAddress, sizeof(addrInfo.mAddress));
+
+        if (!addrInfo.mPreferred || addrInfo.mMeshLocal)
+        {
+            ifa_cacheinfo cacheinfo;
+
+            memset(&cacheinfo, 0, sizeof(cacheinfo));
+            cacheinfo.ifa_valid = UINT32_MAX;
+
+            AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
         }
 
-        pollTimeoutMs = static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count());
-
-        pfd.fd      = mNetlinkFd;
-        pfd.events  = POLLIN;
-        pfd.revents = 0;
-
-        pollResult = poll(&pfd, 1, pollTimeoutMs);
-        if (pollResult == 0)
+        if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) == -1)
         {
-            errno = ETIMEDOUT;
-            ExitNow(error = OTBR_ERROR_ERRNO);
-        }
-        if (pollResult < 0 && errno == EINTR)
-        {
+            results[i] = {OTBR_ERROR_ERRNO, errno};
             continue;
         }
-        VerifyOrExit(pollResult >= 0, error = OTBR_ERROR_ERRNO);
 
-        if ((pfd.revents & POLLIN) != 0)
+        otbrLogInfo("Sent request#%u to %s %s/%u", req.nh.nlmsg_seq, (change.mIsAdded ? "add" : "remove"),
+                    Ip6Address(addrInfo.mAddress).ToString().c_str(), addrInfo.mPrefixLength);
+
+        pendingAcks.push_back({req.nh.nlmsg_seq, i, false});
+        ++pendingAckCount;
+    }
+
+    if (pendingAckCount > 0)
+    {
+        auto          deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(static_cast<int>(kNetlinkAckTimeoutMs));
+        struct pollfd pfd;
+        int           pollResult;
+
+        do
         {
+            auto now = std::chrono::steady_clock::now();
+            int  pollTimeoutMs;
+
+            if (now >= deadline)
+            {
+                break;
+            }
+
+            pollTimeoutMs =
+                static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count());
+
+            pfd.fd      = mNetlinkFd;
+            pfd.events  = POLLIN;
+            pfd.revents = 0;
+
+            pollResult = poll(&pfd, 1, pollTimeoutMs);
+            if (pollResult == 0)
+            {
+                break;
+            }
+
+            if (pollResult < 0 && errno == EINTR)
+            {
+                continue;
+            }
+
+            if (pollResult < 0)
+            {
+                for (PendingAck &pendingAck : pendingAcks)
+                {
+                    if (!pendingAck.mIsDone)
+                    {
+                        results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, errno};
+                        pendingAck.mIsDone               = true;
+                        --pendingAckCount;
+                    }
+                }
+                break;
+            }
+
+            if ((pfd.revents & POLLIN) == 0)
+            {
+                for (PendingAck &pendingAck : pendingAcks)
+                {
+                    if (!pendingAck.mIsDone)
+                    {
+                        results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, EIO};
+                        pendingAck.mIsDone               = true;
+                        --pendingAckCount;
+                    }
+                }
+                break;
+            }
+
             union
             {
                 nlmsghdr mHeader;
@@ -293,51 +345,74 @@ otbrError Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo,
             {
                 continue;
             }
-            VerifyOrExit(length >= 0, error = OTBR_ERROR_ERRNO);
+            if (length < 0)
+            {
+                for (PendingAck &pendingAck : pendingAcks)
+                {
+                    if (!pendingAck.mIsDone)
+                    {
+                        results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, errno};
+                        pendingAck.mIsDone               = true;
+                        --pendingAckCount;
+                    }
+                }
+                break;
+            }
 
             for (nlmsghdr *header = &response.mHeader; NLMSG_OK(header, static_cast<size_t>(length));
                  header           = NLMSG_NEXT(header, length))
             {
-                if (header->nlmsg_seq != seq)
+                for (PendingAck &pendingAck : pendingAcks)
                 {
-                    continue;
-                }
-
-                VerifyOrExit(header->nlmsg_type == NLMSG_ERROR, errno = EPROTO; error = OTBR_ERROR_ERRNO);
-                VerifyOrExit(header->nlmsg_len >= NLMSG_LENGTH(sizeof(nlmsgerr)), errno = EBADMSG;
-                             error = OTBR_ERROR_ERRNO);
-
-                {
-                    nlmsgerr *errMsg    = reinterpret_cast<nlmsgerr *>(NLMSG_DATA(header));
-                    int       kernelErr = (errMsg->error < 0) ? -errMsg->error : errMsg->error;
-
-                    if (kernelErr == 0 || (aIsAdded && kernelErr == EEXIST) ||
-                        (!aIsAdded && (kernelErr == ENOENT || kernelErr == EADDRNOTAVAIL)))
+                    if (pendingAck.mIsDone || header->nlmsg_seq != pendingAck.mSequence)
                     {
-                        ExitNow(error = OTBR_ERROR_NONE);
+                        continue;
                     }
 
-                    errno = kernelErr;
-                    ExitNow(error = OTBR_ERROR_ERRNO);
+                    const UnicastAddressChange &change = aChanges[pendingAck.mChangeIndex];
+
+                    if (header->nlmsg_type != NLMSG_ERROR)
+                    {
+                        results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, EPROTO};
+                    }
+                    else if (header->nlmsg_len < NLMSG_LENGTH(sizeof(nlmsgerr)))
+                    {
+                        results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, EBADMSG};
+                    }
+                    else
+                    {
+                        nlmsgerr *errMsg    = reinterpret_cast<nlmsgerr *>(NLMSG_DATA(header));
+                        int       kernelErr = (errMsg->error < 0) ? -errMsg->error : errMsg->error;
+
+                        if (kernelErr == 0 || (change.mIsAdded && change.mAllowAlreadyExists && kernelErr == EEXIST) ||
+                            (!change.mIsAdded && (kernelErr == ENOENT || kernelErr == EADDRNOTAVAIL)))
+                        {
+                            results[pendingAck.mChangeIndex] = {OTBR_ERROR_NONE, 0};
+                        }
+                        else
+                        {
+                            results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, kernelErr};
+                        }
+                    }
+
+                    pendingAck.mIsDone = true;
+                    --pendingAckCount;
+                    break;
                 }
             }
         }
-        else
+        while (pendingAckCount > 0);
+    }
+
+    for (PendingAck &pendingAck : pendingAcks)
+    {
+        if (!pendingAck.mIsDone)
         {
-            errno = EIO;
-            ExitNow(error = OTBR_ERROR_ERRNO);
+            results[pendingAck.mChangeIndex] = {OTBR_ERROR_ERRNO, ETIMEDOUT};
         }
     }
 
-exit:
-    if (error != OTBR_ERROR_NONE)
-    {
-        otbrLogWarning("Failed request#%u to %s %s/%u: %s", seq, (aIsAdded ? "add" : "remove"),
-                       Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength,
-                       strerror(errno));
-    }
-
-    return error;
+    return results;
 }
 
 } // namespace otbr

--- a/src/host/posix/netif_unix.cpp
+++ b/src/host/posix/netif_unix.cpp
@@ -58,10 +58,11 @@ void Netif::PlatformSpecificInit(void)
     /* Empty */
 }
 
-void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+otbrError Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
 {
     OTBR_UNUSED_VARIABLE(aAddressInfo);
     OTBR_UNUSED_VARIABLE(aIsAdded);
+    return OTBR_ERROR_NONE;
 }
 
 } // namespace otbr

--- a/src/host/posix/netif_unix.cpp
+++ b/src/host/posix/netif_unix.cpp
@@ -58,11 +58,10 @@ void Netif::PlatformSpecificInit(void)
     /* Empty */
 }
 
-otbrError Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+std::vector<Netif::UnicastAddressChangeResult> Netif::ProcessUnicastAddressChanges(
+    const std::vector<UnicastAddressChange> &aChanges)
 {
-    OTBR_UNUSED_VARIABLE(aAddressInfo);
-    OTBR_UNUSED_VARIABLE(aIsAdded);
-    return OTBR_ERROR_NONE;
+    return std::vector<UnicastAddressChangeResult>(aChanges.size(), {OTBR_ERROR_NONE, 0});
 }
 
 } // namespace otbr

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -62,6 +62,62 @@
 #include "host/posix/netif.hpp"
 #include "utils/socket_utils.hpp"
 
+namespace otbr {
+
+class NetifUnicastAddressCacheTestPeer
+{
+public:
+    static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(
+        const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+        const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+        const std::function<otbrError(const Ip6AddressInfo &, bool)> &aChangeHandler)
+    {
+        return Netif::ReconcileIp6UnicastAddresses(aCachedAddrInfos, aDesiredAddrInfos, aChangeHandler);
+    }
+};
+
+} // namespace otbr
+
+TEST(Netif, ReconcileUnicastAddressesReplacesStaleMetadataAfterSuccessfulAdd)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x07, 0x7f}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, false, true);
+
+    std::vector<otbr::Ip6AddressInfo> updated =
+        otbr::NetifUnicastAddressCacheTestPeer::ReconcileIp6UnicastAddresses(
+            {kCached}, {kDesired}, [&](const otbr::Ip6AddressInfo &aAddrInfo, bool aIsAdded) {
+                if (!aIsAdded)
+                {
+                    EXPECT_EQ(aAddrInfo, kCached);
+                    return OTBR_ERROR_ERRNO;
+                }
+
+                EXPECT_EQ(aAddrInfo, kDesired);
+                return OTBR_ERROR_NONE;
+            });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kDesired);
+}
+
+TEST(Netif, ReconcileUnicastAddressesKeepsCachedEntryWhenReplacementAddFails)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x07, 0x7f}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, false, true);
+
+    std::vector<otbr::Ip6AddressInfo> updated =
+        otbr::NetifUnicastAddressCacheTestPeer::ReconcileIp6UnicastAddresses(
+            {kCached}, {kDesired},
+            [&](const otbr::Ip6AddressInfo &, bool) { return OTBR_ERROR_ERRNO; });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kCached);
+}
+
 // Only Test on linux platform for now.
 #ifdef __linux__
 

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -67,12 +67,60 @@ namespace otbr {
 class NetifUnicastAddressCacheTestPeer
 {
 public:
+    struct Change
+    {
+        Ip6AddressInfo mAddressInfo;
+        bool           mIsAdded;
+        bool           mAllowAlreadyExists;
+    };
+
     static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(
         const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
         const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
         const std::function<otbrError(const Ip6AddressInfo &, bool)> &aChangeHandler)
     {
-        return Netif::ReconcileIp6UnicastAddresses(aCachedAddrInfos, aDesiredAddrInfos, aChangeHandler);
+        return Netif::ReconcileIp6UnicastAddresses(
+            aCachedAddrInfos, aDesiredAddrInfos,
+            [&](const std::vector<Netif::UnicastAddressChange> &aChanges) {
+                std::vector<Netif::UnicastAddressChangeResult> results;
+
+                results.reserve(aChanges.size());
+                for (const Netif::UnicastAddressChange &change : aChanges)
+                {
+                    results.push_back({aChangeHandler(change.mAddressInfo, change.mIsAdded), 0});
+                }
+
+                return results;
+            });
+    }
+
+    static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(
+        const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+        const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+        const std::function<std::vector<otbrError>(const std::vector<Change> &)> &aChangeHandler)
+    {
+        return Netif::ReconcileIp6UnicastAddresses(
+            aCachedAddrInfos, aDesiredAddrInfos,
+            [&](const std::vector<Netif::UnicastAddressChange> &aChanges) {
+                std::vector<Change>                           changes;
+                std::vector<otbrError>                        errors;
+                std::vector<Netif::UnicastAddressChangeResult> results;
+
+                changes.reserve(aChanges.size());
+                for (const Netif::UnicastAddressChange &change : aChanges)
+                {
+                    changes.push_back({change.mAddressInfo, change.mIsAdded, change.mAllowAlreadyExists});
+                }
+
+                errors = aChangeHandler(changes);
+                results.reserve(errors.size());
+                for (otbrError error : errors)
+                {
+                    results.push_back({error, 0});
+                }
+
+                return results;
+            });
     }
 };
 
@@ -113,6 +161,62 @@ TEST(Netif, ReconcileUnicastAddressesKeepsCachedEntryWhenReplacementAddFails)
         otbr::NetifUnicastAddressCacheTestPeer::ReconcileIp6UnicastAddresses(
             {kCached}, {kDesired},
             [&](const otbr::Ip6AddressInfo &, bool) { return OTBR_ERROR_ERRNO; });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kCached);
+}
+
+TEST(Netif, ReconcileUnicastAddressesBatchesRemoveAndAdd)
+{
+    const otIp6Address kCachedAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x07, 0x7f}};
+    const otIp6Address kDesiredAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x08, 0x80}};
+    const otbr::Ip6AddressInfo kCached(kCachedAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kDesiredAddress, 64, 0, true, false);
+    size_t                     batchCount = 0;
+
+    std::vector<otbr::Ip6AddressInfo> updated =
+        otbr::NetifUnicastAddressCacheTestPeer::ReconcileIp6UnicastAddresses(
+            {kCached}, {kDesired},
+            [&](const std::vector<otbr::NetifUnicastAddressCacheTestPeer::Change> &aChanges) {
+                ++batchCount;
+                EXPECT_EQ(aChanges.size(), 2U);
+                if (aChanges.size() == 2U)
+                {
+                    EXPECT_EQ(aChanges[0].mAddressInfo, kCached);
+                    EXPECT_FALSE(aChanges[0].mIsAdded);
+                    EXPECT_EQ(aChanges[1].mAddressInfo, kDesired);
+                    EXPECT_TRUE(aChanges[1].mIsAdded);
+                }
+                return std::vector<otbrError>{OTBR_ERROR_NONE, OTBR_ERROR_NONE};
+            });
+
+    EXPECT_EQ(batchCount, 1U);
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kDesired);
+}
+
+TEST(Netif, ReconcileUnicastAddressesDoesNotAllowExistingAddressForMetadataReplacement)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x03, 0xf1, 0x47, 0xce, 0x85, 0xd3, 0x07, 0x7f}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, false, true);
+
+    std::vector<otbr::Ip6AddressInfo> updated =
+        otbr::NetifUnicastAddressCacheTestPeer::ReconcileIp6UnicastAddresses(
+            {kCached}, {kDesired},
+            [&](const std::vector<otbr::NetifUnicastAddressCacheTestPeer::Change> &aChanges) {
+                EXPECT_EQ(aChanges.size(), 2U);
+                if (aChanges.size() == 2U)
+                {
+                    EXPECT_FALSE(aChanges[0].mIsAdded);
+                    EXPECT_TRUE(aChanges[1].mIsAdded);
+                    EXPECT_FALSE(aChanges[1].mAllowAlreadyExists);
+                }
+                return std::vector<otbrError>{OTBR_ERROR_ERRNO, OTBR_ERROR_ERRNO};
+            });
 
     ASSERT_EQ(updated.size(), 1U);
     EXPECT_EQ(updated[0], kCached);


### PR DESCRIPTION
## Summary

This PR hardens Linux unicast netif handling by tying cache mutation to verified netlink outcomes.

## Problem

`UpdateIp6UnicastAddresses()` previously updated `mIp6UnicastAddresses` optimistically, without confirming whether the kernel accepted each unicast add/remove request.  
When RTNETLINK rejected a request, OTBR cache could diverge from kernel state.

## Changes

- Unicast address updates now verify the matching netlink ACK by request sequence.
- ACK wait is bounded by an absolute timeout deadline.
- ACK parsing validates `nlmsgerr` payload length before dereference.
- Transient `recv()` interruptions (`EINTR`, `EAGAIN`, `EWOULDBLOCK`) are retried while waiting.
- Idempotent outcomes are treated as success:
  - add: `EEXIST`
  - remove: `ENOENT`, `EADDRNOTAVAIL`
- `UpdateIp6UnicastAddresses()` now mutates local cache only for operations that succeeded.

## Why this is safe

- Successful paths preserve existing behavior.
- Failure handling is stricter and prevents cache/kernel drift.
- Timeout handling avoids indefinite wait on unrelated netlink traffic.

## Validation

- `clang-format` check (LLVM 19) on modified files.
- `git diff --check` clean.
- Linux CI/runtime validation is still required for full end-to-end netlink path verification.

Fixes #3244
