### PR TITLE
[web] support HTTPS reverse proxy for API calls

### DIFF
--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -287,7 +287,7 @@
                     console.log(response);
                     $scope.res = response.data.result;
                     if (response.data.result == 'successful') {
-                        var image = "http://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=v%3D1%26%26eui%3D" + response.data.eui64 +"%26%26cc%3D" + $scope.thread.pskd +"&amp;qzone=1&amp;margin=0&amp;size=400x400&amp;ecc=L";
+                        var image = "https://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=v%3D1%26%26eui%3D" + response.data.eui64 +"%26%26cc%3D" + $scope.thread.pskd +"&amp;qzone=1&amp;margin=0&amp;size=400x400&amp;ecc=L";
                         $scope.showQRCode(event, image);
                     } else {
                         $scope.showQRAlert(event, "sorry, can not generate the QR code.");
@@ -440,6 +440,10 @@
 
         $scope.restServerPort = '8081';
         var formatRestAddr = function(host, port) {
+            // When using HTTPS, omit port (assumes client sees 443 and reverse proxy routes to correct backend port)
+            if (window.location.protocol === 'https:') {
+                return (host.indexOf(':') > -1) ? '[' + host + ']' : host;
+            }
             return (host.indexOf(':') > -1) ? '[' + host + ']:' + port : host + ':' + port;
         };
         $scope.ipAddr = formatRestAddr(window.location.hostname, $scope.restServerPort);
@@ -505,7 +509,7 @@
         $scope.dataInit = async function() {
             let response;
         
-            $http.get('http://' + $scope.ipAddr + '/api/node', {
+            $http.get(window.location.protocol + '//' + $scope.ipAddr + '/api/node', {
                     headers: {
                         'Accept': 'application/json'
                     }
@@ -609,7 +613,7 @@
         // GET request to check action status
         $scope.getActionStatus = async function(action_id) {
 
-            const response = await $http.get('http://' + $scope.ipAddr + '/api/actions/' + action_id, {
+            const response = await $http.get(window.location.protocol + '//' + $scope.ipAddr + '/api/actions/' + action_id, {
                 headers: {
                     'Accept': 'application/vnd.api+json'
                 }
@@ -628,7 +632,7 @@
             console.log("discover network ...");  // Debugging log message
             do {
                 // start discovery task
-                const postResponse = await $http.post('http://' + $scope.ipAddr + '/api/actions', $scope.createRequestBodyUpdateDeviceCollection(deviceCount), {
+                const postResponse = await $http.post(window.location.protocol + '//' + $scope.ipAddr + '/api/actions', $scope.createRequestBodyUpdateDeviceCollection(deviceCount), {
                     headers: {
                         'Content-Type': 'application/vnd.api+json',
                         'Accept': 'application/vnd.api+json'
@@ -670,7 +674,7 @@
 
         // GET device collection
         $scope.fetchDevices = async function () {
-            const response = await $http.get('http://' + $scope.ipAddr + '/api/devices', {
+            const response = await $http.get(window.location.protocol + '//' + $scope.ipAddr + '/api/devices', {
                 headers: {
                     'Accept': 'application/json'
                 }
@@ -689,7 +693,7 @@
 
             do {
                 // Fetch device diagnostics
-                const postResponse = await $http.post('http://' + $scope.ipAddr + '/api/actions', $scope.createRequestBody(device_id), {
+                const postResponse = await $http.post(window.location.protocol + '//' + $scope.ipAddr + '/api/actions', $scope.createRequestBody(device_id), {
                     headers: {
                         'Content-Type': 'application/vnd.api+json',
                         'Accept': 'application/vnd.api+json'
@@ -785,7 +789,7 @@
             const devices = await $scope.fetchDevices();
 
             // Delete diagnostics entries
-            await $http.delete('http://' + $scope.ipAddr + '/api/diagnostics').then(function(response) {
+            await $http.delete(window.location.protocol + '//' + $scope.ipAddr + '/api/diagnostics').then(function(response) {
                 console.log(`Deleted diagnostics status ${response.status}`);
             });
 
@@ -793,7 +797,7 @@
             await $scope.fetchDiagnosticsForDevices(devices);
 
             // Fetch the list of device diagnostics
-            const getResponse = await $http.get('http://' + $scope.ipAddr + '/api/diagnostics', {
+            const getResponse = await $http.get(window.location.protocol + '//' + $scope.ipAddr + '/api/diagnostics', {
                 headers: {
                     'Accept': 'application/json'
                 }

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -440,11 +440,22 @@
 
         $scope.restServerPort = '8081';
         var formatRestAddr = function(host, port) {
-            // When using HTTPS, omit port (assumes client sees 443 and reverse proxy routes to correct backend port)
+            // Remove existing IPv6 brackets if present
+            var normalizedHost = host.replace(/^\[(.*)\]$/, '$1');
+            
+            var formattedHost = (normalizedHost.indexOf(':') > -1) ? '[' + normalizedHost + ']' : normalizedHost;
+
+            // When using HTTPS, assume reverse proxy places web UI and API on same port
             if (window.location.protocol === 'https:') {
-                return (host.indexOf(':') > -1) ? '[' + host + ']' : host;
+                // If the target API host is the same as the Web UI host
+                if (normalizedHost === window.location.hostname.replace(/^\[(.*)\]$/, '$1')) {
+                    // Use the web UI full host string (including non-standard port if present)
+                    return window.location.host;
+                }
+                // Otherwise, assume the proxy handles the port translation for the external host
+                return formattedHost;
             }
-            return (host.indexOf(':') > -1) ? '[' + host + ']:' + port : host + ':' + port;
+            return formattedHost + ':' + port;
         };
         $scope.ipAddr = formatRestAddr(window.location.hostname, $scope.restServerPort);
 

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -452,8 +452,8 @@
                     // Use the web UI full host string (including non-standard port if present)
                     return window.location.host;
                 }
-                // Otherwise, assume the proxy handles the port translation for the external host
-                return formattedHost;
+                // Otherwise, preserve the configured port for external hosts
+                return formattedHost + ':' + port;
             }
             return formattedHost + ':' + port;
         };

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -445,15 +445,9 @@
             
             var formattedHost = (normalizedHost.indexOf(':') > -1) ? '[' + normalizedHost + ']' : normalizedHost;
 
-            // When using HTTPS, assume reverse proxy places web UI and API on same port
-            if (window.location.protocol === 'https:') {
-                // If the target API host is the same as the Web UI host
-                if (normalizedHost === window.location.hostname.replace(/^\[(.*)\]$/, '$1')) {
-                    // Use the web UI full host string (including non-standard port if present)
-                    return window.location.host;
-                }
-                // Otherwise, preserve the configured port for external hosts
-                return formattedHost + ':' + port;
+            // When using HTTPS and the target API host matches the Web UI host, use the web UI host (including port if present)
+            if (window.location.protocol === 'https:' && normalizedHost === window.location.hostname.replace(/^\[(.*)\]$/, '$1')) {
+                return window.location.host;
             }
             return formattedHost + ':' + port;
         };


### PR DESCRIPTION
I'm running the web UI behind my existing reverse proxy and authentication middleware, which is configured to properly pass both the web UI and API over HTTPS and port 443. However, the topology tab fails to load due to mixed content errors, as HTTP is hardcoded, as is port 8081 for API calls.

My reference Traefik config, in case these breadcrumbs help someone else in a similar situation:
```yaml
services:
  otbr:
    labels:
      traefik.enable: "true"
      # Web UI (Port 8080)
      traefik.http.routers.otbr-web.rule: "Host(`otbr.${DOMAIN_NAME}`)"
      traefik.http.routers.otbr-web.middlewares: "authelia@file"
      traefik.http.routers.otbr-web.service: "otbr-web"
      traefik.http.services.otbr-web.loadbalancer.server.url: "http://host.docker.internal:8080"
      # REST API (port 8081)
      traefik.http.routers.otbr-api.rule: "Host(`otbr.${DOMAIN_NAME}`) && PathPrefix(`/api`)"
      traefik.http.routers.otbr-api.middlewares: "authelia@file, otbr-api-strip"
      traefik.http.routers.otbr-api.service: "otbr-api"
      traefik.http.services.otbr-api.loadbalancer.server.url: "http://host.docker.internal:8081"
      # Strip headers as OTBR returns 400 with too many headers or invalid characters in headers
      traefik.http.middlewares.otbr-api-strip.headers.customRequestHeaders.Cookie: ""
      traefik.http.middlewares.otbr-api-strip.headers.customRequestHeaders.Remote-User: ""
      traefik.http.middlewares.otbr-api-strip.headers.customRequestHeaders.Remote-Groups: ""
      traefik.http.middlewares.otbr-api-strip.headers.customRequestHeaders.Remote-Email: ""
      traefik.http.middlewares.otbr-api-strip.headers.customRequestHeaders.Remote-Name: ""
```

---

This commit updates the Web UI to support being served over HTTPS via a reverse proxy.

- Replaces hardcoded 'http://' with 'window.location.protocol' for all REST API calls.
- Modifies formatRestAddr() to conditionally omit the '8081' port when the page is accessed via HTTPS, allowing the proxy's port mapping to handle the request.

These changes ensure the Web UI remains functional when TLS is terminated at a reverse proxy, while maintaining backward compatibility for standard HTTP deployments.

Test results:
<img width="3821" height="1925" alt="image" src="https://github.com/user-attachments/assets/b1bc6596-4ecf-43ad-ab59-506c840b1d2d" />
