### PR TITLE
[sdp-proxy] fix heap underflow in SRP Advertising Proxy

### DIFF
--- a/src/sdp_proxy/advertising_proxy.cpp
+++ b/src/sdp_proxy/advertising_proxy.cpp
@@ -123,10 +123,17 @@ void AdvertisingProxy::AdvertisingHandler(otSrpServerServiceUpdateId aId,
 
     error = PublishHostAndItsServices(aHost, update);
 
-    if (error != OTBR_ERROR_NONE || update->mCallbackCount == 0)
+    for (auto it = mOutstandingUpdates.begin(); it != mOutstandingUpdates.end(); ++it)
     {
-        mOutstandingUpdates.pop_back();
-        otSrpServerHandleServiceUpdateResult(GetInstance(), aId, OtbrErrorToOtError(error));
+        if (it->mId == aId)
+        {
+            if (error != OTBR_ERROR_NONE || it->mCallbackCount == 0)
+            {
+                mOutstandingUpdates.erase(it);
+                otSrpServerHandleServiceUpdateResult(GetInstance(), aId, OtbrErrorToOtError(error));
+            }
+            break;
+        }
     }
 
 exit:


### PR DESCRIPTION
This commit fixes a heap underflow in the SRP Advertising Proxy due to calling pop_back() on the empty mOutstandingUpdates vector.

When a synchronous mDNS error occurs during
PublishHostAndItsServices, the callback OnMdnsPublishResult erases the outstanding update from the vector synchronously. Since the handler was assuming the update was still at the back of the vector, it would call pop_back() on an empty vector.

This fix checks if the outstanding update exists by searching for it by its update ID before erasing it or notifying the result, which avoids the heap underflow and potential double-reporting.