### PR TITLE
[rest] fix out-of-bounds map write in diagnostic handler

### DIFF
--- a/src/rest/network_diag_handler.cpp
+++ b/src/rest/network_diag_handler.cpp
@@ -383,12 +383,14 @@ otError NetworkDiagHandler::GetDiagnosticsStatus(const char  *aAddressString,
 
 void NetworkDiagHandler::StopDiagnosticsRequest(void)
 {
+    otMeshDiagCancel(mInstance);
     mRequestState          = RequestState::kIdle;
     mDiagQueryRequestState = RequestState::kIdle;
 }
 
 void NetworkDiagHandler::Clear(void)
 {
+    StopDiagnosticsRequest();
     mDiagSet.clear();
     mChildTables.clear();
     mChildIps.clear();
@@ -1095,12 +1097,12 @@ void NetworkDiagHandler::MeshChildIp6AddrResponseHandler(otError                
     otIp6Address   ip6Address;
     auto           it = mChildIps.find(mDiagQueryRequestRloc);
 
+    VerifyOrExit(it != mChildIps.end(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(it->second.mState == RequestState::kPending, error = OT_ERROR_INVALID_STATE);
+
     VerifyOrExit(aError == OT_ERROR_NONE || aError == OT_ERROR_PENDING || aError == OT_ERROR_RESPONSE_TIMEOUT);
     VerifyOrExit(aIp6AddrIterator != nullptr);
     VerifyOrExit(aChildRloc16 != 65534);
-
-    VerifyOrExit(it != mChildIps.end(), error = OT_ERROR_INVALID_STATE);
-    VerifyOrExit(it->second.mState == RequestState::kPending, error = OT_ERROR_INVALID_STATE);
 
     // otbrLogWarning("%s:%d Have child IP from 0x%04x for child 0x%04x", __FILE__, __LINE__, mDiagQueryRequestRloc,
     //                aChildRloc16);


### PR DESCRIPTION
In NetworkDiagHandler::MeshChildIp6AddrResponseHandler, the iterator was checked for end-of-map validity after several other VerifyOrExit conditions were evaluated. If one of the preceding checks failed (e.g., aIp6AddrIterator was nullptr in a terminal or timeout event), the code exited early to the 'exit:' label. Because 'error' was initialized to OT_ERROR_NONE and unmodified by early exits, the cleanup block attempted to write to 'it->second' even if 'it' was at the end of the 'mChildIps' map (e.g. when mChildIps was cleared due to DELETE /api/diagnostics). This caused a near-null pointer dereference and SIGSEGV crash.

This commit fixes the issue by:
- Validating that the iterator 'it' is not equal to 'mChildIps.end()' and setting 'error = OT_ERROR_INVALID_STATE' before checking any other VerifyOrExit condition.
- Invoking 'otMeshDiagCancel(mInstance)' inside both 'Clear()' and 'StopDiagnosticsRequest()' to safely abort any outstanding queries and avoid delivering late callback events to the handlers.