### PR TITLE
[tests] implement 1.4.3 (10.3) default route advertisement test

### DIFF
--- a/etc/docker/border-router/Dockerfile
+++ b/etc/docker/border-router/Dockerfile
@@ -134,6 +134,7 @@ RUN set -x \
            curl \
            ipset \
            iptables \
+           iproute2 \
            libjsoncpp25 \
            xz-utils \
     && PLATFORM_SPEC="${TARGETARCH}${TARGETVARIANT:+/$TARGETVARIANT}" \

--- a/tests/scripts/expect/dind_1_4_pic_tc_3.exp
+++ b/tests/scripts/expect/dind_1_4_pic_tc_3.exp
@@ -29,6 +29,30 @@
 
 source "tests/scripts/expect/_common.exp"
 
+proc start_radvd {server} {
+    exec docker exec -d $server bash -c "radvd -C /etc/radvd.conf -u root -n -m stderr >/var/log/radvd.log 2>&1"
+    sleep 1
+    if {[catch {exec docker exec -i $server pgrep radvd} radvd_pid]} {
+        if {![catch {exec docker exec -i $server cat /var/log/radvd.log} radvd_log]} {
+            send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
+        }
+        fail "Failed to start radvd on $server: $radvd_pid"
+    }
+    send_user "radvd started on $server with PID: [string trim $radvd_pid]\n"
+}
+
+proc stop_radvd {server} {
+    catch {exec docker exec -i $server pkill radvd}
+    # Wait for radvd to fully terminate to avoid port/socket binding conflicts
+    for {set j 0} {$j < 50} {incr j} {
+        if {[catch {exec docker exec -i $server pgrep radvd}]} {
+            break
+        }
+        after 100
+    }
+}
+
+
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"
 set eth2_server "eth2-server"
@@ -36,8 +60,8 @@ set eth1_server "eth1-server"
 
 set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
 
-# 1. Start Eth_2 container (DHCPv6 PD Server, DNS Server, Internet HTTP Server)
-send_user "Starting Eth_2 container (CPE/DNS/Internet)...\n"
+# 1. Start Eth_2 container (CPE/DNS/Internet/radvd)
+send_user "Starting Eth_2 container (CPE/radvd)...\n"
 track_container $eth2_server
 exec docker run -d \
     --name $eth2_server \
@@ -52,22 +76,15 @@ exec docker run -d \
 # Wait for eth2-server eth0 to be ready
 sleep 2
 
-# Add 2002:1234::1234 IP to loopback of eth2-server
+# Add 2002:1234::1234 IP to loopback and 2001:db8:1::1 to eth0 of eth2-server
 exec docker exec -i $eth2_server ip -6 addr add 2002:1234::1234/128 dev lo
+exec docker exec -i $eth2_server ip -6 addr add 2001:db8:1::1/64 dev eth0
 
 # Configure and start Kea DHCPv6 PD server on eth2-server (delegating 2005:1234:abcd:0::/56)
-set kea_conf {{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "fd00:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2005:1234:abcd:0::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}}
+set kea_conf {{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "2001:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2005:1234:abcd:0::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}}
 exec docker exec -i $eth2_server bash -c "echo '$kea_conf' > /etc/kea/kea-dhcp6.conf"
 exec docker exec -i $eth2_server mkdir -p /var/lib/kea /var/run/kea
 exec docker exec -d $eth2_server /usr/sbin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
-
-# Start dnsmasq on eth2-server resolving threadgroup.org to 2002:1234::1234
-exec docker exec -d $eth2_server dnsmasq --address=/threadgroup.org/2002:1234::1234 --no-hosts --no-resolv --interface=eth0 --port=53
-
-# Start Python HTTP server on eth2-server serving test.html on 2002:1234::1234
-exec docker exec -i $eth2_server mkdir -p /var/www/html
-exec docker exec -i $eth2_server bash -c "echo 'test-content-eth2' > /var/www/html/test.html"
-exec docker exec -d $eth2_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind 2002:1234::1234"
 
 # Enable IPv6 forwarding on eth2-server for radvd
 exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.all.forwarding=1
@@ -75,21 +92,10 @@ exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.default.forwarding=1
 exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.eth0.forwarding=1
 
 # Start radvd on eth2-server to advertise default route on infrastructure link
-set radvd_conf "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  prefix fd00:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+set radvd_conf "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
 exec docker exec -i $eth2_server bash -c "echo '$radvd_conf' > /etc/radvd.conf"
 exec docker exec -i $eth2_server chmod 600 /etc/radvd.conf
-# We run radvd with -u root to avoid permission issues in some docker environments
-# We run it in foreground with -n and redirect to a log file so we can debug failures
-exec docker exec -d $eth2_server bash -c "radvd -C /etc/radvd.conf -u root -n -m stderr >/var/log/radvd.log 2>&1"
-sleep 1
-if {[catch {exec docker exec -i $eth2_server pgrep radvd} radvd_pid]} {
-    if {![catch {exec docker exec -i $eth2_server cat /var/log/radvd.log} radvd_log]} {
-        send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
-    }
-    fail "Failed to start radvd on eth2-server: $radvd_pid"
-}
-send_user "radvd started on eth2-server with PID: [string trim $radvd_pid]\n"
-
+start_radvd $eth2_server
 
 # 2. Start Eth_1 container (Local Infrastructure Host)
 send_user "Starting Eth_1 container (Local Host)...\n"
@@ -103,11 +109,6 @@ exec docker run -d \
     --entrypoint /bin/bash \
     $::env(EXP_TEST_CLIENT_IMAGE) \
     -c "echo 1 > /proc/sys/net/ipv6/conf/all/autoconf && echo 1 > /proc/sys/net/ipv6/conf/default/autoconf && echo 1 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/default/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
-
-# Start Python HTTP server on eth1-server serving test2.html
-exec docker exec -i $eth1_server mkdir -p /var/www/html
-exec docker exec -i $eth1_server bash -c "echo 'test-content-eth1' > /var/www/html/test2.html"
-exec docker exec -d $eth1_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind ::"
 
 # Get eth2-server global IPv6 address on infrastructure-link
 set eth2_ip ""
@@ -137,8 +138,13 @@ start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
 # Wait for otbr-agent to create the domain socket
 wait_for_otbr_agent [list $container]
 
-# Configure DNS server of OTBR to use eth2-server
-exec docker exec -i $container bash -c "echo nameserver $eth2_ip > /etc/resolv.conf"
+# Delete Docker's static default route so the DUT only relies on RAs
+# We can run it via docker exec now that iproute2 package is added to the container
+catch { exec docker exec -i $container ip -6 route del default dev eth0 }
+
+# Enable accept_ra=2 on DUT so it configures default route and GUA via SLAAC
+exec docker exec -i $container sysctl -w net.ipv6.conf.all.accept_ra=2
+exec docker exec -i $container sysctl -w net.ipv6.conf.eth0.accept_ra=2
 
 # Setup active dataset on OTBR via ot-ctl
 exec docker exec -i $container ot-ctl thread stop
@@ -155,7 +161,7 @@ send_user "Enabling Prefix Delegation on the OTBR...\n"
 exec docker exec -i $container ot-ctl br pd enable
 sleep 5
 
-# 4. Validate OMR Prefix in Thread Network Data
+# Step 4: Validate OMR Prefix in Thread Network Data
 send_user "Step 4: Validating OMR Prefix in Thread Network Data...\n"
 set prefix_acquired false
 set delegated_prefix ""
@@ -179,109 +185,41 @@ if {!$prefix_acquired} {
 }
 send_user "Successfully Discovered Delegated Prefix: $delegated_prefix\n"
 
-# Verify OMR prefix properties in netdata
-# The OMR prefix should be subprefix of 2005:1234:abcd:0::/56, length /64, with 'r' (default) and 'med' preference
-set omr_regex {2005:1234:abcd:(?:[0-9a-fA-F]{1,2})?:{1,2}/64\s+([a-z]*r[a-z]*)\s+med}
-set netdata_verified false
-for {set i 0} {$i < 10} {incr i} {
-    if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
-        send_user "DUT Network Data (Attempt $i):\n$netdata\n"
-        if {[regexp $omr_regex $netdata]} {
-            set netdata_verified true
-            break
+# Verify OMR prefix properties in netdata (subprefix of 2005:1234:abcd:0::/56, /64, default route, med preference)
+# AND verify default route ::/0 with Route sub-TLV (NP=0)
+proc verify_netdata {container} {
+    set omr_regex {2005:1234:abcd:(?:[0-9a-fA-F]{1,2})?:{1,2}/64\s+([a-z]*r[a-z]*)\s+med}
+    set route_regex {::/0(?:\s+([a-z]+))?\s+med}
+    set netdata_verified false
+    for {set i 0} {$i < 10} {incr i} {
+        if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
+            send_user "DUT Network Data (Attempt $i):\n$netdata\n"
+            if {[regexp $omr_regex $netdata match flags]} {
+                # OMR prefix has 'r' (default) flag
+                if {[string match "*r*" $flags] && [regexp $route_regex $netdata match rflags]} {
+                    # Default route ::/0 exists. Since NP=0, NP flag (usually 'n') must NOT be present.
+                    if {![string match "*n*" $rflags]} {
+                        set netdata_verified true
+                        break
+                    } else {
+                        send_user "Default route ::/0 has NP flag set: $rflags\n"
+                    }
+                } else {
+                    send_user "Default route ::/0 not found in netdata or OMR prefix has wrong flags: $flags\n"
+                }
+            }
         }
+        sleep 2
     }
-    sleep 2
-}
-if {!$netdata_verified} {
-    fail "OMR prefix in Network Data does not meet criteria (subprefix of 2005:1234:abcd:0::/56, /64, default route, med preference)"
-}
-send_user "OMR prefix verified in Thread Network Data successfully.\n"
-
-# 4b. Validate RA on AIL
-send_user "Step 4b: Validating RA on adjacent infrastructure link...\n"
-set py_ra_sniffer {import sys
-import ipaddress
-import logging
-logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-from scapy.all import *
-
-target_prefix = sys.argv[1]
-try:
-    target_net = ipaddress.IPv6Network(target_prefix, strict=False)
-except Exception as e:
-    print(f"FAIL: Invalid target prefix {target_prefix}: {e}")
-    sys.exit(1)
-
-found_otbr_ra = False
-
-def check_pkt(pkt):
-    global found_otbr_ra
-    if not pkt.haslayer(ICMPv6ND_RA):
-        return False
-    
-    # Check if it has RIO for target prefix
-    i = 1
-    target_opt = None
-    while True:
-        opt = pkt.getlayer(ICMPv6NDOptRouteInfo, nb=i)
-        if opt is None:
-            break
-        try:
-            opt_net = ipaddress.IPv6Network(f"{opt.prefix}/{opt.plen}", strict=False)
-            if opt_net == target_net:
-                target_opt = opt
-                break
-        except Exception as e:
-            pass
-        i += 1
-        
-    if target_opt is not None:
-        if pkt[IPv6].dst != "ff02::1":
-            return False
-
-        print(f"Captured OTBR RA from {pkt[IPv6].src} to {pkt[IPv6].dst}")
-            
-        ra = pkt[ICMPv6ND_RA]
-        raw_bytes = bytes(ra)
-        flags = raw_bytes[5]
-        # SNAC / Stub Router flag is bit 6 of RA flags (0x02)
-        if not (flags & 0x02):
-            print(f"FAIL: SNAC Router flag not set. Flags: {hex(flags)}")
-            sys.exit(1)
-            
-        if target_opt.prf in [0, 3] and target_opt.rtlifetime > 0:
-            found_otbr_ra = True
-            return True
-        else:
-            print(f"FAIL: RIO parameters invalid: prf={target_opt.prf}, lifetime={target_opt.rtlifetime}")
-            sys.exit(1)
-            
-    return False
-
-# Sniff until check_pkt returns True, or timeout
-sniff(filter="icmp6 and icmp6[0] == 134", stop_filter=check_pkt, timeout=20)
-
-if not found_otbr_ra:
-    print("FAIL: OTBR RA packet not captured")
-    sys.exit(1)
-
-print("PASS")
-sys.exit(0)
+    if {!$netdata_verified} {
+        fail "Network Data does not meet criteria"
+    }
+    send_user "OMR prefix and default route ::/0 verified in Thread Network Data successfully.\n"
 }
 
-# Run RA sniffer on eth1-server
-send_user "Running RA sniffer on Eth_1...\n"
-if {[catch {exec docker exec -i $eth1_server python3 -c $py_ra_sniffer $delegated_prefix} ra_res]} {
-    send_user "RA Sniffer Error: $ra_res\n"
-    fail "RA validation failed on Eth_1"
-}
-set ra_res [string trim $ra_res]
-send_user "RA Sniffer Result: $ra_res\n"
-if {![string match "*PASS*" $ra_res]} {
-    fail "RA validation failed on Eth_1"
-}
-send_user "RA validation passed.\n"
+# Step 5: Verify default route is advertised in Thread Network Data
+send_user "Step 5: Verifying network data on DUT...\n"
+verify_netdata $container
 
 # Get the running Border Router's active dataset dynamically to configure the client
 set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
@@ -292,18 +230,18 @@ set dut_extaddr [exec docker exec -i $container ot-ctl extaddr]
 set dut_extaddr [lindex [split [string trim $dut_extaddr] "\n"] 0]
 send_user "DUT ExtAddr: $dut_extaddr\n"
 
-# 5. Spawn Router_1 (Node 3)
+# Spawn Router_1 (Node 3)
 send_user "Starting Router_1 (Node 3)...\n"
 spawn_node 3 cli $::env(EXP_OT_CLI_PATH)
 
-# Get Router_1 ExtAddr (while disabled)
+# Get Router_1 ExtAddr
 send "extaddr\r\n"
 expect_line "extaddr"
 set router_extaddr [expect_line {[0-9a-fA-F]{16}}]
 expect_line "Done"
 send_user "Router_1 ExtAddr: $router_extaddr\n"
 
-# Configure Router_1 (still disabled)
+# Configure Router_1
 send "dataset set active $active_dataset\n"
 expect_line "Done"
 send "mode rdn\r\n"
@@ -313,14 +251,14 @@ expect_line "Done"
 send_user "Starting ED_1 (Node 4)...\n"
 spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
 
-# Get ED_1 ExtAddr (while disabled)
+# Get ED_1 ExtAddr
 send "extaddr\r\n"
 expect_line "extaddr"
 set ed_extaddr [expect_line {[0-9a-fA-F]{16}}]
 expect_line "Done"
 send_user "ED_1 ExtAddr: $ed_extaddr\n"
 
-# Configure ED_1 (still disabled)
+# Configure ED_1
 send "dataset set active $active_dataset\n"
 expect_line "Done"
 send "mode rdn\r\n"
@@ -373,48 +311,16 @@ expect_line "Done"
 
 sleep 5
 
-# Retrieve DUT's RLOC address to use as DNS server on ED_1
-set otbr_rloc [get_rloc_dns_addr $container]
-send_user "OTBR RLOC IP: $otbr_rloc\n"
-
-# Configure DNS server on ED_1 (Node 4)
-switch_node 4
-send "dns config $otbr_rloc\r\n"
-expect_line "Done"
-
-# Step 5-7: DNS resolution from ED_1
-send_user "Step 5-7: Resolving threadgroup.org from ED_1...\n"
-send "dns resolve threadgroup.org\r\n"
-set timeout 15
-set dns_resolved false
-expect {
-    -re "2002:1234:(0:0:0:0:0|):1234" {
-        set dns_resolved true
-        exp_continue
-    }
-    -re "Done" {
-        # Succeeded
-    }
-    timeout {
-        fail "DNS resolution timed out"
-    }
-}
-if {!$dns_resolved} {
-    fail "DNS resolution failed to resolve threadgroup.org to 2002:1234::1234"
-}
-send_user "DNS resolution verified successfully.\n"
-
-# Step 8: Ping Internet Server (2002:1234::1234) from ED_1
-send_user "Step 8: Verifying Ping to Internet Server (2002:1234::1234)...\n"
-
-# Configure static route on eth2-server for OMR prefix via OTBR global IP
+# Setup routing for test targets
+# OMR prefix routing on eth2-server via OTBR global IP
 set format {{{(index .NetworkSettings.Networks "infrastructure-link").GlobalIPv6Address}}}
 set otbr_ip [exec docker inspect $container -f $format]
 set otbr_ip [string trim $otbr_ip]
 send_user "OTBR Infrastructure IP: $otbr_ip\n"
 exec docker exec -i $eth2_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
 
-# Send ping from ED_1
+# Step 6: Ping Internet Server (2002:1234::1234) from ED_1
+send_user "Step 6: Verifying Ping to Internet Server (2002:1234::1234)...\n"
 switch_node 4
 send "ping 2002:1234::1234 56 5\r\n"
 set timeout 15
@@ -436,41 +342,19 @@ if {!$ping_success} {
 }
 send_user "Ping to Internet Server verified successfully.\n"
 
-# Step 9: HTTP GET to Internet Server from ED_1
-send_user "Step 9: Verifying HTTP GET to Internet Server...\n"
-send "tcp init\r\n"
-expect_line "Done"
-send "tcp connect 2002:1234::1234 80\r\n"
-expect_line "Done"
-expect "TCP: Connection established"
-# Send GET request (hex representation)
-# "GET /test.html HTTP/1.1\r\nHost: threadgroup.org\r\n\r\n"
-send "tcp send -x 474554202F746573742E68746D6C20485454502F312E310D0A486F73743A2074687265616467726F75702E6F72670D0A0D0A\r\n"
-expect_line "Done"
-set timeout 15
-set http_success false
-expect {
-    -re "test-content-eth2" {
-        set http_success true
-        exp_continue
-    }
-    -re "TCP: Reached end of stream" {
-        # Done
-    }
-}
-send "tcp deinit\r\n"
-expect_line "Done"
+# Step 7: Reconfigure radvd on eth2-server to stop advertising default route
+send_user "Step 7: Reconfiguring radvd to stop advertising default route...\n"
+stop_radvd $eth2_server
+set radvd_conf_no_default "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  AdvDefaultLifetime 0;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+exec docker exec -i $eth2_server bash -c "echo '$radvd_conf_no_default' > /etc/radvd.conf"
+start_radvd $eth2_server
+sleep 4
 
-if {!$http_success} {
-    fail "HTTP GET to Internet Server failed"
-}
-send_user "HTTP GET to Internet Server verified successfully.\n"
-
-# Step 10: Ping Local Server (Eth_1) from ED_1
-send_user "Step 10: Verifying Ping to Local Server (Eth_1)...\n"
+# Step 8: Verify DUT *still* advertises default route in Thread Network Data
+send_user "Step 8: Verifying default route is still advertised in Thread Network Data...\n"
+verify_netdata $container
 
 # Get SLAAC IP of eth1-server
-# Poll until SLAAC IP is configured on eth1-server
 set eth1_slaac ""
 for {set i 0} {$i < 10} {incr i} {
     if {![catch {exec docker exec -i $eth1_server ip -6 addr show dev eth0 scope global} addrs]} {
@@ -496,7 +380,8 @@ send_user "Eth_1 SLAAC GUA: $eth1_slaac\n"
 # Configure static route on eth1-server for OMR prefix via OTBR
 exec docker exec -i $eth1_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
 
-# Send ping from ED_1 to Eth_1 SLAAC IP
+# Step 9: Ping local server Eth_1 from ED_1
+send_user "Step 9: Verifying Ping to Local Host (Eth_1) works...\n"
 switch_node 4
 send "ping $eth1_slaac 56 5\r\n"
 set timeout 15
@@ -510,43 +395,115 @@ expect {
         # Finished
     }
     timeout {
-        send_user "Error: Ping to local server timed out\n"
+        send_user "Error: Ping to local host timed out\n"
     }
 }
 if {!$ping_success} {
-    fail "Ping from ED_1 to Local Server failed"
+    fail "Ping from ED_1 to Local Host failed"
 }
-send_user "Ping to Local Server verified successfully.\n"
+send_user "Ping to Local Host verified successfully.\n"
 
-# Step 11: HTTP GET to Local Server (Eth_1) from ED_1
-send_user "Step 11: Verifying HTTP GET to Local Server...\n"
-send "tcp init\r\n"
-expect_line "Done"
-send "tcp connect $eth1_slaac 80\r\n"
-expect_line "Done"
-expect "TCP: Connection established"
-# Send GET request (hex representation)
-# "GET /test2.html HTTP/1.1\r\nHost: localtest.org\r\n\r\n"
-send "tcp send -x 474554202F74657374322E68746D6C20485454502F312E310D0A486F73743A206C6F63616C746573742E6F72670D0A0D0A\r\n"
-expect_line "Done"
+# Step 10: Ping 2002:1234::1234 from ED_1. Ping response MUST NOT be received. Ping request MUST NOT be sent on AIL.
+send_user "Step 10: Verifying Ping to Internet Server does NOT work and is NOT forwarded...\n"
+
+# Start tcpdump on eth2-server to detect any ICMPv6 echo requests (line-buffered with -l)
+# Run in background via exec docker exec -d. Timeout in 8 seconds to allow ping tool to finish.
+exec docker exec -d $eth2_server bash -c "timeout 8 tcpdump -l -c 1 -i eth0 'icmp6 and icmp6\[0\] == 128' > /var/log/tcpdump.log 2>&1"
+sleep 1
+
+# Send ping from ED_1
+switch_node 4
+send "ping 2002:1234::1234 56 5\r\n"
 set timeout 15
-set http_success false
+set ping_received false
 expect {
-    -re "test-content-eth1" {
-        set http_success true
+    -re "bytes from" {
+        set ping_received true
         exp_continue
     }
-    -re "TCP: Reached end of stream" {
-        # Done
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        # Expected
     }
 }
-send "tcp deinit\r\n"
-expect_line "Done"
-
-if {!$http_success} {
-    fail "HTTP GET to Local Server failed"
+if {$ping_received} {
+    catch {
+        set radvd_log [exec docker exec -i $eth2_server cat /var/log/radvd.log]
+        send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
+    }
+    fail "Ping from ED_1 to Internet Server succeeded, but it was expected to fail"
 }
-send_user "HTTP GET to Local Server verified successfully.\n"
+
+# Check if tcpdump captured any packet
+sleep 9
+set tcpdump_log [exec docker exec -i $eth2_server cat /var/log/tcpdump.log]
+send_user "tcpdump log on eth2-server:\n$tcpdump_log\n"
+if {![string match "*listening on*" $tcpdump_log]} {
+    fail "tcpdump failed to start on eth2-server: $tcpdump_log"
+}
+if {![regexp {\y0 packets captured} $tcpdump_log]} {
+    fail "Ping request was forwarded by DUT onto AIL or tcpdump failed to complete: $tcpdump_log"
+}
+send_user "Verified: Ping request was not forwarded to AIL and no response was received.\n"
+
+# Step 11: Reconfigure radvd on eth2-server to start advertising default route again
+send_user "Step 11: Reconfiguring radvd to start advertising default route again...\n"
+stop_radvd $eth2_server
+set radvd_conf_with_default "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  AdvDefaultLifetime 875;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+exec docker exec -i $eth2_server bash -c "echo '$radvd_conf_with_default' > /etc/radvd.conf"
+start_radvd $eth2_server
+sleep 4
+
+# Step 12: Verify default route is advertised in Thread Network Data
+send_user "Step 12: Verifying default route is advertised in Thread Network Data again...\n"
+verify_netdata $container
+
+# Step 13: Ping Internet Server (2002:1234::1234) from ED_1. Verify success.
+send_user "Step 13: Verifying Ping to Internet Server (2002:1234::1234) works again...\n"
+switch_node 4
+send "ping 2002:1234::1234 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to internet server timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Internet Server failed"
+}
+send_user "Ping to Internet Server verified successfully.\n"
+
+# Step 14: Ping local server Eth_1 from ED_1. Verify success.
+send_user "Step 14: Verifying Ping to Local Host (Eth_1) works again...\n"
+send "ping $eth1_slaac 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to local host timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Local Host failed"
+}
+send_user "Ping to Local Host verified successfully.\n"
 
 # Cleanup routing
 catch { exec ip -6 route del 2002:1234::1234 }
@@ -554,4 +511,4 @@ catch { exec ip -6 route del 2002:1234::1234 }
 # Cleanup containers
 send_user "Tearing down containers...\n"
 dispose_all
-send_user "# IPv6 Connectivity using DHCPv6-PD delegated OMR prefix integration test completed successfully!\n"
+send_user "# IPv6 default route advertisement (1_4_PIC_TC_3) integration test completed successfully!\n"

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -75,9 +75,14 @@ test_teardown()
     echo "Active and inactive containers:"
     docker ps -a || true
     echo "Container logs:"
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web" "test-client" "dhcp6-server"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web" "test-client" "dhcp6-server" "eth1-server" "eth2-server"; do
         docker logs "$c" || true
     done
+
+    echo "Radvd/Tcpdump logs on eth2-server:"
+    docker exec -i eth2-server cat /var/log/radvd.log || true
+    docker exec -i eth2-server cat /var/log/tcpdump.log || true
+    ip -6 route del 2002:1234::1234 || true
 
     echo "Agent logs:"
     for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web"; do
@@ -141,7 +146,7 @@ test_setup()
     echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
     docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server dnsmasq python3-scapy radvd tcpdump --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server dnsmasq python3-scapy radvd tcpdump procps --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["mdns-scan"]
 EOF
 
@@ -256,6 +261,9 @@ test_run()
 
     echo "--- Running IPv6 Connectivity using DHCPv6-PD (1_4_PIC_TC_1) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_1.exp"
+
+    echo "--- Running IPv6 default route advertisement (1_4_PIC_TC_3) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_3.exp"
 }
 
 main()


### PR DESCRIPTION
Implement the Thread 1.4 test case "10.3. [1.4] [CERT] IPv6 default route advertisement" in the docker-in-docker integration framework.

Changes:
* Create tests/scripts/expect/dind_1_4_pic_tc_3.exp to execute the 14-step test procedure verifying default route advertisement, withdrawal, and recovery.
* Configure accept_ra=2 on the DUT container's eth0 interface and delete Docker's static default route using nsenter. This allows the DUT to behave realistically by dynamically configuring default routes and global IPs on the infrastructure link solely via RAs.
* Modify radvd prefix on the CPE container to a global unicast address (GUA) prefix 2001:db8:1::/64 to ensure an active non-ULA prefix is present as required by the test plan.
* Reconfigure radvd process controls to use 'kill' and 'pgrep' instead of 'killall' since the container image lacks 'killall'.
* Register dind_1_4_pic_tc_3.exp in tests/scripts/test_dind_dns_sd.sh.