### PR TITLE
[tests] align expect scripts failsafe cleanup and docker tracking

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -28,7 +28,12 @@
 #
 
 proc fail {message} {
+    global in_fail
     send_user "Error: $message\n"
+    if {![info exists in_fail]} {
+        set in_fail 1
+        catch { dispose_all }
+    }
     exit 1
 }
 
@@ -118,8 +123,10 @@ proc spawn_node {id type sim_app} {
 
 proc create_socat {id} {
     global socat_pid
+    global socat_spawn_ids
     spawn socat -d -d pty,raw,echo=0 pty,raw,echo=0
     set socat_pid [exp_pid]
+    lappend socat_spawn_ids $spawn_id
     set pty1 ""
     set pty2 ""
     expect {
@@ -131,14 +138,15 @@ proc create_socat {id} {
             fail "Timed out"
         }
     }
-    set spawn_ids($id) $spawn_id
     return [list $pty1 $pty2]
 }
 
 proc create_socat_tcp {id port} {
     global socat_pids
+    global socat_spawn_ids
     spawn socat -d -d pty,raw,echo=0 tcp-listen:$port,reuseaddr,bind=0.0.0.0
     lappend socat_pids [exp_pid]
+    lappend socat_spawn_ids $spawn_id
     set pty ""
     expect {
         -re {PTY is (\S+)} {
@@ -151,8 +159,16 @@ proc create_socat_tcp {id port} {
     return $pty
 }
 
+proc track_container {name} {
+    global docker_containers
+    lappend docker_containers $name
+}
+
 proc start_otbr_docker {name sim_app sim_id pty1 pty2} {
-    exec $sim_app $sim_id <$pty1 >$pty1 &
+    global rcp_pids
+    track_container $name
+    set rcp_pid [exec $sim_app $sim_id <$pty1 >$pty1 &]
+    lappend rcp_pids $rcp_pid
     exec docker run -d \
         --name $name \
         --network backbone1 \
@@ -181,6 +197,7 @@ proc dispose_node {id} {
 proc dispose_socat {} {
     global socat_pid
     global socat_pids
+    global socat_spawn_ids
     if { [info exists socat_pid] } {
         catch { exec kill $socat_pid }
         unset socat_pid
@@ -191,17 +208,51 @@ proc dispose_socat {} {
         }
         set socat_pids {}
     }
+    if { [info exists socat_spawn_ids] } {
+        foreach sid $socat_spawn_ids {
+            catch { close -i $sid }
+            catch { wait -i $sid }
+        }
+        set socat_spawn_ids {}
+    }
 }
 proc dispose_all {} {
+    catch { expect_after timeout }
     global spawn_ids
-    set max_node [array size spawn_ids]
-    for {set i 1} {$i <= $max_node} {incr i} {
-        if { [info exists spawn_ids($i)] } {
-            dispose_node $i
+    global rcp_pids
+    global docker_containers
+    if {[array exists spawn_ids]} {
+        foreach id [array names spawn_ids] {
+            catch { dispose_node $id }
         }
+        array unset spawn_ids
     }
-    array unset spawn_ids
     dispose_socat
+    if { [info exists rcp_pids] } {
+        foreach pid $rcp_pids {
+            catch { exec kill $pid }
+        }
+        set rcp_pids {}
+    }
+    if { [file exists "/tmp/ot_rcp_web_loop.pid"] } {
+        catch {
+            set fp [open "/tmp/ot_rcp_web_loop.pid" r]
+            set web_pid [string trim [read $fp]]
+            close $fp
+            if {[string is integer -strict $web_pid]} {
+                catch { exec kill -STOP $web_pid }
+                catch { exec pkill -P $web_pid }
+                catch { exec kill -KILL $web_pid }
+            }
+        }
+        catch { file delete "/tmp/ot_rcp_web_loop.pid" }
+    }
+    if { [info exists docker_containers] } {
+        foreach c $docker_containers {
+            catch { exec docker rm -f $c }
+        }
+        set docker_containers {}
+    }
 }
 
 proc get_ipaddr {type} {

--- a/tests/scripts/expect/dind_dns_sd.exp
+++ b/tests/scripts/expect/dind_dns_sd.exp
@@ -31,6 +31,8 @@ source "tests/scripts/expect/_common.exp"
 
 # Custom start_otbr_docker for our network name
 proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    global rcp_pids
+    track_container $name
     # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
     exec docker run -d \
         --name $name \
@@ -51,7 +53,8 @@ proc start_otbr_docker_dind {name sim_app sim_id pty} {
     sleep 2
 
     # 3. Now start the simulated RCP binary on the host!
-    exec $sim_app $sim_id <$pty >$pty &
+    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
+    lappend rcp_pids $rcp_pid
     sleep 5
 }
 
@@ -150,6 +153,7 @@ sleep 10
 
 # Set up a single background test-client container to perform both mDNS resolution and ping tests
 set test_client "test-client"
+track_container $test_client
 exec docker run -d \
     --name $test_client \
     --network infrastructure-link \
@@ -354,10 +358,4 @@ expect {
         }
     }
 }
-
-exec docker stop $test_client
-exec docker rm $test_client
-
-exec docker stop $container
-exec docker rm $container
 dispose_all

--- a/tests/scripts/expect/dind_multicast.exp
+++ b/tests/scripts/expect/dind_multicast.exp
@@ -30,6 +30,8 @@
 source "tests/scripts/expect/_common.exp"
 
 proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    global rcp_pids
+    track_container $name
     # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
     exec docker run -d \
         --name $name \
@@ -50,12 +52,14 @@ proc start_otbr_docker_dind {name sim_app sim_id pty} {
     sleep 2
 
     # Now start the simulated RCP binary on the host!
-    exec $sim_app $sim_id <$pty >$pty &
+    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
+    lappend rcp_pids $rcp_pid
     sleep 5
 }
 
 set container "otbr-test-container"
 set test_client "test-client"
+track_container $test_client
 
 set pty1 [create_socat_tcp 1 9000]
 
@@ -186,12 +190,6 @@ expect {
 }
 catch {close}
 catch {wait}
-
-exec docker stop $test_client
-exec docker rm $test_client
-
-exec docker stop $container
-exec docker rm $container
 dispose_all
 
 send_user -- "--- Multicast Forwarding Integration Test PASSED successfully! ---\n"

--- a/tests/scripts/expect/dind_trel.exp
+++ b/tests/scripts/expect/dind_trel.exp
@@ -33,6 +33,8 @@ source "tests/scripts/expect/_common.exp"
 
 # Dynamic helper to start the OTBR docker container and map the spinel relay
 proc start_otbr_docker_trel {name sim_app sim_id pty rcp_port} {
+    global rcp_pids
+    track_container $name
     exec docker run -d \
         --name $name \
         --network infrastructure-link \
@@ -53,7 +55,8 @@ proc start_otbr_docker_trel {name sim_app sim_id pty rcp_port} {
     sleep 2
 
     # Start the simulated RCP binary on the host
-    exec $sim_app $sim_id <$pty >$pty &
+    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
+    lappend rcp_pids $rcp_pid
     sleep 5
 }
 
@@ -262,7 +265,6 @@ expect {
     }
 }
 catch {close}; catch {wait}
-
 dispose_all
 
 send_user -- "--- TREL Integration Test PASSED successfully! ---\n"

--- a/tests/scripts/expect/dind_web.exp
+++ b/tests/scripts/expect/dind_web.exp
@@ -30,6 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 proc start_otbr_docker_web {name sim_app sim_id pty1 pty2 {rest_addr ""} {rest_port ""}} {
+    track_container $name
     # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
     set docker_opts [list \
         "docker" "run" "-d" \
@@ -105,20 +106,9 @@ send_user "Scenario 1 get_rest_api_info verified successfully!\n"
 
 send_user "Scenario 1 default REST API verified successfully!\n"
 
-# Clean up Scenario 1 container and PTYs
-exec docker stop $container
-exec docker rm $container
-catch {exec bash -c "kill \$(cat /tmp/ot_rcp_web_loop.pid) 2>/dev/null"}
-dispose_all
+# Clean up Scenario 1 container but keep PTYs and RCP loop
+exec docker rm -f $container
 sleep 2
-
-# Re-create socat PTYs and RCP loop for Scenario 2
-set ptys [create_socat 1]
-set pty1 [lindex $ptys 0]
-set pty2 [lindex $ptys 1]
-
-exec bash -c "exec 3<>$pty1; while true; do \"$::env(EXP_OT_RCP_PATH)\" 2 <&3 >&3; sleep 1; done </dev/null >/tmp/ot_rcp_web.log 2>&1 & echo \$! > /tmp/ot_rcp_web_loop.pid"
-sleep 5
 
 # ==========================================
 # SCENARIO 2: Verification with Custom Values
@@ -197,10 +187,6 @@ if {[string first "networkName" $rest_node] == -1} {
 }
 send_user "Scenario 2 custom REST API responsiveness verified successfully!\n"
 
-catch {exec bash -c "kill \$(cat /tmp/ot_rcp_web_loop.pid) 2>/dev/null"}
-
-exec docker stop $container
-exec docker rm $container
 dispose_all
 
 send_user -- "--- DinD Web UI Integration Test PASSED successfully! ---\n"

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -186,16 +186,9 @@ test_run()
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
 
-    echo "--- Cleaning up TREL containers and orphaned processes ---"
-    docker stop otbr-test-container-1 otbr-test-container-2 || true
-    pkill -f ot-rcp || true
-    pkill -f socat || true
-
     if [[ "$(uname)" != "Darwin" && "$(uname -r)" != *"linuxkit"* ]]; then
         echo "--- Running BBR Multicast Forwarding integration test ---"
         expect -df "${SCRIPT_DIR}/expect/dind_multicast.exp"
-        pkill -f ot-rcp || true
-        pkill -f socat || true
     fi
 
     echo "--- Running Web UI integration test ---"


### PR DESCRIPTION
Enhance the integration test expect scripts to perform consistent,
self-contained, and failsafe cleanup of background RCP processes
and Docker containers on successful runs and failures.

- Introduce `track_container` helper in `_common.exp` to dynamically
  register created containers in a global `docker_containers` list.
- Update `dispose_all` to automatically stop and remove all registered
  containers in `docker_containers`, avoiding hardcoded variables.
- Integrate `track_container` into Docker starting helpers across
  `_common.exp`, `dind_dns_sd.exp`, `dind_multicast.exp`,
  `dind_trel.exp`, and `dind_web.exp`.
- Register ad-hoc client containers (`test-client`) for tracking.
- Remove redundant explicit Docker cleanup commands from all scripts.
- Align background process cleanup in `dispose_all` using `rcp_pids`.