### PR TITLE
[border-agent] validate MeshCop TXT entry length in D-Bus handler

### DIFF
--- a/src/border_agent/border_agent.cpp
+++ b/src/border_agent/border_agent.cpp
@@ -382,8 +382,10 @@ void BorderAgent::EncodeVendorTxtData(const VendorTxtEntries &aVendorEntries)
     {
         otbrError error = Mdns::Publisher::EncodeTxtData(txtList, mVendorTxtData);
 
-        assert(error == OTBR_ERROR_NONE);
-        OTBR_UNUSED_VARIABLE(error);
+        if (error != OTBR_ERROR_NONE)
+        {
+            otbrLogResult(error, "Failed to encode vendor TXT data");
+        }
     }
 
     if (mVendorTxtDataChangedCallback != nullptr)

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -1335,6 +1335,9 @@ void DBusThreadObjectRcp::UpdateMeshCopTxtHandler(DBusRequest &aRequest)
     VerifyOrExit(DBusMessageToTuple(*aRequest.GetMessage(), args) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
     for (const auto &entry : updatedTxtEntries)
     {
+        VerifyOrExit(!entry.mKey.empty() &&
+                         entry.mKey.length() + entry.mValue.size() + 1 <= Mdns::Publisher::kMaxTextEntrySize,
+                     error = OT_ERROR_INVALID_ARGS);
         update[entry.mKey] = entry.mValue;
     }
     for (const auto reservedKey : {"rv", "tv", "sb", "nn", "xp", "at", "pt", "dn", "sq", "bb", "omr"})

--- a/src/mdns/mdns.hpp
+++ b/src/mdns/mdns.hpp
@@ -419,9 +419,9 @@ public:
      */
     static otbrError DecodeTxtData(TxtList &aTxtList, const uint8_t *aTxtData, uint16_t aTxtLength);
 
-protected:
     static constexpr uint8_t kMaxTextEntrySize = 255;
 
+protected:
 #if !OTBR_ENABLE_MDNS_OPENTHREAD
 
     class Registration


### PR DESCRIPTION
This commit handles oversized vendor entries in D-Bus calls to prevent unexpected daemon exits.

When the D-Bus method UpdateVendorMeshCopTxtEntries is invoked, it previously accepted entry updates without checking if the length of the key and value exceeded the DNS-SD limit. This caused the EncodeTxtData function to return an error, triggering a strict assertion failure and process exit in EncodeVendorTxtData.

This fix adds entry length validation to the D-Bus handler: VerifyOrExit(entry.mKey.length() + entry.mValue.size() + 1 <=
             Mdns::Publisher::kMaxTextEntrySize,
             error = OT_ERROR_INVALID_ARGS);

It also replaces the assertion in EncodeVendorTxtData with a warning log to avoid aborting execution.