### PR TITLE
[host] fix D-Bus method hangs on Spinel set-property failures

### DIFF
--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -889,29 +889,53 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     switch (mWaitingKeyTable[aTid])
     {
     case SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS:
-        VerifyOrExit(aKey == SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS, error = OTBR_ERROR_INVALID_STATE);
-        CallAndClear(mDatasetSetActiveTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            otOperationalDatasetTlvs datasetTlvs;
-            VerifyOrExit(ParseOperationalDatasetTlvs(aData, aLength, datasetTlvs) == OT_ERROR_NONE,
-                         error = OTBR_ERROR_PARSE);
-            mPropsObserver->SetDatasetActiveTlvs(datasetTlvs);
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mDatasetSetActiveTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mDatasetSetActiveTask, OT_ERROR_NONE);
+            {
+                otOperationalDatasetTlvs datasetTlvs;
+                VerifyOrExit(ParseOperationalDatasetTlvs(aData, aLength, datasetTlvs) == OT_ERROR_NONE,
+                             error = OTBR_ERROR_PARSE);
+                mPropsObserver->SetDatasetActiveTlvs(datasetTlvs);
+            }
         }
         break;
 
     case SPINEL_PROP_NET_IF_UP:
-        VerifyOrExit(aKey == SPINEL_PROP_NET_IF_UP, error = OTBR_ERROR_INVALID_STATE);
-        CallAndClear(mIp6SetEnabledTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            bool isUp;
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_BOOL_S, &isUp));
-            SafeInvoke(mNetifStateChangedCallback, isUp);
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mIp6SetEnabledTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_NET_IF_UP, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mIp6SetEnabledTask, OT_ERROR_NONE);
+            {
+                bool isUp;
+                SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_BOOL_S, &isUp));
+                SafeInvoke(mNetifStateChangedCallback, isUp);
+            }
         }
         break;
 
     case SPINEL_PROP_NET_STACK_UP:
-        VerifyOrExit(aKey == SPINEL_PROP_NET_STACK_UP, error = OTBR_ERROR_INVALID_STATE);
-        CallAndClear(mThreadSetEnabledTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mThreadSetEnabledTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_NET_STACK_UP, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mThreadSetEnabledTask, OT_ERROR_NONE);
+        }
         break;
 
     case SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET_TLVS:
@@ -951,22 +975,58 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
         break;
 
     case SPINEL_PROP_HOST_POWER_STATE:
-        CallAndClear(mSetHostPowerStateTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mSetHostPowerStateTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_HOST_POWER_STATE, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mSetHostPowerStateTask, OT_ERROR_NONE);
+        }
         otbrLogInfo("Set Host Power result: %s", spinel_status_to_cstr(status));
         break;
 
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ENABLE:
-        CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ENABLE, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        }
         otbrLogInfo("Set Ephemeral Key Enable result: %s", spinel_status_to_cstr(status));
         break;
 
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ACTIVATE:
-        CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ACTIVATE, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        }
         otbrLogInfo("Activate Ephemeral Key result: %s", spinel_status_to_cstr(status));
         break;
 
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_DEACTIVATE:
-        CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+        }
+        else
+        {
+            VerifyOrExit(aKey == SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_DEACTIVATE, error = OTBR_ERROR_INVALID_STATE);
+            CallAndClear(mEphemeralKeyTask, OT_ERROR_NONE);
+        }
         otbrLogInfo("Deactivate Ephemeral Key result: %s", spinel_status_to_cstr(status));
         break;
 

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -891,8 +891,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mDatasetSetActiveTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mDatasetSetActiveTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -910,8 +912,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_NET_IF_UP:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mIp6SetEnabledTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mIp6SetEnabledTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -928,8 +932,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_NET_STACK_UP:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mThreadSetEnabledTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mThreadSetEnabledTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -941,8 +947,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET_TLVS:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         { // Failed case
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mDatasetMgmtSetPendingTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mDatasetMgmtSetPendingTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else if (aKey != SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET_TLVS)
         {
@@ -977,8 +985,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_HOST_POWER_STATE:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mSetHostPowerStateTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mSetHostPowerStateTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -991,8 +1001,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ENABLE:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mEphemeralKeyTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -1005,8 +1017,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_ACTIVATE:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mEphemeralKeyTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {
@@ -1019,8 +1033,10 @@ otbrError NcpSpinel::HandleResponseForPropSet(spinel_tid_t      aTid,
     case SPINEL_PROP_BORDER_AGENT_EPHEMERAL_KEY_DEACTIVATE:
         if (aKey == SPINEL_PROP_LAST_STATUS)
         {
-            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
-            CallAndClear(mEphemeralKeyTask, ot::Spinel::SpinelStatusToOtError(status));
+            error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status);
+            CallAndClear(mEphemeralKeyTask,
+                         (error == OTBR_ERROR_NONE) ? ot::Spinel::SpinelStatusToOtError(status) : OT_ERROR_PARSE);
+            SuccessOrExit(error);
         }
         else
         {


### PR DESCRIPTION
Asynchronous D-Bus methods like Join(), Leave(), SetHostPowerState(), and ActivateEphemeralKeyMode() invoke co-processor transactions in NcpHost.

In NcpSpinel::HandleResponseForPropSet, responses were verified for properties such as SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS, SPINEL_PROP_NET_IF_UP, SPINEL_PROP_NET_STACK_UP, and others. However, the handler failed to check for SPINEL_PROP_LAST_STATUS, which is the co-processor's standard response on transaction failures.

This resulted in the async task's result never being set and the callback never being invoked whenever a co-processor set-property command failed. Consequently, the D-Bus request would hang indefinitely, leading to flaky CI test timeouts when simulation hosts were under high load.

This commit updates NcpSpinel::HandleResponseForPropSet to check for SPINEL_PROP_LAST_STATUS on these properties, correctly unpacking the co-processor's error status and propagating it to the associated task callback.