### PR TITLE
trel: add Extended PAN ID exclusion filter

### DIFF
--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -51,6 +51,9 @@ readonly OT_REST_LISTEN_ADDR
 OT_REST_LISTEN_PORT="${OT_REST_LISTEN_PORT:-8081}"
 readonly OT_REST_LISTEN_PORT
 
+TREL_EXCLUDE_EXTPANID="${TREL_EXCLUDE_EXTPANID:-}"
+readonly TREL_EXCLUDE_EXTPANID
+
 OT_FORWARD_INGRESS_CHAIN="OT_FORWARD_INGRESS"
 readonly OT_FORWARD_INGRESS_CHAIN
 
@@ -85,6 +88,21 @@ iptables -t nat -A POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
 iptables -t filter -A FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
 iptables -t filter -A FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
 
+trel_filter_args=()
+
+if [ -n "${TREL_EXCLUDE_EXTPANID}" ]; then
+    OLD_IFS="${IFS}"
+    IFS=','
+    for extpanid in ${TREL_EXCLUDE_EXTPANID}; do
+        extpanid="$(echo "${extpanid}" | tr -d '[:space:]')"
+        if [ -n "${extpanid}" ]; then
+            trel_filter_args+=(--trel-exclude-extpanid "${extpanid}")
+        fi
+    done
+    IFS="${OLD_IFS}"
+fi
+
+echo "TREL excluded Extended PAN IDs: ${TREL_EXCLUDE_EXTPANID:-<none>}"
 echo "Starting otbr-agent..."
 
 exec s6-notifyoncheck -d -s 300 -w 300 -n 0 stdbuf -oL \
@@ -94,6 +112,7 @@ exec s6-notifyoncheck -d -s 300 -w 300 -n 0 stdbuf -oL \
         --model-name "${OT_VENDOR_MODEL}" \
         -I "${OT_THREAD_IF}" \
         -B "${OT_INFRA_IF}" \
+        "${trel_filter_args[@]}" \
         "${OT_RCP_DEVICE}" \
         "trel://${OT_INFRA_IF}" \
         --rest-listen-address "${OT_REST_LISTEN_ADDR}" \

--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -94,7 +94,7 @@ if [ -n "${TREL_EXCLUDE_EXTPANID}" ]; then
     OLD_IFS="${IFS}"
     IFS=','
     for extpanid in ${TREL_EXCLUDE_EXTPANID}; do
-        extpanid="$(echo "${extpanid}" | tr -d '[:space:]')"
+        extpanid="$(printf '%s' "${extpanid}" | tr -d '[:space:]')"
         if [ -n "${extpanid}" ]; then
             trel_filter_args+=(--trel-exclude-extpanid "${extpanid}")
         fi

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -125,6 +125,13 @@ void Application::Init(const std::string &aRestListenAddress, int aRestListenPor
                 mHost.GetCoprocessorVersion());
 }
 
+#if OTBR_ENABLE_TREL_DNSSD
+void Application::SetTrelExcludeExtPanIds(std::vector<Utils::TrelExtPanId> aExcludeExtPanIds)
+{
+    mTrelExcludeExtPanIds = std::move(aExcludeExtPanIds);
+}
+#endif
+
 void Application::Deinit(void)
 {
     switch (mHost.GetCoprocessorType())
@@ -272,6 +279,7 @@ void Application::InitRcpMode(const std::string &aRestListenAddress, int aRestLi
 #endif
 #if OTBR_ENABLE_TREL_DNSSD
     mMdnsStateSubject.AddObserver(*mTrelDnssd);
+    mTrelDnssd->SetExcludeExtPanIds(mTrelExcludeExtPanIds);
 #endif
 #if OTBR_ENABLE_DNSSD_PLAT
     mMdnsStateSubject.AddObserver(mDnssdPlatform);

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -76,6 +76,7 @@
 #include "host/posix/multicast_routing_manager.hpp"
 #include "host/posix/netif.hpp"
 #include "utils/infra_link_selector.hpp"
+#include "utils/trel_extpanid.hpp"
 
 namespace otbr {
 
@@ -121,6 +122,15 @@ public:
      * This method initializes the Application instance.
      */
     void Init(const std::string &aRestListenAddress, int aRestListenPort);
+
+#if OTBR_ENABLE_TREL_DNSSD
+    /**
+     * This method sets the Extended PAN IDs to exclude from discovered TREL peers.
+     *
+     * @param[in] aExcludeExtPanIds  The Extended PAN IDs to exclude.
+     */
+    void SetTrelExcludeExtPanIds(std::vector<Utils::TrelExtPanId> aExcludeExtPanIds);
+#endif
 
     /**
      * This method de-initializes the Application instance.
@@ -303,6 +313,7 @@ private:
 #endif
 #if OTBR_ENABLE_TREL_DNSSD
     std::unique_ptr<TrelDnssd::TrelDnssd> mTrelDnssd;
+    std::vector<Utils::TrelExtPanId>      mTrelExcludeExtPanIds;
 #endif
 #if OTBR_ENABLE_OPENWRT
     std::unique_ptr<ubus::UBusAgent> mUbusAgent;

--- a/src/agent/realmain.cpp
+++ b/src/agent/realmain.cpp
@@ -55,6 +55,7 @@
 #include "common/mainloop.hpp"
 #include "common/types.hpp"
 #include "host/thread_host.hpp"
+#include "utils/trel_extpanid.hpp"
 
 #ifdef OTBR_ENABLE_PLATFORM_ANDROID
 #include <log/log.h>
@@ -92,6 +93,7 @@ enum
 #ifndef OTBR_PRODUCT_NAME
     OTBR_OPT_MODEL_NAME,
 #endif
+    OTBR_OPT_TREL_EXCLUDE_EXTPANID,
 };
 
 #ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
@@ -119,6 +121,7 @@ static const struct option kOptions[] = {
 #ifndef OTBR_PRODUCT_NAME
     {"model-name", required_argument, nullptr, OTBR_OPT_MODEL_NAME},
 #endif
+    {"trel-exclude-extpanid", required_argument, nullptr, OTBR_OPT_TREL_EXCLUDE_EXTPANID},
     {0, 0, 0, 0}};
 
 static bool ParseInteger(const char *aStr, long &aOutResult)
@@ -185,6 +188,9 @@ static void PrintHelp(const char *aProgramName)
 #ifndef OTBR_PRODUCT_NAME
     fprintf(stderr, "     --model-name           Model Name.\n");
 #endif
+    fprintf(stderr,
+            "     --trel-exclude-extpanid  Exclude discovered TREL peers whose Extended PAN ID matches the given "
+            "16-character hex value. May be specified multiple times. ':' and '-' separators are accepted.\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "%s", otSysGetRadioUrlHelpString());
 }
@@ -242,20 +248,21 @@ static otbrLogLevel GetDefaultLogLevel(void)
 
 static int realmain(int argc, char *argv[])
 {
-    otbrLogLevel              logLevel = GetDefaultLogLevel();
-    int                       opt;
-    int                       ret               = EXIT_SUCCESS;
-    const char               *interfaceName     = kDefaultInterfaceName;
-    bool                      verbose           = false;
-    bool                      syslogDisable     = false;
-    bool                      printRadioVersion = false;
-    bool                      enableAutoAttach  = true;
-    const char               *restListenAddress = "127.0.0.1";
-    int                       restListenPort    = kPortNumber;
-    const char               *dataPath          = "";
-    std::vector<const char *> radioUrls;
-    std::vector<const char *> backboneInterfaceNames;
-    long                      parseResult;
+    otbrLogLevel                           logLevel = GetDefaultLogLevel();
+    int                                    opt;
+    int                                    ret               = EXIT_SUCCESS;
+    const char                            *interfaceName     = kDefaultInterfaceName;
+    bool                                   verbose           = false;
+    bool                                   syslogDisable     = false;
+    bool                                   printRadioVersion = false;
+    bool                                   enableAutoAttach  = true;
+    const char                            *restListenAddress = "127.0.0.1";
+    int                                    restListenPort    = kPortNumber;
+    const char                            *dataPath          = "";
+    std::vector<const char *>              radioUrls;
+    std::vector<const char *>              backboneInterfaceNames;
+    std::vector<otbr::Utils::TrelExtPanId> trelExcludeExtPanIds;
+    long                                   parseResult;
 
 #ifdef OTBR_VENDOR_NAME
     const char *vendorName = OTBR_VENDOR_NAME;
@@ -345,6 +352,20 @@ static int realmain(int argc, char *argv[])
             dataPath = optarg;
             break;
 
+        case OTBR_OPT_TREL_EXCLUDE_EXTPANID:
+        {
+            otbr::Utils::TrelExtPanId extPanId;
+
+            if (!otbr::Utils::ParseTrelExcludeExtPanId(optarg, extPanId))
+            {
+                fprintf(stderr, "Invalid Extended PAN ID for --trel-exclude-extpanid: %s\n", optarg);
+                ExitNow(ret = EXIT_FAILURE);
+            }
+
+            trelExcludeExtPanIds.push_back(extPanId);
+            break;
+        }
+
         default:
             PrintHelp(argv[0]);
             ExitNow(ret = EXIT_FAILURE);
@@ -406,6 +427,10 @@ static int realmain(int argc, char *argv[])
         otbr::Application app(*host, interfaceName, backboneInterfaceName);
 
         gApp = &app;
+
+#if OTBR_ENABLE_TREL_DNSSD
+        app.SetTrelExcludeExtPanIds(std::move(trelExcludeExtPanIds));
+#endif
 
 #if OTBR_ENABLE_BORDER_AGENT
 #if !defined(OTBR_VENDOR_NAME) || !defined(OTBR_PRODUCT_NAME)

--- a/src/trel_dnssd/CMakeLists.txt
+++ b/src/trel_dnssd/CMakeLists.txt
@@ -34,4 +34,5 @@ add_library(otbr-trel-dnssd
 target_link_libraries(otbr-trel-dnssd PRIVATE
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     otbr-common
+    otbr-utils
 )

--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -47,6 +47,7 @@
 #include "common/code_utils.hpp"
 #include "utils/hex.hpp"
 #include "utils/string_utils.hpp"
+#include "utils/trel_extpanid.hpp"
 
 static const char kTrelServiceName[] = "_trel._udp";
 
@@ -283,6 +284,11 @@ void TrelDnssd::HandleUnpublishTrelServiceError(otbrError aError)
     }
 }
 
+void TrelDnssd::SetExcludeExtPanIds(const std::vector<Utils::TrelExtPanId> &aExcludeExtPanIds)
+{
+    mExcludeExtPanIds = aExcludeExtPanIds;
+}
+
 void TrelDnssd::OnTrelServiceInstanceAdded(const Mdns::Publisher::DiscoveredInstanceInfo &aInstanceInfo)
 {
     std::string        instanceName = StringUtils::ToLowercase(aInstanceInfo.mName);
@@ -330,6 +336,12 @@ void TrelDnssd::OnTrelServiceInstanceAdded(const Mdns::Publisher::DiscoveredInst
         Peer peer(aInstanceInfo.mTxtData, peerInfo.mSockAddr);
 
         VerifyOrExit(peer.mValid, otbrLogWarning("Peer %s is invalid", aInstanceInfo.mName.c_str()));
+
+        if (ShouldExcludePeer(peer))
+        {
+            otbrLogInfo("Peer %s excluded by Extended PAN ID filter", aInstanceInfo.mName.c_str());
+            ExitNow();
+        }
 
         otPlatTrelHandleDiscoveredPeerInfo(mHost.GetInstance(), &peerInfo);
 
@@ -528,6 +540,21 @@ exit:
     }
 
     return;
+}
+
+void TrelDnssd::Peer::ReadExtPanIdFromTxtData(void)
+{
+    mHasExtPanId = false;
+    SuccessOrExit(Utils::ReadTrelExtPanIdFromTxtData(mTxtData.data(), static_cast<uint16_t>(mTxtData.size()), mExtPanId,
+                                                     mHasExtPanId));
+
+exit:
+    return;
+}
+
+bool TrelDnssd::ShouldExcludePeer(const Peer &aPeer) const
+{
+    return Utils::ShouldExcludeTrelPeer(aPeer.mHasExtPanId, aPeer.mExtPanId, mExcludeExtPanIds);
 }
 
 } // namespace TrelDnssd

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -46,6 +46,7 @@
 #include "common/types.hpp"
 #include "host/rcp_host.hpp"
 #include "mdns/mdns.hpp"
+#include "utils/trel_extpanid.hpp"
 
 namespace otbr {
 
@@ -109,6 +110,13 @@ public:
      */
     void HandleMdnsState(Mdns::Publisher::State aState) override;
 
+    /**
+     * This method sets the Extended PAN IDs to exclude from discovered TREL peers.
+     *
+     * @param[in] aExcludeExtPanIds  The Extended PAN IDs to exclude.
+     */
+    void SetExcludeExtPanIds(const std::vector<Utils::TrelExtPanId> &aExcludeExtPanIds);
+
 private:
     static constexpr size_t   kPeerCacheSize             = 256;
     static constexpr uint16_t kCheckNetifReadyIntervalMs = 5000;
@@ -137,15 +145,19 @@ private:
             , mSockAddr(aSockAddr)
         {
             ReadExtAddrFromTxtData();
+            ReadExtPanIdFromTxtData();
         }
 
         void ReadExtAddrFromTxtData(void);
+        void ReadExtPanIdFromTxtData(void);
 
         Clock::time_point    mDiscoverTime;
         std::vector<uint8_t> mTxtData;
         otSockAddr           mSockAddr;
         otExtAddress         mExtAddr;
-        bool                 mValid = false;
+        Utils::TrelExtPanId  mExtPanId{};
+        bool                 mValid       = false;
+        bool                 mHasExtPanId = false;
     };
 
     using PeerMap = std::map<std::string, Peer>;
@@ -168,16 +180,18 @@ private:
     void     CheckPeersNumLimit(void);
     void     RemoveAllPeers(void);
     uint16_t CountDuplicatePeers(const Peer &aPeer);
+    bool     ShouldExcludePeer(const Peer &aPeer) const;
 
-    Mdns::Publisher &mPublisher;
-    Host::RcpHost   &mHost;
-    TaskRunner       mTaskRunner;
-    std::string      mTrelNetif;
-    uint32_t         mTrelNetifIndex = 0;
-    uint64_t         mSubscriberId   = 0;
-    RegisterInfo     mRegisterInfo;
-    PeerMap          mPeers;
-    bool             mMdnsPublisherReady = false;
+    Mdns::Publisher                 &mPublisher;
+    Host::RcpHost                   &mHost;
+    TaskRunner                       mTaskRunner;
+    std::string                      mTrelNetif;
+    uint32_t                         mTrelNetifIndex = 0;
+    uint64_t                         mSubscriberId   = 0;
+    RegisterInfo                     mRegisterInfo;
+    PeerMap                          mPeers;
+    std::vector<Utils::TrelExtPanId> mExcludeExtPanIds;
+    bool                             mMdnsPublisherReady = false;
 };
 
 /**

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(otbr-utils
     sha256.cpp
     socket_utils.cpp
     steering_data.cpp
+    trel_extpanid.cpp
     string_utils.cpp
     system_utils.cpp
 )

--- a/src/utils/trel_extpanid.cpp
+++ b/src/utils/trel_extpanid.cpp
@@ -34,10 +34,8 @@
 #include "utils/trel_extpanid.hpp"
 
 #include <cstring>
-#include <string>
 
 #include "common/code_utils.hpp"
-#include "utils/string_utils.hpp"
 
 namespace otbr {
 namespace Utils {
@@ -133,17 +131,15 @@ bool IsTrelExcludedExtPanId(const TrelExtPanId &aPeer, const std::vector<TrelExt
     return false;
 }
 
-bool ShouldExcludeTrelPeer(bool                             aHasExtPanId,
-                           const TrelExtPanId              &aPeerExtPanId,
-                           const std::vector<TrelExtPanId> &aExcluded)
+bool ShouldExcludeTrelPeer(bool aHasExtPanId, const TrelExtPanId &aPeerExtPanId, const std::vector<TrelExtPanId> &aExcluded)
 {
     return aHasExtPanId && !aExcluded.empty() && IsTrelExcludedExtPanId(aPeerExtPanId, aExcluded);
 }
 
 bool ReadTrelExtPanIdFromTxtData(const uint8_t *aTxtData, uint16_t aTxtLength, TrelExtPanId &aOut, bool &aHasExtPanId)
 {
-    bool     success = true;
-    uint16_t offset  = 0;
+    bool   success = true;
+    size_t offset  = 0;
 
     aHasExtPanId = false;
 
@@ -151,10 +147,10 @@ bool ReadTrelExtPanIdFromTxtData(const uint8_t *aTxtData, uint16_t aTxtLength, T
 
     while (offset < aTxtLength)
     {
-        uint16_t entrySize = aTxtData[offset];
-        uint16_t keyStart  = offset + 1;
-        uint16_t entryEnd  = keyStart + entrySize;
-        uint16_t keyEnd    = keyStart;
+        size_t entrySize = aTxtData[offset];
+        size_t keyStart  = offset + 1;
+        size_t entryEnd  = keyStart + entrySize;
+        size_t keyEnd    = keyStart;
 
         VerifyOrExit(entryEnd <= aTxtLength, success = false);
 
@@ -165,11 +161,11 @@ bool ReadTrelExtPanIdFromTxtData(const uint8_t *aTxtData, uint16_t aTxtLength, T
 
         if (keyEnd != entryEnd)
         {
-            uint16_t valStart = keyEnd + 1;
-            uint16_t valLen   = entryEnd - valStart;
+            size_t valStart = keyEnd + 1;
+            size_t valLen   = entryEnd - valStart;
 
-            if (StringUtils::EqualCaseInsensitive(
-                    std::string(reinterpret_cast<const char *>(&aTxtData[keyStart]), keyEnd - keyStart), "xp"))
+            if (keyEnd - keyStart == 2 && (aTxtData[keyStart] == 'x' || aTxtData[keyStart] == 'X') &&
+                (aTxtData[keyStart + 1] == 'p' || aTxtData[keyStart + 1] == 'P'))
             {
                 VerifyOrExit(valLen == kTrelExtPanIdLength, success = false);
                 memcpy(aOut.data(), &aTxtData[valStart], kTrelExtPanIdLength);

--- a/src/utils/trel_extpanid.cpp
+++ b/src/utils/trel_extpanid.cpp
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Utilities for TREL Extended PAN ID exclusion.
+ */
+
+#include "utils/trel_extpanid.hpp"
+
+#include <cstring>
+#include <string>
+
+#include "common/code_utils.hpp"
+#include "utils/string_utils.hpp"
+
+namespace otbr {
+namespace Utils {
+
+namespace {
+
+bool ParseHexNibble(char aChar, uint8_t &aNibble)
+{
+    bool valid = true;
+
+    if ('0' <= aChar && aChar <= '9')
+    {
+        aNibble = static_cast<uint8_t>(aChar - '0');
+    }
+    else if ('a' <= aChar && aChar <= 'f')
+    {
+        aNibble = static_cast<uint8_t>(10 + (aChar - 'a'));
+    }
+    else if ('A' <= aChar && aChar <= 'F')
+    {
+        aNibble = static_cast<uint8_t>(10 + (aChar - 'A'));
+    }
+    else
+    {
+        valid = false;
+    }
+
+    return valid;
+}
+
+bool IsHexSeparator(char aChar)
+{
+    return aChar == ':' || aChar == '-';
+}
+
+} // namespace
+
+bool ParseTrelExcludeExtPanId(const char *aStr, TrelExtPanId &aOut)
+{
+    bool    success     = false;
+    size_t  index       = 0;
+    uint8_t nibbleCount = 0;
+    uint8_t byte        = 0;
+
+    VerifyOrExit(aStr != nullptr);
+
+    for (const char *cur = aStr; *cur != '\0'; ++cur)
+    {
+        if (IsHexSeparator(*cur))
+        {
+            continue;
+        }
+
+        {
+            uint8_t nibble = 0;
+
+            VerifyOrExit(ParseHexNibble(*cur, nibble));
+
+            if (nibbleCount == 0)
+            {
+                byte        = static_cast<uint8_t>(nibble << 4);
+                nibbleCount = 1;
+            }
+            else
+            {
+                byte |= nibble;
+                VerifyOrExit(index < kTrelExtPanIdLength);
+                aOut[index++] = byte;
+                nibbleCount   = 0;
+            }
+        }
+    }
+
+    VerifyOrExit(nibbleCount == 0);
+    VerifyOrExit(index == kTrelExtPanIdLength);
+
+    success = true;
+
+exit:
+    return success;
+}
+
+bool IsTrelExcludedExtPanId(const TrelExtPanId &aPeer, const std::vector<TrelExtPanId> &aExcluded)
+{
+    for (const TrelExtPanId &excluded : aExcluded)
+    {
+        if (aPeer == excluded)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ShouldExcludeTrelPeer(bool                             aHasExtPanId,
+                           const TrelExtPanId              &aPeerExtPanId,
+                           const std::vector<TrelExtPanId> &aExcluded)
+{
+    return aHasExtPanId && !aExcluded.empty() && IsTrelExcludedExtPanId(aPeerExtPanId, aExcluded);
+}
+
+bool ReadTrelExtPanIdFromTxtData(const uint8_t *aTxtData, uint16_t aTxtLength, TrelExtPanId &aOut, bool &aHasExtPanId)
+{
+    bool     success = true;
+    uint16_t offset  = 0;
+
+    aHasExtPanId = false;
+
+    VerifyOrExit(aTxtData != nullptr);
+
+    while (offset < aTxtLength)
+    {
+        uint16_t entrySize = aTxtData[offset];
+        uint16_t keyStart  = offset + 1;
+        uint16_t entryEnd  = keyStart + entrySize;
+        uint16_t keyEnd    = keyStart;
+
+        VerifyOrExit(entryEnd <= aTxtLength, success = false);
+
+        while (keyEnd < entryEnd && aTxtData[keyEnd] != '=')
+        {
+            keyEnd++;
+        }
+
+        if (keyEnd != entryEnd)
+        {
+            uint16_t valStart = keyEnd + 1;
+            uint16_t valLen   = entryEnd - valStart;
+
+            if (StringUtils::EqualCaseInsensitive(
+                    std::string(reinterpret_cast<const char *>(&aTxtData[keyStart]), keyEnd - keyStart), "xp"))
+            {
+                VerifyOrExit(valLen == kTrelExtPanIdLength, success = false);
+                memcpy(aOut.data(), &aTxtData[valStart], kTrelExtPanIdLength);
+                aHasExtPanId = true;
+                break;
+            }
+        }
+
+        offset = entryEnd;
+    }
+
+exit:
+    return success;
+}
+
+} // namespace Utils
+} // namespace otbr

--- a/src/utils/trel_extpanid.hpp
+++ b/src/utils/trel_extpanid.hpp
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Utilities for TREL Extended PAN ID exclusion.
+ */
+
+#ifndef OTBR_UTILS_TREL_EXTPANID_HPP_
+#define OTBR_UTILS_TREL_EXTPANID_HPP_
+
+#include "openthread-br/config.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace otbr {
+namespace Utils {
+
+constexpr size_t kTrelExtPanIdLength = 8;
+
+using TrelExtPanId = std::array<uint8_t, kTrelExtPanIdLength>;
+
+/**
+ * Parses a user-supplied Extended PAN ID hex string.
+ *
+ * Accepts compact, colon-separated, and hyphen-separated hex input. The value
+ * must decode to exactly eight bytes, parsed left to right.
+ *
+ * @param[in]  aStr  The input string.
+ * @param[out] aOut  The parsed Extended PAN ID.
+ *
+ * @returns `true` when parsing succeeds; otherwise `false`.
+ */
+bool ParseTrelExcludeExtPanId(const char *aStr, TrelExtPanId &aOut);
+
+/**
+ * Determines whether @p aPeer matches any entry in @p aExcluded.
+ *
+ * @param[in] aPeer      The peer Extended PAN ID.
+ * @param[in] aExcluded  The exclusion list.
+ *
+ * @returns `true` when @p aPeer is excluded; otherwise `false`.
+ */
+bool IsTrelExcludedExtPanId(const TrelExtPanId &aPeer, const std::vector<TrelExtPanId> &aExcluded);
+
+/**
+ * Determines whether a discovered TREL peer should be excluded.
+ *
+ * Peers without a valid Extended PAN ID in TXT are never excluded.
+ *
+ * @param[in] aHasExtPanId     Whether the peer TXT contained a valid `xp` value.
+ * @param[in] aPeerExtPanId    The peer Extended PAN ID from TXT.
+ * @param[in] aExcluded        The exclusion list.
+ *
+ * @returns `true` when the peer should be excluded; otherwise `false`.
+ */
+bool ShouldExcludeTrelPeer(bool                             aHasExtPanId,
+                           const TrelExtPanId              &aPeerExtPanId,
+                           const std::vector<TrelExtPanId> &aExcluded);
+
+/**
+ * Reads the Extended PAN ID from a TREL DNS-SD TXT record (`xp` key).
+ *
+ * @param[in]  aTxtData       A pointer to the TXT data.
+ * @param[in]  aTxtLength     The TXT data length in bytes.
+ * @param[out] aOut           The parsed Extended PAN ID.
+ * @param[out] aHasExtPanId   Set to `true` when a valid `xp` value is present.
+ *
+ * @returns `true` when parsing succeeds; otherwise `false`.
+ */
+bool ReadTrelExtPanIdFromTxtData(const uint8_t *aTxtData, uint16_t aTxtLength, TrelExtPanId &aOut, bool &aHasExtPanId);
+
+} // namespace Utils
+} // namespace otbr
+
+#endif // OTBR_UTILS_TREL_EXTPANID_HPP_

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(otbr-gtest-unit
     test_once_callback.cpp
     test_pskc.cpp
     test_task_runner.cpp
+    test_trel_extpanid.cpp
 )
 target_link_libraries(otbr-gtest-unit
     mbedtls

--- a/tests/gtest/test_trel_extpanid.cpp
+++ b/tests/gtest/test_trel_extpanid.cpp
@@ -1,0 +1,193 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using ::testing::ElementsAreArray;
+
+#include "utils/trel_extpanid.hpp"
+
+using otbr::Utils::IsTrelExcludedExtPanId;
+using otbr::Utils::kTrelExtPanIdLength;
+using otbr::Utils::ParseTrelExcludeExtPanId;
+using otbr::Utils::ReadTrelExtPanIdFromTxtData;
+using otbr::Utils::ShouldExcludeTrelPeer;
+using otbr::Utils::TrelExtPanId;
+
+namespace {
+
+const TrelExtPanId kAppleExtPanId = {0xdb, 0x80, 0x67, 0x60, 0x15, 0xdb, 0x4b, 0x6e};
+const TrelExtPanId kOtherExtPanId = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+
+TEST(TrelExtPanId, ParseCompactLowercase)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_TRUE(ParseTrelExcludeExtPanId("db80676015db4b6e", extPanId));
+    EXPECT_THAT(extPanId, ElementsAreArray(kAppleExtPanId));
+}
+
+TEST(TrelExtPanId, ParseCompactUppercase)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_TRUE(ParseTrelExcludeExtPanId("DB80676015DB4B6E", extPanId));
+    EXPECT_THAT(extPanId, ElementsAreArray(kAppleExtPanId));
+}
+
+TEST(TrelExtPanId, ParseColonSeparated)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_TRUE(ParseTrelExcludeExtPanId("db:80:67:60:15:db:4b:6e", extPanId));
+    EXPECT_THAT(extPanId, ElementsAreArray(kAppleExtPanId));
+}
+
+TEST(TrelExtPanId, ParseHyphenSeparated)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_TRUE(ParseTrelExcludeExtPanId("db-80-67-60-15-db-4b-6e", extPanId));
+    EXPECT_THAT(extPanId, ElementsAreArray(kAppleExtPanId));
+}
+
+TEST(TrelExtPanId, RejectInvalidHex)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_FALSE(ParseTrelExcludeExtPanId("nothex", extPanId));
+}
+
+TEST(TrelExtPanId, RejectWrongLength)
+{
+    TrelExtPanId extPanId{};
+
+    EXPECT_FALSE(ParseTrelExcludeExtPanId("001122334455667", extPanId));
+    EXPECT_FALSE(ParseTrelExcludeExtPanId("001122334455667788", extPanId));
+}
+
+TEST(TrelExtPanId, MatchExcludedPeer)
+{
+    const std::vector<TrelExtPanId> excluded = {kAppleExtPanId};
+
+    EXPECT_TRUE(IsTrelExcludedExtPanId(kAppleExtPanId, excluded));
+    EXPECT_FALSE(IsTrelExcludedExtPanId(kOtherExtPanId, excluded));
+}
+
+TEST(TrelExtPanId, MatchMultipleExcludedPeers)
+{
+    const std::vector<TrelExtPanId> excluded = {kAppleExtPanId, kOtherExtPanId};
+
+    EXPECT_TRUE(IsTrelExcludedExtPanId(kOtherExtPanId, excluded));
+    EXPECT_FALSE(IsTrelExcludedExtPanId(TrelExtPanId{}, excluded));
+}
+
+TEST(TrelExtPanId, ShouldExcludePeerWithoutExtPanId)
+{
+    const std::vector<TrelExtPanId> excluded = {kAppleExtPanId};
+
+    EXPECT_FALSE(ShouldExcludeTrelPeer(false, kAppleExtPanId, excluded));
+}
+
+TEST(TrelExtPanId, ShouldExcludePeerWithMatchingExtPanId)
+{
+    const std::vector<TrelExtPanId> excluded = {kAppleExtPanId};
+
+    EXPECT_TRUE(ShouldExcludeTrelPeer(true, kAppleExtPanId, excluded));
+    EXPECT_FALSE(ShouldExcludeTrelPeer(true, kOtherExtPanId, excluded));
+}
+
+TEST(TrelExtPanId, ShouldExcludePeerWithEmptyExclusionList)
+{
+    const std::vector<TrelExtPanId> excluded = {};
+
+    EXPECT_FALSE(ShouldExcludeTrelPeer(true, kAppleExtPanId, excluded));
+}
+
+static std::vector<uint8_t> BuildTrelTxtData(const TrelExtPanId *aExtPanId)
+{
+    std::vector<uint8_t> txtData;
+    const uint8_t        xa[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+    txtData.push_back(static_cast<uint8_t>(2 + 1 + sizeof(xa)));
+    txtData.insert(txtData.end(), {'x', 'a', '='});
+    txtData.insert(txtData.end(), xa, xa + sizeof(xa));
+
+    if (aExtPanId != nullptr)
+    {
+        txtData.push_back(static_cast<uint8_t>(2 + 1 + kTrelExtPanIdLength));
+        txtData.insert(txtData.end(), {'x', 'p', '='});
+        txtData.insert(txtData.end(), aExtPanId->begin(), aExtPanId->end());
+    }
+
+    return txtData;
+}
+
+TEST(TrelExtPanId, ReadExtPanIdFromTxtData)
+{
+    const std::vector<uint8_t> txtData = BuildTrelTxtData(&kAppleExtPanId);
+    TrelExtPanId               extPanId{};
+    bool                       hasExtPanId = false;
+
+    EXPECT_TRUE(
+        ReadTrelExtPanIdFromTxtData(txtData.data(), static_cast<uint16_t>(txtData.size()), extPanId, hasExtPanId));
+    EXPECT_TRUE(hasExtPanId);
+    EXPECT_THAT(extPanId, ElementsAreArray(kAppleExtPanId));
+}
+
+TEST(TrelExtPanId, ReadExtPanIdFromTxtDataWithoutXp)
+{
+    const std::vector<uint8_t> txtData = BuildTrelTxtData(nullptr);
+    TrelExtPanId               extPanId{};
+    bool                       hasExtPanId = false;
+
+    EXPECT_TRUE(
+        ReadTrelExtPanIdFromTxtData(txtData.data(), static_cast<uint16_t>(txtData.size()), extPanId, hasExtPanId));
+    EXPECT_FALSE(hasExtPanId);
+}
+
+TEST(TrelExtPanId, ReadExtPanIdFromTxtDataRejectsInvalidXpLength)
+{
+    std::vector<uint8_t> txtData = BuildTrelTxtData(nullptr);
+
+    txtData.push_back(static_cast<uint8_t>(2 + 1 + 4));
+    txtData.insert(txtData.end(), {'x', 'p', '='});
+    txtData.insert(txtData.end(), {0x01, 0x02, 0x03, 0x04});
+
+    TrelExtPanId extPanId{};
+    bool         hasExtPanId = false;
+
+    EXPECT_FALSE(
+        ReadTrelExtPanIdFromTxtData(txtData.data(), static_cast<uint16_t>(txtData.size()), extPanId, hasExtPanId));
+    EXPECT_FALSE(hasExtPanId);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

This adds an opt-in TREL peer exclusion filter based on Thread Extended PAN ID.

The new `otbr-agent` option is:

```text
--trel-exclude-extpanid <hex>
```

The option may be specified multiple times. Accepted input formats include compact, colon-separated, and hyphen-separated hex forms, for example:

```text
db80676015db4b6e
db:80:67:60:15:db:4b:6e
db-80-67-60-15-db-4b-6e
```

The Docker border-router startup script also supports a convenience environment variable:

```text
TREL_EXCLUDE_EXTPANID=db80676015db4b6e
```

Comma-separated values are supported and are translated into repeated `--trel-exclude-extpanid` arguments.

## Motivation

In environments with multiple Thread fabrics on the same infrastructure network, a border router can discover TREL peers belonging to a different Thread fabric.

This change allows an operator to explicitly exclude known foreign Extended PAN IDs while keeping TREL enabled for valid peers on the same infrastructure link.

This is intended as a targeted alternative to disabling TREL entirely or blocking traffic at the firewall layer.

## Behaviour

When no exclusion is configured, behaviour is unchanged.

When one or more excluded Extended PAN IDs are configured:

* TREL DNS-SD discovery still runs normally.
* Peers with matching Extended PAN IDs are ignored before being passed to OpenThread core.
* Peers without a parsed Extended PAN ID are not filtered at this layer.
* Valid non-excluded TREL peers continue to operate normally.

## Testing

Local validation completed:

* Unit tests: `TrelExtPanId.*` passed, 14/14.
* Formatting: `clang-format` passed on changed C++ files.
* Additional integration-level coverage added for:

  * peer exclusion matching,
  * reading Extended PAN ID from TXT data,
  * TXT boundary cases.
* CLI invalid input handling tested.
* Docker startup env passthrough tested, including comma-separated values.
* Source-built Docker image validated on real OTBR hardware.

Hardware validation summary:

* Two OTBR instances on the same Thread network continued to discover and use each other over TREL.
* TREL peers from a known foreign Extended PAN ID were discovered via mDNS but excluded before appearing in the OpenThread TREL peer table.
* CPU remained low.
* TREL counters remained healthy with zero outbound failures.

Made with [Cursor](https://cursor.com)