### PR TITLE
[tests] clean up stale otbr-agent processes in ncp_mode runner

### DIFF
--- a/tests/scripts/ncp_mode
+++ b/tests/scripts/ncp_mode
@@ -295,6 +295,7 @@ otbr_exec_expect_script()
         sudo killall ot-cli-mtd || true
         sudo killall ot-ncp-ftd || true
         sudo killall ot-ncp-mtd || true
+        sudo killall "${OTBR_AGENT}" || true
         sudo rm -rf tmp
         mkdir tmp
         # avahi-browser is used to discover the service and verify in the test cases no matter what OTBR_MDNS is.


### PR DESCRIPTION
Clean up any stale, orphan `otbr-agent` processes at the start of each expect script loop in the `ncp_mode` test runner.

Under POSIX expect test execution, the `spawn` command launches the `otbr-agent` as `sudo` (running as root). If the expect script exits, the child process can sometimes be orphaned instead of terminated. This leaves the `otbr-agent` alive on the host system and holding ownership of the `io.openthread.BorderRouter.wpan0` D-Bus name.

In subsequent test scripts, the newly launched `otbr-agent` is unable to claim the D-Bus name, and all D-Bus requests are forwarded to the orphan `otbr-agent` process. Since its co-processor has been killed, the orphan agent hangs and subsequent `.Join` and properties `Get` method calls fail with a `NoReply` timeout.

Explicitly killing `otbr-agent` between test scripts prevents stale process leakage and resolves D-Bus communication timeouts.