### PR TITLE
[rcp-host] fix UAF in ThreadDetachGracefullyCallback

### DIFF
--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -389,7 +389,8 @@ void RcpHost::HandleStateChanged(otChangedFlags aFlags)
         if (IsAttached() && mJoinReceiver != nullptr)
         {
             otbrLogInfo("Join succeeded");
-            SafeInvokeAndClear(mJoinReceiver, OT_ERROR_NONE, "Join succeeded");
+            auto joinReceiver = std::move(mJoinReceiver);
+            SafeInvoke(joinReceiver, OT_ERROR_NONE, "Join succeeded");
         }
     }
 }
@@ -575,11 +576,11 @@ void RcpHost::Join(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs, const A
     SuccessOrExit(error = otThreadSetEnabled(mInstance, true), errorMsg = "Failed to bring up Thread stack");
 
     // Abort an ongoing join()
-    if (mJoinReceiver != nullptr)
     {
-        SafeInvoke(mJoinReceiver, OT_ERROR_ABORT, "Join() is aborted");
+        auto joinReceiver = std::move(mJoinReceiver);
+        mJoinReceiver     = aReceiver;
+        SafeInvoke(joinReceiver, OT_ERROR_ABORT, "Join() is aborted");
     }
-    mJoinReceiver     = aReceiver;
     receiveResultHere = false;
 
 exit:
@@ -664,7 +665,8 @@ void RcpHost::SendMgmtPendingSetCallback(otError aError, void *aContext)
 
 void RcpHost::SendMgmtPendingSetCallback(otError aError)
 {
-    SafeInvokeAndClear(mScheduleMigrationReceiver, aError, "");
+    auto migrationReceiver = std::move(mScheduleMigrationReceiver);
+    SafeInvoke(migrationReceiver, aError, "");
 }
 
 void RcpHost::SetThreadEnabled(bool aEnabled, const AsyncResultReceiver aReceiver)
@@ -779,14 +781,19 @@ void RcpHost::ThreadDetachGracefullyCallback(void *aContext)
 
 void RcpHost::ThreadDetachGracefullyCallback(void)
 {
-    SafeInvokeAndClear(mJoinReceiver, OT_ERROR_ABORT, "Aborted by leave/disable operation");
-    SafeInvokeAndClear(mScheduleMigrationReceiver, OT_ERROR_ABORT, "Aborted by leave/disable operation");
+    std::vector<DetachGracefullyCallback> callbacks;
 
-    for (auto &callback : mDetachGracefullyCallbacks)
+    callbacks.swap(mDetachGracefullyCallbacks);
+    auto joinReceiver      = std::move(mJoinReceiver);
+    auto migrationReceiver = std::move(mScheduleMigrationReceiver);
+
+    SafeInvoke(joinReceiver, OT_ERROR_ABORT, "Aborted by leave/disable operation");
+    SafeInvoke(migrationReceiver, OT_ERROR_ABORT, "Aborted by leave/disable operation");
+
+    for (auto &callback : callbacks)
     {
         callback();
     }
-    mDetachGracefullyCallbacks.clear();
 }
 
 void RcpHost::ConditionalErasePersistentInfo(bool aErase)
@@ -808,7 +815,8 @@ void RcpHost::DisableThreadAfterDetach(void)
     UpdateThreadEnabledState(ThreadEnabledState::kStateDisabled);
 
 exit:
-    SafeInvokeAndClear(mSetThreadEnabledReceiver, error, errorMsg);
+    auto receiver = std::move(mSetThreadEnabledReceiver);
+    SafeInvoke(receiver, error, errorMsg);
 }
 
 void RcpHost::SetCountryCode(const std::string &aCountryCode, const AsyncResultReceiver &aReceiver)

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -241,14 +241,6 @@ public:
     bool IsAttached(void);
 
 private:
-    static void SafeInvokeAndClear(AsyncResultReceiver &aReceiver, otError aError, const std::string &aErrorInfo = "")
-    {
-        if (aReceiver)
-        {
-            aReceiver(aError, aErrorInfo);
-            aReceiver = nullptr;
-        }
-    }
     static void SafeInvoke(const AsyncResultReceiver &aReceiver, otError aError, const std::string &aErrorInfo = "")
     {
         if (aReceiver)

--- a/tests/gtest/test_rcp_host_api.cpp
+++ b/tests/gtest/test_rcp_host_api.cpp
@@ -526,3 +526,67 @@ TEST(RcpHostApi, ThreadRoleChangedCallbackInvoked)
 
     host.Deinit();
 }
+
+TEST(RcpHostApi, ThreadDetachGracefullyCallbackReentrancy)
+{
+    otbr::MainloopContext mainloop;
+    otbr::Host::RcpHost   host("wpan0", std::vector<const char *>(), /* aBackboneInterfaceName */ "",
+                               /* aDryRun */ false,
+                               /* aEnableAutoAttach */ false);
+
+    host.Init();
+
+    otInstance              *instance = ot::FakePlatform::CurrentInstance();
+    otOperationalDataset     dataset;
+    otOperationalDatasetTlvs datasetTlvs;
+
+    ASSERT_EQ(otDatasetCreateNewNetwork(instance, &dataset), OT_ERROR_NONE);
+    otDatasetConvertToTlvs(&dataset, &datasetTlvs);
+    ASSERT_EQ(otDatasetSetActiveTlvs(instance, &datasetTlvs), OT_ERROR_NONE);
+
+    // Make sure the device is in Leader role first.
+    ASSERT_EQ(otIp6SetEnabled(instance, true), OT_ERROR_NONE);
+    ASSERT_EQ(otThreadSetEnabled(instance, true), OT_ERROR_NONE);
+
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 5,
+                         [&]() { return host.GetDeviceRole() == OT_DEVICE_ROLE_LEADER; });
+    ASSERT_EQ(host.GetDeviceRole(), OT_DEVICE_ROLE_LEADER);
+
+    // Queue multiple Join calls with a different dataset to trigger the ThreadDetachGracefully recursive scenario
+    otOperationalDataset     joinDataset;
+    otOperationalDatasetTlvs joinDatasetTlvs;
+    ASSERT_EQ(otDatasetCreateNewNetwork(instance, &joinDataset), OT_ERROR_NONE);
+    otDatasetConvertToTlvs(&joinDataset, &joinDatasetTlvs);
+
+    bool done1 = false, done2 = false, done3 = false, done4 = false;
+    host.Join(joinDatasetTlvs, [&](otError aError, const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aError);
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        done1 = true;
+    });
+    host.Join(joinDatasetTlvs, [&](otError aError, const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aError);
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        done2 = true;
+    });
+    host.Join(joinDatasetTlvs, [&](otError aError, const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aError);
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        done3 = true;
+    });
+    host.Join(joinDatasetTlvs, [&](otError aError, const std::string &aErrorMsg) {
+        OT_UNUSED_VARIABLE(aError);
+        OT_UNUSED_VARIABLE(aErrorMsg);
+        done4 = true;
+    });
+
+    // Force the detach callbacks to run.
+    MainloopProcessUntil(mainloop, /* aTimeoutSec */ 5, [&]() { return done1 && done2 && done3 && done4; });
+
+    EXPECT_TRUE(done1);
+    EXPECT_TRUE(done2);
+    EXPECT_TRUE(done3);
+    EXPECT_TRUE(done4);
+
+    host.Deinit();
+}


### PR DESCRIPTION
This commit fixes a potential heap use-after-free (UAF) in RcpHost::ThreadDetachGracefullyCallback. The function iterates over mDetachGracefullyCallbacks, whose elements can recursively trigger ThreadDetachGracefully() and push new elements back into mDetachGracefullyCallbacks.

If the vector gets reallocated during a non-final iteration of the range-based for loop, the loop's cached iterators become dangling, leading to undefined behavior or a process crash.

This is resolved by moving the callbacks vector to a local variable before iterating, isolating the active loop from any recursive modifications.

We also add a ThreadDetachGracefullyCallbackReentrancy gtest to exercise and prevent regressions for this scenario.