### PR TITLE
[github-actions] remove unused and secondary Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,31 +69,6 @@ jobs:
             build_args: ""
             platforms: "linux/amd64,linux/arm/v7,linux/arm64"
             push: yes
-          - image_tag: "focal"
-            base_image: "ubuntu:focal"
-            build_args: ""
-            platforms: "linux/amd64,linux/arm64"
-            push: yes
-          - image_tag: "reference-device"
-            base_image: "ubuntu:bionic"
-            build_args: >-
-              --build-arg REFERENCE_DEVICE=1
-              --build-arg BORDER_ROUTING=0
-              --build-arg MDNS=mDNSResponder
-              --build-arg NAT64=0
-              --build-arg WEB_GUI=0
-              --build-arg REST_API=0
-              --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON -DOTBR_OT_DISCOVERY_PROXY=OFF'
-            platforms: "linux/amd64,linux/arm/v7,linux/arm64"
-            push: yes
-          - image_tag: "test"
-            base_image: "ubuntu:bionic"
-            build_args: >-
-              --build-arg OT_BACKBONE_CI=1
-              --build-arg REFERENCE_DEVICE=1
-              --build-arg OTBR_OPTIONS='-DOTBR_DUA_ROUTING=ON -DOT_DUA=ON'
-            platforms: "linux/amd64,linux/arm/v7,linux/arm64"
-            push: no
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:


### PR DESCRIPTION
This commit removes the build and push configurations for the following Docker image targets from the buildx matrix in docker.yml:

- focal: The image built on ubuntu:focal.
- reference-device: The image configured for Thread Test Harness and reference-device testing.
- test: The smoke-test/CI-only compilation target image.

This leaves only the default latest image (built on ubuntu:bionic) in the workflow matrix.