### PR TITLE
[tests] add DinD expect script for BBR multicast forwarding

### DIFF
--- a/tests/scripts/expect/dind_multicast.exp
+++ b/tests/scripts/expect/dind_multicast.exp
@@ -1,0 +1,198 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
+    exec docker run -d \
+        --name $name \
+        --network infrastructure-link \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --add-host=host.docker.internal:host-gateway \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv4.conf.default.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.default.forwarding=1 \
+        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
+        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
+        -e OT_INFRA_IF=eth0 \
+        -e OT_THREAD_IF=wpan0 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
+    sleep 2
+
+    # Now start the simulated RCP binary on the host!
+    exec $sim_app $sim_id <$pty >$pty &
+    sleep 5
+}
+
+set container "otbr-test-container"
+set test_client "test-client"
+
+set pty1 [create_socat_tcp 1 9000]
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+set test_maddr "ff05::abcd"
+
+# Start border router in Docker on the DinD host
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+set socket_ready false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state}]} {
+        set socket_ready true
+        break
+    }
+    sleep 2
+}
+if {!$socket_ready} {
+    fail "ot-ctl failed to communicate with otbr-agent"
+}
+
+# Setup active dataset on OTBR via ot-ctl
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+set leader false
+for {set i 0} {$i < 20} {incr i} {
+    spawn docker exec -i $container ot-ctl state
+    set timeout 3
+    expect {
+        "leader" {
+            set leader true
+            break
+        }
+        timeout {
+            # Not leader yet
+        }
+    }
+    catch {close}
+    catch {wait}
+    sleep 2
+}
+if {!$leader} {
+    catch {send_user [exec docker exec -i $container cat /var/log/otbr-agent.log]}
+    fail "OTBR did not become leader."
+}
+
+# Ensure OTBR container ignores ICMPv6 echo requests so ping replies come only from Thread device
+exec docker exec -i $container sysctl -w net.ipv6.icmp.echo_ignore_all=1
+
+# Wait 15 seconds for the Border Routing Manager to fully stabilize its dynamic OMR prefix
+send_user "Waiting 15 seconds for the dynamic OMR prefix to stabilize...\n"
+sleep 15
+
+# Get the running Border Router's active dataset dynamically to configure the client
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [string trim $active_dataset]
+
+# Join Thread network from Node 4 (ot-cli-ftd)
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child\|router"
+expect_line "Done"
+
+# Subscribe to the site-local multicast address
+send "ipmaddr add ${test_maddr}\n"
+expect_line "Done"
+sleep 5
+
+# Set up the test-client container on the infrastructure link
+exec docker run -d \
+    --name $test_client \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "echo 0 > /proc/sys/net/ipv6/conf/all/autoconf && echo 0 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
+
+# Check if the host kernel supports Route Information Option (RIO) / accept_ra_rt_info_max_plen processing
+set has_rio [expr {[catch {exec docker exec -i $test_client test -f /proc/sys/net/ipv6/conf/all/accept_ra_rt_info_max_plen}] == 0}]
+
+if {$has_rio} {
+    send_user "Host kernel supports RIO processing. Enabling accept_ra_rt_info_max_plen.\n"
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
+    # Trigger a Router Solicitation to fetch RAs immediately and let kernel auto-install the OMR route
+    exec docker exec -i $test_client rdisc6 eth0
+} else {
+    send_user "Warning: Host kernel does NOT support RIO processing (CONFIG_IPV6_ROUTE_INFO is disabled). Falling back to static route.\n"
+
+    # Retrieve the global IPv6 address of the OTBR container on the bridge network
+    set format "\{\{range .NetworkSettings.Networks\}\}\{\{.GlobalIPv6Address\}\}\{\{end\}\}"
+    set otbr_ip [exec docker inspect otbr-test-container -f $format]
+    send_user "OTBR Infrastructure IPv6 Address: $otbr_ip\n"
+
+    # Manually install static route to Thread ULA subnet (fc00::/7) via the OTBR, bypassing host kernel RIO limitation
+    exec docker exec -i $test_client ip -6 route add fc00::/7 via $otbr_ip dev eth0
+}
+send_user "Test Client routing table:\n"
+send_user [exec docker exec -i $test_client ip -6 route]
+
+# Ping the multicast address from the test client on the infrastructure network
+send_user "Pinging site-local multicast address ${test_maddr} from test client...\n"
+spawn docker exec -i $test_client ping6 -I eth0 -t 5 -c 10 $test_maddr
+set timeout 20
+expect {
+    "10 packets transmitted, 10 received, 0% packet loss" {
+        send_user "\n# Ping from infra host to Thread device multicast address succeeded!\n"
+    }
+    timeout {
+        fail "Ping from infra host to Thread device multicast address timed out"
+    }
+    eof {
+        fail "Ping from infra host to Thread device multicast address failed (EOF)"
+    }
+}
+catch {close}
+catch {wait}
+
+exec docker stop $test_client
+exec docker rm $test_client
+
+exec docker stop $container
+exec docker rm $container
+dispose_all
+
+send_user -- "--- Multicast Forwarding Integration Test PASSED successfully! ---\n"
+exit 0

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -185,6 +185,11 @@ test_run()
 
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
+
+    if [[ "$(uname)" != "Darwin" && "$(uname -r)" != *"linuxkit"* ]]; then
+        echo "--- Running BBR Multicast Forwarding integration test ---"
+        expect -df "${SCRIPT_DIR}/expect/dind_multicast.exp"
+    fi
 }
 
 main()


### PR DESCRIPTION
This commit introduces a new expect script to verify Backbone Router (BBR) multicast forwarding functionality in a Docker-in-Docker (DinD) environment.

Specifically, the test:
1. Starts the OTBR Docker container in DinD mode on the infrastructure link.
2. Spawns a simulated OpenThread CLI device, joins the Thread network, and subscribes to a site-local scope multicast address (ff05::abcd).
3. Sets up a background test client on the infrastructure link to ping the site-local multicast address.
4. Validates 100% reachability from the infrastructure link host to the subscribed Thread device across the border router.

Additionally, `test_dind_dns_sd.sh` is updated to execute this test conditionally on platforms where the Backbone Router feature is enabled (skipping execution on macOS/linuxkit where BBR is disabled).