### PR TITLE
[tests] implement DinD test for SRP TC 2.8 Removing Services

### DIFF
--- a/tests/scripts/expect/dind_srp_tc_8.exp
+++ b/tests/scripts/expect/dind_srp_tc_8.exp
@@ -1,0 +1,384 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+
+set pty1 [create_socat_tcp 1 9000]
+set container "otbr-test-container"
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# Step 1: BR_1 (DUT) Enable: switch on.
+send_user "Starting OTBR Docker container (BR_1 / DUT)...\n"
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+set socket_ready false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state}]} {
+        set socket_ready true
+        break
+    }
+    sleep 2
+}
+if {!$socket_ready} {
+    fail "ot-ctl failed to communicate with otbr-agent"
+}
+
+# Step 2: Eth_1, ED_1 Enable
+# Setup active dataset on OTBR and start Thread
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+set leader false
+for {set i 0} {$i < 20} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl state} state] && [string match "*leader*" $state]} {
+        set leader true
+        break
+    }
+    sleep 2
+}
+if {!$leader} {
+    fail "OTBR did not become leader"
+}
+
+# Enable SRP server explicitly
+exec docker exec -i $container ot-ctl srp server auto disable
+exec docker exec -i $container ot-ctl srp server enable
+sleep 2
+
+# Wait 15 seconds for the dynamic OMR prefix to fully stabilize
+send_user "Waiting 15 seconds for the dynamic OMR prefix to stabilize...\n"
+sleep 15
+
+# Step 3: BR_1 (DUT) Automatically adds SRP Server info in Network Data
+send_user "Step 3: Verifying SRP Server information in Network Data...\n"
+set netdata [exec docker exec -i $container ot-ctl netdata show]
+check_string_contains $netdata "44970 5d"
+
+# Get the running Border Router's active dataset dynamically to configure clients
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [string trim $active_dataset]
+
+# Enable ED_1 (Node 4)
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active $active_dataset\r\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+expect_line "Done"
+
+set omr_addr_1 [get_omr_addr]
+expect_line "Done"
+set mleid_1 [get_ipaddr mleid]
+send_user "ED_1 ML-EID Address: $mleid_1\n"
+send_user "ED_1 OMR Address: $omr_addr_1\n"
+sleep 1
+
+# Set up test-client container to verify from adjacent infrastructure link (Eth_1)
+set test_client "test-client"
+track_container $test_client
+exec docker run -d \
+    --name $test_client \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "echo 0 > /proc/sys/net/ipv6/conf/all/autoconf && echo 0 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
+
+# Configure routes on test client
+set has_rio [expr {[catch {exec docker exec -i $test_client test -e /proc/sys/net/ipv6/conf/all/accept_ra_rt_info_max_plen}] == 0}]
+if {$has_rio} {
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+    exec docker exec -i $test_client sysctl -w net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
+    exec docker exec -i $test_client rdisc6 eth0
+} else {
+    set format {{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}}
+    set otbr_ip [string trim [exec docker inspect $container -f $format]]
+    exec docker exec -i $test_client ip -6 route add fc00::/7 via $otbr_ip dev eth0
+}
+sleep 2
+
+# Retrieve Border Router's DNS server address
+set otbr_addrs [exec docker exec -i $container ot-ctl ipaddr]
+set otbr_dns_addr ""
+foreach addr [split $otbr_addrs "\n"] {
+    set addr [string trim $addr]
+    if {[string match -nocase "*:ff:fe00:fc00" $addr]} {
+        set otbr_dns_addr $addr
+        break
+    }
+}
+if {$otbr_dns_addr eq ""} {
+    set otbr_dns_addr [string trim [lindex [split $otbr_addrs "\n"] 0]]
+}
+send_user "OTBR DNS Server Address: $otbr_dns_addr\n"
+
+# Step 4: ED_1 sends SRP Update registering service-test-1
+send_user "Step 4: ED_1 sending SRP Update for service-test-1...\n"
+switch_node 4
+send "srp client leaseinterval 600\r\n"
+expect_line "Done"
+send "srp client keyleaseinterval 1200\r\n"
+expect_line "Done"
+send "srp client host name host-test-1\r\n"
+expect_line "Done"
+send "srp client host address $omr_addr_1\r\n"
+expect_line "Done"
+send "srp client service add service-test-1 _thread-test._udp 55555\r\n"
+expect_line "Done"
+send "srp client autostart enable\r\n"
+expect_line "Done"
+
+# Step 5: BR_1 (DUT) sends success SRP Update Response
+send_user "Step 5: Verifying SRP registration success for service 1...\n"
+wait_for "srp client host state" "Registered"
+expect_line "Done"
+send_user "SRP registration for service 1 successful.\n"
+
+# Step 6-7: ED_1 unicast DNS query to DUT
+send_user "Step 6-7: Verifying unicast DNS query from ED_1 for service 1...\n"
+send "dns config $otbr_dns_addr\r\n"
+expect_line "Done"
+send "dns browse _thread-test._udp.default.service.arpa.\r\n"
+set timeout 30
+set found_srv1 0
+expect {
+    -re "service-test-1" {
+        set found_srv1 1
+        exp_continue
+    }
+    -re "Done" {
+    }
+    timeout {
+        fail "Unicast DNS PTR query timed out"
+    }
+}
+if {!$found_srv1} {
+    fail "Unicast DNS PTR query response missing 'service-test-1'"
+}
+send_user "Unicast DNS query for service 1 successful.\n"
+
+# Step 8-9: Eth_1 sends mDNS query SRV for service-test-1
+send_user "Step 8-9: Verifying mDNS resolution from Eth_1 (test-client) for service 1...\n"
+set py_mdns_check_srv1 {import time
+from zeroconf import Zeroconf, IPVersion
+
+zc = Zeroconf(ip_version=IPVersion.V6Only)
+found_srv = False
+for _ in range(10):
+    info = zc.get_service_info('_thread-test._udp.local.', 'service-test-1._thread-test._udp.local.', 2000)
+    if info and info.port == 55555 and info.server == 'host-test-1.local.':
+        found_srv = True
+        break
+    time.sleep(1)
+
+print('SRV1:FOUND' if found_srv else 'SRV1:MISSING')
+zc.close()
+}
+
+set mdns_res [exec docker exec -i $test_client python3 -c $py_mdns_check_srv1]
+set mdns_res [string trim $mdns_res]
+send_user "mDNS Check 1 Result: $mdns_res\n"
+if {$mdns_res ne "SRV1:FOUND"} {
+    fail "mDNS SRV resolution for service 1 failed"
+}
+
+# Step 10: ED_1 sends SRP Update adding service-test-2
+send_user "Step 10: ED_1 adding service-test-2...\n"
+switch_node 4
+send "srp client service add service-test-2 _thread-test._udp 55556\r\n"
+expect_line "Done"
+
+# Step 11: BR_1 (DUT) sends success SRP Update Response
+send_user "Step 11: Verifying SRP registration success for service 2...\n"
+sleep 2
+send "srp client service\r\n"
+expect {
+    -re "service-test-2.*state:Registered" {
+        # Succeeded
+    }
+    timeout {
+        fail "SRP registration for service 2 timed out or not registered"
+    }
+}
+expect_line "Done"
+send_user "SRP registration for service 2 successful.\n"
+
+# Step 12-13: ED_1 unicast DNS query to DUT for service 2
+send_user "Step 12-13: Verifying unicast DNS query from ED_1 containing service 2...\n"
+send "dns browse _thread-test._udp.default.service.arpa.\r\n"
+set timeout 30
+set found_srv2 0
+expect {
+    -re "service-test-2" {
+        set found_srv2 1
+        exp_continue
+    }
+    -re "Done" {
+    }
+    timeout {
+        fail "Unicast DNS query timed out"
+    }
+}
+if {!$found_srv2} {
+    fail "Unicast DNS query response missing 'service-test-2'"
+}
+send_user "Unicast DNS query for service 2 successful.\n"
+
+# Step 14-15: Eth_1 repeats mDNS query for service 1
+send_user "Step 14-15: Confirming service 1 is still present via mDNS...\n"
+set mdns_res [exec docker exec -i $test_client python3 -c $py_mdns_check_srv1]
+set mdns_res [string trim $mdns_res]
+send_user "mDNS Repeat Check Result: $mdns_res\n"
+if {$mdns_res ne "SRV1:FOUND"} {
+    fail "mDNS repeat check failed: service 1 missing"
+}
+
+# Step 16: ED_1 sends SRP Update removing service-test-1 only
+send_user "Step 16: ED_1 removing service-test-1 (shortening key lease interval)...\n"
+switch_node 4
+send "srp client keyleaseinterval 600\r\n"
+expect_line "Done"
+send "srp client service remove service-test-1 _thread-test._udp\r\n"
+expect_line "Done"
+
+# Step 17: BR_1 (DUT) sends success SRP Update Response
+send_user "Step 17: Verifying removal processed...\n"
+sleep 3
+send "srp client service\r\n"
+expect {
+    -re "service-test-1" {
+        fail "service-test-1 was not removed"
+    }
+    -re "Done" {
+    }
+    timeout {
+        fail "srp client service timed out"
+    }
+}
+
+# Step 18-21: ED_1 unicast DNS query for service 1 (must be 0 answers) and service 2
+send_user "Step 18-21: Verifying unicast DNS queries from ED_1 (service 1 removed, service 2 active)...\n"
+send "dns browse _thread-test._udp.default.service.arpa.\r\n"
+set timeout 30
+set found_srv1 0
+set found_srv2 0
+expect {
+    -re "service-test-1" {
+        set found_srv1 1
+        exp_continue
+    }
+    -re "service-test-2" {
+        set found_srv2 1
+        exp_continue
+    }
+    -re "Done" {
+    }
+    timeout {
+        fail "Unicast DNS browse timed out"
+    }
+}
+if {$found_srv1} {
+    fail "Unicast DNS browse incorrectly returned removed 'service-test-1'"
+}
+if {!$found_srv2} {
+    fail "Unicast DNS browse missing 'service-test-2'"
+}
+send_user "Unicast DNS query verified: 0 answer records for service 1, valid answer for service 2.\n"
+
+# Step 22-23: Eth_1 sends mDNS query SRV for service-test-1 (DUT must NOT send response)
+send_user "Step 22-23: Verifying DUT does not respond to mDNS query for service 1...\n"
+set py_mdns_check_removed {import time
+from zeroconf import Zeroconf, IPVersion
+
+zc = Zeroconf(ip_version=IPVersion.V6Only)
+found_srv = False
+for _ in range(5):
+    info = zc.get_service_info('_thread-test._udp.local.', 'service-test-1._thread-test._udp.local.', 2000)
+    if info and info.port is not None:
+        found_srv = True
+        break
+    time.sleep(1)
+
+print('SRV1:STILL_EXISTS' if found_srv else 'SRV1:REMOVED')
+zc.close()
+}
+set mdns_res [exec docker exec -i $test_client python3 -c $py_mdns_check_removed]
+set mdns_res [string trim $mdns_res]
+send_user "mDNS Check Removed Result: $mdns_res\n"
+if {$mdns_res ne "SRV1:REMOVED"} {
+    fail "DUT incorrectly responded to mDNS query for removed service 1"
+}
+
+# Step 24-25: Eth_1 sends mDNS query PTR for _thread-test._udp.local (must return service 2 only)
+send_user "Step 24-25: Verifying mDNS PTR query returns service 2 only...\n"
+set py_mdns_browse_ptr {import time
+from zeroconf import Zeroconf, IPVersion, ServiceBrowser
+
+services = set()
+class Listener:
+    def add_service(self, zc, type_, name):
+        services.add(name)
+    def update_service(self, zc, type_, name):
+        pass
+    def remove_service(self, zc, type_, name):
+        pass
+
+zc = Zeroconf(ip_version=IPVersion.V6Only)
+browser = ServiceBrowser(zc, '_thread-test._udp.local.', Listener())
+time.sleep(4)
+print('PTR_SERVICES:' + ','.join(sorted(services)))
+browser.cancel()
+zc.close()
+}
+set mdns_res [exec docker exec -i $test_client python3 -c $py_mdns_browse_ptr]
+set mdns_res [string trim $mdns_res]
+send_user "mDNS Browse PTR Result: $mdns_res\n"
+if {$mdns_res ne "PTR_SERVICES:service-test-2._thread-test._udp.local."} {
+    fail "mDNS PTR query returned incorrect services (expected service-test-2 only): $mdns_res"
+}
+
+# Cleanup
+dispose_all
+send_user "# Removing Some Published Services (1_3_SRP_TC_8) integration test completed successfully!\n"
+exit 0

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -201,6 +201,9 @@ test_run()
     echo "--- Running SRP Name Compression (1_3_SRP_TC_6) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_srp_tc_6.exp"
 
+    echo "--- Running Removing Some Published Services (1_3_SRP_TC_8) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_srp_tc_8.exp"
+
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
 


### PR DESCRIPTION
Implement the verification script dind_srp_tc_8.exp to systematically test all 25 steps of the "Removing Some Published Services" procedure using the Docker-in-Docker framework:
- Verify SRP Server info appears in Thread network data.
- Register multiple service instances from ED_1 (ot-cli-ftd).
- Verify unicast DNS resolution from Thread end devices.
- Verify mDNS advertising proxy discovery from Eth_1 (test-client).
- Execute selective service removal (TTL=0) via CLI.
- Confirm subsequent DNS queries for the removed service return 0 answers while remaining services resolve successfully.
- Verify mDNS PTR browsing returns only the remaining active services.