### PR TITLE
[host] set OpenThread log level after `otInstance` initialization

### DIFF
--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -227,8 +227,14 @@ otbrLogLevel ConvertProtoToOtbrLogLevel(ProtoLogLevel aProtoLogLevel)
 otError RcpHost::SetOtbrAndOtLogLevel(otbrLogLevel aLevel)
 {
     otError error = OT_ERROR_NONE;
+
     otbrLogSetLevel(aLevel);
-    error = otLoggingSetLevel(ConvertToOtLogLevel(aLevel));
+
+    if (GetInstance() != nullptr)
+    {
+        error = otSetLogLevel(GetInstance(), ConvertToOtLogLevel(aLevel));
+    }
+
     return error;
 }
 
@@ -241,10 +247,10 @@ void RcpHost::Init(void)
     FeatureFlagList featureFlagList;
 #endif
 
-    VerifyOrExit(otLoggingSetLevel(level) == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
-
     mInstance = otSysInit(&mConfig);
     assert(mInstance != nullptr);
+
+    VerifyOrExit(otSetLogLevel(mInstance, level) == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
 
     {
         otError result = otSetStateChangedCallback(mInstance, &RcpHost::HandleStateChanged, this);
@@ -954,10 +960,17 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
     va_end(ap);
 }
 
+extern "C" void otPlatLogHandleLogLevelChanged(otInstance *aInstance, otLogLevel aLogLevel)
+{
+    OTBR_UNUSED_VARIABLE(aInstance);
+
+    otbrLogSetLevel(RcpHost::ConvertToOtbrLogLevel(aLogLevel));
+    otbrLogInfo("OpenThread log level changed to %d", aLogLevel);
+}
+
 extern "C" void otPlatLogHandleLevelChanged(otLogLevel aLogLevel)
 {
     otbrLogSetLevel(RcpHost::ConvertToOtbrLogLevel(aLogLevel));
-    otbrLogInfo("OpenThread log level changed to %d", aLogLevel);
 }
 
 } // namespace Host

--- a/src/host/thread_host.cpp
+++ b/src/host/thread_host.cpp
@@ -50,7 +50,6 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
     CoprocessorType             coprocessorType;
     otPlatformCoprocessorUrls   urls;
     std::unique_ptr<ThreadHost> host;
-    otLogLevel                  level = ConvertToOtLogLevel(otbrLogGetLevel());
 
     VerifyOrDie(aRadioUrls.size() <= OT_PLATFORM_CONFIG_MAX_RADIO_URLS, "Too many Radio URLs!");
 
@@ -59,8 +58,6 @@ std::unique_ptr<ThreadHost> ThreadHost::Create(const char                      *
     {
         urls.mUrls[urls.mNum++] = url;
     }
-
-    VerifyOrDie(otLoggingSetLevel(level) == OT_ERROR_NONE, "Failed to set OT log Level!");
 
     coprocessorType = otSysInitCoprocessor(&urls);
 


### PR DESCRIPTION
The OpenThread logging API is enhanced to also provide a per-instance `otSetLogLevel()` API. This commit updates the `RcpHost` to use the new API and also ensure to set the log level when (and only after) the `otInstance` is initialized. Additionally, the platform log level change callback is updated to also support the new callback `otPlatLogHandleLogLevelChanged()`.