### PR TITLE
[ncp-spinel] fix uninitialized stack read in DecodeDnssdService

### DIFF
--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -676,7 +676,7 @@ void NcpSpinel::HandleValueInserted(spinel_prop_key_t aKey, const uint8_t *aBuff
         otPlatDnssdService           service;
         Mdns::Publisher::SubTypeList subTypeList;
         const char                  *subTypeArray[kMaxSubTypes];
-        uint16_t                     subTypeCount;
+        uint16_t                     subTypeCount = kMaxSubTypes;
         Mdns::Publisher::TxtData     txtData;
         otPlatDnssdRequestId         requestId;
         const uint8_t               *callbackData;
@@ -788,7 +788,7 @@ void NcpSpinel::HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffe
     {
         otPlatDnssdService   service;
         const char          *subTypeArray[kMaxSubTypes];
-        uint16_t             subTypeCount;
+        uint16_t             subTypeCount = kMaxSubTypes;
         otPlatDnssdRequestId requestId;
         const uint8_t       *callbackData;
         uint16_t             callbackDataSize;
@@ -799,7 +799,7 @@ void NcpSpinel::HandleValueRemoved(spinel_prop_key_t aKey, const uint8_t *aBuffe
         callbackDataCopy.assign(callbackData, callbackData + callbackDataSize);
 
         mPublisher->UnpublishService(
-            service.mHostName, service.mServiceType, [this, requestId, callbackDataCopy](otbrError aError) {
+            service.mServiceInstance, service.mServiceType, [this, requestId, callbackDataCopy](otbrError aError) {
                 OT_UNUSED_VARIABLE(SendDnssdResult(requestId, callbackDataCopy, OtbrErrorToOtError(aError)));
             });
         break;

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -494,7 +494,7 @@ private:
 
     static constexpr uint8_t  kMaxTids             = 16;
     static constexpr uint16_t kCallbackDataMaxSize = sizeof(uint64_t); // Maximum size of a function pointer.
-    static constexpr uint16_t kMaxSubTypes         = 8;                // Maximum number of sub types in a MDNS service.
+    static constexpr uint16_t kMaxSubTypes         = 64;               // Maximum number of sub types in a MDNS service.
 
     template <typename Function, typename... Args> static void SafeInvoke(Function &aFunc, Args &&...aArgs)
     {


### PR DESCRIPTION
NcpSpinel::HandleValueInserted() and HandleValueRemoved() declared the subTypeCount variable without initialization, then passed it to ot::Spinel::DecodeDnssdService() as an in/out parameter. Since the decoder uses the input value as the loop/array capacity bound, stack residue in this variable could lead to stack corruption or SRP registration drops if the residue is incorrect and the spinel frame contains sub-type labels.

This commit fixes the stack corruption by:
- Initializing subTypeCount to kMaxSubTypes.
- Increasing kMaxSubTypes from 8 to 64 to support a larger number of sub-type labels.

Additionally, this commit corrects the UnpublishService argument inside HandleValueRemoved() from service.mHostName to service.mServiceInstance, matching the mdns publisher interface and avoiding functional errors.