### PR TITLE
[tests] increase spawn wait time for otbr simulation nodes

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -132,6 +132,7 @@ proc spawn_node {id type sim_app} {
         }
         otbr {
             spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -d7 --vendor-name="OpenThreadTest" --model-name="BorderRouter" "spinel+hdlc+forkpty://${sim_app}?forkpty-arg=${id}"
+            sleep 3
         }
     }
 


### PR DESCRIPTION
In expect integration tests, otbr-agent is spawned with a simulation co-processor (ot-ncp-ftd). Previously, the wait time before sending the first D-Bus command was only 1 second.

Under heavy load or resource constraints in CI, the co-processor may take longer to fully boot, initialize the serial driver, and listen on Spinel. When the Join command is sent too early, Spinel frames can be dropped, causing the agent's D-Bus request to hang and eventually time out after 10 seconds.

This commit increases the wait delay to 3 seconds after spawning the agent, matching the delay used in Docker-based tests and preventing timing flakiness.