### PR TITLE
[tests] fix mDNS resolution race condition in DinD tests

### DIFF
--- a/tests/scripts/expect/dind_srp_tc_1.exp
+++ b/tests/scripts/expect/dind_srp_tc_1.exp
@@ -426,7 +426,7 @@ zc = Zeroconf(ip_version=IPVersion.V6Only)
 info = ServiceInfo('_thread-test._udp.local.', 'service-test-1._thread-test._udp.local.')
 for _ in range(10):
     info.request(zc, 2000)
-    if info.server is not None:
+    if info.server is not None and info.addresses_by_version(IPVersion.V6Only):
         break
     time.sleep(1)
 if info.server is None:

--- a/tests/scripts/expect/dind_srp_tc_13.exp
+++ b/tests/scripts/expect/dind_srp_tc_13.exp
@@ -239,7 +239,7 @@ zc = Zeroconf(ip_version=IPVersion.V6Only)
 info = ServiceInfo('_thread-test._udp.local.', 'service-test-1._thread-test._udp.local.')
 for _ in range(10):
     info.request(zc, 2000)
-    if info.server is not None:
+    if info.server is not None and info.addresses_by_version(IPVersion.V6Only):
         break
     time.sleep(1)
 

--- a/tests/scripts/expect/dind_srp_tc_2.exp
+++ b/tests/scripts/expect/dind_srp_tc_2.exp
@@ -214,7 +214,7 @@ info1 = ServiceInfo('_thread-test._udp.local.', 'service-test-1._thread-test._ud
 resolved1 = False
 for _ in range(10):
     info1.request(zc, 2000)
-    if info1.port == 33333 and info1.server == 'host-test-1.local.':
+    if info1.port == 33333 and info1.server == 'host-test-1.local.' and info1.addresses_by_version(IPVersion.V6Only):
         resolved1 = True
         break
     time.sleep(1)
@@ -327,7 +327,7 @@ info1 = ServiceInfo('_thread-test._udp.local.', 'service-test-1._thread-test._ud
 resolved1 = False
 for _ in range(10):
     info1.request(zc, 2000)
-    if info1.port == 33333 and info1.server == 'host-test-1.local.':
+    if info1.port == 33333 and info1.server == 'host-test-1.local.' and info1.addresses_by_version(IPVersion.V6Only):
         resolved1 = True
         break
     time.sleep(1)
@@ -351,7 +351,7 @@ info2 = ServiceInfo('_thread-test._udp.local.', 'service-test-2._thread-test._ud
 resolved2 = False
 for _ in range(10):
     info2.request(zc, 2000)
-    if info2.port == 44444 and info2.server == 'host-test-2.local.':
+    if info2.port == 44444 and info2.server == 'host-test-2.local.' and info2.addresses_by_version(IPVersion.V6Only):
         resolved2 = True
         break
     time.sleep(1)


### PR DESCRIPTION
This commit fixes a race condition in the Python mDNS resolution checks in the Docker-in-Docker (DinD) integration tests.

Previously, the Python verification scripts used a retry loop calling `info.request(zc, 2000)` and exited immediately as soon as the SRV attributes (such as server name or port) were retrieved. However, because mDNS responses can be split, the host's AAAA address record query could still be outstanding when the loop exited, resulting in empty address lists (`info.addresses_by_version(...)` returning empty `[]`) and test failures.

This issue specifically caused flaky/consistent failures under the `mDNSResponder` configuration.

Changes:
- Modify `dind_srp_tc_1.exp`, `dind_srp_tc_2.exp`, and `dind_srp_tc_13.exp` to check `info.addresses_by_version(...)` inside the retry loop before breaking, ensuring both service and address records are successfully resolved.