### PR TITLE
[bootstrap] replace snap with apt-get for shfmt installation

### DIFF
--- a/tests/scripts/bootstrap.sh
+++ b/tests/scripts/bootstrap.sh
@@ -119,8 +119,7 @@ case "$(uname)" in
 
         if [ "$BUILD_TARGET" == pretty-check ]; then
             sudo bash "$(dirname "$0")/install-llvm.sh"
-            sudo apt-get install -y shellcheck
-            sudo snap install shfmt
+            sudo apt-get install --no-install-recommends -y shellcheck shfmt
             npm install prettier@2.0.4
         fi
 


### PR DESCRIPTION
The shfmt installation via snap was failing in certain environments. This change replaces the snap installation with apt-get and consolidates it with the shellcheck installation in bootstrap.sh to ensure more reliable environment setup for pretty-check.