### PR TITLE
[rest] add REST API version in /.well-known/thread for API discovery

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -24,6 +24,43 @@ tags:
     description: Collection of Thread network diagnostic responses.
 paths:
 
+  ### Well-Known ##############################################################
+  #############################################################################
+  /.well-known/thread/br-rest:
+    get:
+      operationId: getWellKnownThread
+      summary: Read API version and entry points
+      description: |
+        Information about the supported API version (see gray tag at the top of this specification), API location (base path), and links to its entry points.
+
+        ## Static
+        API version, location, and entry points are known at compile time.
+
+        ## Link Attributes (`/.well-known/thread/br-rest`)
+        `rel="self" type="application/json"`
+      tags:
+        - Well-Known
+      responses:
+        "200":
+          $ref: "#/components/responses/WellKnownThread200"
+
+    options:
+      operationId: optionsWellKnownThread
+      tags:
+        - Well-Known
+      summary: List of allowed operations.
+      description: |
+        Lists allowed operations.
+      responses:
+        "204":
+          description: List of allowed operations.
+          headers:
+            Allow:
+              description: Allowed operations
+              schema:
+                type: string
+                example: "GET, OPTIONS"
+
   ### Information #############################################################
   #############################################################################
   /api/node:
@@ -2399,6 +2436,46 @@ components:
           description: Joiner expiration time in milliseconds on response and seconds on request 
           default: 60 
 
+    WellKnownThread:
+      type: object
+      required:
+        - api
+        - links
+      properties:
+        api:
+          type: object
+          required:
+            - version
+            - base
+          properties:
+            version:
+              type: string
+              pattern: ^[0-9]+\.[0-9]+(\.[0-9]+)?$
+              description: Semantic version (MAJOR.MINOR.PATCH) of the API
+            base:
+              type: string
+              pattern: ^/[/.a-zA-Z0-9_-]*$
+        links:
+          type: array
+          items:
+            type: object
+            required:
+              - href
+              - rel
+            properties:
+              href:
+                type: string
+                format: uri-reference
+              rel:
+                type: string
+              type:
+                type: array
+                minItems: 1
+                items:
+                  type: string
+              title:
+                type: string
+
   ### Parameters ##############################################################
   #############################################################################
   parameters:
@@ -2516,6 +2593,39 @@ components:
   ### Responses ###############################################################
   #############################################################################
   responses:
+
+    WellKnownThread200:
+      description: |
+        JSON (RFC 8259) providing the API version resource object and links to the API entry points.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/WellKnownThread"
+          example:
+            api:
+              version: 0.3.0
+              base: /api/
+            links:
+              - href: /.well-known/thread/br-rest
+                rel: self
+                type:
+                  - application/json
+              - href: /api/node
+                rel: node
+                type:
+                  - application/vnd.api+json
+              - href: /api/actions
+                rel: task
+                type:
+                  - application/vnd.api+json
+              - href: /api/devices
+                rel: device
+                type:
+                  - application/vnd.api+json
+              - href: /api/diagnostics
+                rel: diagnostic
+                type:
+                  - application/vnd.api+json
 
     BadRequestError:
       description: |

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -50,6 +50,7 @@
 #include "rest/rest_devices_coll.hpp"     // Devices Collection
 #include "rest/rest_diagnostics_coll.hpp" // Diagnostics Collection
 #include "rest/services.hpp"
+#include "rest/version.hpp"
 #include "utils/string_utils.hpp"
 
 #include <cJSON.h>
@@ -109,6 +110,8 @@
 
 #define OT_REST_ROUTE_DIAGNOSTICS "/api/diagnostics"
 #define OT_REST_ROUTE_DIAGNOSTICS_ID "/api/diagnostics/:id"
+
+#define OT_REST_ROUTE_WELLKNOWN_THREAD "/.well-known/thread/br-rest"
 
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -187,6 +190,9 @@ RestWebServer::RestWebServer(Host::RcpHost &aHost)
     mServer.Delete(OT_REST_ROUTE_DIAGNOSTICS_ID,
                    MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemDeleteHandler));
     mServer.Options(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
+
+    mServer.Get(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
+    mServer.Options(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
 }
 
 RestWebServer::~RestWebServer(void)
@@ -1148,8 +1154,7 @@ void RestWebServer::ApiActionsHandler(const Request &aRequest, Response &aRespon
         aResponse.set_header("Allow", "GET, POST, DELETE, OPTIONS");
         break;
     default:
-        // aResponse.SetAllowMethods(methods);
-        errorDetails = "method not supported";
+        errorDetails = "not supported";
         statusCode   = StatusCode::MethodNotAllowed_405;
         break;
     }
@@ -1520,7 +1525,6 @@ void RestWebServer::ApiDiagnosticsHandler(const Request &aRequest, Response &aRe
         break;
     case HttpMethod::kPost:
     default:
-        // aResponse.SetAllowMethods(methods);
         errorDetails = "not supported";
         statusCode   = StatusCode::MethodNotAllowed_405;
         break;
@@ -1552,7 +1556,6 @@ void RestWebServer::ApiDevicesHandler(const Request &aRequest, Response &aRespon
         aResponse.set_header("Allow", "GET, DELETE, OPTIONS");
         break;
     default:
-        // aResponse.SetAllowMethods(methods);
         errorDetails = "not supported";
         statusCode   = StatusCode::MethodNotAllowed_405;
         break;
@@ -1595,7 +1598,7 @@ exit:
     }
 }
 
-otError RestWebServer::HasValidChars(const Request &aRequest, std::string &aErrorDetails)
+otError RestWebServer::HasValidChars(const Request &aRequest, std::string &aErrorDetails) const
 {
     otError          error            = OT_ERROR_NONE;
     constexpr size_t kMaxHeaderParams = 32;
@@ -1811,6 +1814,81 @@ void RestWebServer::ApiDevicesNodeInit()
     thisextaddr_str = StringUtils::ToLowercase(thisextaddr_str);
 
     mServices.GetNetworkDiagHandler().SetDeviceItemAttributes(thisextaddr_str, aDeviceInfo);
+}
+
+void RestWebServer::WellKnownThreadHandler(const Request &aRequest, Response &aResponse) const
+{
+    StatusCode  statusCode = StatusCode::OK_200;
+    std::string errorDetails;
+    VerifyOrExit(HasValidChars(aRequest, errorDetails) == OT_ERROR_NONE, statusCode = StatusCode::BadRequest_400);
+
+    switch (GetMethod(aRequest))
+    {
+    case HttpMethod::kGet:
+        WellKnownThreadGetHandler(aRequest, aResponse);
+        break;
+
+    case HttpMethod::kOptions:
+        aResponse.status = StatusCode::NoContent_204;
+        aResponse.set_header("Allow", "GET, OPTIONS");
+        break;
+
+    default:
+        errorDetails = "not supported";
+        statusCode   = StatusCode::MethodNotAllowed_405;
+        break;
+    }
+exit:
+    if (statusCode != StatusCode::OK_200)
+    {
+        otbrLogWarning("%s:%d Error (%d)", __FILE__, __LINE__, statusCode);
+        ErrorHandler(aResponse, statusCode, errorDetails);
+    }
+}
+
+void RestWebServer::WellKnownThreadGetHandler(const Request &aRequest, Response &aResponse) const
+{
+    OT_UNUSED_VARIABLE(aRequest);
+
+    // Static JSON discovery metadata per RFC 8615 and OpenAPI specification
+    // API version from rest/version.hpp
+    // Routes use OT_REST_ROUTE_* macros for consistency with endpoint definitions
+    static const std::string kWellKnownThreadJson = R"({
+  "api": {
+    "version": ")" OTBR_REST_API_VERSION R"(",
+    "base": "/api/"
+  },
+  "links": [
+    {
+      "href": ")" OT_REST_ROUTE_WELLKNOWN_THREAD R"(",
+      "rel": "self",
+      "type": [")" OT_REST_CONTENT_TYPE_JSON R"("]
+    },
+    {
+      "href": ")" OT_REST_ROUTE_NODE R"(",
+      "rel": "node",
+      "type": [")" OT_REST_CONTENT_TYPE_JSONAPI R"("]
+    },
+    {
+      "href": ")" OT_REST_ROUTE_ACTIONS R"(",
+      "rel": "task",
+      "type": [")" OT_REST_CONTENT_TYPE_JSONAPI R"("]
+    },
+    {
+      "href": ")" OT_REST_ROUTE_DEVICES R"(",
+      "rel": "device",
+      "type": [")" OT_REST_CONTENT_TYPE_JSONAPI R"("]
+    },
+    {
+      "href": ")" OT_REST_ROUTE_DIAGNOSTICS R"(",
+      "rel": "diagnostic",
+      "type": [")" OT_REST_CONTENT_TYPE_JSONAPI R"("]
+    }
+  ]
+})";
+
+    aResponse.set_content(kWellKnownThreadJson, OT_REST_CONTENT_TYPE_JSON);
+    aResponse.status = StatusCode::OK_200;
 }
 
 /**

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -158,10 +158,13 @@ private:
     void ApiDiagnosticsDeleteHandler(const Request &aRequest, Response &aResponse);
     void ApiDiagnosticsItemDeleteHandler(const Request &aRequest, Response &aResponse);
 
+    void WellKnownThreadHandler(const Request &aRequest, Response &aResponse) const;
+    void WellKnownThreadGetHandler(const Request &aRequest, Response &aResponse) const;
+
     void                               RoutingErrorHandler(const Request &aRequest, Response &aResponse);
     std::map<std::string, std::string> ExtractFieldsQueries(const Request               &aRequest,
                                                             const std::set<std::string> &aContainedTypes) const;
-    otError                            HasValidChars(const Request &aRequest, std::string &aErrorDetails);
+    otError                            HasValidChars(const Request &aRequest, std::string &aErrorDetails) const;
 
     otInstance *GetInstance(void) const { return mHost.GetThreadHelper()->GetInstance(); }
 

--- a/src/rest/version.hpp
+++ b/src/rest/version.hpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OTBR_REST_VERSION_HPP_
+#define OTBR_REST_VERSION_HPP_
+
+/**
+ * REST API implementation version (semantic versioning: MAJOR.MINOR.PATCH)
+ *
+ * This version indicates what the running code supports.
+ * It may differ from the OpenAPI specification version (openapi.yaml info.version).
+ *
+ * Version increment rules:
+ * - MAJOR: Breaking changes (incompatible API changes)
+ * - MINOR: New features (backward compatible) or breaking changes during 0.x
+ * - PATCH: Bug fixes (backward compatible)
+ */
+#define OTBR_REST_API_VERSION "0.3.0"
+
+#endif // OTBR_REST_VERSION_HPP_

--- a/src/rest/version.hpp
+++ b/src/rest/version.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, The OpenThread Authors.
+ *  Copyright (c) 2026, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
- .well-known/thread resource (RFC 8615) providing semantic API version string and entry point links
- Added OpenAPI schema