### PR TITLE
[tests] update docker test to verify bi-directional IPv6 ping connectivity

### DIFF
--- a/tests/scripts/expect/dind_dns_sd.exp
+++ b/tests/scripts/expect/dind_dns_sd.exp
@@ -31,6 +31,7 @@ proc fail {message} {
     send_user "Error: $message\n"
     exit 1
 }
+
 source "tests/scripts/expect/_common.exp"
 
 # Custom start_otbr_docker for our network name
@@ -49,7 +50,7 @@ proc start_otbr_docker_dind {name sim_app sim_id pty} {
     }
     send_user "Network Gateway: $gateway\n"
 
-    # 1. Start the child container in sleep mode
+    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
     exec docker run -d \
         --name $name \
         --network infrastructure-link \
@@ -58,15 +59,15 @@ proc start_otbr_docker_dind {name sim_app sim_id pty} {
         --add-host=host.docker.internal:host-gateway \
         --sysctl net.ipv6.conf.all.disable_ipv6=0 \
         --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv4.conf.default.forwarding=1 \
         --sysctl net.ipv6.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.default.forwarding=1 \
         -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
         -e EXP_GATEWAY_IP=$gateway \
-        --entrypoint /bin/bash \
-        $::env(EXP_OTBR_DOCKER_IMAGE) \
-        -c "sleep infinity"
-
-    # 2. Start otbr-agent in the child container, which connects to socat
-    exec docker exec -d $name bash -c "otbr-agent -d7 -v --vendor-name=OpenThread --model-name=OTBR -I wpan0 -B eth0 spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh >/var/log/otbr-agent.log 2>&1"
+        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
+        -e OT_INFRA_IF=eth0 \
+        -e OT_THREAD_IF=wpan0 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
     sleep 2
 
     # 3. Now start the simulated RCP binary on the host!
@@ -147,11 +148,21 @@ exec docker exec -i $container ot-ctl srp server auto disable
 exec docker exec -i $container ot-ctl srp server enable
 sleep 2
 
+# Wait 15 seconds for the Border Routing Manager to fully stabilize its dynamic OMR prefix
+send_user "Waiting 15 seconds for the dynamic OMR prefix to stabilize...\n"
+sleep 15
+
+# Get the running Border Router's active dataset dynamically to configure the client
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [string trim $active_dataset]
+
 # Join Thread network from Node 4 (ot-cli-ftd)
 spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
-send "dataset set active ${dataset}\n"
+send "dataset set active $active_dataset\n"
 expect_line "Done"
-send "mode n\r\n"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
 expect_line "Done"
 send "ifconfig up\r\n"
 expect_line "Done"
@@ -172,8 +183,43 @@ send "srp client service add ot-service _ipps._tcp 12345\r\n"
 expect_line "Done"
 sleep 10
 
-# Verify service via mdns-scan from our test client container
-spawn docker run --rm --network infrastructure-link test-client-mdnsresponder
+# Set up a single background test-client container to perform both mDNS resolution and ping tests
+set test_client "test-client"
+exec docker run -d \
+    --name $test_client \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "echo 0 > /proc/sys/net/ipv6/conf/all/autoconf && echo 0 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
+
+# Check if the host kernel supports Route Information Option (RIO) / accept_ra_rt_info_max_plen processing
+set has_rio [expr {[catch {exec docker exec -i $test_client test -f /proc/sys/net/ipv6/conf/all/accept_ra_rt_info_max_plen}] == 0}]
+
+if {$has_rio} {
+    send_user "Host kernel supports RIO processing. Enabling accept_ra_rt_info_max_plen.\n"
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
+    # Trigger a Router Solicitation to fetch RAs immediately and let kernel auto-install the OMR route
+    exec docker exec -i $test_client rdisc6 eth0
+} else {
+    send_user "Warning: Host kernel does NOT support RIO processing (CONFIG_IPV6_ROUTE_INFO is disabled). Falling back to static route.\n"
+
+    # Retrieve the global IPv6 address of the OTBR container on the bridge network
+    set format "\{\{range .NetworkSettings.Networks\}\}\{\{.GlobalIPv6Address\}\}\{\{end\}\}"
+    set otbr_ip [exec docker inspect otbr-test-container -f $format]
+    send_user "OTBR Infrastructure IPv6 Address: $otbr_ip\n"
+
+    # Manually install static route to Thread ULA subnet (fc00::/7) via the OTBR, bypassing host kernel RIO limitation
+    exec docker exec -i $test_client ip -6 route add fc00::/7 via $otbr_ip dev eth0
+}
+send_user "Test Client routing table:\n"
+send_user [exec docker exec -i $test_client ip -6 route]
+
+# 1. Verify service via mdns-scan from our single test client container
+spawn docker exec -i $test_client mdns-scan
 set timeout 10
 expect {
     "ot-service._ipps._tcp.local" {
@@ -185,6 +231,37 @@ expect {
 }
 catch {close}
 catch {wait}
+
+# 2. Discover the Thread device's IPv6 address via mDNS and verify connectivity (OMR)
+set py_cmd {from zeroconf import Zeroconf, IPVersion; import socket; info = Zeroconf().get_service_info('_ipps._tcp.local.', 'ot-service._ipps._tcp.local.'); addrs = info.addresses_by_version(IPVersion.V6Only) if info else []; print(socket.inet_ntop(socket.AF_INET6, addrs[0])) if addrs else None}
+set discovered_ip [exec docker exec -i $test_client python3 -c $py_cmd]
+set discovered_ip [string trim $discovered_ip]
+if {$discovered_ip == ""} {
+    send_user "Error: Failed to discover Thread device IPv6 address via mDNS\n"
+    exit 1
+}
+send_user "Discovered Thread device IPv6 address via mDNS: $discovered_ip\n"
+
+spawn docker exec -i $test_client ping6 -c 5 $discovered_ip
+set timeout 15
+expect {
+    "5 packets transmitted, 5 received, 0% packet loss" {
+        send_user "\n# Ping from infra host to discovered Thread device succeeded!\n"
+    }
+    timeout {
+        send_user "Error: Ping from infra host to discovered Thread device timed out\n"
+        exit 1
+    }
+    eof {
+        send_user "Error: Ping from infra host to discovered Thread device failed (EOF)\n"
+        exit 1
+    }
+}
+catch {close}
+catch {wait}
+
+exec docker stop $test_client
+exec docker rm $test_client
 
 exec docker stop $container
 exec docker rm $container

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -70,12 +70,14 @@ die()
 test_teardown()
 {
     echo "--- Tearing down test environment ---"
+    echo "Active and inactive containers:"
+    docker ps -a || true
     echo "Container logs:"
     docker logs "${CONTAINER_NAME}" || true
+    echo "Test client logs:"
+    docker logs "test-client" || true
     echo "Agent logs:"
     docker exec -i "${CONTAINER_NAME}" cat /var/log/otbr-agent.log || true
-    echo "Process status:"
-    docker exec -i "${CONTAINER_NAME}" ps aux || true
     docker stop "${CONTAINER_NAME}" || true
     for c in $(docker network inspect "${INFRA_NET_NAME}" -f '{{range $id, $el := .Containers}}{{$id}} {{end}}' 2>/dev/null || true); do
         docker stop "$c" || true
@@ -120,11 +122,11 @@ test_setup()
         echo "Network ${INFRA_NET_NAME} already exists."
     fi
 
-    # 3. Build the test client image with mdns-scan
-    echo "Building test client image with mdns-scan..."
+    # 3. Build the test client image with mdns-scan and ping/ndisc6 tools
+    echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
     docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y mdns-scan --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["mdns-scan"]
 EOF
 
@@ -151,6 +153,7 @@ test_run()
     export EXP_TUN_NAME="wpan0"
     export EXP_LEADER_NODE_ID=1
     export EXP_REPO_ROOT="${REPO_ROOT}"
+    export EXP_TEST_CLIENT_IMAGE="${TEST_CLIENT_IMAGE}"
 
     local ot_cli
     local ot_rcp


### PR DESCRIPTION
Refactor the Docker-in-Docker (DinD) mDNS service discovery integration test to dynamically query the active Thread dataset, launch the OTBR container using its native s6-overlay entrypoint, and run a complete bi-directional IPv6 ping connectivity test from the infrastructure network.

- OTBR Container Management:
  - Launch the OTBR Docker container using its native s6-overlay /init entrypoint and config environment variables (OT_RCP_DEVICE, OT_INFRA_IF, OT_THREAD_IF) rather than manual bash script execution.
  - Configure sysctls to enable IPv4 and IPv6 forwarding by default.
  - Wait 15 seconds after startup for the Border Routing Manager to fully stabilize its dynamic OMR prefix.

- Simulated Thread Node Configuration:
  - Query the active Thread dataset dynamically using `ot-ctl dataset active -x` instead of utilizing hardcoded static datasets.
  - Configure simulated Node 4 as a Full End Device (FED) using "mode rdn" and "routereligible disable" to keep its radio active when idle and prevent router-role promotion races.

- Test Client Setup & Routing:
  - Install ping, ndisc6, zeroconf, and iproute2 in the test client container.
  - Spin up a single, persistent test-client container on the bridge network with IPv6 autoconf disabled to avoid SLAAC address clutter.
  - Add dual-path RIO capability checking: dynamically configure/enable accept_ra_rt_info_max_plen and run rdisc6 if RIO is supported by the host kernel, or fallback to installing a manual route to fc00::/7 via the OTBR's infrastructure IPv6 address if not.

- Verification Flow:
  - Run `mdns-scan` from the persistent test-client container to verify SRP registration.
  - Discover the Thread device's OMR IPv6 address via a custom python script using the `zeroconf` library.
  - Ping the discovered Thread device IPv6 address from the test client and verify zero packet loss.

- Teardown & Diagnostics:
  - Collect active and inactive docker container lists along with test client container logs during test teardown.