### PR TITLE
[rest] fix getNetworkDiagnosticTask off-by-one crash

### DIFF
--- a/src/rest/actions/network_diagnostic.cpp
+++ b/src/rest/actions/network_diagnostic.cpp
@@ -206,10 +206,15 @@ bool NetworkDiagnostic::Validate(const cJSON &aJson)
     errormsg = KEY_TYPES;
     VerifyOrExit(types != nullptr);
     VerifyOrExit(cJSON_IsArray(types));
-    cJSON_ArrayForEach(item, types)
     {
-        VerifyOrExit(cJSON_IsString(item));
-        SuccessOrExit(DiagnosticTypes::FindId(item->valuestring, id));
+        std::set<uint8_t> uniqueTypes;
+        cJSON_ArrayForEach(item, types)
+        {
+            VerifyOrExit(cJSON_IsString(item));
+            SuccessOrExit(DiagnosticTypes::FindId(item->valuestring, id));
+            uniqueTypes.insert(id);
+        }
+        VerifyOrExit(uniqueTypes.size() <= DiagnosticTypes::kMaxTotalCount);
     }
 
     ok = true;

--- a/src/rest/diagnostic_types.hpp
+++ b/src/rest/diagnostic_types.hpp
@@ -41,9 +41,36 @@ namespace rest {
 class DiagnosticTypes
 {
 public:
-    static constexpr uint32_t kMaxTotalCount      = 26; ///< Total number of recognized types
+    static constexpr uint32_t kMaxTotalCount      = 27; ///< Total number of recognized types
     static constexpr uint32_t kMaxQueryCount      = 3;  ///< Number of types that require a diag query
     static constexpr uint32_t kMaxResettableCount = 2;  ///< Number of types that can be reset
+
+    static constexpr uint32_t CountTotalTypes(uint32_t aIndex)
+    {
+        return (aIndex >= kTypeListSize)
+                   ? 0
+                   : ((kTypeInfos[aIndex].mJsonKey != nullptr) ? 1 : 0) + CountTotalTypes(aIndex + 1);
+    }
+
+    static constexpr uint32_t CountQueryTypes(uint32_t aIndex)
+    {
+        return (aIndex >= kTypeListSize)
+                   ? 0
+                   : (((kTypeInfos[aIndex].mJsonKey != nullptr) && (kTypeInfos[aIndex].mProperties & kPropertyQuery))
+                          ? 1
+                          : 0) +
+                         CountQueryTypes(aIndex + 1);
+    }
+
+    static constexpr uint32_t CountResettableTypes(uint32_t aIndex)
+    {
+        return (aIndex >= kTypeListSize)
+                   ? 0
+                   : (((kTypeInfos[aIndex].mJsonKey != nullptr) && (kTypeInfos[aIndex].mProperties & kPropertyCanReset))
+                          ? 1
+                          : 0) +
+                         CountResettableTypes(aIndex + 1);
+    }
 
     static const char *GetJsonKey(uint8_t aTypeId);
     static bool        RequiresQuery(uint8_t aTypeId);
@@ -108,6 +135,13 @@ private:
 
     static const std::unordered_map<std::string, uint8_t> kKeyMap;
 };
+
+static_assert(DiagnosticTypes::kMaxTotalCount == DiagnosticTypes::CountTotalTypes(0),
+              "kMaxTotalCount must match the number of recognized types");
+static_assert(DiagnosticTypes::kMaxQueryCount == DiagnosticTypes::CountQueryTypes(0),
+              "kMaxQueryCount must match the number of query types");
+static_assert(DiagnosticTypes::kMaxResettableCount == DiagnosticTypes::CountResettableTypes(0),
+              "kMaxResettableCount must match the number of resettable types");
 
 } // namespace rest
 } // namespace otbr


### PR DESCRIPTION
DiagnosticTypes::kKeyMap has 27 entries (ids 0-9, 14-17, 19-21, 23-31, 34), but DiagnosticTypes::kMaxTotalCount was set to 26. This caused an assertion failure and crashed the otbr-agent root daemon whenever a REST call requested all 27 valid types. In NDEBUG builds, this led to a 1-byte out-of-bounds write.

This commit addresses the issue by:
1. Increasing kMaxTotalCount to 27.
2. Implementing compile-time static_assert checks using recursive constexpr helper functions to dynamically validate kMaxTotalCount, kMaxQueryCount, and kMaxResettableCount against the key map table, preventing future off-by-one regressions.
3. Validating request types array size in NetworkDiagnostic::Validate to ensure the unique type count does not exceed kMaxTotalCount.