### PR TITLE
[rest] use RFC 7807 "detail" key in error responses

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1118,7 +1118,7 @@ std::string ErrorDetails2JsonString(httplib::StatusCode aErrorCode,
 
     cJSON_AddItemToObject(error, "title", cJSON_CreateString(aErrorMessage.c_str()));
     cJSON_AddItemToObject(error, "status", cJSON_CreateNumber(static_cast<int16_t>(aErrorCode)));
-    cJSON_AddItemToObject(error, "details", cJSON_CreateString(aErrorDetails.c_str()));
+    cJSON_AddItemToObject(error, "detail", cJSON_CreateString(aErrorDetails.c_str()));
 
     ret = Json2String(error);
 


### PR DESCRIPTION
The OpenAPI spec declares error bodies follow RFC 7807 (openapi.yaml:2142) and defines the field as "detail" (singular), matching RFC 7807 §3.1. The serializer emitted "details" (plural), so spec-compliant clients silently missed error descriptions.