### PR TITLE
[docker] add Docker-in-Docker integration testing

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,64 @@
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Docker Test
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-br-posix' && github.run_id) || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-check:
+    runs-on: ubuntu-24.04
+    env:
+      VERBOSE: 1
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
+      with:
+        submodules: recursive
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+    - name: Build DinD Runner Image
+      run: |
+        docker build -t otbr-dind-runner -f etc/docker/test/Dockerfile.dind_runner .
+    - name: Run DinD Integration Test
+      run: |
+        docker run --privileged --rm \
+          -v "$(pwd)":/usr/src/ot-br-posix \
+          -w /usr/src/ot-br-posix \
+          -e DOCKER_HOST=unix:///var/run/docker.sock \
+          otbr-dind-runner \
+          bash -c "dockerd --host=unix:///var/run/docker.sock >/dev/null 2>&1 & ./tests/scripts/test_dind_dns_sd.sh"

--- a/etc/docker/border-router/Dockerfile
+++ b/etc/docker/border-router/Dockerfile
@@ -32,6 +32,7 @@ ARG GITHUB_REPO="openthread/ot-br-posix"
 ARG GIT_COMMIT="HEAD"
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG OTBR_OPTIONS=""
 
 ENV S6_OVERLAY_VERSION=3.2.1.0
 
@@ -87,6 +88,7 @@ RUN set -x \
                -DOTBR_WEB=ON \
                -DOT_POSIX_NAT64_CIDR="192.168.255.0/24" \
                -DOT_FIREWALL=ON \
+               ${OTBR_OPTIONS} \
                .. \
         && ninja \
         && ninja install) \

--- a/etc/docker/test/Dockerfile.dind_runner
+++ b/etc/docker/test/Dockerfile.dind_runner
@@ -1,0 +1,40 @@
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM docker:dind
+
+# Install OpenThread test dependencies on top of Docker:dind
+RUN apk add --no-cache \
+    bash \
+    build-base \
+    cmake \
+    expect \
+    git \
+    ninja \
+    python3 \
+    socat

--- a/tests/scripts/expect/dind_dns_sd.exp
+++ b/tests/scripts/expect/dind_dns_sd.exp
@@ -1,0 +1,191 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+proc fail {message} {
+    send_user "Error: $message\n"
+    exit 1
+}
+source "tests/scripts/expect/_common.exp"
+
+# Custom start_otbr_docker for our network name
+proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    set format "\{\{range .IPAM.Config\}\}\{\{.Gateway\}\}\n\{\{end\}\}"
+    set output [exec docker network inspect infrastructure-link -f $format]
+    set gateway ""
+    foreach line [split $output "\n"] {
+        if {[string match "*.*" $line]} {
+            set gateway $line
+            break
+        }
+    }
+    if {$gateway == ""} {
+        set gateway [lindex [split $output "\n"] 0]
+    }
+    send_user "Network Gateway: $gateway\n"
+
+    # 1. Start the child container in sleep mode
+    exec docker run -d \
+        --name $name \
+        --network infrastructure-link \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --add-host=host.docker.internal:host-gateway \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
+        -e EXP_GATEWAY_IP=$gateway \
+        --entrypoint /bin/bash \
+        $::env(EXP_OTBR_DOCKER_IMAGE) \
+        -c "sleep infinity"
+
+    # 2. Start otbr-agent in the child container, which connects to socat
+    exec docker exec -d $name bash -c "otbr-agent -d7 -v --vendor-name=OpenThread --model-name=OTBR -I wpan0 -B eth0 spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh >/var/log/otbr-agent.log 2>&1"
+    sleep 2
+
+    # 3. Now start the simulated RCP binary on the host!
+    exec $sim_app $sim_id <$pty >$pty &
+    sleep 5
+}
+
+proc create_socat_tcp {id port} {
+    global socat_pid
+    spawn socat -d -d pty,raw,echo=0 tcp-listen:$port,reuseaddr,bind=0.0.0.0
+    set socat_pid [exp_pid]
+    set pty ""
+    expect {
+        -re {PTY is (\S+)} {
+            set pty $expect_out(1,string)
+        }
+        timeout {
+            send_user "Error: Timed out starting socat\n"; exit 1
+        }
+    }
+    return $pty
+}
+
+set pty1 [create_socat_tcp 1 9000]
+set container "otbr-test-container"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# Start border router in Docker on the DinD host
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+set socket_ready false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state}]} {
+        set socket_ready true
+        break
+    }
+    sleep 2
+}
+if {!$socket_ready} {
+    send_user "Error: ot-ctl failed to communicate with otbr-agent\n"; exit 1
+}
+
+# Setup active dataset on OTBR via ot-ctl
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+set leader false
+for {set i 0} {$i < 20} {incr i} {
+    spawn docker exec -i $container ot-ctl state
+    set timeout 3
+    expect {
+        "leader" {
+            set leader true
+            break
+        }
+        timeout {
+            # Not leader yet
+        }
+    }
+    catch {close}
+    catch {wait}
+    sleep 2
+}
+if {!$leader} {
+    send_user "Error: OTBR did not become leader. Agent logs:\n"
+    catch {send_user [exec docker exec -i $container cat /var/log/otbr-agent.log]}
+    exit 1
+}
+
+# Enable SRP server explicitly
+exec docker exec -i $container ot-ctl srp server auto disable
+exec docker exec -i $container ot-ctl srp server enable
+sleep 2
+
+# Join Thread network from Node 4 (ot-cli-ftd)
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active ${dataset}\n"
+expect_line "Done"
+send "mode n\r\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+set omr_addr [get_omr_addr]
+sleep 1
+
+# Configure SRP client on simulated Thread device
+send "srp client autostart enable\r\n"
+expect_line "Done"
+send "srp client host name otbr-ncp-test\r\n"
+expect_line "Done"
+send "srp client host address $omr_addr\r\n"
+expect_line "Done"
+send "srp client service add ot-service _ipps._tcp 12345\r\n"
+expect_line "Done"
+sleep 10
+
+# Verify service via mdns-scan from our test client container
+spawn docker run --rm --network infrastructure-link test-client-mdnsresponder
+set timeout 10
+expect {
+    "ot-service._ipps._tcp.local" {
+        send_user "\n# Service successfully discovered via mdns-scan!\n"
+    }
+    timeout {
+        send_user "Error: Service not found via mdns-scan\n"; exit 1
+    }
+}
+catch {close}
+catch {wait}
+
+exec docker stop $container
+exec docker rm $container
+dispose_all

--- a/tests/scripts/spinel_proxy.sh
+++ b/tests/scripts/spinel_proxy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+exec 3<>/dev/tcp/"${EXP_GATEWAY_IP:-host.docker.internal}"/9000
+stdbuf -i0 -o0 -e0 cat <&3 &
+stdbuf -i0 -o0 -e0 cat >&3
+kill $!

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -euxo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly REPO_ROOT
+
+#---------------------------------------
+# Configurations
+#---------------------------------------
+OTBR_DOCKER_IMAGE="${OTBR_DOCKER_IMAGE:-openthread/border-router}"
+readonly OTBR_DOCKER_IMAGE
+
+OTBR_DOCKER_FILE="${OTBR_DOCKER_FILE:-${REPO_ROOT}/etc/docker/border-router/Dockerfile}"
+readonly OTBR_DOCKER_FILE
+
+INFRA_NET_NAME="infrastructure-link"
+readonly INFRA_NET_NAME
+
+TEST_CLIENT_IMAGE="test-client-mdnsresponder"
+readonly TEST_CLIENT_IMAGE
+
+CONTAINER_NAME="otbr-test-container"
+readonly CONTAINER_NAME
+
+ABS_TOP_OT_SRCDIR="${REPO_ROOT}/third_party/openthread/repo"
+readonly ABS_TOP_OT_SRCDIR
+
+ABS_TOP_OT_BUILDDIR="${REPO_ROOT}/build/simulation"
+readonly ABS_TOP_OT_BUILDDIR
+
+#----------------------------------------
+# Helper functions
+#----------------------------------------
+die()
+{
+    echo " *** ERROR: $*"
+    exit 1
+}
+
+test_teardown()
+{
+    echo "--- Tearing down test environment ---"
+    echo "Container logs:"
+    docker logs "${CONTAINER_NAME}" || true
+    echo "Agent logs:"
+    docker exec -i "${CONTAINER_NAME}" cat /var/log/otbr-agent.log || true
+    echo "Process status:"
+    docker exec -i "${CONTAINER_NAME}" ps aux || true
+    docker stop "${CONTAINER_NAME}" || true
+    for c in $(docker network inspect "${INFRA_NET_NAME}" -f '{{range $id, $el := .Containers}}{{$id}} {{end}}' 2>/dev/null || true); do
+        docker stop "$c" || true
+        docker rm "$c" || true
+    done
+    sleep 5
+    docker network rm "${INFRA_NET_NAME}" || true
+    pkill -f ot-rcp || true
+    pkill -f ot-cli-ftd || true
+    rm -vf /tmp/otbr-pty1 /tmp/otbr-pty2 || true
+    rm -vf "${REPO_ROOT}"/*.flash* || true
+}
+
+test_setup()
+{
+    echo "--- Setting up test environment ---"
+    rm -vf "${REPO_ROOT}"/*.flash* || true
+
+    for c in $(docker network inspect "${INFRA_NET_NAME}" -f '{{range $id, $el := .Containers}}{{$id}} {{end}}' 2>/dev/null || true); do
+        docker stop "$c" || true
+        docker rm "$c" || true
+    done
+    sleep 5
+
+    echo "Waiting for local Docker daemon to be ready..."
+    until docker info >/dev/null 2>&1; do
+        sleep 1
+    done
+
+    echo "Adding iptables rule to allow port 9000 traffic..."
+    iptables -I INPUT 1 -p tcp --dport 9000 -j ACCEPT || true
+
+    # 1. Build the production Docker image
+    echo "Building production border-router image..."
+    docker build --build-arg OTBR_OPTIONS="-DOTBR_BACKBONE_ROUTER=OFF" -t "${OTBR_DOCKER_IMAGE}" -f "${OTBR_DOCKER_FILE}" "${REPO_ROOT}"
+
+    # 2. Create the IPv6-enabled Docker bridge network for infrastructure-link
+    if ! docker network inspect "${INFRA_NET_NAME}" >/dev/null 2>&1; then
+        echo "Creating ${INFRA_NET_NAME} Docker bridge network..."
+        docker network create --driver bridge --ipv6 --subnet fd00:db8:1::/64 "${INFRA_NET_NAME}"
+    else
+        echo "Network ${INFRA_NET_NAME} already exists."
+    fi
+
+    # 3. Build the test client image with mdns-scan
+    echo "Building test client image with mdns-scan..."
+    docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
+FROM ubuntu:24.04
+RUN apt-get update && apt-get install -y mdns-scan --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["mdns-scan"]
+EOF
+
+    # 4. Build simulated OpenThread CLI and RCP binaries
+    echo "Building simulated binaries..."
+    rm -rf "${ABS_TOP_OT_BUILDDIR}"
+    OT_CMAKE_BUILD_DIR=${ABS_TOP_OT_BUILDDIR}/rcp "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation \
+        -DOT_MTD=OFF -DOT_FTD=OFF -DOT_APP_CLI=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=ON \
+        -DBUILD_TESTING=OFF
+
+    OT_CMAKE_BUILD_DIR=${ABS_TOP_OT_BUILDDIR}/cli "${ABS_TOP_OT_SRCDIR}"/script/cmake-build simulation \
+        -DOT_MTD=OFF -DOT_RCP=OFF -DOT_APP_NCP=OFF -DOT_APP_RCP=OFF \
+        -DOT_BORDER_ROUTING=OFF -DOT_MLR=ON \
+        -DBUILD_TESTING=OFF
+}
+
+test_run()
+{
+    trap test_teardown EXIT
+
+    echo "--- Running integration expect script ---"
+    export EXP_OTBR_DOCKER_IMAGE="${OTBR_DOCKER_IMAGE}"
+    export EXP_OTBR_AGENT_PATH="${REPO_ROOT}/build/src/agent/otbr-agent"
+    export EXP_TUN_NAME="wpan0"
+    export EXP_LEADER_NODE_ID=1
+    export EXP_REPO_ROOT="${REPO_ROOT}"
+
+    local ot_cli
+    local ot_rcp
+    ot_cli=$(find "${ABS_TOP_OT_BUILDDIR}/cli" -name "ot-cli-ftd")
+    ot_rcp=$(find "${ABS_TOP_OT_BUILDDIR}/rcp" -name "ot-rcp")
+    [ -x "$ot_cli" ] || die "cli binary not found"
+    [ -x "$ot_rcp" ] || die "rcp binary not found"
+
+    export EXP_OT_CLI_PATH="$ot_cli"
+    export EXP_OT_RCP_PATH="$ot_rcp"
+
+    expect -df "${SCRIPT_DIR}/expect/dind_dns_sd.exp"
+}
+
+main()
+{
+    test_setup
+    test_run
+}
+
+main "$@"


### PR DESCRIPTION
- Create GitHub Action workflow 'docker-test.yml' to run DinD tests on pull requests and commits to main.
- Add build arg 'OTBR_OPTIONS' to production Dockerfile to customize CMake options at build time.
- Add dind runner Dockerfile and testing scripts.