### PR TITLE
[web] report error and exit when web server fails to start

### DIFF
--- a/src/web/main.cpp
+++ b/src/web/main.cpp
@@ -143,7 +143,10 @@ int main(int argc, char **argv)
     signal(SIGINT, HandleSignal);
 
     sServer.reset(new otbr::Web::WebServer());
-    sServer->StartWebServer(interfaceName, httpListenAddr, port);
+    if (sServer->StartWebServer(interfaceName, httpListenAddr, port) != OTBR_ERROR_NONE)
+    {
+        ret = -1;
+    }
 
     otbrLogDeinit();
 

--- a/src/web/web-service/web_server.cpp
+++ b/src/web/web-service/web_server.cpp
@@ -35,6 +35,9 @@
 
 #include "web/web-service/web_server.hpp"
 
+#include <errno.h>
+#include <string.h>
+
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
 
@@ -82,7 +85,7 @@ void WebServer::Init()
     }
 }
 
-void WebServer::StartWebServer(const char *aIfName, const char *aListenAddr, uint16_t aPort)
+otbrError WebServer::StartWebServer(const char *aIfName, const char *aListenAddr, uint16_t aPort)
 {
     mWpanService.SetInterfaceName(aIfName);
     Init();
@@ -96,7 +99,14 @@ void WebServer::StartWebServer(const char *aIfName, const char *aListenAddr, uin
     ResponseCommission();
     mServer.set_mount_point("/", WEB_FILE_PATH);
 
-    mServer.listen(aListenAddr, aPort);
+    if (!mServer.listen(aListenAddr, aPort))
+    {
+        otbrLogCrit("Failed to start web server on %s:%d: %s (errno %d)", aListenAddr != nullptr ? aListenAddr : "*",
+                    aPort, strerror(errno), errno);
+        return OTBR_ERROR_ERRNO;
+    }
+
+    return OTBR_ERROR_NONE;
 }
 
 void WebServer::StopWebServer(void)

--- a/src/web/web-service/web_server.hpp
+++ b/src/web/web-service/web_server.hpp
@@ -68,8 +68,11 @@ public:
      * @param[in] aIfName      The pointer to the Thread interface name.
      * @param[in] aListenAddr  The http server listen address, can be nullptr for any address.
      * @param[in] aPort        The port of http server.
+     *
+     * @retval OTBR_ERROR_NONE  Successfully started the Web Server.
+     * @retval OTBR_ERROR_ERRNO Failed to start the Web Server.
      */
-    void StartWebServer(const char *aIfName, const char *aListenAddr, uint16_t aPort);
+    otbrError StartWebServer(const char *aIfName, const char *aListenAddr, uint16_t aPort);
 
     /**
      * This method stops the Web Server.


### PR DESCRIPTION
When otbr-web fails to start because the port is already in use, it previously logged a success message and then silently exited with code 0. This led to restart loops in container environments without clear error indication.

This change modifies WebServer::StartWebServer to check the return value of httplib::Server::listen(). If it fails, a critical error is logged including the system error message (e.g., 'Address already in use'), and an error code is returned. main.cpp is updated to check this return value and exit with a non-zero code on failure.

Fixes: https://github.com/openthread/ot-br-posix/issues/3278