### PR TITLE
[web] prevent OT CLI command injection via newline characters

### DIFF
--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -161,6 +161,12 @@ char *OpenThreadClient::Execute(const char *aFormat, ...)
         ExitNow();
     }
 
+    if (memchr(&mBuffer[1], '\n', ret) != nullptr || memchr(&mBuffer[1], '\r', ret) != nullptr)
+    {
+        otbrLogErr("OT CLI command contains line break; rejecting to prevent command injection");
+        ExitNow();
+    }
+
     mBuffer[0]       = '\n';
     mBuffer[ret + 1] = '\n';
     ret += 2;

--- a/src/web/web-service/ot_client.hpp
+++ b/src/web/web-service/ot_client.hpp
@@ -41,6 +41,8 @@
 namespace otbr {
 namespace Web {
 
+class WebServiceTest;
+
 #define OT_SCANNED_NET_BUFFER_SIZE 250
 #define OT_SET_MAX_DATA_SIZE 250
 #define OT_NETWORK_NAME_MAX_SIZE 17
@@ -122,6 +124,8 @@ public:
     bool FactoryReset(void);
 
 private:
+    friend class WebServiceTest;
+
     void Disconnect(void);
     void DiscardRead(void);
 

--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -129,7 +129,8 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     else if (credentialType == CREDENTIAL_TYPE_PSKD)
     {
         VerifyOrExit(client.Execute("ifconfig up") != nullptr, ret = kWpanStatus_JoinFailed);
-        VerifyOrExit(client.Execute("joiner start %s", pskd.c_str()) != nullptr, ret = kWpanStatus_JoinFailed);
+        VerifyOrExit(client.Execute("joiner start %s", escapeOtCliEscapable(pskd).c_str()) != nullptr,
+                     ret = kWpanStatus_JoinFailed);
         VerifyOrExit((rval = client.Read("Join ", 5000)) != nullptr, ret = kWpanStatus_JoinFailed);
         if (strstr(rval, "Join success"))
         {
@@ -154,7 +155,8 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     }
 
     VerifyOrExit(client.Execute("thread start") != nullptr, ret = kWpanStatus_JoinFailed);
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetFailed);
 
 exit:
@@ -233,7 +235,8 @@ std::string WpanService::HandleFormNetworkRequest(const std::string &aFormReques
                  kWpanStatus_Ok);
     VerifyOrExit(client.Execute("ifconfig up") != nullptr, ret = kWpanStatus_FormFailed);
     VerifyOrExit(client.Execute("thread start") != nullptr, ret = kWpanStatus_FormFailed);
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetFailed);
 exit:
 
@@ -275,7 +278,8 @@ std::string WpanService::HandleAddPrefixRequest(const std::string &aAddPrefixReq
         prefix += "/64";
     }
 
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetGatewayFailed);
     VerifyOrExit(client.Execute("netdata register") != nullptr, ret = kWpanStatus_SetGatewayFailed);
 exit:
@@ -315,7 +319,8 @@ std::string WpanService::HandleDeletePrefixRequest(const std::string &aDeleteReq
         prefix += "/64";
     }
 
-    VerifyOrExit(client.Execute("prefix remove %s", prefix.c_str()) != nullptr, ret = kWpanStatus_SetGatewayFailed);
+    VerifyOrExit(client.Execute("prefix remove %s", escapeOtCliEscapable(prefix).c_str()) != nullptr,
+                 ret = kWpanStatus_SetGatewayFailed);
     VerifyOrExit(client.Execute("netdata register") != nullptr, ret = kWpanStatus_SetGatewayFailed);
 exit:
 
@@ -574,7 +579,8 @@ std::string WpanService::HandleCommission(const std::string &aCommissionRequest)
             }
             else if (strcmp(rval, "active") == 0)
             {
-                VerifyOrExit(client.Execute("commissioner joiner add * %s", pskd.c_str()) != nullptr,
+                VerifyOrExit(client.Execute("commissioner joiner add * %s", escapeOtCliEscapable(pskd).c_str()) !=
+                                 nullptr,
                              ret = kWpanStatus_Down);
                 root["error"] = ret;
                 ExitNow();
@@ -612,7 +618,8 @@ int WpanService::joinActiveDataset(otbr::Web::OpenThreadClient &aClient,
     int ret = kWpanStatus_Ok;
 
     VerifyOrExit(aClient.Execute("dataset clear") != nullptr, ret = kWpanStatus_SetFailed);
-    VerifyOrExit(aClient.Execute("dataset networkkey %s", aNetworkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(aClient.Execute("dataset networkkey %s", escapeOtCliEscapable(aNetworkKey).c_str()) != nullptr,
+                 ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset channel %u", aChannel) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset panid %u", aPanId) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset commit active") != nullptr, ret = kWpanStatus_SetFailed);
@@ -632,10 +639,12 @@ int WpanService::formActiveDataset(otbr::Web::OpenThreadClient &aClient,
     int ret = kWpanStatus_Ok;
 
     VerifyOrExit(aClient.Execute("dataset init new") != nullptr, ret = kWpanStatus_SetFailed);
-    VerifyOrExit(aClient.Execute("dataset networkkey %s", aNetworkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(aClient.Execute("dataset networkkey %s", escapeOtCliEscapable(aNetworkKey).c_str()) != nullptr,
+                 ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset networkname %s", escapeOtCliEscapable(aNetworkName).c_str()) != nullptr,
                  ret = kWpanStatus_SetFailed);
-    VerifyOrExit(aClient.Execute("dataset pskc %s", aPskc.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(aClient.Execute("dataset pskc %s", escapeOtCliEscapable(aPskc).c_str()) != nullptr,
+                 ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset channel %u", aChannel) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset extpanid %016" PRIx64, aExtPanId) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset panid %u", aPanId) != nullptr, ret = kWpanStatus_SetFailed);
@@ -653,10 +662,12 @@ std::string WpanService::escapeOtCliEscapable(const std::string &aArg)
     {
         switch (c)
         {
-        case ' ':
-        case '\t':
         case '\r':
         case '\n':
+            break;
+
+        case ' ':
+        case '\t':
         case '\\':
             strbuf.sputc('\\');
             // Fallthrough

--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -129,7 +129,8 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     else if (credentialType == CREDENTIAL_TYPE_PSKD)
     {
         VerifyOrExit(client.Execute("ifconfig up") != nullptr, ret = kWpanStatus_JoinFailed);
-        VerifyOrExit(client.Execute("joiner start %s", pskd.c_str()) != nullptr, ret = kWpanStatus_JoinFailed);
+        VerifyOrExit(client.Execute("joiner start %s", escapeOtCliEscapable(pskd).c_str()) != nullptr,
+                     ret = kWpanStatus_JoinFailed);
         VerifyOrExit((rval = client.Read("Join ", 5000)) != nullptr, ret = kWpanStatus_JoinFailed);
         if (strstr(rval, "Join success"))
         {
@@ -154,7 +155,8 @@ std::string WpanService::HandleJoinNetworkRequest(const std::string &aJoinReques
     }
 
     VerifyOrExit(client.Execute("thread start") != nullptr, ret = kWpanStatus_JoinFailed);
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetFailed);
 
 exit:
@@ -233,7 +235,8 @@ std::string WpanService::HandleFormNetworkRequest(const std::string &aFormReques
                  kWpanStatus_Ok);
     VerifyOrExit(client.Execute("ifconfig up") != nullptr, ret = kWpanStatus_FormFailed);
     VerifyOrExit(client.Execute("thread start") != nullptr, ret = kWpanStatus_FormFailed);
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetFailed);
 exit:
 
@@ -275,7 +278,8 @@ std::string WpanService::HandleAddPrefixRequest(const std::string &aAddPrefixReq
         prefix += "/64";
     }
 
-    VerifyOrExit(client.Execute("prefix add %s paso%s", prefix.c_str(), (defaultRoute ? "r" : "")) != nullptr,
+    VerifyOrExit(client.Execute("prefix add %s paso%s", escapeOtCliEscapable(prefix).c_str(),
+                                (defaultRoute ? "r" : "")) != nullptr,
                  ret = kWpanStatus_SetGatewayFailed);
     VerifyOrExit(client.Execute("netdata register") != nullptr, ret = kWpanStatus_SetGatewayFailed);
 exit:
@@ -315,7 +319,8 @@ std::string WpanService::HandleDeletePrefixRequest(const std::string &aDeleteReq
         prefix += "/64";
     }
 
-    VerifyOrExit(client.Execute("prefix remove %s", prefix.c_str()) != nullptr, ret = kWpanStatus_SetGatewayFailed);
+    VerifyOrExit(client.Execute("prefix remove %s", escapeOtCliEscapable(prefix).c_str()) != nullptr,
+                 ret = kWpanStatus_SetGatewayFailed);
     VerifyOrExit(client.Execute("netdata register") != nullptr, ret = kWpanStatus_SetGatewayFailed);
 exit:
 
@@ -574,7 +579,8 @@ std::string WpanService::HandleCommission(const std::string &aCommissionRequest)
             }
             else if (strcmp(rval, "active") == 0)
             {
-                VerifyOrExit(client.Execute("commissioner joiner add * %s", pskd.c_str()) != nullptr,
+                VerifyOrExit(client.Execute("commissioner joiner add * %s", escapeOtCliEscapable(pskd).c_str()) !=
+                                 nullptr,
                              ret = kWpanStatus_Down);
                 root["error"] = ret;
                 ExitNow();
@@ -612,7 +618,8 @@ int WpanService::joinActiveDataset(otbr::Web::OpenThreadClient &aClient,
     int ret = kWpanStatus_Ok;
 
     VerifyOrExit(aClient.Execute("dataset clear") != nullptr, ret = kWpanStatus_SetFailed);
-    VerifyOrExit(aClient.Execute("dataset networkkey %s", aNetworkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(aClient.Execute("dataset networkkey %s", escapeOtCliEscapable(aNetworkKey).c_str()) != nullptr,
+                 ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset channel %u", aChannel) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset panid %u", aPanId) != nullptr, ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset commit active") != nullptr, ret = kWpanStatus_SetFailed);
@@ -632,7 +639,8 @@ int WpanService::formActiveDataset(otbr::Web::OpenThreadClient &aClient,
     int ret = kWpanStatus_Ok;
 
     VerifyOrExit(aClient.Execute("dataset init new") != nullptr, ret = kWpanStatus_SetFailed);
-    VerifyOrExit(aClient.Execute("dataset networkkey %s", aNetworkKey.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
+    VerifyOrExit(aClient.Execute("dataset networkkey %s", escapeOtCliEscapable(aNetworkKey).c_str()) != nullptr,
+                 ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset networkname %s", escapeOtCliEscapable(aNetworkName).c_str()) != nullptr,
                  ret = kWpanStatus_SetFailed);
     VerifyOrExit(aClient.Execute("dataset pskc %s", aPskc.c_str()) != nullptr, ret = kWpanStatus_SetFailed);
@@ -655,8 +663,6 @@ std::string WpanService::escapeOtCliEscapable(const std::string &aArg)
         {
         case ' ':
         case '\t':
-        case '\r':
-        case '\n':
         case '\\':
             strbuf.sputc('\\');
             // Fallthrough

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -65,6 +65,8 @@
 namespace otbr {
 namespace Web {
 
+class WebServiceTest;
+
 /**
  * This class provides web service to manage WPAN.
  */
@@ -169,6 +171,8 @@ public:
     std::string CommissionDevice(const char *aPskd, const char *aNetworkPassword);
 
 private:
+    friend class WebServiceTest;
+
     int                formActiveDataset(otbr::Web::OpenThreadClient &aClient,
                                          const std::string           &aNetworkKey,
                                          const std::string           &aNetworkName,

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -56,6 +56,32 @@ target_link_libraries(otbr-gtest-unit
 )
 gtest_discover_tests(otbr-gtest-unit)
 
+if(OTBR_WEB)
+    pkg_check_modules(JSONCPP_GTEST jsoncpp REQUIRED)
+
+    add_executable(otbr-gtest-web
+        ${OTBR_PROJECT_DIRECTORY}/src/web/web-service/ot_client.cpp
+        ${OTBR_PROJECT_DIRECTORY}/src/web/web-service/wpan_service.cpp
+        test_web.cpp
+    )
+    target_include_directories(otbr-gtest-web
+        PRIVATE
+            ${JSONCPP_GTEST_INCLUDE_DIRS}
+    )
+    target_link_libraries(otbr-gtest-web
+        $<$<BOOL:${JSONCPP_GTEST_LIBRARY_DIRS}>:-L$<JOIN:${JSONCPP_GTEST_LIBRARY_DIRS}," -L">>
+        ${JSONCPP_GTEST_LIBRARIES}
+        otbr-common
+        otbr-utils
+        openthread-ftd
+        openthread-posix
+        mbedtls
+        pthread
+        GTest::gmock_main
+    )
+    gtest_discover_tests(otbr-gtest-web)
+endif()
+
 add_executable(otbr-gtest-unit-dnssd
     ${OTBR_PROJECT_DIRECTORY}/src/common/types.cpp
     ${OTBR_PROJECT_DIRECTORY}/src/common/logging.cpp

--- a/tests/gtest/test_web.cpp
+++ b/tests/gtest/test_web.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "web/web-service/ot_client.hpp"
+#include "web/web-service/wpan_service.hpp"
+
+namespace otbr {
+namespace Web {
+
+class WebServiceTest : public testing::Test
+{
+protected:
+    static void SetSocket(OpenThreadClient &aClient, int aSocket) { aClient.mSocket = aSocket; }
+
+    static std::string EscapeOtCliEscapable(const std::string &aArg) { return WpanService::escapeOtCliEscapable(aArg); }
+};
+
+TEST_F(WebServiceTest, ExecuteRejectsLineBreaks)
+{
+    int sockets[2];
+
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+
+    {
+        OpenThreadClient client("wpan0");
+
+        SetSocket(client, sockets[0]);
+        EXPECT_EQ(client.Execute("dataset networkname %s", "network\nreset"), nullptr);
+        EXPECT_EQ(client.Execute("dataset networkname %s", "network\rreset"), nullptr);
+        EXPECT_EQ(client.Execute("dataset networkname %s", "network\r\nreset"), nullptr);
+        EXPECT_EQ(client.Execute("dataset networkname %s", "\nnetwork"), nullptr);
+        EXPECT_EQ(client.Execute("dataset networkname %s", "network\n"), nullptr);
+    }
+
+    EXPECT_EQ(close(sockets[1]), 0);
+}
+
+TEST_F(WebServiceTest, EscapeOtCliEscapable)
+{
+    EXPECT_EQ(EscapeOtCliEscapable("alpha beta\tgamma\\delta\r\nepsilon"), "alpha\\ beta\\\tgamma\\\\delta\r\nepsilon");
+}
+
+} // namespace Web
+} // namespace otbr


### PR DESCRIPTION
User-controlled strings (pskd, prefix, networkKey, pskc) from the web interface are passed into OpenThreadClient::Execute(), which builds newline-framed commands for the OT daemon Unix socket. A raw CR or LF byte in any of these fields terminates the current command and starts a new one, allowing arbitrary OT CLI command injection.

## Summary

- Reject CR and LF characters before sending commands to the OpenThread daemon.
- Escape spaces, tabs, and backslashes in user-controlled CLI arguments.
- Keep generated PSKc values unchanged.
- Add tests for CR, LF, CRLF, leading and trailing newlines, and argument escaping.

## Testing

- `otbr-gtest-web`
