### PR TITLE
[tests] add dind integration test for dhcp6 prefix delegation

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -32,6 +32,25 @@ proc fail {message} {
     send_user "Error: $message\n"
     if {![info exists in_fail]} {
         set in_fail 1
+        global docker_containers
+        if {[info exists docker_containers]} {
+            foreach c $docker_containers {
+                send_user "\n=== $c logs ===\n"
+                if {[catch {exec docker logs $c 2>&1} log_out]} {
+                    send_user "Failed to get logs: $log_out\n"
+                } else {
+                    send_user "$log_out\n"
+                }
+                if {[string match "*otbr*" $c]} {
+                    send_user "\n=== $c otbr-agent logs ===\n"
+                    if {[catch {exec docker exec -i $c cat /var/log/otbr-agent.log 2>&1} agent_out]} {
+                        send_user "Failed to get agent logs: $agent_out\n"
+                    } else {
+                        send_user "$agent_out\n"
+                    }
+                }
+            }
+        }
         catch { dispose_all }
     }
     exit 1

--- a/tests/scripts/expect/dind_dhcp6_pd.exp
+++ b/tests/scripts/expect/dind_dhcp6_pd.exp
@@ -1,0 +1,276 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+proc get_ipv6_64_prefix {ip} {
+    set ip [lindex [split $ip "/"] 0]
+    set parts [split [string map {:: " "} $ip] " "]
+    if {[llength $parts] == 2} {
+        set left [split [lindex $parts 0] ":"]
+        set right [split [lindex $parts 1] ":"]
+        set missing [expr {8 - [llength $left] - [llength $right]}]
+        set segments [concat $left [lrepeat $missing "0"] $right]
+    } else {
+        set segments [split $ip ":"]
+    }
+    set normalized {}
+    foreach seg [lrange $segments 0 3] {
+        if {$seg == ""} {set seg 0}
+        lappend normalized [format "%x" "0x$seg"]
+    }
+    return [join $normalized ":"]
+}
+
+# Custom start_otbr_docker for our network name
+proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    global rcp_pids
+    track_container $name
+    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
+    exec docker run -d \
+        --name $name \
+        --network infrastructure-link \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --add-host=host.docker.internal:host-gateway \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv4.conf.default.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.default.forwarding=1 \
+        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
+        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
+        -e OT_INFRA_IF=eth0 \
+        -e OT_THREAD_IF=wpan0 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
+    sleep 2
+
+    # Now start the simulated RCP binary on the host!
+    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
+    lappend rcp_pids $rcp_pid
+    sleep 5
+}
+
+set pty1 [create_socat_tcp 1 9000]
+set container "otbr-test-container"
+set dhcp6_server "dhcp6-server"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# 1. Start the DHCPv6 Prefix Delegation server container using Kea DHCPv6 in background
+send_user "Starting Kea DHCPv6 Prefix Delegation server container...\n"
+track_container $dhcp6_server
+exec docker run -d \
+    --name $dhcp6_server \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c {mkdir -p /var/lib/kea /var/run/kea && chmod -R 777 /var/lib/kea /var/run/kea && echo '{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "fd00:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2001:db8:9000:200::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}' > /etc/kea/kea-dhcp6.conf && sleep 2 && /usr/sbin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf}
+# Give Kea server time to initialize
+sleep 3
+
+# 2. Start border router in Docker on the DinD host
+send_user "Starting OTBR Docker container...\n"
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+set socket_ready false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state}]} {
+        set socket_ready true
+        break
+    }
+    sleep 2
+}
+if {!$socket_ready} {
+    fail "ot-ctl failed to communicate with otbr-agent"
+}
+
+# Setup active dataset on OTBR via ot-ctl
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+set leader false
+for {set i 0} {$i < 20} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state} state] && [string match "*leader*" $state]} {
+        set leader true
+        break
+    }
+    sleep 2
+}
+if {!$leader} {
+    catch {send_user [exec docker exec -i $container cat /var/log/otbr-agent.log]}
+    fail "OTBR did not become leader"
+}
+
+# 3. Enable DHCPv6 Prefix Delegation explicitly
+send_user "Enabling Prefix Delegation on the OTBR...\n"
+exec docker exec -i $container ot-ctl br pd enable
+sleep 5
+
+# Poll until a delegated prefix is acquired and visible in OMR prefix
+set prefix_acquired false
+set delegated_prefix ""
+for {set i 0} {$i < 20} {incr i} {
+    if {[catch {exec docker exec -i $container ot-ctl br pd omrprefix} pd_omr]} {
+        set pd_omr ""
+    }
+    set pd_omr [string trim $pd_omr]
+    send_user "Current DHCPv6 PD OMR Prefix: $pd_omr\n"
+    
+    if {[regexp {([0-9a-fA-F:]+/64)} $pd_omr match prefix]} {
+        set delegated_prefix $prefix
+        set prefix_acquired true
+        break
+    }
+    sleep 2
+}
+
+if {!$prefix_acquired} {
+    fail "DHCPv6 PD client failed to acquire a prefix from the server"
+}
+send_user "Successfully Discovered Delegated Prefix: $delegated_prefix\n"
+
+# Get the running Border Router's active dataset dynamically to configure the client
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [lindex [split [string trim $active_dataset] "\n"] 0]
+
+# 4. Join Thread network from Node 4 (ot-cli-ftd)
+send_user "Starting Simulated Thread Device (Node 4)...\n"
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+expect_line "Done"
+# Retrieve Node 4 global addresses and locate the SLAAC address matching the delegated prefix
+set slaac_addr ""
+for {set i 0} {$i < 10} {incr i} {
+    send "ipaddr\r\n"
+    set timeout 2
+    expect {
+        -re {([0-9a-fA-F:]+:[0-9a-fA-F:]+)\r?\n} {
+            set addr $expect_out(1,string)
+            set addr [string trim $addr]
+            set target_prefix [get_ipv6_64_prefix $delegated_prefix]
+            if {[get_ipv6_64_prefix $addr] == $target_prefix} {
+                set slaac_addr $addr
+                send_user "Found SLAAC Address in Delegated Prefix: $slaac_addr\n"
+            }
+            exp_continue
+        }
+        -re "Done\r?\n> " {
+            # finished parsing
+        }
+    }
+    if {$slaac_addr != ""} {
+        break
+    }
+    sleep 2
+}
+
+if {$slaac_addr == ""} {
+    fail "Simulated Thread Device did not configure an address under the delegated prefix"
+}
+
+# 5. Verify Bidirectional Routing (Ping from Thread Client Node 4 to Infrastructure Server)
+send_user "Verifying connectivity via PAN-to-WAN Ping...\n"
+
+# Retrieve the global IPv6 address of the dhcp6-server container
+set format "{{(index .NetworkSettings.Networks \"infrastructure-link\").GlobalIPv6Address}}"
+set server_ip [exec docker inspect $dhcp6_server -f $format]
+set server_ip [string trim $server_ip]
+send_user "Infrastructure Server IPv6 Address: $server_ip\n"
+
+# Check if the host kernel supports Route Information Option (RIO) / accept_ra_rt_info_max_plen processing
+set has_rio [expr {[catch {exec docker exec $dhcp6_server test -f /proc/sys/net/ipv6/conf/all/accept_ra_rt_info_max_plen}] == 0}]
+
+if {$has_rio} {
+    send_user "Host kernel supports RIO processing. Enabling accept_ra_rt_info_max_plen.\n"
+    exec docker exec $dhcp6_server sysctl -w net.ipv6.conf.all.accept_ra=2
+    exec docker exec $dhcp6_server sysctl -w net.ipv6.conf.eth0.accept_ra=2
+    exec docker exec $dhcp6_server sysctl -w net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+    exec docker exec $dhcp6_server sysctl -w net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
+    # Trigger a Router Solicitation to fetch RAs immediately and let kernel auto-install the OMR route
+    catch {exec docker exec $dhcp6_server rdisc6 eth0}
+    sleep 2
+} else {
+    send_user "Warning: Host kernel does NOT support RIO processing (CONFIG_IPV6_ROUTE_INFO is disabled). Falling back to static route.\n"
+    
+    # Retrieve the global IPv6 address of the OTBR container on the bridge network
+    set format "{{(index .NetworkSettings.Networks \"infrastructure-link\").GlobalIPv6Address}}"
+    set otbr_ip [exec docker inspect $container -f $format]
+    set otbr_ip [string trim $otbr_ip]
+    send_user "OTBR Infrastructure IPv6 Address: $otbr_ip\n"
+
+    # Add a static route on the dhcp6-server container for the delegated prefix via the OTBR
+    exec docker exec $dhcp6_server ip -6 route add $delegated_prefix via $otbr_ip dev eth0
+}
+
+send_user "Infrastructure Server routing table:\n"
+catch {send_user [exec docker exec $dhcp6_server ip -6 route]}
+
+# Send ping command from Node 4 (Thread client) to the infrastructure server
+switch_node 4
+send "ping $server_ip 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re {bytes from} {
+        set ping_success true
+    }
+    timeout {
+        send_user "Error: PAN-to-WAN Ping timed out\n"
+    }
+}
+
+if {!$ping_success} {
+    fail "PAN-to-WAN Ping verification failed"
+}
+
+send_user "\n# Bidirectional routing verified successfully via PAN-to-WAN Ping!\n"
+
+# 6. Clean up containers
+send_user "Tearing down containers...\n"
+dispose_all
+send_user "# DHCPv6 Prefix Delegation integration test completed successfully!\n"

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -75,7 +75,7 @@ test_teardown()
     echo "Active and inactive containers:"
     docker ps -a || true
     echo "Container logs:"
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client" "dhcp6-server"; do
         docker logs "$c" || true
     done
 
@@ -84,7 +84,7 @@ test_teardown()
         docker exec -i "$c" cat /var/log/otbr-agent.log || true
     done
 
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-web" "test-client" "dhcp6-server"; do
         docker stop "$c" || true
         docker rm "$c" || true
     done
@@ -122,9 +122,9 @@ test_setup()
     iptables -I INPUT 1 -p tcp --dport 9000 -j ACCEPT || true
 
     # 1. Build the production Docker image
-    local otbr_options=""
+    local otbr_options="-DOTBR_DHCP6_PD=ON -DOTBR_DHCP6_PD_CLIENT=openthread"
     if [[ "$(uname)" == "Darwin" || "$(uname -r)" == *"linuxkit"* ]]; then
-        otbr_options="-DOTBR_BACKBONE_ROUTER=OFF"
+        otbr_options="${otbr_options} -DOTBR_BACKBONE_ROUTER=OFF"
     fi
     echo "Building production border-router image with OTBR_MDNS=${OTBR_MDNS} OTBR_OPTIONS=${otbr_options}..."
     docker build --build-arg OTBR_MDNS="${OTBR_MDNS}" --build-arg OTBR_OPTIONS="${otbr_options}" -t "${OTBR_DOCKER_IMAGE}" -f "${OTBR_DOCKER_FILE}" "${REPO_ROOT}"
@@ -141,7 +141,7 @@ test_setup()
     echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
     docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["mdns-scan"]
 EOF
 
@@ -186,6 +186,8 @@ test_run()
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
 
+    echo "--- Running DHCPv6 Prefix Delegation integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_dhcp6_pd.exp"
     if [[ "$(uname)" != "Darwin" && "$(uname -r)" != *"linuxkit"* ]]; then
         echo "--- Running BBR Multicast Forwarding integration test ---"
         expect -df "${SCRIPT_DIR}/expect/dind_multicast.exp"


### PR DESCRIPTION
Add a new integration test dind_dhcp6_pd.exp to verify DHCPv6 Prefix Delegation (PD) capability inside a Docker-in-Docker context.

- Integrate dind_dhcp6_pd.exp test suite using expect, launching a Kea DHCPv6 Prefix Delegation server alongside the simulated Thread Border Router.
- Verify Thread OMR prefix auto-configuration, SLAAC address allocations on simulated node 4, and WAN-to-PAN bidirectional connectivity via conntracked ping sweeps.
- Add runtime kernel accept_ra_rt_info_max_plen validation for RIO route autodiscovery on host platforms, with static route fallback.
- Configure fail procedure inside _common.exp to trigger dispose_all cleanups natively on failure exit paths.
- Integrate client compile flags -DOTBR_DHCP6_PD=ON and -DOTBR_DHCP6_PD_CLIENT=openthread into the DinD image builder in test_dind_dns_sd.sh, and enable test execution.