### PR TITLE
This commit adds TREL support for NCP intrastructure.

### DIFF
--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -37,6 +37,8 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+#include <openthread/error.h>
+
 #include "agent/application.hpp"
 #include "common/code_utils.hpp"
 #include "common/mainloop_manager.hpp"
@@ -74,6 +76,9 @@ Application::Application(Host::ThreadHost  &aHost,
 #if OTBR_ENABLE_EPSKC
     , mEphemeralKeyUdpProxy(mHost)
 #endif
+#endif
+#if OTBR_ENABLE_TREL
+    , mTrelUdpProxy(mHost)
 #endif
 #if OTBR_ENABLE_DBUS_SERVER
     , mDBusAgent(MakeDBusDependentComponents())
@@ -387,7 +392,7 @@ void Application::InitNcpMode(void)
     }
     ncpHost.InitInfraIfCallbacks(*mInfraIf);
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
     mMdnsStateSubject.AddObserver(ncpHost);
 #endif
 #if OTBR_ENABLE_BORDER_AGENT && OTBR_ENABLE_BORDER_AGENT_MESHCOP_SERVICE
@@ -420,19 +425,6 @@ void Application::InitNcpMode(void)
             OTBR_UNUSED_VARIABLE(aLength);
 #endif
         });
-    mHost.SetUdpForwardToHostCallback([this](const uint8_t *aUdpPayload, uint16_t aLength,
-                                             const otIp6Address &aPeerAddr, uint16_t aPeerPort, uint16_t aLocalPort) {
-        if (aLocalPort == mBorderAgentUdpProxy.GetThreadPort())
-        {
-            mBorderAgentUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
-        }
-#if OTBR_ENABLE_EPSKC
-        else if (aLocalPort == mEphemeralKeyUdpProxy.GetThreadPort())
-        {
-            mEphemeralKeyUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
-        }
-#endif // OTBR_ENABLE_EPSKC
-    });
 #if OTBR_ENABLE_EPSKC
     mHost.AddEphemeralKeyStateChangedCallback([this](otBorderAgentEphemeralKeyState aState, uint16_t aPort) {
         if (aState == OT_BORDER_AGENT_STATE_STARTED)
@@ -452,6 +444,55 @@ void Application::InitNcpMode(void)
 #endif // OTBR_ENABLE_EPSKC
     SetBorderAgentOnInitState();
 #endif
+#if OTBR_ENABLE_BORDER_AGENT || OTBR_ENABLE_TREL
+    mHost.SetUdpForwardToHostCallback([this](const uint8_t *aUdpPayload, uint16_t aLength,
+                                             const otIp6Address &aPeerAddr, uint16_t aPeerPort, uint16_t aLocalPort) {
+#if OTBR_ENABLE_BORDER_AGENT
+        if (aLocalPort == mBorderAgentUdpProxy.GetThreadPort())
+        {
+            mBorderAgentUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
+            return;
+        }
+#if OTBR_ENABLE_EPSKC
+        if (aLocalPort == mEphemeralKeyUdpProxy.GetThreadPort())
+        {
+            mEphemeralKeyUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
+            return;
+        }
+#endif
+#endif
+#if OTBR_ENABLE_TREL
+        if (aLocalPort == mTrelUdpProxy.GetThreadPort())
+        {
+            mTrelUdpProxy.SendToPeer(aUdpPayload, aLength, aPeerAddr, aPeerPort);
+        }
+#endif
+    });
+#endif
+#if OTBR_ENABLE_TREL
+    ncpHost.SetTrelStateChangedCallback([this, &ncpHost](bool aEnabled, uint16_t aThreadPort) {
+        if (!aEnabled || aThreadPort == 0)
+        {
+            otbrLogInfo(
+                "TREL state from NCP: disabled or no thread port (enabled=%s threadPort=%u), stopping UDP proxy",
+                aEnabled ? "true" : "false", aThreadPort);
+            mTrelUdpProxy.Stop();
+            return;
+        }
+        otbrLogInfo("TREL state from NCP: enabled, threadPort=%u — starting UDP proxy and reporting host port to NCP",
+                    aThreadPort);
+        mTrelUdpProxy.Start(aThreadPort);
+        otError err = ncpHost.SetTrelHostUdpPort(true, mTrelUdpProxy.GetHostPort());
+        if (err != OT_ERROR_NONE)
+        {
+            otbrLogWarning("Failed reporting TREL host UDP port to NCP: %s", otThreadErrorToString(err));
+        }
+        else
+        {
+            otbrLogInfo("Reported TREL host UDP port %u to NCP", mTrelUdpProxy.GetHostPort());
+        }
+    });
+#endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mHost.SetBackboneRouterStateChangedCallback(
         [this](otBackboneRouterState aState) { mMulticastRoutingManager->HandleStateChange(aState); });
@@ -465,6 +506,10 @@ void Application::InitNcpMode(void)
 #endif
 
 #if OTBR_ENABLE_DNSSD_PLAT
+    mDnssdPlatform.SetDnssdStateChangedCallback([&ncpHost](otPlatDnssdState aState) {
+        otbrLogInfo("DnssdPlatform -> NCP: otPlatDnssdState=%s", (aState == OT_PLAT_DNSSD_READY) ? "READY" : "STOPPED");
+        ncpHost.NotifyDnssdPlatformStateToNcp(aState);
+    });
     mDnssdPlatform.Start();
 #endif
 }
@@ -476,7 +521,13 @@ void Application::DeinitNcpMode(void)
     mBorderAgent.Deinit();
     mBorderAgentUdpProxy.Stop();
 #endif
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_TREL
+    mTrelUdpProxy.Stop();
+#endif
+#if OTBR_ENABLE_DNSSD_PLAT
+    mDnssdPlatform.Stop();
+#endif
+#if OTBR_ENABLE_MDNS
     mPublisher->Stop();
 #endif
     mNetif->Deinit();

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -291,6 +291,9 @@ private:
 #endif
 
 #endif
+#if OTBR_ENABLE_TREL
+    UdpProxy mTrelUdpProxy;
+#endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     std::unique_ptr<BackboneRouter::BackboneAgent> mBackboneAgent;
     std::unique_ptr<MulticastRoutingManager>       mMulticastRoutingManager;

--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -393,10 +393,33 @@ void NcpHost::SetMdnsPublisher(Mdns::Publisher *aPublisher)
 }
 #endif
 
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
 void NcpHost::HandleMdnsState(Mdns::Publisher::State aState)
 {
     mNcpSpinel.DnssdSetState(aState);
+}
+#endif
+
+#if OTBR_ENABLE_DNSSD_PLAT
+void NcpHost::NotifyDnssdPlatformStateToNcp(otPlatDnssdState aState)
+{
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
+    Mdns::Publisher::State mdnsState =
+        (aState == OT_PLAT_DNSSD_READY) ? Mdns::Publisher::State::kReady : Mdns::Publisher::State::kIdle;
+    mNcpSpinel.DnssdSetState(mdnsState);
+#endif
+}
+#endif
+
+#if OTBR_ENABLE_TREL
+void NcpHost::SetTrelStateChangedCallback(NcpSpinel::TrelStateChangedCallback aCallback)
+{
+    mNcpSpinel.SetTrelStateChangedCallback(aCallback);
+}
+
+otError NcpHost::SetTrelHostUdpPort(bool aEnabled, uint16_t aHostPort)
+{
+    return mNcpSpinel.SetTrelHostUdpPort(aEnabled, aHostPort);
 }
 #endif
 

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -34,6 +34,8 @@
 #ifndef OTBR_AGENT_NCP_HOST_HPP_
 #define OTBR_AGENT_NCP_HOST_HPP_
 
+#include <openthread/platform/dnssd.h>
+
 #include "lib/spinel/coprocessor_type.h"
 #include "lib/spinel/spinel_driver.hpp"
 
@@ -82,7 +84,7 @@ class NcpHost : public MainloopProcessor,
                 public NcpNetworkProperties,
                 public Netif::Dependencies,
                 public InfraIf::Dependencies
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
     ,
                 public Mdns::StateObserver
 #endif
@@ -151,6 +153,14 @@ public:
     void SetMdnsPublisher(Mdns::Publisher *aPublisher);
 #endif
 
+#if OTBR_ENABLE_DNSSD_PLAT
+    void NotifyDnssdPlatformStateToNcp(otPlatDnssdState aState);
+#endif
+#if OTBR_ENABLE_TREL
+    void    SetTrelStateChangedCallback(NcpSpinel::TrelStateChangedCallback aCallback);
+    otError SetTrelHostUdpPort(bool aEnabled, uint16_t aHostPort);
+#endif
+
     void InitNetifCallbacks(Netif &aNetif);
     void InitInfraIfCallbacks(InfraIf &aInfraIf);
     void SetHostPowerState(uint8_t aPowerState, const AsyncResultReceiver &aReceiver);
@@ -165,7 +175,7 @@ public:
 #endif
 
 private:
-#if OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
     void HandleMdnsState(Mdns::Publisher::State aState) override;
 #endif
     otbrError UdpForward(const uint8_t      *aUdpPayload,

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -274,6 +274,9 @@ void NcpSpinel::SrpServerSetEnabled(bool aEnabled)
     }
 }
 
+#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
 void NcpSpinel::DnssdSetState(Mdns::Publisher::State aState)
 {
     otError          error;
@@ -286,7 +289,44 @@ void NcpSpinel::DnssdSetState(Mdns::Publisher::State aState)
         otbrLogWarning("Failed to call DnssdSetState, %s", otThreadErrorToString(error));
     }
 }
-#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#endif
+
+#if OTBR_ENABLE_TREL
+void NcpSpinel::SetTrelStateChangedCallback(const TrelStateChangedCallback &aCallback)
+{
+    mTrelStateChangedCallback = aCallback;
+
+    otbrLogInfo("SetTrelStateChangedCallback: setting initial SPINEL_PROP_TREL_USER_ENABLE");
+    if (SetProperty(SPINEL_PROP_TREL_USER_ENABLE,
+                    [](ot::Spinel::Encoder &aEncoder) { return aEncoder.WriteBool(true); }) != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to set TREL user enable on NCP");
+    }
+}
+
+otError NcpSpinel::SetTrelHostUdpPort(bool aEnabled, uint16_t aHostPort)
+{
+    otError      error        = OT_ERROR_NONE;
+    EncodingFunc encodingFunc = [aEnabled, aHostPort](ot::Spinel::Encoder &aEncoder) {
+        otError encErr = OT_ERROR_NONE;
+        SuccessOrExit(encErr = aEncoder.WriteBool(aEnabled));
+        SuccessOrExit(encErr = aEncoder.WriteUint16(aHostPort));
+    exit:
+        return encErr;
+    };
+
+    otbrLogInfo("SetTrelHostUdpPort: enabled=%s hostUdpPort=%u -> SPINEL_PROP_TREL_STATE SET",
+                aEnabled ? "true" : "false", aHostPort);
+
+    error = SetProperty(SPINEL_PROP_TREL_STATE, encodingFunc);
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to set TREL host UDP port on NCP, %s", otThreadErrorToString(error));
+    }
+
+    return error;
+}
+#endif
 
 void NcpSpinel::SetBorderAgentMeshCoPServiceChangedCallback(const BorderAgentMeshCoPServiceChangedCallback &aCallback)
 {
@@ -614,13 +654,30 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
         break;
     }
 
+#if OTBR_ENABLE_TREL
+    case SPINEL_PROP_TREL_STATE:
+    {
+        bool                enabled;
+        uint16_t            port;
+        ot::Spinel::Decoder decoder;
+
+        decoder.Init(aBuffer, aLength);
+        SuccessOrExit(decoder.ReadBool(enabled), error = OTBR_ERROR_PARSE);
+        SuccessOrExit(decoder.ReadUint16(port), error = OTBR_ERROR_PARSE);
+        otbrLogInfo("HandleValueIs: SPINEL_PROP_TREL_STATE enabled=%s threadUdpPort=%u (notification)",
+                    enabled ? "true" : "false", port);
+        SafeInvoke(mTrelStateChangedCallback, enabled, port);
+        break;
+    }
+#endif
+
     default:
         otbrLogWarning("Received unrecognized key: %u", aKey);
         break;
     }
 
 exit:
-    otbrLogResult(error, "%s, Property:%s", __FUNCTION__, spinel_prop_key_to_cstr(aKey));
+    otbrLogResult(error, "%s, key: %u, Property:%s", __FUNCTION__, aKey, spinel_prop_key_to_cstr(aKey));
     return;
 }
 
@@ -734,7 +791,81 @@ void NcpSpinel::HandleValueInserted(spinel_prop_key_t aKey, const uint8_t *aBuff
                                                      [this, callbackDataCopy](const otPlatDnssdBrowseResult &aResult) {
                                                          SendDnssdBrowseResult(aResult, callbackDataCopy);
                                                      },
-                                                     mDiscoveryProxyId++));
+                                                     AllocateDnssdStableId(callbackDataCopy)));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_SRV_RESOLVER:
+    {
+        otPlatDnssdSrvResolver srvResolver;
+        const uint8_t         *callbackData;
+        uint16_t               callbackDataSize;
+        std::vector<uint8_t>   callbackDataCopy;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdSrvResolver(decoder, srvResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        DnssdPlatform::Get().StartServiceResolver(srvResolver,
+                                                  std::make_shared<DnssdPlatform::StdSrvCallback>(
+                                                      [this, callbackDataCopy](const otPlatDnssdSrvResult &aResult) {
+                                                          SendDnssdSrvResult(aResult, callbackDataCopy);
+                                                      },
+                                                      AllocateDnssdStableId(callbackDataCopy)));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_TXT_RESOLVER:
+    {
+        otPlatDnssdTxtResolver txtResolver;
+        const uint8_t         *callbackData;
+        uint16_t               callbackDataSize;
+        std::vector<uint8_t>   callbackDataCopy;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdTxtResolver(decoder, txtResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        DnssdPlatform::Get().StartTxtResolver(txtResolver,
+                                              std::make_shared<DnssdPlatform::StdTxtCallback>(
+                                                  [this, callbackDataCopy](const otPlatDnssdTxtResult &aResult) {
+                                                      SendDnssdTxtResult(aResult, callbackDataCopy);
+                                                  },
+                                                  AllocateDnssdStableId(callbackDataCopy)));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_IP6_ADDRESS_RESOLVER:
+    {
+        otPlatDnssdAddressResolver addrResolver;
+        const uint8_t             *callbackData;
+        uint16_t                   callbackDataSize;
+        std::vector<uint8_t>       callbackDataCopy;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdAddressResolver(decoder, addrResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        DnssdPlatform::Get().StartIp6AddressResolver(
+            addrResolver, std::make_shared<DnssdPlatform::StdAddressCallback>(
+                              [this, callbackDataCopy](const otPlatDnssdAddressResult &aResult) {
+                                  SendDnssdAddressResult(SPINEL_PROP_DNSSD_IP6_ADDRESS_RESULT, aResult,
+                                                         callbackDataCopy);
+                              },
+                              AllocateDnssdStableId(callbackDataCopy)));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_IP4_ADDRESS_RESOLVER:
+    {
+        otPlatDnssdAddressResolver addrResolver;
+        const uint8_t             *callbackData;
+        uint16_t                   callbackDataSize;
+        std::vector<uint8_t>       callbackDataCopy;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdAddressResolver(decoder, addrResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        DnssdPlatform::Get().StartIp4AddressResolver(
+            addrResolver, std::make_shared<DnssdPlatform::StdAddressCallback>(
+                              [this, callbackDataCopy](const otPlatDnssdAddressResult &aResult) {
+                                  SendDnssdAddressResult(SPINEL_PROP_DNSSD_IP4_ADDRESS_RESULT, aResult,
+                                                         callbackDataCopy);
+                              },
+                              AllocateDnssdStableId(callbackDataCopy)));
         break;
     }
 #endif // OTBR_ENABLE_DNSSD_PLAT
@@ -799,7 +930,7 @@ void NcpSpinel::HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffe
         callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
 
         mPublisher->UnpublishService(
-            service.mHostName, service.mServiceType, [this, requestId, callbackDataCopy](otbrError aError) {
+            service.mServiceInstance, service.mServiceType, [this, requestId, callbackDataCopy](otbrError aError) {
                 OT_UNUSED_VARIABLE(SendDnssdResult(requestId, callbackDataCopy, OtbrErrorToOtError(aError)));
             });
         break;
@@ -821,6 +952,100 @@ void NcpSpinel::HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffe
         break;
     }
 #endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#if OTBR_ENABLE_DNSSD_PLAT
+    case SPINEL_PROP_DNSSD_BROWSER:
+    {
+        otPlatDnssdBrowser   browser;
+        const uint8_t       *callbackData;
+        uint16_t             callbackDataSize;
+        std::vector<uint8_t> callbackDataCopy;
+        uint64_t             stableId;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdBrowser(decoder, browser, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        VerifyOrExit(ReleaseDnssdStableId(callbackDataCopy, stableId), error = OTBR_ERROR_NOT_FOUND);
+
+        DnssdPlatform::Get().StopServiceBrowser(
+            browser, DnssdPlatform::StdBrowseCallback(
+                         [](const DnssdPlatform::BrowseResult &aResult) { OT_UNUSED_VARIABLE(aResult); }, stableId));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_SRV_RESOLVER:
+    {
+        otPlatDnssdSrvResolver srvResolver;
+        const uint8_t         *callbackData;
+        uint16_t               callbackDataSize;
+        std::vector<uint8_t>   callbackDataCopy;
+        uint64_t               stableId;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdSrvResolver(decoder, srvResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        VerifyOrExit(ReleaseDnssdStableId(callbackDataCopy, stableId), error = OTBR_ERROR_NOT_FOUND);
+
+        DnssdPlatform::Get().StopServiceResolver(
+            srvResolver, DnssdPlatform::StdSrvCallback(
+                             [](const DnssdPlatform::SrvResult &aResult) { OT_UNUSED_VARIABLE(aResult); }, stableId));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_TXT_RESOLVER:
+    {
+        otPlatDnssdTxtResolver txtResolver;
+        const uint8_t         *callbackData;
+        uint16_t               callbackDataSize;
+        std::vector<uint8_t>   callbackDataCopy;
+        uint64_t               stableId;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdTxtResolver(decoder, txtResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        VerifyOrExit(ReleaseDnssdStableId(callbackDataCopy, stableId), error = OTBR_ERROR_NOT_FOUND);
+
+        DnssdPlatform::Get().StopTxtResolver(
+            txtResolver, DnssdPlatform::StdTxtCallback(
+                             [](const DnssdPlatform::TxtResult &aResult) { OT_UNUSED_VARIABLE(aResult); }, stableId));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_IP6_ADDRESS_RESOLVER:
+    {
+        otPlatDnssdAddressResolver addrResolver;
+        const uint8_t             *callbackData;
+        uint16_t                   callbackDataSize;
+        std::vector<uint8_t>       callbackDataCopy;
+        uint64_t                   stableId;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdAddressResolver(decoder, addrResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        VerifyOrExit(ReleaseDnssdStableId(callbackDataCopy, stableId), error = OTBR_ERROR_NOT_FOUND);
+
+        DnssdPlatform::Get().StopIp6AddressResolver(
+            addrResolver,
+            DnssdPlatform::StdAddressCallback(
+                [](const DnssdPlatform::AddressResult &aResult) { OT_UNUSED_VARIABLE(aResult); }, stableId));
+        break;
+    }
+    case SPINEL_PROP_DNSSD_IP4_ADDRESS_RESOLVER:
+    {
+        otPlatDnssdAddressResolver addrResolver;
+        const uint8_t             *callbackData;
+        uint16_t                   callbackDataSize;
+        std::vector<uint8_t>       callbackDataCopy;
+        uint64_t                   stableId;
+
+        SuccessOrExit(ot::Spinel::DecodeDnssdAddressResolver(decoder, addrResolver, callbackData, callbackDataSize));
+        callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
+
+        VerifyOrExit(ReleaseDnssdStableId(callbackDataCopy, stableId), error = OTBR_ERROR_NOT_FOUND);
+
+        DnssdPlatform::Get().StopIp4AddressResolver(
+            addrResolver,
+            DnssdPlatform::StdAddressCallback(
+                [](const DnssdPlatform::AddressResult &aResult) { OT_UNUSED_VARIABLE(aResult); }, stableId));
+        break;
+    }
+#endif // OTBR_ENABLE_DNSSD_PLAT
     case SPINEL_PROP_BACKBONE_ROUTER_MULTICAST_LISTENER:
     {
         const otIp6Address *addr;
@@ -865,6 +1090,22 @@ otbrError NcpSpinel::HandleResponseForPropGet(spinel_tid_t      aTid,
         SafeInvoke(mBorderAgentMeshCoPServiceChangedCallback, isActive, port, data, dataLen);
         break;
     }
+#if OTBR_ENABLE_TREL
+    case SPINEL_PROP_TREL_STATE:
+    {
+        bool                enabled;
+        uint16_t            port;
+        ot::Spinel::Decoder decoder;
+
+        decoder.Init(aData, aLength);
+        SuccessOrExit(decoder.ReadBool(enabled), error = OTBR_ERROR_PARSE);
+        SuccessOrExit(decoder.ReadUint16(port), error = OTBR_ERROR_PARSE);
+        otbrLogInfo("HandleResponseForPropGet: SPINEL_PROP_TREL_STATE enabled=%s threadUdpPort=%u (GET response)",
+                    enabled ? "true" : "false", port);
+        SafeInvoke(mTrelStateChangedCallback, enabled, port);
+        break;
+    }
+#endif
 
     default:
         VerifyOrExit(aKey == mWaitingKeyTable[aTid], error = OTBR_ERROR_INVALID_STATE);
@@ -1359,6 +1600,80 @@ otError NcpSpinel::SendDnssdBrowseResult(const otPlatDnssdBrowseResult &aResult,
     }
 
     return error;
+}
+
+otError NcpSpinel::SendDnssdSrvResult(const otPlatDnssdSrvResult &aResult, const std::vector<uint8_t> &aCallbackData)
+{
+    otError      error        = OT_ERROR_NONE;
+    EncodingFunc encodingFunc = [&aResult, &aCallbackData](ot::Spinel::Encoder &aEncoder) {
+        return EncodeDnssdSrvResult(aEncoder, aResult, aCallbackData.data(), aCallbackData.size());
+    };
+
+    error = SetProperty(SPINEL_PROP_DNSSD_SRV_RESULT, encodingFunc);
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to send DnssdSrvResult: %s", otThreadErrorToString(error));
+    }
+
+    return error;
+}
+
+otError NcpSpinel::SendDnssdTxtResult(const otPlatDnssdTxtResult &aResult, const std::vector<uint8_t> &aCallbackData)
+{
+    otError      error        = OT_ERROR_NONE;
+    EncodingFunc encodingFunc = [&aResult, &aCallbackData](ot::Spinel::Encoder &aEncoder) {
+        return EncodeDnssdTxtResult(aEncoder, aResult, aCallbackData.data(), aCallbackData.size());
+    };
+
+    error = SetProperty(SPINEL_PROP_DNSSD_TXT_RESULT, encodingFunc);
+
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to send DnssdTxtResult: %s", otThreadErrorToString(error));
+    }
+
+    return error;
+}
+
+otError NcpSpinel::SendDnssdAddressResult(spinel_prop_key_t               aKey,
+                                          const otPlatDnssdAddressResult &aResult,
+                                          const std::vector<uint8_t>     &aCallbackData)
+{
+    otError      error        = OT_ERROR_NONE;
+    EncodingFunc encodingFunc = [&aResult, &aCallbackData](ot::Spinel::Encoder &aEncoder) {
+        return EncodeDnssdAddressResult(aEncoder, aResult, aCallbackData.data(), aCallbackData.size());
+    };
+
+    error = SetProperty(aKey, encodingFunc);
+
+    if (error != OT_ERROR_NONE)
+    {
+        otbrLogWarning("Failed to send DnssdAddressResult: %s", otThreadErrorToString(error));
+    }
+
+    return error;
+}
+
+uint64_t NcpSpinel::AllocateDnssdStableId(const std::vector<uint8_t> &aCallbackData)
+{
+    uint64_t id = mDiscoveryProxyId++;
+
+    mDnssdStableIdByCallbackData[aCallbackData] = id;
+    return id;
+}
+
+bool NcpSpinel::ReleaseDnssdStableId(const std::vector<uint8_t> &aCallbackData, uint64_t &aStableIdOut)
+{
+    auto iter = mDnssdStableIdByCallbackData.find(aCallbackData);
+
+    if (iter == mDnssdStableIdByCallbackData.end())
+    {
+        return false;
+    }
+
+    aStableIdOut = iter->second;
+    mDnssdStableIdByCallbackData.erase(iter);
+    return true;
 }
 #endif
 

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -35,9 +35,12 @@
 #define OTBR_AGENT_NCP_SPINEL_HPP_
 
 #include <functional>
+#include <map>
 #include <memory>
 
 #include <vector>
+
+#include "openthread-br/config.h"
 
 #include <openthread/backbone_router_ftd.h>
 #include <openthread/border_agent.h>
@@ -347,13 +350,16 @@ public:
      */
     void SrpServerSetAutoEnableMode(bool aEnabled);
 
+#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+
+#if OTBR_ENABLE_MDNS && (OTBR_ENABLE_SRP_ADVERTISING_PROXY || OTBR_ENABLE_DNSSD_PLAT)
     /**
      * This method sets the dnssd state on NCP.
      *
      * @param[in] aState  The dnssd state.
      */
     void DnssdSetState(Mdns::Publisher::State aState);
-#endif // OTBR_ENABLE_SRP_ADVERTISING_PROXY
+#endif
 
 #if OTBR_ENABLE_MDNS
     /**
@@ -379,6 +385,18 @@ public:
      * @param[in] aCallback  The callback function.
      */
     void AddEphemeralKeyStateChangedCallback(const EphemeralKeyStateChangedCallback &aCallback);
+
+#if OTBR_ENABLE_TREL
+    /**
+     * Invoked when the NCP signals TREL state (`SPINEL_PROP_TREL_STATE`): `aThreadPort` is the UDP port on the
+     * NCP/Thread side to associate with the host UDP proxy.
+     */
+    using TrelStateChangedCallback = std::function<void(bool aEnabled, uint16_t aThreadPort)>;
+
+    void SetTrelStateChangedCallback(const TrelStateChangedCallback &aCallback);
+
+    otError SetTrelHostUdpPort(bool aEnabled, uint16_t aHostPort);
+#endif
 
     /**
      * This method forwards a UDP packet to the NCP.
@@ -582,7 +600,14 @@ private:
                                   uint16_t            &aLocalPort);
     otError SendDnssdResult(otPlatDnssdRequestId aRequestId, const std::vector<uint8_t> &aCallbackData, otError aError);
 #if OTBR_ENABLE_DNSSD_PLAT
-    otError SendDnssdBrowseResult(const otPlatDnssdBrowseResult &aResult, const std::vector<uint8_t> &aCallbackData);
+    otError  SendDnssdBrowseResult(const otPlatDnssdBrowseResult &aResult, const std::vector<uint8_t> &aCallbackData);
+    otError  SendDnssdSrvResult(const otPlatDnssdSrvResult &aResult, const std::vector<uint8_t> &aCallbackData);
+    otError  SendDnssdTxtResult(const otPlatDnssdTxtResult &aResult, const std::vector<uint8_t> &aCallbackData);
+    otError  SendDnssdAddressResult(spinel_prop_key_t               aKey,
+                                    const otPlatDnssdAddressResult &aResult,
+                                    const std::vector<uint8_t>     &aCallbackData);
+    uint64_t AllocateDnssdStableId(const std::vector<uint8_t> &aCallbackData);
+    bool     ReleaseDnssdStableId(const std::vector<uint8_t> &aCallbackData, uint64_t &aStableIdOut);
 #endif
 
     ot::Spinel::SpinelDriver *mSpinelDriver;
@@ -606,7 +631,8 @@ private:
     otbr::Mdns::Publisher *mPublisher;
 #endif
 #if OTBR_ENABLE_DNSSD_PLAT
-    uint64_t mDiscoveryProxyId;
+    uint64_t                                 mDiscoveryProxyId;
+    std::map<std::vector<uint8_t>, uint64_t> mDnssdStableIdByCallbackData;
 #endif
 
     AsyncTaskPtr mDatasetSetActiveTask;
@@ -629,6 +655,9 @@ private:
     BackboneRouterStateChangedCallback       mBackboneRouterStateChangedCallback;
     BackboneRouterMulticastListenerCallback  mBackboneRouterMulticastListenerCallback;
     EphemeralKeyStateChangedCallback         mEphemeralKeyStateChangedCallback;
+#if OTBR_ENABLE_TREL
+    TrelStateChangedCallback mTrelStateChangedCallback;
+#endif
 };
 
 } // namespace Host

--- a/src/host/posix/dnssd.hpp
+++ b/src/host/posix/dnssd.hpp
@@ -343,13 +343,48 @@ private:
 
         bool IsEmpty(void) { return mEntries.empty(); }
 
+        /**
+         * Returns how many registered callbacks should receive results for @p aReportedInfraIfIndex.
+         * A registered index of 0 matches any reported index (NCP may use 0 before infra-if is known).
+         */
+        size_t GetMatchCountForInfraIf(uint64_t aReportedInfraIfIndex) const
+        {
+            size_t n = 0;
+
+            for (const auto &entry : mEntries)
+            {
+                if (InfraIfIndexMatches(entry.first, aReportedInfraIfIndex))
+                {
+                    n++;
+                }
+            }
+            return n;
+        }
+
+        /** Comma-separated registered `mInfraIfIndex` values (0 means wildcard for matching; see
+         * `InfraIfIndexMatches`). */
+        std::string ListRegisteredInfraIfIndices(void) const
+        {
+            std::string s;
+
+            for (const auto &entry : mEntries)
+            {
+                if (!s.empty())
+                {
+                    s += ",";
+                }
+                s += std::to_string(entry.first);
+            }
+            return s.empty() ? std::string("(none)") : s;
+        }
+
         void InvokeAllCallbacks(uint64_t aInfraIfIndex, CallbackResultType &aResult)
         {
             std::vector<CallbackPtrType> copyCallbacks;
 
             for (auto &entry : mEntries)
             {
-                if (entry.first == aInfraIfIndex)
+                if (InfraIfIndexMatches(entry.first, aInfraIfIndex))
                 {
                     copyCallbacks.push_back(entry.second);
                 }
@@ -362,6 +397,11 @@ private:
         }
 
     private:
+        static bool InfraIfIndexMatches(uint64_t aRegisteredIfIndex, uint64_t aReportedIfIndex)
+        {
+            return aRegisteredIfIndex == aReportedIfIndex || aRegisteredIfIndex == 0;
+        }
+
         using IteratorType = typename std::vector<RequestType>::iterator;
 
         IteratorType FindEntry(uint64_t aInfraIfIndex, const CallbackType &aCallback)

--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -213,6 +213,12 @@ void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aIns
     otbrLogInfo("Service %s is resolved successfully: %s %s host %s addresses %zu", aType.c_str(),
                 aInstanceInfo.mRemoved ? "remove" : "add", aInstanceInfo.mName.c_str(), aInstanceInfo.mHostName.c_str(),
                 aInstanceInfo.mAddresses.size());
+    if (aInstanceInfo.mRemoved)
+    {
+        otbrLogInfo(
+            "DNSSD lc mDNS publisher: dispatching removal to subscribers (DnssdPlatform/others) for inst=%s type=%s",
+            aInstanceInfo.mName.c_str(), aType.c_str());
+    }
 
     if (!aInstanceInfo.mRemoved)
     {
@@ -276,7 +282,9 @@ void Publisher::OnServiceRemoved(uint32_t aNetifIndex, std::string aType, std::s
 {
     DiscoveredInstanceInfo instanceInfo;
 
-    otbrLogInfo("Service %s.%s is removed from netif %u.", aInstanceName.c_str(), aType.c_str(), aNetifIndex);
+    otbrLogInfo("DNSSD lc mDNS publisher: service instance departed inst=%s type=%s ifIndex=%u "
+                "(reason=browse_remove_event from mDNS stack; not an OTBR subscription cleanup)",
+                aInstanceName.c_str(), aType.c_str(), static_cast<unsigned>(aNetifIndex));
 
     instanceInfo.mRemoved    = true;
     instanceInfo.mNetifIndex = aNetifIndex;

--- a/src/mdns/mdns_avahi.cpp
+++ b/src/mdns/mdns_avahi.cpp
@@ -1191,6 +1191,9 @@ void PublisherAvahi::ServiceSubscription::HandleBrowseResult(AvahiServiceBrowser
         Resolve(aInterfaceIndex, aProtocol, aName, aType);
         break;
     case AVAHI_BROWSER_REMOVE:
+        otbrLogInfo("DNSSD lc mDNS (Avahi): browse REMOVE inst=%s type=%s ifIndex=%u "
+                    "(AVAHI_BROWSER_REMOVE — service departed on this interface)",
+                    aName, aType, static_cast<unsigned>(aInterfaceIndex));
         mPublisherAvahi->OnServiceRemoved(static_cast<uint32_t>(aInterfaceIndex), aType, aName);
         RemoveServiceResolver(aName);
         break;

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -1194,6 +1194,9 @@ void PublisherMDnsSd::ServiceSubscription::HandleBrowseResult(DNSServiceRef     
     }
     else
     {
+        otbrLogInfo("DNSSD lc mDNS (dns_sd): browse REMOVE inst=%s type=%s ifIndex=%u "
+                    "(DNSServiceBrowse callback without kDNSServiceFlagsAdd — service left or goodbye)",
+                    aInstanceName, aType, aInterfaceIndex);
         mPublisher.OnServiceRemoved(aInterfaceIndex, mType, aInstanceName);
         Remove(aInterfaceIndex, aInstanceName, aType, aDomain);
     }


### PR DESCRIPTION
- Implements a host-side TREL UDP proxy driven by SPINEL_PROP_TREL_STATE notifications from the NCP
- Extends the DNS-SD proxy path so Browse/Srv/Txt/Ip6/Ip4 resolvers and their results round-trip over SPINEL with stable callback IDs
- Updates the host mDNS publisher to treat infra-interface index 0 as "any interface" to match the NCP's wildcard value
- Implements the required SPINEL commands (TREL_USER_ENABLE, TREL_STATE, DNSSD_*_RESOLVER / DNSSD_*_RESULT).