### PR TITLE
[docker] add short Git SHA tags to border-router Docker image

### DIFF
--- a/.github/workflows/docker-border-router.yml
+++ b/.github/workflows/docker-border-router.yml
@@ -159,6 +159,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
This commit adds the `type=sha,prefix=sha-,format=short` tag to the metadata generated for the openthread/border-router Docker image.

This ensures that every push or merge to main builds and pushes an image containing a unique, immutable tag (sha-<short_sha>) corresponding to the specific Git commit.

This allows downstream and production users to secure their supply chain by pinning and auditing their Docker deployment manifests using stable, un-overwritten tags instead of rolling mutable tags.