### PR TITLE
[tests] fix race condition in SRP recovery reboot test

### DIFF
--- a/tests/scripts/expect/dind_srp_tc_11.exp
+++ b/tests/scripts/expect/dind_srp_tc_11.exp
@@ -357,6 +357,14 @@ sleep 5
 # Since ED_1 is already configured, it should automatically detect the new port/SN and send an update.
 send_user "Step 14: Verifying ED_1 automatically re-registers...\n"
 switch_node 4
+if {[info exists port_after]} {
+    if {[scan $port_after %x portDec] != 1} {
+        fail "Failed to parse port_after: $port_after"
+    }
+    send_user "Waiting for ED_1 to update SRP server port to $portDec...\n"
+    wait_for "srp client server" ":$portDec\\s"
+    expect_line "Done"
+}
 wait_for "srp client host state" "Registered"
 expect_line "Done"
 


### PR DESCRIPTION
Resolve a pre-existing race condition in dind_srp_tc_11.exp:
- After the DUT reboots, the SRP server port changes.
- The test was checking 'srp client host state' immediately and matching 'Registered' from the pre-reboot state, before the client actually detected the port change and re-registered.
- Added a loop to wait for the client's registered server port to match the new server port before checking the host state.