### PR TITLE
[dbus] Add support for setting pending dataset delay timer for AttachAllNodesTo

### DIFF
--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -882,9 +882,9 @@ void ThreadApiDBus::sHandleDBusPendingCall(DBusPendingCall *aPending, void *aThr
     (api->*Handler)(aPending);
 }
 
-ClientError ThreadApiDBus::AttachAllNodesTo(const std::vector<uint8_t> &aDataset)
+ClientError ThreadApiDBus::AttachAllNodesTo(const std::vector<uint8_t> &aDataset, uint32_t aDelayMs)
 {
-    auto args = std::tie(aDataset);
+    auto args = std::tie(aDataset, aDelayMs);
     return CallDBusMethodSync(OTBR_DBUS_ATTACH_ALL_NODES_TO_METHOD, args);
 }
 

--- a/src/dbus/client/thread_api_dbus.cpp
+++ b/src/dbus/client/thread_api_dbus.cpp
@@ -884,8 +884,17 @@ void ThreadApiDBus::sHandleDBusPendingCall(DBusPendingCall *aPending, void *aThr
 
 ClientError ThreadApiDBus::AttachAllNodesTo(const std::vector<uint8_t> &aDataset, uint32_t aDelayMs)
 {
-    auto args = std::tie(aDataset, aDelayMs);
-    return CallDBusMethodSync(OTBR_DBUS_ATTACH_ALL_NODES_TO_METHOD, args);
+    // Omit delay_timer_ms when using default (0) for backward compatibility with older servers
+    if (aDelayMs == 0)
+    {
+        auto args = std::tie(aDataset);
+        return CallDBusMethodSync(OTBR_DBUS_ATTACH_ALL_NODES_TO_METHOD, args);
+    }
+    else
+    {
+        auto args = std::tie(aDataset, aDelayMs);
+        return CallDBusMethodSync(OTBR_DBUS_ATTACH_ALL_NODES_TO_METHOD, args);
+    }
 }
 
 ClientError ThreadApiDBus::SetBorderAgentEnabled(bool aEnabled)

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -174,6 +174,8 @@ public:
      *                       automatically.
      * @param[in] aDelayMs   The delay timer in milliseconds to embed in the pending dataset.
      *                       Use 0 (default) for 300 seconds (5 minutes). Maximum is 72 hours.
+     *                       When 0, the delay_timer_ms argument is omitted from the DBus call for
+     *                       backward compatibility with older servers.
      *
      * @retval ERROR_NONE              Successfully requested the Thread network migration.
      * @retval ERROR_DBUS              D-Bus encode/decode error.

--- a/src/dbus/client/thread_api_dbus.hpp
+++ b/src/dbus/client/thread_api_dbus.hpp
@@ -169,8 +169,11 @@ public:
      *
      * If the device has already attached to a network, send a request to migrate the existing network.
      *
-     * @param[in] aDataset  The Operational Dataset that contains parameter values of the Thread network to attach
-     *                      to. It must have a valid Delay Timer and Pending Timestamp.
+     * @param[in] aDataset   The Operational Dataset that contains parameter values of the Thread network to attach
+     *                       to. It must be a full dataset. The Delay Timer and Pending Timestamp will be added
+     *                       automatically.
+     * @param[in] aDelayMs   The delay timer in milliseconds to embed in the pending dataset.
+     *                       Use 0 (default) for 300 seconds (5 minutes). Maximum is 72 hours.
      *
      * @retval ERROR_NONE              Successfully requested the Thread network migration.
      * @retval ERROR_DBUS              D-Bus encode/decode error.
@@ -180,7 +183,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS   Arguments are invalid.
      * @retval OT_ERROR_BUSY           There is an ongoing request.
      */
-    ClientError AttachAllNodesTo(const std::vector<uint8_t> &aDataset);
+    ClientError AttachAllNodesTo(const std::vector<uint8_t> &aDataset, uint32_t aDelayMs = 0);
 
     /**
      * This method performs a factory reset.

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -466,9 +466,16 @@ void DBusThreadObjectRcp::AttachAllNodesToHandler(DBusRequest &aRequest)
     uint32_t             delayTimerMs = 0;
     otError              error        = OT_ERROR_NONE;
 
-    auto args = std::tie(dataset, delayTimerMs);
-
-    VerifyOrExit(DBusMessageToTuple(*aRequest.GetMessage(), args) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
+    // Try parsing with both arguments first (new API)
+    auto argsWithDelay = std::tie(dataset, delayTimerMs);
+    if (DBusMessageToTuple(*aRequest.GetMessage(), argsWithDelay) != OTBR_ERROR_NONE)
+    {
+        // Fall back to parsing only dataset argument (old API, for backward compatibility)
+        auto argsDatasetOnly = std::tie(dataset);
+        VerifyOrExit(DBusMessageToTuple(*aRequest.GetMessage(), argsDatasetOnly) == OTBR_ERROR_NONE,
+                     error = OT_ERROR_INVALID_ARGS);
+        delayTimerMs = 0; // Use default
+    }
 
     mHost.GetThreadHelper()->AttachAllNodesTo(dataset, delayTimerMs,
                                               [aRequest](otError error, int64_t aAttachDelayMs) mutable {

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -463,15 +463,17 @@ void DBusThreadObjectRcp::AttachHandler(DBusRequest &aRequest)
 void DBusThreadObjectRcp::AttachAllNodesToHandler(DBusRequest &aRequest)
 {
     std::vector<uint8_t> dataset;
-    otError              error = OT_ERROR_NONE;
+    uint32_t             delayTimerMs = 0;
+    otError              error        = OT_ERROR_NONE;
 
-    auto args = std::tie(dataset);
+    auto args = std::tie(dataset, delayTimerMs);
 
     VerifyOrExit(DBusMessageToTuple(*aRequest.GetMessage(), args) == OTBR_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
 
-    mHost.GetThreadHelper()->AttachAllNodesTo(dataset, [aRequest](otError error, int64_t aAttachDelayMs) mutable {
-        aRequest.ReplyOtResult<int64_t>(error, aAttachDelayMs);
-    });
+    mHost.GetThreadHelper()->AttachAllNodesTo(dataset, delayTimerMs,
+                                              [aRequest](otError error, int64_t aAttachDelayMs) mutable {
+                                                  aRequest.ReplyOtResult<int64_t>(error, aAttachDelayMs);
+                                              });
 
 exit:
     if (error != OT_ERROR_NONE)

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -67,7 +67,7 @@
     <!-- AttachAllNodesTo: Request to attach all nodes to the specified Thread network.
       @dataset: The Operational Dataset that contains parameter values of the Thread network
                 to attach to. It must be a full dataset.
-      @delay_timer_ms: The delay timer value in milliseconds to embed in the pending dataset.
+      @delay_timer_ms: (Optional) The delay timer value in milliseconds to embed in the pending dataset.
                        If 0, the default of 300 seconds (300000 ms) is used. Maximum is 72 hours
                        (259200000 ms).
       @delay_ms: The delay between the method returns and the dataset takes effect, in

--- a/src/dbus/server/introspect.xml
+++ b/src/dbus/server/introspect.xml
@@ -67,6 +67,9 @@
     <!-- AttachAllNodesTo: Request to attach all nodes to the specified Thread network.
       @dataset: The Operational Dataset that contains parameter values of the Thread network
                 to attach to. It must be a full dataset.
+      @delay_timer_ms: The delay timer value in milliseconds to embed in the pending dataset.
+                       If 0, the default of 300 seconds (300000 ms) is used. Maximum is 72 hours
+                       (259200000 ms).
       @delay_ms: The delay between the method returns and the dataset takes effect, in
                  milliseconds. If this value is 0, then the node is attached to the given network
                  when this method returns. If this value is not 0, then the node is attached to
@@ -75,6 +78,7 @@
     -->
     <method name="AttachAllNodesTo">
       <arg name="dataset" type="ay"/>
+      <arg name="delay_timer_ms" type="u"/>
       <arg name="delay_ms" type="x" direction="out"/>
     </method>
 

--- a/src/host/thread_helper.cpp
+++ b/src/host/thread_helper.cpp
@@ -560,9 +560,11 @@ exit:
     return error;
 }
 
-void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, AttachHandler aHandler)
+void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, uint32_t aDelayMs, AttachHandler aHandler)
 {
-    constexpr uint32_t kDelayTimerMilliseconds = 300 * 1000;
+    constexpr uint32_t kDefaultDelayTimerMilliseconds = 300 * 1000;
+    constexpr uint32_t kMaxDelayTimerMilliseconds     = 72 * 60 * 60 * 1000; // 72 hours
+    uint32_t           delayTimerMs                   = (aDelayMs == 0) ? kDefaultDelayTimerMilliseconds : aDelayMs;
 
     otError                  error = OT_ERROR_NONE;
     otOperationalDatasetTlvs datasetTlvs;
@@ -576,6 +578,7 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, At
         otbrLogWarning("Attach Handler is nullptr");
         ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
+    VerifyOrExit(delayTimerMs <= kMaxDelayTimerMilliseconds, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(mAttachHandler == nullptr && mJoinerHandler == nullptr, error = OT_ERROR_BUSY);
 
     VerifyOrExit(aDatasetTlvs.size() <= sizeof(datasetTlvs.mTlvs), error = OT_ERROR_INVALID_ARGS);
@@ -593,8 +596,12 @@ void ThreadHelper::AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, At
     canImpactNetworkConnectivity = otDatasetAffectsConnectivity(mInstance, &datasetTlvs);
     if (canImpactNetworkConnectivity)
     {
-        attachDelayMs = kDelayTimerMilliseconds;
-        SuccessOrExit(error = ProcessDatasetForMigration(datasetTlvs, attachDelayMs));
+        attachDelayMs = delayTimerMs;
+        SuccessOrExit(error = ProcessDatasetForMigration(datasetTlvs, delayTimerMs));
+    }
+    else if (aDelayMs > 0)
+    {
+        otbrLogWarning("Delay timer specified but dataset change does not impact network connectivity, ignoring delay");
     }
 
     assert(datasetTlvs.mLength > 0);

--- a/src/host/thread_helper.hpp
+++ b/src/host/thread_helper.hpp
@@ -171,10 +171,13 @@ public:
     /**
      * This method makes all nodes in the current network attach to the network specified by the dataset TLVs.
      *
-     * @param[in] aDatasetTlvs  The dataset TLVs.
+     * @param[in] aDatasetTlvs  The dataset TLVs. Must be a full dataset. The Delay Timer and Pending Timestamp
+     *                          TLVs will be added automatically.
+     * @param[in] aDelayMs      The delay timer in milliseconds to embed in the pending dataset.
+     *                          Use 0 for the default of 300 seconds (300000 ms). Maximum is 72 hours.
      * @param[in] aHandler      The result handler.
      */
-    void AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, AttachHandler aHandler);
+    void AttachAllNodesTo(const std::vector<uint8_t> &aDatasetTlvs, uint32_t aDelayMs, AttachHandler aHandler);
 
     /**
      * This method resets the OpenThread stack.

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -336,6 +336,7 @@ EOF
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
+        uint32:0 \
         | grep "int64 300000"
 
     ot_ctl dataset pending | grep "Active Timestamp: 2"
@@ -351,6 +352,7 @@ EOF
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
+        uint32:0 \
         | grep "int64 0"
     ot_ctl state | grep "leader"
 
@@ -376,6 +378,7 @@ EOF
         --type=method_call --reply-timeout=40000 --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
+        uint32:0 \
         | grep "int64 300000"
 
     ot_ctl state | grep "leader"

--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -336,7 +336,6 @@ EOF
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
-        uint32:0 \
         | grep "int64 300000"
 
     ot_ctl dataset pending | grep "Active Timestamp: 2"
@@ -352,7 +351,6 @@ EOF
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
-        uint32:0 \
         | grep "int64 0"
     ot_ctl state | grep "leader"
 
@@ -378,7 +376,6 @@ EOF
         --type=method_call --reply-timeout=40000 --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.AttachAllNodesTo \
         "array:byte:${dataset}" \
-        uint32:0 \
         | grep "int64 300000"
 
     ot_ctl state | grep "leader"


### PR DESCRIPTION
Adds support for extending the input parameters to the `AttachAllNodesTo` dbus API to allow the caller to set the pending dataset delay timer. This is intended for supporting pending dataset changes that involve a network key change on networks with ICD LIT devices (or other sleepy device types) that have idle mode durations that are longer than the common default pending dataset timeout (5 minutes). Alternatively, callers of this API can also elect to supply a value that is shorter than the compile-time default. The addition of this parameter leaves the decision up to the caller, which can be useful to be able to vary depending on the dataset change and the current idle mode duration times of the devices on the network. 