### PR TITLE
[discovery-proxy] restart query iteration to prevent heap UAF

### DIFF
--- a/src/sdp_proxy/discovery_proxy.cpp
+++ b/src/sdp_proxy/discovery_proxy.cpp
@@ -256,6 +256,7 @@ void DiscoveryProxy::OnServiceDiscovered(const std::string                      
             instanceInfo.mHostName = translatedHostName.c_str();
 
             otDnssdQueryHandleDiscoveredServiceInstance(mHost.GetInstance(), serviceFullName.c_str(), &instanceInfo);
+            query = nullptr;
         }
     }
 }
@@ -310,6 +311,7 @@ void DiscoveryProxy::OnHostDiscovered(const std::string                         
             std::string hostFullName = TranslateDomain(resolvedHostName, domain);
 
             otDnssdQueryHandleDiscoveredHost(mHost.GetInstance(), hostFullName.c_str(), &hostInfo);
+            query = nullptr;
         }
     }
 


### PR DESCRIPTION
DiscoveryProxy::OnServiceDiscovered() and OnHostDiscovered() iterate the OpenThread proxy-query list with otDnssdGetNextQuery() while, inside the loop body, calling
otDnssdQueryHandleDiscoveredServiceInstance() or
otDnssdQueryHandleDiscoveredHost(). Those calls dequeue the current query from the internal list and can heap-free the message depending on the build configuration. The next iteration then dereferences the stale pointer via query->GetNext() in otDnssdGetNextQuery(), causing a heap use-after-free (UAF).

This commit fixes the issue by setting the query pointer to nullptr after handling a query in the loops. Setting it to nullptr forces the next loop iteration to restart scanning safely from the head of the list. Because handled queries are always dequeued, the size of the list always decreases, guaranteeing the loop will terminate without accessing stale query pointers.