### PR TITLE
[build] remove all references to DUA

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -50,84 +50,84 @@ jobs:
       matrix:
         include:
           - name: "Border Router (OT mDNS)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
             border_routing: 1
             internet: 0
             otbr_mdns: "openthread"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
             border_routing: 1
             internet: 0
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router (Avahi)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
             border_routing: 1
             internet: 0
             otbr_mdns: "avahi"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router TREL (OT mDNS)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_DNS_UPSTREAM_QUERY=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_DNS_UPSTREAM_QUERY=ON"
             border_routing: 1
             internet: 0
             otbr_mdns: "openthread"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 2
           - name: "Border Router TREL (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON"
             border_routing: 1
             internet: 0
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 2
           - name: "Border Router MATN (OT mDNS)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
             border_routing: 1
             internet: 0
             otbr_mdns: "openthread"
             cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py
             packet_verification: 1
           - name: "Border Router MATN (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
             border_routing: 1
             internet: 0
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py
             packet_verification: 1
           - name: "Border Router Internet Access Features (OT mDNS)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_DHCP6_PD=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_DHCP6_PD=ON"
             border_routing: 1
             internet: 1
             otbr_mdns: "openthread"
             cert_scripts: ./tests/scripts/thread-cert/border_router/internet/*.py
             packet_verification: 1
           - name: "Border Router Internet Access Features (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_DHCP6_PD=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_DHCP6_PD=ON"
             border_routing: 1
             internet: 1
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/internet/*.py
             packet_verification: 1
           - name: "Backbone Router (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_OT_DISCOVERY_PROXY=OFF"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_OT_DISCOVERY_PROXY=OFF"
             border_routing: 0
             internet: 0
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/backbone/*.py
             packet_verification: 1
           - name: "Border Router with OT Core Advertising Proxy (avahi)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF -DOTBR_OT_SRP_ADV_PROXY=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF -DOTBR_OT_SRP_ADV_PROXY=ON"
             border_routing: 1
             internet: 0
             otbr_mdns: "avahi"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 1
           - name: "Border Router with OT Core Advertising Proxy (mDNSResponder)"
-            otbr_options: "-DOT_DUA=ON -DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF -DOTBR_OT_SRP_ADV_PROXY=ON"
+            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_BORDER_AGENT_MESHCOP_SERVICE=OFF -DOTBR_OT_SRP_ADV_PROXY=ON"
             border_routing: 1
             internet: 0
             otbr_mdns: "mDNSResponder"

--- a/etc/yocto/otbr_git.bb
+++ b/etc/yocto/otbr_git.bb
@@ -56,7 +56,6 @@ EXTRA_OECMAKE += " \
     -DOTBR_VENDOR_NAME="OpenThread" \
     -DOTBR_PRODUCT_NAME="Border Router" \
     -DOTBR_MESHCOP_SERVICE_INSTANCE_NAME="OpenThread Border Router" \
-    -DOT_DUA=OFF \
     -DOT_POSIX_SETTINGS_PATH='"/tmp/"' \
     -DOT_MLR=OFF \
 "

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -29,7 +29,6 @@
 set(OT_15_4 ON CACHE STRING "enable 802.15.4 radio link" FORCE)
 set(OT_ANYCAST_LOCATOR ON CACHE STRING "enable anycast locator" FORCE)
 set(OT_BACKBONE_ROUTER ${OTBR_BACKBONE_ROUTER} CACHE STRING "Enable Backbone Router feature in OpenThread" FORCE)
-set(OT_BACKBONE_ROUTER_DUA_NDPROXYING OFF CACHE STRING "Configure DUA ND Proxy feature in OpenThread" FORCE)
 set(OT_BORDER_AGENT ON CACHE STRING "enable border agent" FORCE)
 set(OT_BORDER_AGENT_EPSKC ON CACHE STRING "enable border agent ephemeral PSKc" FORCE)
 set(OT_BORDER_AGENT_ID ON CACHE STRING "enable border agent ID" FORCE)
@@ -126,9 +125,6 @@ if (OTBR_BORDER_AGENT)
 endif()
 
 if (NOT OT_THREAD_VERSION STREQUAL "1.1")
-    if (OT_REFERENCE_DEVICE)
-        set(OT_DUA ON CACHE STRING "Enable Thread 1.2 DUA for reference devices")
-    endif()
     set(OT_LINK_METRICS_SUBJECT ON CACHE STRING "enable link metrics subject" FORCE)
 endif()
 
@@ -157,7 +153,6 @@ target_compile_definitions(ot-config INTERFACE
 
 if (NOT OT_THREAD_VERSION STREQUAL "1.1")
     target_compile_definitions(ot-config INTERFACE
-        "-DOPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE=1"
         "-DOPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE=1"
     )
 endif()


### PR DESCRIPTION
This change removes the compilation options and configurations for Domain Unicast Address (DUA) from the OpenThread Border Router (OTBR) repository.

The following modifications were made:
- Removed the `OT_BACKBONE_ROUTER_DUA_NDPROXYING` option definition and `OT_DUA` configuration for reference devices in the `third_party/openthread/CMakeLists.txt` file.
- Removed `-DOPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE=1` from compile definitions.
- Cleaned up Yocto recipe `etc/yocto/otbr_git.bb` by removing the `-DOT_DUA=OFF` configuration option.
- Removed the `-DOT_DUA=ON` setting from all strategic test matrix definitions in the `.github/workflows/border_router.yml` file.