### PR TITLE
[tests] add dind integration test for TREL attach and connectivity

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -357,3 +357,45 @@ proc get_ipv6_regex {addr} {
     return "${regex}(?!\[0-9a-fA-F:\])"
 }
 
+proc get_rloc_dns_addr {container} {
+    set addrs [exec docker exec -i $container ot-ctl ipaddr]
+    foreach addr [split $addrs "\n"] {
+        set addr [string trim $addr]
+        if {[string match -nocase "*:ff:fe00:fc00" $addr]} {
+            return $addr
+        }
+    }
+    return [string trim [lindex [split $addrs "\n"] 0]]
+}
+
+proc wait_for_otbr_agent {containers} {
+    foreach c $containers {
+        set socket_ready false
+        for {set i 0} {$i < 10} {incr i} {
+            if {![catch {exec docker exec -i $c ot-ctl state}]} {
+                set socket_ready true
+                break
+            }
+            sleep 2
+        }
+        if {!$socket_ready} {
+            fail "ot-ctl failed to communicate with otbr-agent on $c"
+        }
+    }
+}
+
+proc wait_for_container_state {container expected_state} {
+    set state_reached false
+    for {set i 0} {$i < 20} {incr i} {
+        if {![catch {exec docker exec -i $container ot-ctl state} state] && [string match "*$expected_state*" $state]} {
+            set state_reached true
+            break
+        }
+        sleep 2
+    }
+    if {!$state_reached} {
+        fail "$container did not become $expected_state"
+    }
+}
+
+

--- a/tests/scripts/expect/dind_dpr_tc_2.exp
+++ b/tests/scripts/expect/dind_dpr_tc_2.exp
@@ -45,19 +45,7 @@ send_user "Starting BR_2 container...\n"
 start_otbr_docker_dind $container2 $::env(EXP_OT_RCP_PATH) 3 $pty2 9001
 
 # Wait for otbr-agents to create the domain sockets
-foreach c [list $container1 $container2] {
-    set socket_ready false
-    for {set i 0} {$i < 10} {incr i} {
-        if {![catch {exec docker exec -i $c ot-ctl state}]} {
-            set socket_ready true
-            break
-        }
-        sleep 2
-    }
-    if {!$socket_ready} {
-        fail "ot-ctl failed to communicate with otbr-agent on $c"
-    }
-}
+wait_for_otbr_agent [list $container1 $container2]
 
 # Stop default thread and interfaces
 foreach c [list $container1 $container2] {
@@ -76,17 +64,7 @@ exec docker exec -i $container1 ot-ctl ifconfig up
 exec docker exec -i $container1 ot-ctl thread start
 
 # Wait for BR_1 to become leader
-set leader false
-for {set i 0} {$i < 20} {incr i} {
-    if {![catch {exec docker exec -i $container1 ot-ctl state} state] && [string match "*leader*" $state]} {
-        set leader true
-        break
-    }
-    sleep 2
-}
-if {!$leader} {
-    fail "BR_1 (DUT) did not become leader"
-}
+wait_for_container_state $container1 "leader"
 
 # Enable SRP server explicitly on BR_1
 exec docker exec -i $container1 ot-ctl srp server auto disable
@@ -146,17 +124,7 @@ exec docker exec -i $container2 ot-ctl ifconfig up
 exec docker exec -i $container2 ot-ctl thread start
 
 # Wait for BR_2 to become leader
-set leader false
-for {set i 0} {$i < 20} {incr i} {
-    if {![catch {exec docker exec -i $container2 ot-ctl state} state] && [string match "*leader*" $state]} {
-        set leader true
-        break
-    }
-    sleep 2
-}
-if {!$leader} {
-    fail "BR_2 did not become leader"
-}
+wait_for_container_state $container2 "leader"
 
 # Enable SRP server explicitly on BR_2
 exec docker exec -i $container2 ot-ctl srp server auto disable
@@ -209,33 +177,11 @@ send_user "Waiting 15 seconds for prefixes to stabilize...\n"
 sleep 15
 
 # Retrieve BR_1's RLOC address to use as DNS server for ED_1
-set br1_addrs [exec docker exec -i $container1 ot-ctl ipaddr]
-set br1_dns_addr ""
-foreach addr [split $br1_addrs "\n"] {
-    set addr [string trim $addr]
-    if {[string match -nocase "*:ff:fe00:fc00" $addr]} {
-        set br1_dns_addr $addr
-        break
-    }
-}
-if {$br1_dns_addr eq ""} {
-    set br1_dns_addr [string trim [lindex [split $br1_addrs "\n"] 0]]
-}
+set br1_dns_addr [get_rloc_dns_addr $container1]
 send_user "BR_1 DNS Server Address: $br1_dns_addr\n"
 
 # Retrieve BR_2's RLOC address to use as DNS server for ED_2
-set br2_addrs [exec docker exec -i $container2 ot-ctl ipaddr]
-set br2_dns_addr ""
-foreach addr [split $br2_addrs "\n"] {
-    set addr [string trim $addr]
-    if {[string match -nocase "*:ff:fe00:fc00" $addr]} {
-        set br2_dns_addr $addr
-        break
-    }
-}
-if {$br2_dns_addr eq ""} {
-    set br2_dns_addr [string trim [lindex [split $br2_addrs "\n"] 0]]
-}
+set br2_dns_addr [get_rloc_dns_addr $container2]
 send_user "BR_2 DNS Server Address: $br2_dns_addr\n"
 
 

--- a/tests/scripts/expect/dind_trel_tc_1.exp
+++ b/tests/scripts/expect/dind_trel_tc_1.exp
@@ -1,0 +1,327 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+# Dynamic helper to start the OTBR docker container and map the spinel relay
+# Start relays and containers
+set pty1 [create_socat_tcp 1 9000]
+set pty2 [create_socat_tcp 2 9001]
+
+set container1 "otbr-test-container-1"
+set container2 "otbr-test-container-2"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+send_user -- "--- Starting container 1 (BR Leader/DUT) ---\n"
+start_otbr_docker_dind $container1 $::env(EXP_OT_RCP_PATH) 2 $pty1 9000
+
+send_user -- "--- Starting container 2 (Router_1) ---\n"
+start_otbr_docker_dind $container2 $::env(EXP_OT_RCP_PATH) 3 $pty2 9001
+
+# Spawn Router_2 (Node 4) on host
+send_user -- "--- Spawning CLI Node 4 (Router_2) ---\n"
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+
+# Ensure both containers have initialized correctly and otbr-agent socket is ready
+wait_for_otbr_agent [list $container1 $container2]
+
+# Stop Thread, down interface, and set routerselectionjitter on both containers initially
+foreach c [list $container1 $container2] {
+    exec docker exec -i $c ot-ctl thread stop
+    exec docker exec -i $c ot-ctl ifconfig down
+    exec docker exec -i $c ot-ctl routerselectionjitter 1
+}
+
+# Configure Active Dataset on both containers and Node 4
+send_user -- "--- Configuring Active Dataset on all nodes ---\n"
+exec docker exec -i $container1 ot-ctl dataset set active $dataset
+exec docker exec -i $container2 ot-ctl dataset set active $dataset
+
+switch_node 4
+send "dataset set active $dataset\n"
+expect_line "Done"
+
+# Start Thread on container 1 (Leader/DUT)
+send_user -- "--- Starting Thread on Container 1 ---\n"
+exec docker exec -i $container1 ot-ctl ifconfig up
+exec docker exec -i $container1 ot-ctl thread start
+
+# Wait for Container 1 to become leader
+wait_for_container_state $container1 "leader"
+
+# Retrieve Extended MAC Address and RLOC16 of Leader/DUT
+set br_extaddr [exec docker exec -i $container1 ot-ctl extaddr]
+set br_extaddr [string trim [lindex [split $br_extaddr "\n"] 0]]
+send_user "BR Leader ExtAddr: $br_extaddr\n"
+
+# Start Thread on container 2 (Router_1)
+send_user -- "--- Starting Thread on Container 2 ---\n"
+exec docker exec -i $container2 ot-ctl ifconfig up
+exec docker exec -i $container2 ot-ctl thread start
+
+# Start Thread on Node 4 (Router_2)
+send_user -- "--- Starting Thread on CLI Node 4 ---\n"
+switch_node 4
+send "ifconfig up\n"
+expect_line "Done"
+send "thread start\n"
+expect_line "Done"
+
+# Wait for Container 2 to become router
+wait_for_container_state $container2 "router"
+
+# Wait for Node 4 to become router
+switch_node 4
+wait_for "state" "router"
+expect_line "Done"
+
+# Retrieve Extended MAC Addresses of Router_1 and Router_2
+set r1_extaddr [exec docker exec -i $container2 ot-ctl extaddr]
+set r1_extaddr [string trim [lindex [split $r1_extaddr "\n"] 0]]
+send_user "Router_1 ExtAddr: $r1_extaddr\n"
+
+switch_node 4
+send "extaddr\n"
+set r2_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "Router_2 ExtAddr: $r2_extaddr\n"
+
+# Set up MAC isolation: Router_1 and Router_2 must only allow BR Leader (DUT)
+send_user -- "--- Setting up MAC filter isolation ---\n"
+exec docker exec -i $container2 ot-ctl macfilter addr clear
+exec docker exec -i $container2 ot-ctl macfilter addr allowlist
+exec docker exec -i $container2 ot-ctl macfilter addr add $br_extaddr
+
+switch_node 4
+send "macfilter addr clear\n"
+expect_line "Done"
+send "macfilter addr allowlist\n"
+expect_line "Done"
+send "macfilter addr add $br_extaddr\n"
+expect_line "Done"
+
+# Wait for neighbor tables to update and stabilize
+send_user -- "--- Waiting 15 seconds for neighbors to stabilize ---\n"
+sleep 15
+
+# Verify that Router_1 only sees Leader and not Router_2
+send_user -- "--- Verifying neighbors on Router_1 ---\n"
+set r1_neighbors [exec docker exec -i $container2 ot-ctl neighbor table]
+check_string_contains $r1_neighbors $br_extaddr
+if {[string match "*$r2_extaddr*" $r1_neighbors]} {
+    fail "Router_1 neighbor table contains Router_2, isolation failed!"
+}
+
+# Verify that Router_2 only sees Leader and not Router_1
+send_user -- "--- Verifying neighbors on Router_2 ---\n"
+switch_node 4
+send "neighbor table\n"
+expect {
+    -re $r1_extaddr {
+        fail "Router_2 neighbor table contains Router_1, isolation failed!"
+    }
+    -re $br_extaddr {
+        # Found Leader, good
+        exp_continue
+    }
+    -re "Done" {
+        # completed
+    }
+}
+
+# --- Step 2: Multi-Radio Detection ---
+send_user -- "--- Step 2: Verifying multi-radio peer discovery ---\n"
+set discovered false
+for {set i 0} {$i < 10} {incr i} {
+    set trel_peers [exec docker exec -i $container2 ot-ctl trel peers]
+    if {[string match "*$br_extaddr*" $trel_peers]} {
+        set discovered true
+        break
+    }
+    sleep 2
+}
+if {!$discovered} {
+    fail "Router_1 did not discover BR Leader as TREL peer."
+}
+
+set multiradio_list [exec docker exec -i $container2 ot-ctl multiradio neighbor list]
+if {![regexp "ExtAddr:\\s*$br_extaddr" $multiradio_list]} {
+    fail "BR Leader not found in Router_1 multiradio neighbor list."
+}
+if {![regexp {Radios:\[.*15\.4.*TREL.*\]} $multiradio_list]} {
+    fail "BR Leader entry in Router_1 does not support both 15.4 and TREL."
+}
+send_user "Multi-radio neighbor info verified successfully!\n"
+
+# --- Step 3: Router_1 pings BR (DUT) using link-local address ---
+send_user -- "--- Step 3: Router_1 pings BR Leader (DUT) (Link-Local) ---\n"
+set br_linklocal [exec docker exec -i $container1 ot-ctl ipaddr linklocal]
+set br_linklocal [string trim [lindex [split $br_linklocal "\n"] 0]]
+send_user "BR linklocal address: $br_linklocal\n"
+
+# Reset TREL counters
+exec docker exec -i $container1 ot-ctl trel counters reset
+exec docker exec -i $container2 ot-ctl trel counters reset
+
+# Ping from Router_1
+set ping_output [exec docker exec -i $container2 ot-ctl ping $br_linklocal 500 1]
+send_user "Ping output: $ping_output\n"
+check_string_contains $ping_output "bytes from"
+
+# Verify TREL counters
+set r1_trel_counters [exec docker exec -i $container2 ot-ctl trel counters]
+set br_trel_counters [exec docker exec -i $container1 ot-ctl trel counters]
+
+# Verify Router_1 TREL outbound packets > 0 and DUT TREL inbound packets > 0
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel_counters match r1_out] || $r1_out == 0} {
+    fail "Router_1 did not send TREL packets."
+}
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $br_trel_counters match br_in] || $br_in == 0} {
+    fail "BR Leader did not receive TREL packets."
+}
+# Verify DUT TREL outbound packets > 0 and Router_1 TREL inbound packets > 0 (for ping reply)
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $br_trel_counters match br_out] || $br_out == 0} {
+    fail "BR Leader did not send TREL response."
+}
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel_counters match r1_in] || $r1_in == 0} {
+    fail "Router_1 did not receive TREL response."
+}
+send_user "TREL Ping Link-Local verified: Router_1 -> BR (DUT) -> Router_1\n"
+
+# --- Step 4: Router_2 pings BR (DUT) (Link-Local) ---
+send_user -- "--- Step 4: Router_2 pings BR Leader (DUT) (15.4 only) ---\n"
+
+# Ping from Router_2 (Node 4)
+switch_node 4
+send "ping $br_linklocal 500 1\n"
+expect {
+    -re "bytes from" {
+        send_user "Ping succeeded!\n"
+    }
+    timeout {
+        fail "Ping from Router_2 to BR Leader timed out."
+    }
+}
+expect_line "Done"
+
+# Verify Router_2 (15.4-only) is not discovered as a TREL peer on DUT
+set trel_peers [exec docker exec -i $container1 ot-ctl trel peers]
+if {[string match "*$r2_extaddr*" $trel_peers]} {
+    fail "Router_2 (15.4-only) incorrectly discovered as TREL peer on DUT."
+}
+send_user "Verified: Router_2 (15.4 only) is not discovered as a TREL peer on DUT.\n"
+
+# --- Step 5: Router_1 pings Router_2 (Mesh-Local EID) ---
+send_user -- "--- Step 5: Router_1 pings Router_2 via DUT (Mesh-Local EID) ---\n"
+# Get Router_2 ML-EID
+switch_node 4
+send "ipaddr mleid\n"
+set r2_mleid [expect_line {[0-9a-fA-F]{1,4}:[0-9a-fA-F:]+}]
+expect_line "Done"
+send_user "Router_2 ML-EID: $r2_mleid\n"
+
+# Reset TREL counters
+exec docker exec -i $container1 ot-ctl trel counters reset
+exec docker exec -i $container2 ot-ctl trel counters reset
+
+# Ping from Router_1
+set ping_output [exec docker exec -i $container2 ot-ctl ping $r2_mleid 500 1]
+send_user "Ping output: $ping_output\n"
+check_string_contains $ping_output "bytes from"
+
+# Verify TREL counters
+set r1_trel [exec docker exec -i $container2 ot-ctl trel counters]
+set br_trel [exec docker exec -i $container1 ot-ctl trel counters]
+
+# Verification:
+# Ping request: Router_1 (TREL Out) -> DUT (TREL In -> Forward over 15.4) -> Router_2
+# Ping reply:   Router_2 -> (15.4) -> DUT (Forward over TREL -> TREL Out) -> Router_1 (TREL In)
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel match r1_out] || $r1_out == 0} {
+    fail "Router_1 did not send TREL packet for ping request."
+}
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $br_trel match br_in] || $br_in == 0} {
+    fail "BR Leader did not receive TREL packet for ping request."
+}
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $br_trel match br_out] || $br_out == 0} {
+    fail "BR Leader did not send TREL packet for ping reply."
+}
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel match r1_in] || $r1_in == 0} {
+    fail "Router_1 did not receive TREL packet for ping reply."
+}
+send_user "Verified TREL routing for Router_1 -> Router_2 ping successfully!\n"
+
+# --- Step 6: Router_2 pings Router_1 (Mesh-Local EID) ---
+send_user -- "--- Step 6: Router_2 pings Router_1 via DUT (Mesh-Local EID) ---\n"
+# Get Router_1 ML-EID
+set r1_mleid [exec docker exec -i $container2 ot-ctl ipaddr mleid]
+set r1_mleid [string trim [lindex [split $r1_mleid "\n"] 0]]
+send_user "Router_1 ML-EID: $r1_mleid\n"
+
+# Reset TREL counters
+exec docker exec -i $container1 ot-ctl trel counters reset
+exec docker exec -i $container2 ot-ctl trel counters reset
+
+# Ping from Router_2
+switch_node 4
+send "ping $r1_mleid 500 1\n"
+expect {
+    -re "bytes from" {
+        send_user "Ping succeeded!\n"
+    }
+    timeout {
+        fail "Ping from Router_2 to Router_1 timed out."
+    }
+}
+expect_line "Done"
+
+# Verify TREL counters
+set r1_trel [exec docker exec -i $container2 ot-ctl trel counters]
+set br_trel [exec docker exec -i $container1 ot-ctl trel counters]
+
+# Verification:
+# Ping request: Router_2 -> (15.4) -> DUT (Forward over TREL -> TREL Out) -> Router_1 (TREL In)
+# Ping reply:   Router_1 (TREL Out) -> DUT (TREL In -> Forward over 15.4) -> Router_2
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel match r1_in] || $r1_in == 0} {
+    fail "Router_1 did not receive TREL packet for ping request."
+}
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $br_trel match br_out] || $br_out == 0} {
+    fail "BR Leader did not send TREL packet for ping request."
+}
+if {![regexp {Outbound:\s+Packets\s+([1-9][0-9]*)} $r1_trel match r1_out] || $r1_out == 0} {
+    fail "Router_1 did not send TREL packet for ping reply."
+}
+if {![regexp {Inbound:\s+Packets\s+([1-9][0-9]*)} $br_trel match br_in] || $br_in == 0} {
+    fail "BR Leader did not receive TREL packet for ping reply."
+}
+send_user "Verified TREL routing for Router_2 -> Router_1 ping successfully!\n"
+
+dispose_all
+send_user -- "--- TREL Attach and Connectivity (1_4_TREL_TC_1) Integration Test PASSED successfully! ---\n"
+exit 0

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -222,6 +222,9 @@ test_run()
     echo "--- Running TREL integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel.exp"
 
+    echo "--- Running TREL Attach and Connectivity (1_4_TREL_TC_1) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_trel_tc_1.exp"
+
     echo "--- Running NAT64 integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_nat64.exp"
 


### PR DESCRIPTION
This commit adds a new integration test script `dind_trel_tc_1.exp` to verify Thread 1.4 TREL attach and connectivity between multi-radio and single-radio devices.

The test verifies:
- Attaching Thread Devices with different radio links (TREL + 15.4).
- Detection of neighbor multi-radio capabilities via CLI command `multiradio neighbor list`.
- Unicast connectivity over TREL and 15.4 using TREL counters.
- Broadcast/multihop connectivity and routing through the BR.

In addition, this commit registers the expect script in the DinD integration test runner `test_dind_dns_sd.sh`.