### PR TITLE
[tests] add DinD integration test for Web UI frontend

### DIFF
--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -64,7 +64,7 @@ ipset_destroy_if_exist otbr-ingress-allow-dst-swap
 
 echo "OpenThread firewall rules removed."
 
-if test "$e" -ne 0; then
+if test "$e" -ne 0 && test "$e" -ne 5; then
     echo "$e" > /run/s6-linux-init-container-results/exitcode
     /run/s6/basedir/bin/halt
     exit 125

--- a/etc/docker/test/Dockerfile.dind_runner
+++ b/etc/docker/test/Dockerfile.dind_runner
@@ -33,6 +33,7 @@ RUN apk add --no-cache \
     bash \
     build-base \
     cmake \
+    curl \
     expect \
     git \
     ninja \

--- a/src/web/web-service/ot_client.cpp
+++ b/src/web/web-service/ot_client.cpp
@@ -307,12 +307,20 @@ bool OpenThreadClient::FactoryReset(void)
     signal(SIGPIPE, handler);
     Disconnect();
     sleep(4);
-    VerifyOrExit(rval = Connect());
-
-    result = Execute("version");
-    VerifyOrExit(result != nullptr);
-
-    rval = strstr(result, "OPENTHREAD") != nullptr;
+    for (int i = 0; i < 10; ++i)
+    {
+        if (Connect())
+        {
+            if ((result = Execute("version")) != nullptr)
+            {
+                rval = strstr(result, "OPENTHREAD") != nullptr;
+                break;
+            }
+        }
+        Disconnect();
+        sleep(1);
+    }
+    VerifyOrExit(rval);
 
 exit:
     return rval;

--- a/tests/scripts/expect/dind_web.exp
+++ b/tests/scripts/expect/dind_web.exp
@@ -1,0 +1,125 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or paragraphs provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+proc start_otbr_docker_web {name sim_app sim_id pty1 pty2} {
+    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
+    exec docker run -d \
+        --name $name \
+        --network infrastructure-link \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --add-host=host.docker.internal:host-gateway \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv4.conf.default.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.default.forwarding=1 \
+        -v $pty2:/dev/ttyUSB0 \
+        -e OT_RCP_DEVICE=spinel+hdlc+uart:///dev/ttyUSB0 \
+        -e OT_INFRA_IF=eth0 \
+        -e OT_THREAD_IF=wpan0 \
+        -e OT_WEB_LISTEN_ADDR=0.0.0.0 \
+        -p 8080:8080 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
+    sleep 2
+
+    # Now start the simulated RCP binary on the host in a dedicated script restart loop and track its PID
+    exec bash -c "echo 'while true; do \"\$1\" \"\$2\" <\"\$3\" >\"\$3\"; sleep 1; done' > /tmp/ot_rcp_web_loop.sh"
+    exec bash -c "bash /tmp/ot_rcp_web_loop.sh \"$sim_app\" \"$sim_id\" \"$pty1\" </dev/null >/dev/null 2>&1 & echo \$! > /tmp/ot_rcp_web_loop.pid"
+    sleep 5
+}
+
+set ptys [create_socat 1]
+set pty1 [lindex $ptys 0]
+set pty2 [lindex $ptys 1]
+set container "otbr-test-container-web"
+
+start_otbr_docker_web $container $::env(EXP_OT_RCP_PATH) 2 $pty1 $pty2
+
+# Wait for otbr-agent to create the domain socket
+set socket_ready false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state}]} {
+        set socket_ready true
+        break
+    }
+    sleep 2
+}
+if {!$socket_ready} {
+    send_user "Error: ot-ctl failed to communicate with otbr-agent\n"; exit 1
+}
+
+# Stop Thread and down interface initially so we can form network via Web UI
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+
+send_user "Testing Web UI index.html...\n"
+set web_ready false
+for {set i 0} {$i < 15} {incr i} {
+    if {![catch {exec curl -s http://127.0.0.1:8080/index.html} result]} {
+        if {[string first "What is OpenThread" $result] != -1} {
+            set web_ready true
+            break
+        }
+    }
+    sleep 2
+}
+if {!$web_ready} {
+    send_user "Error: Web UI index.html validation failed\n"
+    exit 1
+}
+send_user "Web UI index.html validated successfully!\n"
+
+send_user "Testing Web UI form_network...\n"
+set network_key "00112233445566778899aabbccddeeff"
+set ext_pan_id "0011223344556677"
+set pan_id "0xface"
+set passphrase "123456"
+set channel 12
+set network_name "OpenThreadDocker"
+
+set form_data "{\"networkKey\":\"$network_key\",\"prefix\":\"fd11:22::\",\"defaultRoute\":true,\"extPanId\":\"$ext_pan_id\",\"panId\":\"$pan_id\",\"passphrase\":\"$passphrase\",\"channel\":$channel,\"networkName\":\"$network_name\"}"
+
+set result [exec curl -s --header "Content-Type: application/json" --request POST --data $form_data http://127.0.0.1:8080/form_network]
+if {[string first "success" $result] == -1} {
+    send_user "Error: Web UI form_network validation failed: $result\n"
+    exit 1
+}
+send_user "Web UI form_network validated successfully!\n"
+
+catch {exec bash -c "kill \$(cat /tmp/ot_rcp_web_loop.pid) 2>/dev/null"}
+
+exec docker stop $container
+exec docker rm $container
+dispose_all
+
+send_user -- "--- DinD Web UI Integration Test PASSED successfully! ---\n"
+exit 0

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -75,16 +75,16 @@ test_teardown()
     echo "Active and inactive containers:"
     docker ps -a || true
     echo "Container logs:"
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "test-client"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client"; do
         docker logs "$c" || true
     done
 
     echo "Agent logs:"
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web"; do
         docker exec -i "$c" cat /var/log/otbr-agent.log || true
     done
 
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "test-client"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client"; do
         docker stop "$c" || true
         docker rm "$c" || true
     done
@@ -186,10 +186,20 @@ test_run()
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
 
+    echo "--- Cleaning up TREL containers and orphaned processes ---"
+    docker stop otbr-test-container-1 otbr-test-container-2 || true
+    pkill -f ot-rcp || true
+    pkill -f socat || true
+
     if [[ "$(uname)" != "Darwin" && "$(uname -r)" != *"linuxkit"* ]]; then
         echo "--- Running BBR Multicast Forwarding integration test ---"
         expect -df "${SCRIPT_DIR}/expect/dind_multicast.exp"
+        pkill -f ot-rcp || true
+        pkill -f socat || true
     fi
+
+    echo "--- Running Web UI integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_web.exp"
 }
 
 main()


### PR DESCRIPTION
This commit adds a continuous integration test to validate the Web UI frontend functionality in a Docker-in-Docker environment.

Specifically, it introduces the following changes:
- Added `curl` to `Dockerfile.dind_runner` to enable HTTP testing inside the Alpine-based DinD runner.
- Added `dind_web.exp` expect script to spin up the production OTBR Docker container, simulate an RCP via direct PTY volume mounting, and verify both `GET /index.html` and `POST /form_network` endpoints.
- Updated `test_dind_dns_sd.sh` to run the new Web UI expect script and perform intermediate cleanup between test scripts.
- Removed `otbr-agent` dependency from `otbr-web` in s6-rc and updated the `otbr-agent` s6 finish script to ignore exit code 5 (normal daemon exit on factory reset), allowing `otbr-agent` to restart cleanly without halting the container or terminating active HTTP connections.
- Updated `OpenThreadClient::FactoryReset` in `ot_client.cpp` with a robust 10-second retry loop for both `Connect()` and `Execute()` to gracefully handle variable daemon initialization times under s6-overlay supervision.