### PR TITLE
[docker] support reusable workflow for CalVer releases

### DIFF
--- a/.github/workflows/docker-border-router.yml
+++ b/.github/workflows/docker-border-router.yml
@@ -32,9 +32,19 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - 'main'
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag to assign to the image'
+        required: false
+        type: string
+        default: ''
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-br-posix' && github.run_id) || github.ref }}
@@ -158,8 +168,10 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}
           tags: |
             type=ref,event=branch
+            type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short
+            type=raw,value=${{ inputs.release_tag || 'none' }},enable=${{ inputs.release_tag != '' && inputs.release_tag != null }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -45,6 +45,8 @@ jobs:
   create-release:
     name: Create Monthly Release
     runs-on: ubuntu-24.04
+    outputs:
+      tag_name: ${{ steps.generate_tag.outputs.TAG_NAME }}
     
     # Required permission to create tags and releases
     permissions:
@@ -76,6 +78,7 @@ jobs:
             CALVER_TAG="v$(date +'%Y.%m').0"
           fi
           echo "TAG_NAME=$CALVER_TAG" >> $GITHUB_ENV
+          echo "TAG_NAME=$CALVER_TAG" >> $GITHUB_OUTPUT
           echo "Generated tag: $CALVER_TAG"
 
       - name: Create GitHub Release
@@ -87,3 +90,10 @@ jobs:
             --target "${{ github.ref_name }}" \
             --title "OpenThread Border Router $TAG_NAME" \
             --generate-notes
+
+  build-docker:
+    needs: create-release
+    uses: ./.github/workflows/docker-border-router.yml
+    with:
+      release_tag: ${{ needs.create-release.outputs.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
This commit updates the Docker border-router workflow to support being triggered as a reusable workflow (`workflow_call`). This allows monthly-release.yml to trigger it directly using the default GITHUB_TOKEN without running into the API recursion restrictions associated with tag-push triggers.

Changes:
- Add `workflow_call` trigger with an optional `release_tag` input.
- Add `v*` pattern to push tags to build on manual tag pushes.
- Configure `docker/metadata-action` to handle `type=ref,event=tag` and a raw value for the passed `release_tag` input if provided.
- Update `monthly-release.yml` to output the generated CalVer tag and call `docker-border-router.yml` as a reusable workflow.