### PR TITLE
docker: tag border-router images with CalVer release tags

### DIFF
--- a/.github/workflows/docker-border-router.yml
+++ b/.github/workflows/docker-border-router.yml
@@ -32,6 +32,8 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - 'main'
@@ -158,6 +160,7 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short
 


### PR DESCRIPTION
The workflow was only tagging images with branch names and sha-* short hashes, so Docker Hub never reflected the monthly CalVer releases (e.g. v2026.06.0) created by monthly-release.yml.

Two changes:
- Trigger the workflow on v* tag pushes (was branch-only)
- Add type=ref,event=tag to the metadata-action tags list in the merge job
