### PR TITLE
[dbus] fix potential null dereference in MessageHandler

### DIFF
--- a/src/dbus/server/dbus_object.cpp
+++ b/src/dbus/server/dbus_object.cpp
@@ -150,22 +150,34 @@ DBusHandlerResult DBusObject::sMessageHandler(DBusConnection *aConnection, DBusM
 DBusHandlerResult DBusObject::MessageHandler(DBusConnection *aConnection, DBusMessage *aMessage)
 {
     DBusHandlerResult handled = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-    DBusRequest       request(aConnection, aMessage);
-    std::string       interface  = dbus_message_get_interface(aMessage);
-    std::string       memberName = interface + "." + dbus_message_get_member(aMessage);
-    auto              iter       = mMethodHandlers.find(memberName);
 
-    if (dbus_message_get_type(aMessage) == DBUS_MESSAGE_TYPE_METHOD_CALL && iter != mMethodHandlers.end())
+    VerifyOrExit(dbus_message_get_type(aMessage) == DBUS_MESSAGE_TYPE_METHOD_CALL);
+
     {
-        otbrLogDebug("Handling method %s", memberName.c_str());
-        if (otbrLogGetLevel() >= OTBR_LOG_DEBUG)
+        const char *interface = dbus_message_get_interface(aMessage);
+        const char *member    = dbus_message_get_member(aMessage);
+
+        if (interface != nullptr && member != nullptr)
         {
-            DumpDBusMessage(*aMessage);
+            std::string memberName = std::string(interface) + "." + member;
+            auto        iter       = mMethodHandlers.find(memberName);
+
+            if (iter != mMethodHandlers.end())
+            {
+                DBusRequest request(aConnection, aMessage);
+
+                otbrLogDebug("Handling method %s", memberName.c_str());
+                if (otbrLogGetLevel() >= OTBR_LOG_DEBUG)
+                {
+                    DumpDBusMessage(*aMessage);
+                }
+                (iter->second)(request);
+                handled = DBUS_HANDLER_RESULT_HANDLED;
+            }
         }
-        (iter->second)(request);
-        handled = DBUS_HANDLER_RESULT_HANDLED;
     }
 
+exit:
     return handled;
 }
 


### PR DESCRIPTION
DBusObject::MessageHandler constructed a std::string directly from the return value of dbus_message_get_interface(), which is optional in D-Bus spec for METHOD_CALL messages and documented to return NULL when absent. Constructing std::string from a null pointer leads to undefined behavior (typically crashing the process in strlen(NULL)).

This commit fixes the potential crash by:
- Performing strict null checks on both interface and member pointers before constructing the memberName string.
- Safe-routing interface-less method calls so they bypass registered handlers and return DBUS_HANDLER_RESULT_NOT_YET_HANDLED.