### PR TITLE
[tests] refactor start_otbr_docker_dind helper into _common.exp

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -296,3 +296,31 @@ proc check_string_contains {haystack needle} {
         exit 1
     }
 }
+
+proc start_otbr_docker_dind {name sim_app sim_id pty} {
+    global rcp_pids
+    track_container $name
+    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
+    exec docker run -d \
+        --name $name \
+        --network infrastructure-link \
+        --cap-add=NET_ADMIN \
+        --privileged \
+        --add-host=host.docker.internal:host-gateway \
+        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+        --sysctl net.ipv4.conf.all.forwarding=1 \
+        --sysctl net.ipv4.conf.default.forwarding=1 \
+        --sysctl net.ipv6.conf.all.forwarding=1 \
+        --sysctl net.ipv6.conf.default.forwarding=1 \
+        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
+        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
+        -e OT_INFRA_IF=eth0 \
+        -e OT_THREAD_IF=wpan0 \
+        $::env(EXP_OTBR_DOCKER_IMAGE)
+    sleep 2
+
+    # Now start the simulated RCP binary on the host
+    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
+    lappend rcp_pids $rcp_pid
+    sleep 5
+}

--- a/tests/scripts/expect/dind_dhcp6_pd.exp
+++ b/tests/scripts/expect/dind_dhcp6_pd.exp
@@ -48,34 +48,6 @@ proc get_ipv6_64_prefix {ip} {
     return [join $normalized ":"]
 }
 
-# Custom start_otbr_docker for our network name
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # Now start the simulated RCP binary on the host!
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"

--- a/tests/scripts/expect/dind_dns_sd.exp
+++ b/tests/scripts/expect/dind_dns_sd.exp
@@ -29,34 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-# Custom start_otbr_docker for our network name
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # 3. Now start the simulated RCP binary on the host!
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 
 set pty1 [create_socat_tcp 1 9000]

--- a/tests/scripts/expect/dind_multicast.exp
+++ b/tests/scripts/expect/dind_multicast.exp
@@ -29,33 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # Now start the simulated RCP binary on the host!
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 set container "otbr-test-container"
 set test_client "test-client"

--- a/tests/scripts/expect/dind_nat64.exp
+++ b/tests/scripts/expect/dind_nat64.exp
@@ -29,34 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-# Custom start_otbr_docker for our network name
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # Now start the simulated RCP binary on the host!
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"

--- a/tests/scripts/expect/dind_srp_tc_1.exp
+++ b/tests/scripts/expect/dind_srp_tc_1.exp
@@ -29,34 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-# Custom start_otbr_docker for our network name
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # Now start the simulated RCP binary on the host
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"

--- a/tests/scripts/expect/dind_srp_tc_2.exp
+++ b/tests/scripts/expect/dind_srp_tc_2.exp
@@ -29,34 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-# Custom start_otbr_docker for our network name
-proc start_otbr_docker_dind {name sim_app sim_id pty} {
-    global rcp_pids
-    track_container $name
-    # Start the container using its native /init entrypoint (s6-overlay) and custom environment variables
-    exec docker run -d \
-        --name $name \
-        --network infrastructure-link \
-        --cap-add=NET_ADMIN \
-        --privileged \
-        --add-host=host.docker.internal:host-gateway \
-        --sysctl net.ipv6.conf.all.disable_ipv6=0 \
-        --sysctl net.ipv4.conf.all.forwarding=1 \
-        --sysctl net.ipv4.conf.default.forwarding=1 \
-        --sysctl net.ipv6.conf.all.forwarding=1 \
-        --sysctl net.ipv6.conf.default.forwarding=1 \
-        -v $::env(EXP_REPO_ROOT)/tests/scripts/spinel_proxy.sh:/usr/bin/spinel_proxy.sh \
-        -e OT_RCP_DEVICE=spinel+hdlc+forkpty:///usr/bin/spinel_proxy.sh \
-        -e OT_INFRA_IF=eth0 \
-        -e OT_THREAD_IF=wpan0 \
-        $::env(EXP_OTBR_DOCKER_IMAGE)
-    sleep 2
-
-    # Now start the simulated RCP binary on the host
-    set rcp_pid [exec $sim_app $sim_id <$pty >$pty &]
-    lappend rcp_pids $rcp_pid
-    sleep 5
-}
 
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"


### PR DESCRIPTION
This commit addresses a PR #3398 review comment by refactoring the duplicated start_otbr_docker_dind procedure out of individual expect test files into tests/scripts/expect/_common.exp as a shared helper function.

Duplicates were removed from the following test files:
- dind_dhcp6_pd.exp
- dind_dns_sd.exp
- dind_multicast.exp
- dind_nat64.exp
- dind_srp_tc_1.exp
- dind_srp_tc_2.exp