### PR TITLE
[rest] prevent division-by-zero in energy scan callback

### DIFF
--- a/src/rest/commissioner_manager.cpp
+++ b/src/rest/commissioner_manager.cpp
@@ -541,17 +541,21 @@ void CommissionerManager::HandleEnergyScanReportCallback(uint32_t       aChannel
                                                          uint8_t        aEnergyListLength)
 {
     std::bitset<32> mask(aChannelMask);
-    size_t          reportCount = aEnergyListLength / mask.count();
+    size_t          reportCount;
+    size_t          numChannels = mask.count();
 
     VerifyOrExit(mEnergyScanState == kEnergyScanStateSent);
     VerifyOrExit(mEnergyScanChannelMask == aChannelMask);
-    VerifyOrExit(aEnergyListLength == reportCount * mask.count());
+
+    VerifyOrExit(numChannels > 0 && numChannels <= kMaxEnergyScanResults);
+    reportCount = aEnergyListLength / numChannels;
+    VerifyOrExit(aEnergyListLength == reportCount * numChannels);
 
     for (size_t i = 0; i < reportCount; i++)
     {
-        for (size_t channel = 0; channel < mask.count(); channel++)
+        for (size_t channel = 0; channel < numChannels; channel++)
         {
-            int8_t rssi = aEnergyList[(i * mask.count()) + channel];
+            int8_t rssi = aEnergyList[(i * numChannels) + channel];
             mEnergyScanReport.mReports[channel].mMaxRssi.push_back(rssi);
         }
     }


### PR DESCRIPTION
Defers the division by the number of active channels in the energy scan report callback until after verifying that the callback state and channel mask match the active energy scan request.

This prevents a division-by-zero (SIGFPE) crash if a commissioned Thread device on the mesh transmits a MGMT_ED_REPORT.ntf CoAP message with an empty (zero) channel mask, since StartEnergyScan explicitly guarantees the mEnergyScanChannelMask is non-zero.