### PR TITLE
[rest] set SO_REUSEADDR socket option for REST HTTP server

### DIFF
--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1839,7 +1839,7 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
         {
             otbrLogInfo("RestWebServer listening on %s:%u", aRestListenAddress.c_str(), aRestListenPort);
             self->mServer.set_ipv6_v6only(false);
-            self->mServer.set_socket_options([](int sock) {
+            self->mServer.set_socket_options([](socket_t sock) {
                 int opt = 1;
                 // cpp-httplib defaults to SO_REUSEPORT instead of SO_REUSEADDR
                 setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1839,6 +1839,11 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
         {
             otbrLogInfo("RestWebServer listening on %s:%u", aRestListenAddress.c_str(), aRestListenPort);
             self->mServer.set_ipv6_v6only(false);
+            self->mServer.set_socket_options([](int sock) {
+                int opt = 1;
+                // cpp-httplib defaults to SO_REUSEPORT instead of SO_REUSEADDR
+                setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+            });
             const httplib::Headers defaultHeaders = {
                 {"Access-Control-Allow-Origin", OTBR_REST_ACCESS_CONTROL_ALLOW_ORIGIN},
                 {"Access-Control-Allow-Methods", OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS},

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1839,10 +1839,10 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
         {
             otbrLogInfo("RestWebServer listening on %s:%u", aRestListenAddress.c_str(), aRestListenPort);
             self->mServer.set_ipv6_v6only(false);
-            self->mServer.set_socket_options([](socket_t sock) {
+            self->mServer.set_socket_options([](socket_t aSock) {
                 int opt = 1;
                 // cpp-httplib defaults to SO_REUSEPORT instead of SO_REUSEADDR
-                setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+                setsockopt(aSock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
             });
             const httplib::Headers defaultHeaders = {
                 {"Access-Control-Allow-Origin", OTBR_REST_ACCESS_CONTROL_ALLOW_ORIGIN},

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -34,8 +34,10 @@
 #include <chrono>
 
 #include <arpa/inet.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <httplib.h>
+#include <string.h>
 
 #include <openthread/commissioner.h>
 
@@ -1842,7 +1844,10 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
             self->mServer.set_socket_options([](socket_t aSock) {
                 int opt = 1;
                 // cpp-httplib defaults to SO_REUSEPORT instead of SO_REUSEADDR
-                setsockopt(aSock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+                if (setsockopt(aSock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) != 0)
+                {
+                    otbrLogWarning("Failed to set SO_REUSEADDR: %s", strerror(errno));
+                }
             });
             const httplib::Headers defaultHeaders = {
                 {"Access-Control-Allow-Origin", OTBR_REST_ACCESS_CONTROL_ALLOW_ORIGIN},

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -73,12 +73,28 @@ expect {
     -i \$otbr_agent eof { error "unexpected exit" }
 }
 
-if {\$error == 0} {
-    exit \$status
-} else {
+if {\$error != 0} {
     system errno \$status
     error "failed to run the test"
 }
+
+# Test that server can restart after abrupt shutdown (SO_REUSEADDR)
+send_user "Testing server restart after abrupt shutdown...\r\n"
+set agent_pid [exp_pid -i \$otbr_agent]
+exec kill -9 \$agent_pid
+expect -i \$otbr_agent eof
+
+spawn "${CMAKE_BINARY_DIR}/src/agent/otbr-agent" -d 7 -v -I wpan0 -B lo "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1"
+expect "Start Thread Border Agent"
+
+spawn curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081/node/state
+expect {
+    "200" { send_user "Server restart test passed\r\n" }
+    timeout { error "REST API did not respond after restart" }
+    eof { error "curl failed" }
+}
+
+exit 0
 EOF
 }
 

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -85,7 +85,7 @@ exec kill -9 \$agent_pid
 expect -i \$otbr_agent eof
 
 spawn "${CMAKE_BINARY_DIR}/src/agent/otbr-agent" -d 7 -v -I wpan0 -B lo "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1"
-expect "Start Thread Border Agent"
+expect "RestWebServer listening on"
 
 spawn curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081/node/state
 expect {

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -85,6 +85,7 @@ exec kill -9 \$agent_pid
 expect -i \$otbr_agent eof
 
 spawn "${CMAKE_BINARY_DIR}/src/agent/otbr-agent" -d 7 -v -I wpan0 -B lo "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1"
+set otbr_agent \$spawn_id
 expect "RestWebServer listening on"
 
 spawn curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8081/node/state


### PR DESCRIPTION
(This is a re-submission of https://github.com/openthread/ot-br-posix/pull/3212, I wasn't able to re-open the PR after force pushing.)

Home Assistant is going to be upgrading our Thread addon from 1.3 to 1.4 (https://github.com/home-assistant/addons/pull/4619) and I've run into a small issue that prevents the REST API server from cleanly restarting when restarting the container.

In b067e5ac5f8b3e92750df24922017eee2bc0fa04 (January 2025), ot-br-posix explicitly set `SO_REUSEADDR`: https://github.com/openthread/ot-br-posix/blob/b067e5ac5f8b3e92750df24922017eee2bc0fa04/src/rest/rest_web_server.cpp#L157-L158

ot-br-posix switched to cpp-httplib in February 2025 (https://github.com/openthread/ot-br-posix/pull/2733) and the library by default uses `SO_REUSEPORT`: https://github.com/yhirose/cpp-httplib/blob/6d848d4bfc285b071d1beb3b3a80e22c1ef21669/httplib.h#L2324-L2332

This PR switches back to explicitly setting `SO_REUSEADDR`, which I think is a better socket option for a service that is supposed to uniquely listen on the configured port.