### PR TITLE
[dns-utils] replace service/hostname sanity asserts

### DIFF
--- a/src/mdns/mdns.cpp
+++ b/src/mdns/mdns.cpp
@@ -208,7 +208,8 @@ uint64_t Publisher::AddSubscriptionCallbacks(Publisher::DiscoveredServiceInstanc
 
 void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aInstanceInfo)
 {
-    bool checkToInvoke = false;
+    otbrError error         = OTBR_ERROR_NONE;
+    bool      checkToInvoke = false;
 
     otbrLogInfo("Service %s is resolved successfully: %s %s host %s addresses %zu", aType.c_str(),
                 aInstanceInfo.mRemoved ? "remove" : "add", aInstanceInfo.mName.c_str(), aInstanceInfo.mHostName.c_str(),
@@ -229,13 +230,13 @@ void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aIns
         otbrLogInfo("addresses: [ %s ]", addressesString.c_str());
     }
 
-    DnsUtils::CheckServiceNameSanity(aType);
+    SuccessOrExit(error = DnsUtils::CheckServiceNameSanity(aType));
 
-    assert(aInstanceInfo.mNetifIndex > 0);
+    VerifyOrExit(aInstanceInfo.mNetifIndex > 0, error = OTBR_ERROR_INVALID_ARGS);
 
     if (!aInstanceInfo.mRemoved)
     {
-        DnsUtils::CheckHostnameSanity(aInstanceInfo.mHostName);
+        SuccessOrExit(error = DnsUtils::CheckHostnameSanity(aInstanceInfo.mHostName));
     }
 
     UpdateMdnsResponseCounters(mTelemetryInfo.mServiceResolutions, OTBR_ERROR_NONE);
@@ -270,6 +271,13 @@ void Publisher::OnServiceResolved(std::string aType, DiscoveredInstanceInfo aIns
             }
         }
     }
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        UpdateMdnsResponseCounters(mTelemetryInfo.mServiceResolutions, error);
+        UpdateServiceInstanceResolutionEmaLatency(aInstanceInfo.mName, aType, error);
+    }
 }
 
 void Publisher::OnServiceRemoved(uint32_t aNetifIndex, std::string aType, std::string aInstanceName)
@@ -287,14 +295,15 @@ void Publisher::OnServiceRemoved(uint32_t aNetifIndex, std::string aType, std::s
 
 void Publisher::OnHostResolved(std::string aHostName, Publisher::DiscoveredHostInfo aHostInfo)
 {
-    bool checkToInvoke = false;
+    otbrError error         = OTBR_ERROR_NONE;
+    bool      checkToInvoke = false;
 
     otbrLogInfo("Host %s is resolved successfully: host %s addresses %zu ttl %u", aHostName.c_str(),
                 aHostInfo.mHostName.c_str(), aHostInfo.mAddresses.size(), aHostInfo.mTtl);
 
     if (!aHostInfo.mHostName.empty())
     {
-        DnsUtils::CheckHostnameSanity(aHostInfo.mHostName);
+        SuccessOrExit(error = DnsUtils::CheckHostnameSanity(aHostInfo.mHostName));
     }
 
     UpdateMdnsResponseCounters(mTelemetryInfo.mHostResolutions, OTBR_ERROR_NONE);
@@ -329,6 +338,13 @@ void Publisher::OnHostResolved(std::string aHostName, Publisher::DiscoveredHostI
                 break;
             }
         }
+    }
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        UpdateMdnsResponseCounters(mTelemetryInfo.mHostResolutions, error);
+        UpdateHostResolutionEmaLatency(aHostName, error);
     }
 }
 

--- a/src/utils/dns_utils.cpp
+++ b/src/utils/dns_utils.cpp
@@ -181,26 +181,27 @@ std::string UnescapeInstanceName(const std::string &aName)
     return newName;
 }
 
-void CheckHostnameSanity(const std::string &aHostName)
+otbrError CheckHostnameSanity(const std::string &aHostName)
 {
-    OTBR_UNUSED_VARIABLE(aHostName);
+    otbrError error = OTBR_ERROR_NONE;
 
-    assert(aHostName.length() > 0);
-    assert(aHostName.back() == '.');
+    VerifyOrExit(aHostName.length() > 0, error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aHostName.back() == '.', error = OTBR_ERROR_INVALID_ARGS);
+
+exit:
+    return error;
 }
 
-void CheckServiceNameSanity(const std::string &aServiceName)
+otbrError CheckServiceNameSanity(const std::string &aServiceName)
 {
-    size_t dotpos;
+    otbrError error = OTBR_ERROR_NONE;
 
-    OTBR_UNUSED_VARIABLE(aServiceName);
-    OTBR_UNUSED_VARIABLE(dotpos);
+    VerifyOrExit(aServiceName.length() > 0, error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aServiceName.back() != '.', error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(aServiceName.find_first_of('.') != std::string::npos, error = OTBR_ERROR_INVALID_ARGS);
 
-    assert(aServiceName.length() > 0);
-    assert(aServiceName[aServiceName.length() - 1] != '.');
-    dotpos = aServiceName.find_first_of('.');
-    assert(dotpos != std::string::npos);
-    assert(dotpos == aServiceName.find_last_of('.'));
+exit:
+    return error;
 }
 
 } // namespace DnsUtils

--- a/src/utils/dns_utils.hpp
+++ b/src/utils/dns_utils.hpp
@@ -148,19 +148,25 @@ std::string UnescapeInstanceName(const std::string &aName);
  *      The host name must ends with dot.
  *
  * @param[in] aHostName  The host name to check.
+ *
+ * @retval OTBR_ERROR_NONE          The host name is valid.
+ * @retval OTBR_ERROR_INVALID_ARGS  The host name is invalid.
  */
-void CheckHostnameSanity(const std::string &aHostName);
+otbrError CheckHostnameSanity(const std::string &aHostName);
 
 /**
  * This function checks a given service name for sanity.
  *
  * Check criteria:
- *      The service name must contain exactly one dot.
+ *      The service name must contain at least one dot.
  *      The service name must not end with dot.
  *
  * @param[in] aServiceName  The service name to check.
+ *
+ * @retval OTBR_ERROR_NONE          The service name is valid.
+ * @retval OTBR_ERROR_INVALID_ARGS  The service name is invalid.
  */
-void CheckServiceNameSanity(const std::string &aServiceName);
+otbrError CheckServiceNameSanity(const std::string &aServiceName);
 
 } // namespace DnsUtils
 } // namespace otbr

--- a/tests/gtest/test_dns_utils.cpp
+++ b/tests/gtest/test_dns_utils.cpp
@@ -92,3 +92,21 @@ TEST(DnsUtils, TestSplitFullDnsName)
     CheckSplitFullDnsName("com", false, false, true, "", "", "com", ".");
     CheckSplitFullDnsName("", false, false, true, "", "", "", ".");
 }
+
+TEST(DnsUtils, CheckServiceNameSanity)
+{
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("_ipps._tcp"), OTBR_ERROR_NONE);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("_meshcop._udp"), OTBR_ERROR_NONE);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("_S840._sub._matterc._udp"), OTBR_ERROR_NONE);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("_x._sub._foo._tcp"), OTBR_ERROR_NONE);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity(""), OTBR_ERROR_INVALID_ARGS);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("_ipps._tcp."), OTBR_ERROR_INVALID_ARGS);
+    EXPECT_EQ(otbr::DnsUtils::CheckServiceNameSanity("nodots"), OTBR_ERROR_INVALID_ARGS);
+}
+
+TEST(DnsUtils, CheckHostnameSanity)
+{
+    EXPECT_EQ(otbr::DnsUtils::CheckHostnameSanity("host."), OTBR_ERROR_NONE);
+    EXPECT_EQ(otbr::DnsUtils::CheckHostnameSanity(""), OTBR_ERROR_INVALID_ARGS);
+    EXPECT_EQ(otbr::DnsUtils::CheckHostnameSanity("nodot"), OTBR_ERROR_INVALID_ARGS);
+}


### PR DESCRIPTION
Rigid assert statements in DnsUtils::CheckServiceNameSanity and DnsUtils::CheckHostnameSanity assumed standard formatting and would abort otbr-agent if a service type contains multiple dots.

Under OTBR_ENABLE_DNSSD_PLAT, a perfectly legal Thread-mesh DNS-SD browse subtype query (such as _S840._sub._matterc._udp) constructs service type names with three dots, which matches the apple mDNSResponder and RFC 6763 specification, but would trigger the sanity check's assertion and crash the daemon (Availability DoS).

This is resolved by replacing the strict assertions in the sanity check functions with non-crashing VerifyOrExit early-returns.

We also add CheckServiceNameSanity and CheckHostnameSanity unit tests to verify correct behavior on various valid and invalid service type formats and hostnames.