### PR TITLE
[tests] implement Thread 1.4 TREL TC 8.4 (Receive Discovery)

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -292,8 +292,7 @@ proc get_omr_addr {} {
 
 proc check_string_contains {haystack needle} {
     if {![regexp $needle $haystack]} {
-        puts "Error: '$needle' not found."
-        exit 1
+        fail "'$needle' not found."
     }
 }
 
@@ -410,5 +409,21 @@ proc verify_trel_traffic {c1 expected_dir1 c2 expected_dir2} {
                 fail "TREL Inbound packet verification failed on $c."
             }
         }
+    }
+}
+
+proc verify_no_trel_traffic {c} {
+    set cnts [exec docker exec -i $c ot-ctl trel counters]
+    send_user "TREL counters on $c:\n$cnts\n"
+    set inbound_bytes 0
+    set outbound_bytes 0
+    if {[regexp {Inbound:\s+Packets\s+\d+\s+Bytes\s+(\d+)} $cnts match ibytes]} {
+        set inbound_bytes $ibytes
+    }
+    if {[regexp {Outbound:\s+Packets\s+\d+\s+Bytes\s+(\d+)} $cnts match obytes]} {
+        set outbound_bytes $obytes
+    }
+    if {$inbound_bytes > 1000 || $outbound_bytes > 1000} {
+        fail "TREL traffic occurred on $c (Inbound: $inbound_bytes bytes, Outbound: $outbound_bytes bytes) exceeding probe threshold!"
     }
 }

--- a/tests/scripts/expect/dind_trel_tc_3.exp
+++ b/tests/scripts/expect/dind_trel_tc_3.exp
@@ -29,23 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-# Helper to verify no TREL traffic has occurred
-proc verify_no_trel_traffic {c} {
-    set cnts [exec docker exec -i $c ot-ctl trel counters]
-    send_user "TREL counters on $c:\n$cnts\n"
-    set inbound_bytes 0
-    set outbound_bytes 0
-    if {[regexp {Inbound:\s+Packets\s+\d+\s+Bytes\s+(\d+)} $cnts match ibytes]} {
-        set inbound_bytes $ibytes
-    }
-    if {[regexp {Outbound:\s+Packets\s+\d+\s+Bytes\s+(\d+)} $cnts match obytes]} {
-        set outbound_bytes $obytes
-    }
-    if {$inbound_bytes > 1000 || $outbound_bytes > 1000} {
-        fail "TREL traffic occurred on $c (Inbound: $inbound_bytes bytes, Outbound: $outbound_bytes bytes) exceeding probe threshold!"
-    }
-}
-
 # Start relays and containers
 set pty1 [create_socat_tcp 1 9000]
 set pty2 [create_socat_tcp 2 9001]

--- a/tests/scripts/expect/dind_trel_tc_4.exp
+++ b/tests/scripts/expect/dind_trel_tc_4.exp
@@ -1,0 +1,431 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+set router_node_id 3
+
+# Start relays and containers
+set pty1 [create_socat_tcp 1 9000]
+set pty2 [create_socat_tcp 2 9001]
+
+set container1 "otbr-test-container-1"
+set container2 "otbr-test-container-2"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+send_user -- "--- Starting container 1 (BR Leader/DUT) ---\n"
+start_otbr_docker_dind $container1 $::env(EXP_OT_RCP_PATH) 2 $pty1 9000
+
+send_user -- "--- Starting container 2 (Router) ---\n"
+start_otbr_docker_dind $container2 $::env(EXP_OT_RCP_PATH) $router_node_id $pty2 9001
+
+# Spawn Node 4 (ED) on host
+send_user -- "--- Spawning CLI Node 4 (ED) ---\n"
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+
+# Ensure both containers have initialized correctly and otbr-agent socket is ready
+wait_for_otbr_agent [list $container1 $container2]
+
+# Stop Thread, down interface, and set routerselectionjitter initially
+foreach c [list $container1 $container2] {
+    exec docker exec -i $c ot-ctl thread stop
+    exec docker exec -i $c ot-ctl ifconfig down
+    exec docker exec -i $c ot-ctl routerselectionjitter 1
+}
+
+# Configure ED (Node 4) mode to MTD non-sleepy (mode rn)
+switch_node 4
+send "thread stop\n"
+expect_line "Done"
+send "ifconfig down\n"
+expect_line "Done"
+send "mode rn\n"
+expect_line "Done"
+
+# Configure Active Dataset on all nodes
+send_user -- "--- Configuring Active Dataset on all nodes ---\n"
+exec docker exec -i $container1 ot-ctl dataset set active $dataset
+exec docker exec -i $container2 ot-ctl dataset set active $dataset
+
+switch_node 4
+send "dataset set active $dataset\n"
+expect_line "Done"
+
+# Start Thread on DUT (container 1)
+send_user -- "--- Starting Thread on DUT (Leader) ---\n"
+exec docker exec -i $container1 ot-ctl ifconfig up
+exec docker exec -i $container1 ot-ctl thread start
+
+# Wait for DUT to become leader
+wait_for_container_state $container1 "leader"
+
+# Retrieve Extended MAC Address of Leader/DUT
+set br_extaddr [exec docker exec -i $container1 ot-ctl extaddr]
+set br_extaddr [string trim [lindex [split $br_extaddr "\n"] 0]]
+send_user "BR Leader ExtAddr: $br_extaddr\n"
+
+# Configure MAC filter isolation BEFORE starting Thread on Router and ED
+# Router and ED must only allow BR Leader (DUT)
+send_user -- "--- Setting up MAC filter isolation ---\n"
+exec docker exec -i $container2 ot-ctl macfilter addr clear
+exec docker exec -i $container2 ot-ctl macfilter addr allowlist
+exec docker exec -i $container2 ot-ctl macfilter addr add $br_extaddr
+
+switch_node 4
+send "macfilter addr clear\n"
+expect_line "Done"
+send "macfilter addr allowlist\n"
+expect_line "Done"
+send "macfilter addr add $br_extaddr\n"
+expect_line "Done"
+
+# Start Thread on Router (container 2)
+send_user -- "--- Starting Thread on Router ---\n"
+exec docker exec -i $container2 ot-ctl ifconfig up
+exec docker exec -i $container2 ot-ctl thread start
+
+# Start Thread on Node 4 (ED)
+send_user -- "--- Starting Thread on CLI Node 4 (ED) ---\n"
+switch_node 4
+send "ifconfig up\n"
+expect_line "Done"
+send "thread start\n"
+expect_line "Done"
+
+# Wait for Router (container 2) to become router
+wait_for_container_state $container2 "router"
+
+# Wait for Node 4 (ED) to become child
+switch_node 4
+wait_for "state" "child"
+expect_line "Done"
+
+# Retrieve Extended MAC Address of Router and ED
+set r_extaddr [exec docker exec -i $container2 ot-ctl extaddr]
+set r_extaddr [string trim [lindex [split $r_extaddr "\n"] 0]]
+send_user "Router ExtAddr: $r_extaddr\n"
+
+switch_node 4
+send "extaddr\n"
+set ed_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "ED ExtAddr: $ed_extaddr\n"
+
+# Wait for neighbor tables to update and stabilize
+send_user -- "--- Waiting 10 seconds for neighbors to stabilize ---\n"
+sleep 10
+
+# Verify that Router only sees Leader and not ED
+send_user -- "--- Verifying neighbors on Router ---\n"
+set r_neighbors [exec docker exec -i $container2 ot-ctl neighbor table]
+if {![regexp $br_extaddr $r_neighbors]} {
+    fail "Router neighbor table does not contain BR Leader!"
+}
+if {[string match -nocase "*$ed_extaddr*" $r_neighbors]} {
+    fail "Router neighbor table contains ED, isolation failed!"
+}
+
+# Verify that ED only sees Leader and not Router
+send_user -- "--- Verifying parent on ED ---\n"
+switch_node 4
+send "parent\n"
+set found_leader false
+expect {
+    -re "(?i)$r_extaddr" {
+        fail "ED parent is Router, isolation failed!"
+    }
+    -re "(?i)$br_extaddr" {
+        set found_leader true
+        exp_continue
+    }
+    -re "Done" {
+        # completed
+    }
+}
+if {!$found_leader} {
+    fail "ED parent is not BR Leader!"
+}
+
+# --- Step 2: Router pings ED (10 times) ---
+send_user -- "--- Step 2: Router pings ED (10 times) ---\n"
+switch_node 4
+set ed_mleid [string trim [get_ipaddr mleid]]
+send_user "ED ML-EID: $ed_mleid\n"
+
+# Reset TREL counters
+exec docker exec -i $container1 ot-ctl trel counters reset
+exec docker exec -i $container2 ot-ctl trel counters reset
+
+for {set i 0} {$i < 10} {incr i} {
+    catch { exec docker exec -i $container2 ot-ctl ping $ed_mleid 500 1 } ping_output
+    send_user "Ping Router -> ED ($i): $ping_output\n"
+    if {![regexp "bytes from" $ping_output]} {
+        fail "Ping Router -> ED ($i) failed: $ping_output"
+    }
+    after 100
+}
+
+# Verify TREL preferred on Router for DUT
+set multiradio_list [exec docker exec -i $container2 ot-ctl multiradio neighbor list]
+set leader_line ""
+foreach line [split $multiradio_list "\n"] {
+    if {[string match -nocase "*$br_extaddr*" $line]} {
+        set leader_line $line
+        break
+    }
+}
+if {$leader_line eq "" || ![regexp {15\.4\((\d+)\)} $leader_line match pref_15_4] || ![regexp {TREL\((\d+)\)} $leader_line match pref_trel]} {
+    fail "Could not parse multi-radio preferences for BR Leader. Neighbor list: $multiradio_list"
+}
+send_user "BR Leader preferences on Router: 15.4($pref_15_4), TREL($pref_trel)\n"
+if {$pref_trel < $pref_15_4} {
+    fail "TREL radio link is not preferred over 15.4!"
+}
+
+# Verify TREL traffic occurred: Router outbound -> DUT inbound
+verify_trel_traffic $container2 "out" $container1 "in"
+verify_trel_traffic $container2 "in" $container1 "out"
+send_user "TREL Ping verified: Router -> DUT -> ED -> DUT -> Router\n"
+
+
+# --- Step 3: Disable TREL connectivity on Router ---
+send_user -- "--- Step 3: Disabling TREL on Router ---\n"
+exec docker exec -i $container2 ot-ctl trel filter enable
+set filter_status [exec docker exec -i $container2 ot-ctl trel filter]
+if {![string match "*Enabled*" $filter_status]} {
+    fail "Failed to enable TREL filter on Router. Status: $filter_status"
+}
+
+
+# --- Step 4: Router pings ED (10 pings, verify TREL disconnect) ---
+send_user -- "--- Step 4: Trigger TREL disconnect detection (Router pings ED) ---\n"
+# To guarantee detection of disconnect, we will ping and check preference.
+# Router tries to send over TREL to DUT, but it fails.
+for {set i 0} {$i < 25} {incr i} {
+    catch { exec docker exec -i $container2 ot-ctl ping $ed_mleid 500 1 } ping_res
+    send_user "Router ping response ($i): $ping_res\n"
+    after 100
+}
+
+# Verify TREL preference is set to zero on Router for DUT
+set preference_zero_router false
+for {set i 0} {$i < 5} {incr i} {
+    set multiradio_list [exec docker exec -i $container2 ot-ctl multiradio neighbor list]
+    set leader_line ""
+    foreach line [split $multiradio_list "\n"] {
+        if {[string match -nocase "*$br_extaddr*" $line]} {
+            set leader_line $line
+            break
+        }
+    }
+    if {$leader_line ne "" && [regexp {TREL\(0\)} $leader_line]} {
+        set preference_zero_router true
+        break
+    }
+    sleep 2
+}
+if {!$preference_zero_router} {
+    fail "Router did not report DUT TREL preference as 0. Neighbor list: $multiradio_list"
+}
+send_user "TREL preference successfully set to 0 on Router!\n"
+
+
+# --- Step 5: Router pings ED (5 times, expecting all to pass via 15.4 fallback) ---
+send_user -- "--- Step 5: Router pings ED 5 times (expecting 100% success via 15.4 fallback) ---\n"
+# Reset TREL counters to verify no TREL traffic is used
+exec docker exec -i $container1 ot-ctl trel counters reset
+exec docker exec -i $container2 ot-ctl trel counters reset
+
+for {set i 0} {$i < 5} {incr i} {
+    catch { exec docker exec -i $container2 ot-ctl ping $ed_mleid 500 1 } ping_output
+    send_user "Ping Router -> ED ($i) via 15.4: $ping_output\n"
+    if {![regexp "bytes from" $ping_output]} {
+        fail "Ping Router -> ED ($i) via 15.4 failed: $ping_output"
+    }
+    after 100
+}
+
+# Verify no TREL traffic occurred during 15.4 fallback
+verify_no_trel_traffic $container1
+verify_no_trel_traffic $container2
+send_user "15.4 Fallback verified: All pings succeeded and no TREL traffic was observed.\n"
+
+
+# --- Step 6: Re-enable TREL connectivity on Router ---
+send_user -- "--- Step 6: Re-enabling TREL on Router ---\n"
+exec docker exec -i $container2 ot-ctl trel filter disable
+set filter_status [exec docker exec -i $container2 ot-ctl trel filter]
+if {![string match "*Disabled*" $filter_status]} {
+    fail "Failed to disable TREL filter on Router. Status: $filter_status"
+}
+
+sleep 2
+
+
+
+# --- Step 7: Router sends 300 UDP messages to ED (triggers probe / Rx-based discovery) ---
+send_user -- "--- Step 7: Router sends 300 UDP messages to ED to trigger TREL rediscovery ---\n"
+# Open UDP socket on ED (Node 4)
+switch_node 4
+send "udp open\n"
+expect_line "Done"
+send "udp bind :: 1234\n"
+expect_line "Done"
+
+# Spawn ot-ctl on Router and send commands one by one to avoid socket buffer overflow in daemon
+spawn docker exec -i $container2 ot-ctl
+set router_ctl_spawn_id $spawn_id
+
+send -i $router_ctl_spawn_id "udp open\n"
+expect -i $router_ctl_spawn_id "Done"
+expect -i $router_ctl_spawn_id "> "
+
+for {set i 0} {$i < 300} {incr i} {
+    send -i $router_ctl_spawn_id "udp send $ed_mleid 1234 hello\n"
+    expect {
+        -i $router_ctl_spawn_id -re {Done\r*\n> } {
+            # success
+        }
+        -i $router_ctl_spawn_id "Error" {
+            fail "UDP send failed at message $i"
+        }
+        -i $router_ctl_spawn_id timeout {
+            fail "UDP send timed out at message $i"
+        }
+    }
+    if {$i % 50 == 0} {
+        send_user "Sent $i UDP messages...\n"
+    }
+    after 10
+}
+
+send -i $router_ctl_spawn_id "udp close\n"
+expect -i $router_ctl_spawn_id "Done"
+expect -i $router_ctl_spawn_id "> "
+
+send -i $router_ctl_spawn_id "exit\n"
+expect -i $router_ctl_spawn_id eof
+
+# Close socket on ED
+switch_node 4
+send "udp close\n"
+expect_line "Done"
+
+# Verify TREL preference is restored and preferred on Router
+send_user -- "--- Verifying TREL preference is restored on Router ---\n"
+set preference_restored_router false
+for {set i 0} {$i < 10} {incr i} {
+    set multiradio_list [exec docker exec -i $container2 ot-ctl multiradio neighbor list]
+    set leader_line ""
+    foreach line [split $multiradio_list "\n"] {
+        if {[string match -nocase "*$br_extaddr*" $line]} {
+            set leader_line $line
+            break
+        }
+    }
+    if {$leader_line ne "" && [regexp {15\.4\((\d+)\)} $leader_line match pref_15_4] && [regexp {TREL\((\d+)\)} $leader_line match pref_trel]} {
+        if {$pref_trel > 0 && $pref_trel >= $pref_15_4} {
+            set preference_restored_router true
+            break
+        }
+    }
+    sleep 1
+}
+if {!$preference_restored_router} {
+    fail "TREL radio link preference on Router was not restored or preferred. Neighbor list: $multiradio_list"
+}
+send_user "Restored BR Leader preferences on Router: 15.4($pref_15_4), TREL($pref_trel)\n"
+
+# Verify TREL preference is restored and preferred on DUT
+send_user -- "--- Verifying TREL preference is restored on DUT ---\n"
+set preference_restored_dut false
+for {set i 0} {$i < 10} {incr i} {
+    set multiradio_list_dut [exec docker exec -i $container1 ot-ctl multiradio neighbor list]
+    set router_line ""
+    foreach line [split $multiradio_list_dut "\n"] {
+        if {[string match -nocase "*$r_extaddr*" $line]} {
+            set router_line $line
+            break
+        }
+    }
+    if {$router_line ne "" && [regexp {15\.4\((\d+)\)} $router_line match pref_15_4_dut] && [regexp {TREL\((\d+)\)} $router_line match pref_trel_dut]} {
+        if {$pref_trel_dut > 0 && $pref_trel_dut >= $pref_15_4_dut} {
+            set preference_restored_dut true
+            break
+        }
+    }
+    sleep 1
+}
+if {!$preference_restored_dut} {
+    fail "TREL radio link preference on DUT was not restored or preferred. Neighbor list: $multiradio_list_dut"
+}
+send_user "Restored Router preferences on DUT: 15.4($pref_15_4_dut), TREL($pref_trel_dut)\n"
+
+
+# Verify TREL traffic occurred (DUT -> Router or Router -> DUT)
+verify_trel_traffic $container1 "out" $container2 "in"
+
+
+# --- Step 8: Router disables 15.4 radio link ---
+send_user -- "--- Step 8: Disabling 15.4 radio link on Router (using radiofilter) ---\n"
+exec docker exec -i $container2 ot-ctl radiofilter enable
+
+
+
+# --- Step 9: ED pings Router (10 times, must go over TREL) ---
+send_user -- "--- Step 9: ED pings Router (10 times, must use TREL) ---\n"
+set r_mleid [exec docker exec -i $container2 ot-ctl ipaddr mleid]
+set r_mleid [string trim [lindex [split $r_mleid "\n"] 0]]
+send_user "Router ML-EID: $r_mleid\n"
+
+switch_node 4
+for {set i 0} {$i < 10} {incr i} {
+    send "ping $r_mleid 500 1\n"
+    expect {
+        -re "bytes from" {
+            # success
+        }
+        "Done" {
+            fail "Ping from ED to Router failed (received Done without bytes from)!"
+        }
+        timeout {
+            fail "Ping from ED to Router timed out (15.4 disabled, TREL failed)!"
+        }
+    }
+    expect_line "Done"
+    after 100
+}
+
+
+
+dispose_all
+send_user -- "--- TREL Radio Link (Re)discovery through Receive (1_4_TREL_TC_4) Integration Test PASSED successfully! ---\n"
+exit 0
+

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -231,6 +231,9 @@ test_run()
     echo "--- Running TREL Radio Link (Re)discovery using Probe Mechanism (1_4_TREL_TC_3) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_trel_tc_3.exp"
 
+    echo "--- Running TREL Radio Link (Re)discovery through Receive (1_4_TREL_TC_4) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_trel_tc_4.exp"
+
     echo "--- Running NAT64 integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_nat64.exp"
 


### PR DESCRIPTION
This commit implements the Thread 1.4 integration test case 8.4: "Radio Link (Re)discovery through Receive" (TREL_TC_4).

The test case is implemented using the Docker-in-Docker (DinD) framework.

Key changes:
- Created 1_4_TREL_TC_4.md documenting the test spec.
- Created tests/scripts/expect/dind_trel_tc_4.exp which implements the test logic using expect.
- Simulated 15.4 link failure using `iptables` on the DinD host by blocking UDP packets from the Router's simulated radio port (9003). Used the `INPUT` chain instead of `OUTPUT` to prevent `EPERM` errors on `sendto` in the simulated RCP.
- Registered the test in tests/scripts/test_dind_dns_sd.sh.