### PR TITLE
[rest] fix pendingTimestamp OpenAPI spec inaccuracy

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -2284,7 +2284,7 @@ components:
           oneOf:
             - $ref: "#/components/schemas/ActiveDataset"
             - $ref: "#/components/schemas/DatasetTlv"
-        PendingTimestamp:
+        pendingTimestamp:
           $ref: "#/components/schemas/Timestamp"
         delay:
           type: integer


### PR DESCRIPTION
The OpenAPI spec uses capitalized PendingTimestamp instead of pascalCase pendingTimestamp which the implementation uses. Adjust the OpenAPI spec accordingly.