### PR TITLE
[tests] implement 1.4 DNS multi-question test (11.1)

### DIFF
--- a/etc/docker/border-router/Dockerfile
+++ b/etc/docker/border-router/Dockerfile
@@ -134,6 +134,7 @@ RUN set -x \
            curl \
            ipset \
            iptables \
+           iproute2 \
            libjsoncpp25 \
            xz-utils \
     && PLATFORM_SPEC="${TARGETARCH}${TARGETVARIANT:+/$TARGETVARIANT}" \

--- a/tests/scripts/expect/dind_1_4_dns_tc_1.exp
+++ b/tests/scripts/expect/dind_1_4_dns_tc_1.exp
@@ -1,0 +1,367 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+set pty1 [create_socat_tcp 1 9000]
+set pty2 [create_socat_tcp 2 9001]
+set container "otbr-test-container"
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# 1. Start border router in Docker
+send_user "Starting OTBR Docker container...\n"
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+wait_for_otbr_agent [list $container]
+
+# 2. Setup active dataset on OTBR and start Thread
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+wait_for_container_state $container "leader"
+
+# Enable SRP server explicitly
+exec docker exec -i $container ot-ctl srp server auto disable
+exec docker exec -i $container ot-ctl srp server enable
+sleep 2
+
+# Wait 15 seconds for the Border Routing Manager to fully stabilize its prefixes
+send_user "Waiting 15 seconds for prefixes to stabilize...\n"
+sleep 15
+
+# Verify SRP Server info is in network data
+set netdata [exec docker exec -i $container ot-ctl netdata show]
+check_string_contains $netdata "44970 5d"
+
+# Get active dataset to join Thread nodes
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [lindex [split $active_dataset "\n"] 0]
+set active_dataset [string trim $active_dataset]
+
+# Join Thread network from Node 3 (Router_1)
+spawn_node 3 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active $active_dataset\r\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "router"
+expect_line "Done"
+
+set router_omr [get_omr_addr]
+expect_line "Done"
+send_user "Router_1 OMR Address: $router_omr\n"
+
+# Join Thread network from Node 4 (ED_1)
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+send "dataset set active $active_dataset\r\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
+expect_line "Done"
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+expect_line "Done"
+
+set ed_mleid [get_ipaddr mleid]
+send_user "ED_1 ML-EID Address: $ed_mleid\n"
+
+# Set up test-client container to simulate adjacent infrastructure link (Eth_1)
+set test_client "test-client"
+track_container $test_client
+start_test_client $test_client $::env(EXP_TEST_CLIENT_IMAGE)
+
+# Configure routes on test client
+configure_test_client_routes $test_client $container
+sleep 2
+
+# Retrieve Border Router's RLOC address to use as DNS server
+set otbr_dns_addr [get_rloc_dns_addr $container]
+send_user "OTBR DNS Server Address: $otbr_dns_addr\n"
+
+# Fetch test-client's global ULA address and link-local address
+set ula_addr ""
+set ll_addr ""
+for {set i 0} {$i < 10} {incr i} {
+    set tc_addrs [exec docker exec -i $test_client ip -6 addr show dev eth0]
+    foreach line [split $tc_addrs "\n"] {
+        set line [string trim $line]
+        if {[regexp {inet6\s+(\S+)/.*scope\s+global} $line -> addr]} {
+            set ula_addr $addr
+        } elseif {[regexp {inet6\s+(\S+)/.*scope\s+link} $line -> addr]} {
+            set ll_addr $addr
+        }
+    }
+    if {$ula_addr ne "" && $ll_addr ne ""} {
+        break
+    }
+    sleep 1
+}
+send_user "Test client ULA: $ula_addr, Link-local: $ll_addr\n"
+if {$ula_addr eq "" || $ll_addr eq ""} {
+    fail "Failed to find global/ULA or Link-local address on test-client"
+}
+
+# Step 2: Advertise a test service using mDNS on test-client (Eth_1)
+send_user "Step 2: Advertising mDNS service service-test-2 on Eth_1...\n"
+exec docker exec -i $test_client bash -c "cat << 'EOF' > /tmp/publish_infra.py
+import socket
+import time
+from zeroconf import IPVersion, ServiceInfo, Zeroconf
+
+ula_addr = '$ula_addr'
+addresses = [socket.inet_pton(socket.AF_INET6, ula_addr)]
+
+desc = {'key2': 'value2'}
+info = ServiceInfo(
+    '_thread-test._udp.local.',
+    'service-test-2._thread-test._udp.local.',
+    addresses=addresses,
+    port=55556,
+    properties=desc,
+    server='host-eth-1.local.'
+)
+
+zc = Zeroconf(ip_version=IPVersion.V6Only)
+zc.register_service(info)
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    pass
+finally:
+    zc.unregister_service(info)
+    zc.close()
+EOF"
+exec docker exec -d $test_client python3 /tmp/publish_infra.py
+
+# Step 3: Register a test service using SRP on Router_1 (Node 3)
+send_user "Step 3: Registering SRP service service-test-1 on Router_1...\n"
+switch_node 3
+send "srp client host name host-router-1\r\n"
+expect_line "Done"
+send "srp client host address $router_omr\r\n"
+expect_line "Done"
+send "srp client service add service-test-1 _thread-test._udp 55556\r\n"
+expect_line "Done"
+send "srp client service txt service-test-1 key1=value1\r\n"
+expect_line "Done"
+send "srp client autostart enable\r\n"
+expect_line "Done"
+
+wait_for "srp client host state" "Registered"
+expect_line "Done"
+
+# Wait a bit for MDNS/SRP synchronization on BR
+sleep 5
+
+# Step 4: Perform DNS query with QDCOUNT=2 from ED_1 (Node 4) to BR_1 (DUT)
+send_user "Step 4: Sending multi-question query for service-test-1 from ED_1...\n"
+
+# Construct multi-question query hex payload for service-test-1
+set py_cmd "
+def encode_dns_name(domain):
+    parts = domain.strip('.').split('.')
+    encoded = b''
+    for part in parts:
+        encoded += bytes(\[len(part)\]) + part.encode('ascii')
+    encoded += b'\\x00'
+    return encoded
+
+import struct
+header = struct.pack('!HHHHHH', 0x1234, 0x0100, 2, 0, 0, 0)
+q1_name = encode_dns_name('service-test-1._thread-test._udp.default.service.arpa')
+q1 = q1_name + struct.pack('!HH', 33, 1)
+q2 = struct.pack('!H', 0xc00c) + struct.pack('!HH', 16, 1)
+print((header + q1 + q2).hex())
+"
+set query_hex_1 [exec python3 -c $py_cmd]
+set query_hex_1 [string trim $query_hex_1]
+
+switch_node 4
+send "udp open\r\n"
+expect_line "Done"
+send "udp bind :: 12345\r\n"
+expect_line "Done"
+send "udp connect $otbr_dns_addr 53\r\n"
+expect_line "Done"
+send "udp send -x $query_hex_1\r\n"
+expect_line "Done"
+
+set timeout 10
+set response_received 0
+expect {
+    -re "bytes from $otbr_dns_addr 53" {
+        set response_received 1
+    }
+    timeout {
+        fail "ED_1 did not receive UDP response from DNS resolver"
+    }
+}
+send "udp close\r\n"
+expect_line "Done"
+
+# Verify via python script on test-client
+send_user "Step 4 (Verification): Querying service-test-1 from test-client (Eth_1)...\n"
+exec docker cp tests/scripts/expect/dns_multi_question_query.py $test_client:/tmp/dns_multi_question_query.py
+set verify_res [exec docker exec -i $test_client python3 /tmp/dns_multi_question_query.py $otbr_dns_addr service-test-1._thread-test._udp.default.service.arpa.]
+set verify_res [string trim $verify_res]
+send_user "Verification result (service-test-1):\n$verify_res\n"
+if {![string match "*SUCCESS*" $verify_res]} {
+    fail "Verification of multi-question query for service-test-1 failed"
+}
+
+# Step 5: Perform DNS query with QDCOUNT=2 for service-test-2 from test-client
+send_user "Step 5: Verifying multi-question query for service-test-2 from test-client...\n"
+set verify_res2 [exec docker exec -i $test_client python3 /tmp/dns_multi_question_query.py $otbr_dns_addr service-test-2._thread-test._udp.default.service.arpa.]
+set verify_res2 [string trim $verify_res2]
+send_user "Verification result (service-test-2):\n$verify_res2\n"
+if {![string match "*SUCCESS*" $verify_res2]} {
+    fail "Verification of multi-question query for service-test-2 failed"
+}
+
+# Step 6: Single-question DNS query QTYPE=SRV for service-test-1 from ED_1
+send_user "Step 6: Verifying SRV query for service-test-1 from ED_1...\n"
+switch_node 4
+send "dns config $otbr_dns_addr\r\n"
+expect_line "Done"
+send "dns browse _thread-test._udp.default.service.arpa.\r\n"
+set timeout 10
+set found_srv 0
+expect {
+    -re "service-test-1" {
+        set found_srv 1
+        exp_continue
+    }
+    -re "Done" {
+        # resolved
+    }
+    timeout {
+        fail "DNS browse query timed out"
+    }
+}
+if {!$found_srv} {
+    fail "DNS browse response missing service-test-1"
+}
+
+# Step 7: Single-question DNS query QTYPE=TXT for service-test-2 from ED_1
+# (Note: 'dns browse' or standard client tools browse both SRV/TXT/AAAA, but let's resolve TXT explicitly)
+send_user "Step 7: Verifying TXT query for service-test-2 from ED_1...\n"
+# Since OT CLI doesn't have a direct 'dns txt' command, we browse and make sure we can find service-test-2
+send "dns browse _thread-test._udp.default.service.arpa.\r\n"
+set timeout 10
+set found_srv_2 0
+expect {
+    -re "service-test-2" {
+        set found_srv_2 1
+        exp_continue
+    }
+    -re "Done" {
+        # resolved
+    }
+    timeout {
+        fail "DNS browse query for service-test-2 timed out"
+    }
+}
+if {!$found_srv_2} {
+    fail "DNS browse response missing service-test-2"
+}
+
+# Step 8: DNS resolve AAAA for host-eth-1 from ED_1
+send_user "Step 8: Resolving host-eth-1 AAAA from ED_1...\n"
+send "dns resolve host-eth-1.default.service.arpa.\r\n"
+set found_ula 0
+set found_ll 0
+set ula_reg [get_ipv6_regex $ula_addr]
+expect {
+    -re $ula_reg {
+        set found_ula 1
+        exp_continue
+    }
+    -re "fe80:\[0-9a-fA-F:\]+" {
+        set found_ll 1
+        exp_continue
+    }
+    -re "Done" {
+        # resolved
+    }
+    timeout {
+        fail "DNS resolve host-eth-1 query timed out"
+    }
+}
+if {!$found_ula} {
+    fail "DNS resolve host-eth-1 response did not contain ULA address ($ula_addr)"
+}
+if {$found_ll} {
+    fail "DNS resolve host-eth-1 response incorrectly contained link-local address"
+}
+
+# Step 9: DNS resolve AAAA for host-router-1 from ED_1
+send_user "Step 9: Resolving host-router-1 AAAA from ED_1...\n"
+send "dns resolve host-router-1.default.service.arpa.\r\n"
+set found_omr 0
+set found_ll 0
+set omr_reg [get_ipv6_regex $router_omr]
+expect {
+    -re $omr_reg {
+        set found_omr 1
+        exp_continue
+    }
+    -re "fe80:\[0-9a-fA-F:\]+" {
+        set found_ll 1
+        exp_continue
+    }
+    -re "Done" {
+        # resolved
+    }
+    timeout {
+        fail "DNS resolve host-router-1 query timed out"
+    }
+}
+if {!$found_omr} {
+    fail "DNS resolve host-router-1 response did not contain OMR address ($router_omr)"
+}
+if {$found_ll} {
+    fail "DNS resolve host-router-1 response incorrectly contained link-local address"
+}
+
+# Cleanup
+dispose_all
+send_user "# Handling of multi-question DNS queries (1_4_DNS_TC_1) integration test completed successfully!\n"
+exit 0

--- a/tests/scripts/expect/dind_1_4_dns_tc_1.exp
+++ b/tests/scripts/expect/dind_1_4_dns_tc_1.exp
@@ -146,7 +146,7 @@ import time
 from zeroconf import IPVersion, ServiceInfo, Zeroconf
 
 ula_addr = '$ula_addr'
-addresses = [socket.inet_pton(socket.AF_INET6, ula_addr)]
+addresses = \[socket.inet_pton(socket.AF_INET6, ula_addr)\]
 
 desc = {'key2': 'value2'}
 info = ServiceInfo(

--- a/tests/scripts/expect/dind_1_4_pic_tc_1.exp
+++ b/tests/scripts/expect/dind_1_4_pic_tc_1.exp
@@ -1,0 +1,555 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+set pty1 [create_socat_tcp 1 9000]
+set container "otbr-test-container"
+set eth2_server "eth2-server"
+set eth1_server "eth1-server"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# 1. Start Eth_2 container (DHCPv6 PD Server, DNS Server, Internet HTTP Server)
+send_user "Starting Eth_2 container (CPE/DNS/Internet)...\n"
+track_container $eth2_server
+exec docker run -d \
+    --name $eth2_server \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "sleep infinity"
+
+# Wait for eth2-server eth0 to be ready
+sleep 2
+
+# Add 2002:1234::1234 IP to loopback of eth2-server
+exec docker exec -i $eth2_server ip -6 addr add 2002:1234::1234/128 dev lo
+
+# Configure and start Kea DHCPv6 PD server on eth2-server (delegating 2005:1234:abcd:0::/56)
+set kea_conf {{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "fd00:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2005:1234:abcd:0::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}}
+exec docker exec -i $eth2_server bash -c "echo '$kea_conf' > /etc/kea/kea-dhcp6.conf"
+exec docker exec -i $eth2_server mkdir -p /var/lib/kea /var/run/kea
+exec docker exec -d $eth2_server /usr/sbin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
+
+# Start dnsmasq on eth2-server resolving threadgroup.org to 2002:1234::1234
+exec docker exec -d $eth2_server dnsmasq --address=/threadgroup.org/2002:1234::1234 --no-hosts --no-resolv --interface=eth0 --port=53
+
+# Start Python HTTP server on eth2-server serving test.html on 2002:1234::1234
+exec docker exec -i $eth2_server mkdir -p /var/www/html
+exec docker exec -i $eth2_server bash -c "echo 'test-content-eth2' > /var/www/html/test.html"
+exec docker exec -d $eth2_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind 2002:1234::1234"
+
+# Enable IPv6 forwarding on eth2-server for radvd
+exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.all.forwarding=1
+exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.default.forwarding=1
+exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.eth0.forwarding=1
+
+# Start radvd on eth2-server to advertise default route on infrastructure link
+set radvd_conf "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  prefix fd00:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+exec docker exec -i $eth2_server bash -c "echo '$radvd_conf' > /etc/radvd.conf"
+exec docker exec -i $eth2_server chmod 600 /etc/radvd.conf
+# We run radvd with -u root to avoid permission issues in some docker environments
+# We run it in foreground with -n and redirect to a log file so we can debug failures
+exec docker exec -d $eth2_server bash -c "radvd -C /etc/radvd.conf -u root -n -m stderr >/var/log/radvd.log 2>&1"
+sleep 1
+if {[catch {exec docker exec -i $eth2_server pgrep radvd} radvd_pid]} {
+    if {![catch {exec docker exec -i $eth2_server cat /var/log/radvd.log} radvd_log]} {
+        send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
+    }
+    fail "Failed to start radvd on eth2-server: $radvd_pid"
+}
+send_user "radvd started on eth2-server with PID: [string trim $radvd_pid]\n"
+
+
+# 2. Start Eth_1 container (Local Infrastructure Host)
+send_user "Starting Eth_1 container (Local Host)...\n"
+track_container $eth1_server
+exec docker run -d \
+    --name $eth1_server \
+    --network infrastructure-link \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "echo 1 > /proc/sys/net/ipv6/conf/all/autoconf && echo 1 > /proc/sys/net/ipv6/conf/default/autoconf && echo 1 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/default/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
+
+# Start Python HTTP server on eth1-server serving test2.html
+exec docker exec -i $eth1_server mkdir -p /var/www/html
+exec docker exec -i $eth1_server bash -c "echo 'test-content-eth1' > /var/www/html/test2.html"
+exec docker exec -d $eth1_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind ::"
+
+# Get eth2-server global IPv6 address on infrastructure-link
+set eth2_ip ""
+set format {{{(index .NetworkSettings.Networks "infrastructure-link").GlobalIPv6Address}}}
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker inspect $eth2_server -f $format} ip]} {
+        set eth2_ip [string trim $ip]
+        if {$eth2_ip ne ""} {
+            break
+        }
+    }
+    sleep 1
+}
+if {$eth2_ip eq ""} {
+    fail "Failed to get IPv6 address for eth2-server"
+}
+send_user "Eth_2 Server IPv6 Address: $eth2_ip\n"
+
+# Configure routing on DinD runner: route 2002:1234::1234 via eth2-server
+send_user "Configuring routing for internet server on DinD host...\n"
+exec ip -6 route replace 2002:1234::1234 via $eth2_ip
+
+# 3. Start Border Router in Docker (DUT)
+send_user "Starting OTBR Docker container...\n"
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+wait_for_otbr_agent [list $container]
+
+# Configure DNS server of OTBR to use eth2-server
+exec docker exec -i $container bash -c "echo nameserver $eth2_ip > /etc/resolv.conf"
+
+# Setup active dataset on OTBR via ot-ctl
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+wait_for_container_state $container "leader"
+
+# Enable DHCPv6 Prefix Delegation explicitly on OTBR
+send_user "Enabling Prefix Delegation on the OTBR...\n"
+exec docker exec -i $container ot-ctl br pd enable
+sleep 5
+
+# 4. Validate OMR Prefix in Thread Network Data
+send_user "Step 4: Validating OMR Prefix in Thread Network Data...\n"
+set prefix_acquired false
+set delegated_prefix ""
+for {set i 0} {$i < 20} {incr i} {
+    if {[catch {exec docker exec -i $container ot-ctl br pd omrprefix} pd_omr]} {
+        set pd_omr ""
+    }
+    set pd_omr [string trim $pd_omr]
+    send_user "Current DHCPv6 PD OMR Prefix: $pd_omr\n"
+    
+    if {[regexp {([0-9a-fA-F:]+/64)} $pd_omr match prefix]} {
+        set delegated_prefix $prefix
+        set prefix_acquired true
+        break
+    }
+    sleep 2
+}
+
+if {!$prefix_acquired} {
+    fail "DHCPv6 PD client failed to acquire a prefix from the server"
+}
+send_user "Successfully Discovered Delegated Prefix: $delegated_prefix\n"
+
+# Verify OMR prefix properties in netdata
+# The OMR prefix should be subprefix of 2005:1234:abcd:0::/56, length /64, with 'r' (default) and 'med' preference
+set omr_regex {2005:1234:abcd:(?:[0-9a-fA-F]{1,2})?::/64\s+([a-z]*r[a-z]*)\s+med}
+set netdata_verified false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
+        send_user "DUT Network Data (Attempt $i):\n$netdata\n"
+        if {[regexp $omr_regex $netdata]} {
+            set netdata_verified true
+            break
+        }
+    }
+    sleep 2
+}
+if {!$netdata_verified} {
+    fail "OMR prefix in Network Data does not meet criteria (subprefix of 2005:1234:abcd:0::/56, /64, default route, med preference)"
+}
+send_user "OMR prefix verified in Thread Network Data successfully.\n"
+
+# 4b. Validate RA on AIL
+send_user "Step 4b: Validating RA on adjacent infrastructure link...\n"
+set py_ra_sniffer {import sys
+import ipaddress
+from scapy.all import *
+
+target_prefix = sys.argv[1]
+try:
+    target_net = ipaddress.IPv6Network(target_prefix, strict=False)
+except Exception as e:
+    print(f"FAIL: Invalid target prefix {target_prefix}: {e}")
+    sys.exit(1)
+
+found_otbr_ra = False
+
+def check_pkt(pkt):
+    global found_otbr_ra
+    if not pkt.haslayer(ICMPv6ND_RA):
+        return False
+    
+    # Check if it has RIO for target prefix
+    i = 1
+    target_opt = None
+    while True:
+        opt = pkt.getlayer(ICMPv6NDOptRouteInfo, nb=i)
+        if opt is None:
+            break
+        try:
+            opt_net = ipaddress.IPv6Network(f"{opt.prefix}/{opt.plen}", strict=False)
+            if opt_net == target_net:
+                target_opt = opt
+                break
+        except Exception as e:
+            pass
+        i += 1
+        
+    if target_opt is not None:
+        if pkt[IPv6].dst != "ff02::1":
+            return False
+
+        print(f"Captured OTBR RA from {pkt[IPv6].src} to {pkt[IPv6].dst}")
+            
+        ra = pkt[ICMPv6ND_RA]
+        raw_bytes = bytes(ra)
+        flags = raw_bytes[5]
+        # SNAC / Stub Router flag is bit 6 of RA flags (0x02)
+        if not (flags & 0x02):
+            print(f"FAIL: SNAC Router flag not set. Flags: {hex(flags)}")
+            sys.exit(1)
+            
+        if target_opt.prf in [0, 3] and target_opt.rtlifetime > 0:
+            found_otbr_ra = True
+            return True
+        else:
+            print(f"FAIL: RIO parameters invalid: prf={target_opt.prf}, lifetime={target_opt.rtlifetime}")
+            sys.exit(1)
+            
+    return False
+
+# Sniff until check_pkt returns True, or timeout
+sniff(filter="icmp6 and ip6[40] == 134", stop_filter=check_pkt, timeout=20)
+
+if not found_otbr_ra:
+    print("FAIL: OTBR RA packet not captured")
+    sys.exit(1)
+
+print("PASS")
+sys.exit(0)
+}
+
+# Run RA sniffer on eth1-server
+send_user "Running RA sniffer on Eth_1...\n"
+if {[catch {exec docker exec -i $eth1_server python3 -c $py_ra_sniffer $delegated_prefix} ra_res]} {
+    send_user "RA Sniffer Error: $ra_res\n"
+    fail "RA validation failed on Eth_1"
+}
+set ra_res [string trim $ra_res]
+send_user "RA Sniffer Result: $ra_res\n"
+if {![string match "*PASS*" $ra_res]} {
+    fail "RA validation failed on Eth_1"
+}
+send_user "RA validation passed.\n"
+
+# Get the running Border Router's active dataset dynamically to configure the client
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [lindex [split [string trim $active_dataset] "\n"] 0]
+
+# Get DUT ExtAddr
+set dut_extaddr [exec docker exec -i $container ot-ctl extaddr]
+set dut_extaddr [lindex [split [string trim $dut_extaddr] "\n"] 0]
+send_user "DUT ExtAddr: $dut_extaddr\n"
+
+# 5. Spawn Router_1 (Node 3)
+send_user "Starting Router_1 (Node 3)...\n"
+spawn_node 3 cli $::env(EXP_OT_CLI_PATH)
+
+# Get Router_1 ExtAddr (while disabled)
+send "extaddr\r\n"
+expect_line "extaddr"
+set router_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "Router_1 ExtAddr: $router_extaddr\n"
+
+# Configure Router_1 (still disabled)
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+
+# Spawn ED_1 (Node 4)
+send_user "Starting ED_1 (Node 4)...\n"
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+
+# Get ED_1 ExtAddr (while disabled)
+send "extaddr\r\n"
+expect_line "extaddr"
+set ed_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "ED_1 ExtAddr: $ed_extaddr\n"
+
+# Configure ED_1 (still disabled)
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
+expect_line "Done"
+
+# Configure MAC filters to restrict topology: ED_1 (4) <-> Router_1 (3) <-> DUT (1)
+send_user "Configuring MAC filters for topology ED_1 <-> Router_1 <-> DUT...\n"
+
+# On ED_1 (Node 4), only allow Router_1 (Node 3)
+switch_node 4
+send "macfilter addr add $router_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr allowlist\r\n"
+expect_line "Done"
+
+# On Router_1 (Node 3), allow DUT and ED_1
+switch_node 3
+send "macfilter addr add $dut_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr add $ed_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr allowlist\r\n"
+expect_line "Done"
+
+# On DUT (Node 1/container), only allow Router_1
+exec docker exec -i $container ot-ctl macfilter addr add $router_extaddr
+exec docker exec -i $container ot-ctl macfilter addr allowlist
+
+# Now start Thread on Router_1 and wait for router state
+send_user "Starting Thread on Router_1...\n"
+switch_node 3
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "router"
+expect_line "Done"
+
+# Now start Thread on ED_1 and wait for child state
+send_user "Starting Thread on ED_1...\n"
+switch_node 4
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+expect_line "Done"
+
+sleep 5
+
+# Retrieve DUT's RLOC address to use as DNS server on ED_1
+set otbr_rloc [get_rloc_dns_addr $container]
+send_user "OTBR RLOC IP: $otbr_rloc\n"
+
+# Configure DNS server on ED_1 (Node 4)
+switch_node 4
+send "dns config $otbr_rloc\r\n"
+expect_line "Done"
+
+# Step 5-7: DNS resolution from ED_1
+send_user "Step 5-7: Resolving threadgroup.org from ED_1...\n"
+send "dns resolve threadgroup.org\r\n"
+set timeout 15
+set dns_resolved false
+expect {
+    -re "2002:1234:(0:0:0:0:0|):1234" {
+        set dns_resolved true
+        exp_continue
+    }
+    -re "Done" {
+        # Succeeded
+    }
+    timeout {
+        fail "DNS resolution timed out"
+    }
+}
+if {!$dns_resolved} {
+    fail "DNS resolution failed to resolve threadgroup.org to 2002:1234::1234"
+}
+send_user "DNS resolution verified successfully.\n"
+
+# Step 8: Ping Internet Server (2002:1234::1234) from ED_1
+send_user "Step 8: Verifying Ping to Internet Server (2002:1234::1234)...\n"
+
+# Configure static route on eth2-server for OMR prefix via OTBR global IP
+set format {{{(index .NetworkSettings.Networks "infrastructure-link").GlobalIPv6Address}}}
+set otbr_ip [exec docker inspect $container -f $format]
+set otbr_ip [string trim $otbr_ip]
+send_user "OTBR Infrastructure IP: $otbr_ip\n"
+exec docker exec -i $eth2_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
+
+# Send ping from ED_1
+switch_node 4
+send "ping 2002:1234::1234 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to internet server timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Internet Server failed"
+}
+send_user "Ping to Internet Server verified successfully.\n"
+
+# Step 9: HTTP GET to Internet Server from ED_1
+send_user "Step 9: Verifying HTTP GET to Internet Server...\n"
+send "tcp init\r\n"
+expect_line "Done"
+send "tcp connect 2002:1234::1234 80\r\n"
+expect_line "Done"
+expect "TCP: Connection established"
+# Send GET request (hex representation)
+# "GET /test.html HTTP/1.1\r\nHost: threadgroup.org\r\n\r\n"
+send "tcp send -x 474554202F746573742E68746D6C20485454502F312E310D0A486F73743A2074687265616467726F75702E6F72670D0A0D0A\r\n"
+expect_line "Done"
+set timeout 15
+set http_success false
+expect {
+    -re "test-content-eth2" {
+        set http_success true
+        exp_continue
+    }
+    -re "TCP: Reached end of stream" {
+        # Done
+    }
+}
+send "tcp deinit\r\n"
+expect_line "Done"
+
+if {!$http_success} {
+    fail "HTTP GET to Internet Server failed"
+}
+send_user "HTTP GET to Internet Server verified successfully.\n"
+
+# Step 10: Ping Local Server (Eth_1) from ED_1
+send_user "Step 10: Verifying Ping to Local Server (Eth_1)...\n"
+
+# Get SLAAC IP of eth1-server
+# Poll until SLAAC IP is configured on eth1-server
+set eth1_slaac ""
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $eth1_server ip -6 addr show dev eth0 scope global} addrs]} {
+        foreach line [split $addrs "\n"] {
+            if {[string match "*dynamic*" $line]} {
+                if {[regexp {inet6 ([0-9a-fA-F:]+)/64} $line match addr]} {
+                    set eth1_slaac $addr
+                    break
+                }
+            }
+        }
+        if {$eth1_slaac ne ""} {
+            break
+        }
+    }
+    sleep 2
+}
+if {$eth1_slaac == ""} {
+    fail "Eth_1 failed to configure GUA via SLAAC"
+}
+send_user "Eth_1 SLAAC GUA: $eth1_slaac\n"
+
+# Configure static route on eth1-server for OMR prefix via OTBR
+exec docker exec -i $eth1_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
+
+# Send ping from ED_1 to Eth_1 SLAAC IP
+switch_node 4
+send "ping $eth1_slaac 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to local server timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Local Server failed"
+}
+send_user "Ping to Local Server verified successfully.\n"
+
+# Step 11: HTTP GET to Local Server (Eth_1) from ED_1
+send_user "Step 11: Verifying HTTP GET to Local Server...\n"
+send "tcp init\r\n"
+expect_line "Done"
+send "tcp connect $eth1_slaac 80\r\n"
+expect_line "Done"
+expect "TCP: Connection established"
+# Send GET request (hex representation)
+# "GET /test2.html HTTP/1.1\r\nHost: localtest.org\r\n\r\n"
+send "tcp send -x 474554202F74657374322E68746D6C20485454502F312E310D0A486F73743A206C6F63616C746573742E6F72670D0A0D0A\r\n"
+expect_line "Done"
+set timeout 15
+set http_success false
+expect {
+    -re "test-content-eth1" {
+        set http_success true
+        exp_continue
+    }
+    -re "TCP: Reached end of stream" {
+        # Done
+    }
+}
+send "tcp deinit\r\n"
+expect_line "Done"
+
+if {!$http_success} {
+    fail "HTTP GET to Local Server failed"
+}
+send_user "HTTP GET to Local Server verified successfully.\n"
+
+# Cleanup routing
+catch { exec ip -6 route del 2002:1234::1234 }
+
+# Cleanup containers
+send_user "Tearing down containers...\n"
+dispose_all
+send_user "# IPv6 Connectivity using DHCPv6-PD delegated OMR prefix integration test completed successfully!\n"

--- a/tests/scripts/expect/dind_1_4_pic_tc_3.exp
+++ b/tests/scripts/expect/dind_1_4_pic_tc_3.exp
@@ -29,6 +29,30 @@
 
 source "tests/scripts/expect/_common.exp"
 
+proc start_radvd {server} {
+    exec docker exec -d $server bash -c "radvd -C /etc/radvd.conf -u root -n -m stderr >/var/log/radvd.log 2>&1"
+    sleep 1
+    if {[catch {exec docker exec -i $server pgrep radvd} radvd_pid]} {
+        if {![catch {exec docker exec -i $server cat /var/log/radvd.log} radvd_log]} {
+            send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
+        }
+        fail "Failed to start radvd on $server: $radvd_pid"
+    }
+    send_user "radvd started on $server with PID: [string trim $radvd_pid]\n"
+}
+
+proc stop_radvd {server} {
+    catch {exec docker exec -i $server pkill radvd}
+    # Wait for radvd to fully terminate to avoid port/socket binding conflicts
+    for {set j 0} {$j < 50} {incr j} {
+        if {[catch {exec docker exec -i $server pgrep radvd}]} {
+            break
+        }
+        after 100
+    }
+}
+
+
 set pty1 [create_socat_tcp 1 9000]
 set container "otbr-test-container"
 set eth2_server "eth2-server"
@@ -36,8 +60,8 @@ set eth1_server "eth1-server"
 
 set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
 
-# 1. Start Eth_2 container (DHCPv6 PD Server, DNS Server, Internet HTTP Server)
-send_user "Starting Eth_2 container (CPE/DNS/Internet)...\n"
+# 1. Start Eth_2 container (CPE/DNS/Internet/radvd)
+send_user "Starting Eth_2 container (CPE/radvd)...\n"
 track_container $eth2_server
 exec docker run -d \
     --name $eth2_server \
@@ -52,22 +76,15 @@ exec docker run -d \
 # Wait for eth2-server eth0 to be ready
 sleep 2
 
-# Add 2002:1234::1234 IP to loopback of eth2-server
+# Add 2002:1234::1234 IP to loopback and 2001:db8:1::1 to eth0 of eth2-server
 exec docker exec -i $eth2_server ip -6 addr add 2002:1234::1234/128 dev lo
+exec docker exec -i $eth2_server ip -6 addr add 2001:db8:1::1/64 dev eth0
 
 # Configure and start Kea DHCPv6 PD server on eth2-server (delegating 2005:1234:abcd:0::/56)
-set kea_conf {{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "fd00:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2005:1234:abcd:0::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}}
+set kea_conf {{"Dhcp6": {"interfaces-config": {"interfaces": ["eth0"]}, "lease-database": {"type": "memfile", "persist": true, "name": "/var/lib/kea/kea-leases6.csv"}, "preferred-lifetime": 54000, "valid-lifetime": 86400, "subnet6": [{"subnet": "2001:db8:1::/64", "interface": "eth0", "pd-pools": [{"prefix": "2005:1234:abcd:0::", "prefix-len": 56, "delegated-len": 64}], "rapid-commit": true}], "loggers": [{"name": "kea-dhcp6", "output_options": [{"output": "stdout"}], "severity": "DEBUG", "debuglevel": 99}]}}}
 exec docker exec -i $eth2_server bash -c "echo '$kea_conf' > /etc/kea/kea-dhcp6.conf"
 exec docker exec -i $eth2_server mkdir -p /var/lib/kea /var/run/kea
 exec docker exec -d $eth2_server /usr/sbin/kea-dhcp6 -c /etc/kea/kea-dhcp6.conf
-
-# Start dnsmasq on eth2-server resolving threadgroup.org to 2002:1234::1234
-exec docker exec -d $eth2_server dnsmasq --address=/threadgroup.org/2002:1234::1234 --no-hosts --no-resolv --interface=eth0 --port=53
-
-# Start Python HTTP server on eth2-server serving test.html on 2002:1234::1234
-exec docker exec -i $eth2_server mkdir -p /var/www/html
-exec docker exec -i $eth2_server bash -c "echo 'test-content-eth2' > /var/www/html/test.html"
-exec docker exec -d $eth2_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind 2002:1234::1234"
 
 # Enable IPv6 forwarding on eth2-server for radvd
 exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.all.forwarding=1
@@ -75,21 +92,10 @@ exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.default.forwarding=1
 exec docker exec -i $eth2_server sysctl -w net.ipv6.conf.eth0.forwarding=1
 
 # Start radvd on eth2-server to advertise default route on infrastructure link
-set radvd_conf "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  prefix fd00:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+set radvd_conf "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
 exec docker exec -i $eth2_server bash -c "echo '$radvd_conf' > /etc/radvd.conf"
 exec docker exec -i $eth2_server chmod 600 /etc/radvd.conf
-# We run radvd with -u root to avoid permission issues in some docker environments
-# We run it in foreground with -n and redirect to a log file so we can debug failures
-exec docker exec -d $eth2_server bash -c "radvd -C /etc/radvd.conf -u root -n -m stderr >/var/log/radvd.log 2>&1"
-sleep 1
-if {[catch {exec docker exec -i $eth2_server pgrep radvd} radvd_pid]} {
-    if {![catch {exec docker exec -i $eth2_server cat /var/log/radvd.log} radvd_log]} {
-        send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
-    }
-    fail "Failed to start radvd on eth2-server: $radvd_pid"
-}
-send_user "radvd started on eth2-server with PID: [string trim $radvd_pid]\n"
-
+start_radvd $eth2_server
 
 # 2. Start Eth_1 container (Local Infrastructure Host)
 send_user "Starting Eth_1 container (Local Host)...\n"
@@ -103,11 +109,6 @@ exec docker run -d \
     --entrypoint /bin/bash \
     $::env(EXP_TEST_CLIENT_IMAGE) \
     -c "echo 1 > /proc/sys/net/ipv6/conf/all/autoconf && echo 1 > /proc/sys/net/ipv6/conf/default/autoconf && echo 1 > /proc/sys/net/ipv6/conf/eth0/autoconf && echo 2 > /proc/sys/net/ipv6/conf/all/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/default/accept_ra && echo 2 > /proc/sys/net/ipv6/conf/eth0/accept_ra && sleep infinity"
-
-# Start Python HTTP server on eth1-server serving test2.html
-exec docker exec -i $eth1_server mkdir -p /var/www/html
-exec docker exec -i $eth1_server bash -c "echo 'test-content-eth1' > /var/www/html/test2.html"
-exec docker exec -d $eth1_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind ::"
 
 # Get eth2-server global IPv6 address on infrastructure-link
 set eth2_ip ""
@@ -137,8 +138,13 @@ start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
 # Wait for otbr-agent to create the domain socket
 wait_for_otbr_agent [list $container]
 
-# Configure DNS server of OTBR to use eth2-server
-exec docker exec -i $container bash -c "echo nameserver $eth2_ip > /etc/resolv.conf"
+# Delete Docker's static default route so the DUT only relies on RAs
+# We can run it via docker exec now that iproute2 package is added to the container
+catch { exec docker exec -i $container ip -6 route del default dev eth0 }
+
+# Enable accept_ra=2 on DUT so it configures default route and GUA via SLAAC
+exec docker exec -i $container sysctl -w net.ipv6.conf.all.accept_ra=2
+exec docker exec -i $container sysctl -w net.ipv6.conf.eth0.accept_ra=2
 
 # Setup active dataset on OTBR via ot-ctl
 exec docker exec -i $container ot-ctl thread stop
@@ -155,7 +161,7 @@ send_user "Enabling Prefix Delegation on the OTBR...\n"
 exec docker exec -i $container ot-ctl br pd enable
 sleep 5
 
-# 4. Validate OMR Prefix in Thread Network Data
+# Step 4: Validate OMR Prefix in Thread Network Data
 send_user "Step 4: Validating OMR Prefix in Thread Network Data...\n"
 set prefix_acquired false
 set delegated_prefix ""
@@ -179,109 +185,41 @@ if {!$prefix_acquired} {
 }
 send_user "Successfully Discovered Delegated Prefix: $delegated_prefix\n"
 
-# Verify OMR prefix properties in netdata
-# The OMR prefix should be subprefix of 2005:1234:abcd:0::/56, length /64, with 'r' (default) and 'med' preference
-set omr_regex {2005:1234:abcd:(?:[0-9a-fA-F]{1,2})?:{1,2}/64\s+([a-z]*r[a-z]*)\s+med}
-set netdata_verified false
-for {set i 0} {$i < 10} {incr i} {
-    if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
-        send_user "DUT Network Data (Attempt $i):\n$netdata\n"
-        if {[regexp $omr_regex $netdata]} {
-            set netdata_verified true
-            break
+# Verify OMR prefix properties in netdata (subprefix of 2005:1234:abcd:0::/56, /64, default route, med preference)
+# AND verify default route ::/0 with Route sub-TLV (NP=0)
+proc verify_netdata {container} {
+    set omr_regex {2005:1234:abcd:(?:[0-9a-fA-F]{1,2})?:{1,2}/64\s+([a-z]*r[a-z]*)\s+med}
+    set route_regex {::/0(?:\s+([a-z]+))?\s+med}
+    set netdata_verified false
+    for {set i 0} {$i < 10} {incr i} {
+        if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
+            send_user "DUT Network Data (Attempt $i):\n$netdata\n"
+            if {[regexp $omr_regex $netdata match flags]} {
+                # OMR prefix has 'r' (default) flag
+                if {[string match "*r*" $flags] && [regexp $route_regex $netdata match rflags]} {
+                    # Default route ::/0 exists. Since NP=0, NP flag (usually 'n') must NOT be present.
+                    if {![string match "*n*" $rflags]} {
+                        set netdata_verified true
+                        break
+                    } else {
+                        send_user "Default route ::/0 has NP flag set: $rflags\n"
+                    }
+                } else {
+                    send_user "Default route ::/0 not found in netdata or OMR prefix has wrong flags: $flags\n"
+                }
+            }
         }
+        sleep 2
     }
-    sleep 2
-}
-if {!$netdata_verified} {
-    fail "OMR prefix in Network Data does not meet criteria (subprefix of 2005:1234:abcd:0::/56, /64, default route, med preference)"
-}
-send_user "OMR prefix verified in Thread Network Data successfully.\n"
-
-# 4b. Validate RA on AIL
-send_user "Step 4b: Validating RA on adjacent infrastructure link...\n"
-set py_ra_sniffer {import sys
-import ipaddress
-import logging
-logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-from scapy.all import *
-
-target_prefix = sys.argv[1]
-try:
-    target_net = ipaddress.IPv6Network(target_prefix, strict=False)
-except Exception as e:
-    print(f"FAIL: Invalid target prefix {target_prefix}: {e}")
-    sys.exit(1)
-
-found_otbr_ra = False
-
-def check_pkt(pkt):
-    global found_otbr_ra
-    if not pkt.haslayer(ICMPv6ND_RA):
-        return False
-    
-    # Check if it has RIO for target prefix
-    i = 1
-    target_opt = None
-    while True:
-        opt = pkt.getlayer(ICMPv6NDOptRouteInfo, nb=i)
-        if opt is None:
-            break
-        try:
-            opt_net = ipaddress.IPv6Network(f"{opt.prefix}/{opt.plen}", strict=False)
-            if opt_net == target_net:
-                target_opt = opt
-                break
-        except Exception as e:
-            pass
-        i += 1
-        
-    if target_opt is not None:
-        if pkt[IPv6].dst != "ff02::1":
-            return False
-
-        print(f"Captured OTBR RA from {pkt[IPv6].src} to {pkt[IPv6].dst}")
-            
-        ra = pkt[ICMPv6ND_RA]
-        raw_bytes = bytes(ra)
-        flags = raw_bytes[5]
-        # SNAC / Stub Router flag is bit 6 of RA flags (0x02)
-        if not (flags & 0x02):
-            print(f"FAIL: SNAC Router flag not set. Flags: {hex(flags)}")
-            sys.exit(1)
-            
-        if target_opt.prf in [0, 3] and target_opt.rtlifetime > 0:
-            found_otbr_ra = True
-            return True
-        else:
-            print(f"FAIL: RIO parameters invalid: prf={target_opt.prf}, lifetime={target_opt.rtlifetime}")
-            sys.exit(1)
-            
-    return False
-
-# Sniff until check_pkt returns True, or timeout
-sniff(filter="icmp6 and icmp6[0] == 134", stop_filter=check_pkt, timeout=20)
-
-if not found_otbr_ra:
-    print("FAIL: OTBR RA packet not captured")
-    sys.exit(1)
-
-print("PASS")
-sys.exit(0)
+    if {!$netdata_verified} {
+        fail "Network Data does not meet criteria"
+    }
+    send_user "OMR prefix and default route ::/0 verified in Thread Network Data successfully.\n"
 }
 
-# Run RA sniffer on eth1-server
-send_user "Running RA sniffer on Eth_1...\n"
-if {[catch {exec docker exec -i $eth1_server python3 -c $py_ra_sniffer $delegated_prefix} ra_res]} {
-    send_user "RA Sniffer Error: $ra_res\n"
-    fail "RA validation failed on Eth_1"
-}
-set ra_res [string trim $ra_res]
-send_user "RA Sniffer Result: $ra_res\n"
-if {![string match "*PASS*" $ra_res]} {
-    fail "RA validation failed on Eth_1"
-}
-send_user "RA validation passed.\n"
+# Step 5: Verify default route is advertised in Thread Network Data
+send_user "Step 5: Verifying network data on DUT...\n"
+verify_netdata $container
 
 # Get the running Border Router's active dataset dynamically to configure the client
 set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
@@ -292,18 +230,18 @@ set dut_extaddr [exec docker exec -i $container ot-ctl extaddr]
 set dut_extaddr [lindex [split [string trim $dut_extaddr] "\n"] 0]
 send_user "DUT ExtAddr: $dut_extaddr\n"
 
-# 5. Spawn Router_1 (Node 3)
+# Spawn Router_1 (Node 3)
 send_user "Starting Router_1 (Node 3)...\n"
 spawn_node 3 cli $::env(EXP_OT_CLI_PATH)
 
-# Get Router_1 ExtAddr (while disabled)
+# Get Router_1 ExtAddr
 send "extaddr\r\n"
 expect_line "extaddr"
 set router_extaddr [expect_line {[0-9a-fA-F]{16}}]
 expect_line "Done"
 send_user "Router_1 ExtAddr: $router_extaddr\n"
 
-# Configure Router_1 (still disabled)
+# Configure Router_1
 send "dataset set active $active_dataset\n"
 expect_line "Done"
 send "mode rdn\r\n"
@@ -313,14 +251,14 @@ expect_line "Done"
 send_user "Starting ED_1 (Node 4)...\n"
 spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
 
-# Get ED_1 ExtAddr (while disabled)
+# Get ED_1 ExtAddr
 send "extaddr\r\n"
 expect_line "extaddr"
 set ed_extaddr [expect_line {[0-9a-fA-F]{16}}]
 expect_line "Done"
 send_user "ED_1 ExtAddr: $ed_extaddr\n"
 
-# Configure ED_1 (still disabled)
+# Configure ED_1
 send "dataset set active $active_dataset\n"
 expect_line "Done"
 send "mode rdn\r\n"
@@ -373,48 +311,16 @@ expect_line "Done"
 
 sleep 5
 
-# Retrieve DUT's RLOC address to use as DNS server on ED_1
-set otbr_rloc [get_rloc_dns_addr $container]
-send_user "OTBR RLOC IP: $otbr_rloc\n"
-
-# Configure DNS server on ED_1 (Node 4)
-switch_node 4
-send "dns config $otbr_rloc\r\n"
-expect_line "Done"
-
-# Step 5-7: DNS resolution from ED_1
-send_user "Step 5-7: Resolving threadgroup.org from ED_1...\n"
-send "dns resolve threadgroup.org\r\n"
-set timeout 15
-set dns_resolved false
-expect {
-    -re "2002:1234:(0:0:0:0:0|):1234" {
-        set dns_resolved true
-        exp_continue
-    }
-    -re "Done" {
-        # Succeeded
-    }
-    timeout {
-        fail "DNS resolution timed out"
-    }
-}
-if {!$dns_resolved} {
-    fail "DNS resolution failed to resolve threadgroup.org to 2002:1234::1234"
-}
-send_user "DNS resolution verified successfully.\n"
-
-# Step 8: Ping Internet Server (2002:1234::1234) from ED_1
-send_user "Step 8: Verifying Ping to Internet Server (2002:1234::1234)...\n"
-
-# Configure static route on eth2-server for OMR prefix via OTBR global IP
+# Setup routing for test targets
+# OMR prefix routing on eth2-server via OTBR global IP
 set format {{{(index .NetworkSettings.Networks "infrastructure-link").GlobalIPv6Address}}}
 set otbr_ip [exec docker inspect $container -f $format]
 set otbr_ip [string trim $otbr_ip]
 send_user "OTBR Infrastructure IP: $otbr_ip\n"
 exec docker exec -i $eth2_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
 
-# Send ping from ED_1
+# Step 6: Ping Internet Server (2002:1234::1234) from ED_1
+send_user "Step 6: Verifying Ping to Internet Server (2002:1234::1234)...\n"
 switch_node 4
 send "ping 2002:1234::1234 56 5\r\n"
 set timeout 15
@@ -436,41 +342,19 @@ if {!$ping_success} {
 }
 send_user "Ping to Internet Server verified successfully.\n"
 
-# Step 9: HTTP GET to Internet Server from ED_1
-send_user "Step 9: Verifying HTTP GET to Internet Server...\n"
-send "tcp init\r\n"
-expect_line "Done"
-send "tcp connect 2002:1234::1234 80\r\n"
-expect_line "Done"
-expect "TCP: Connection established"
-# Send GET request (hex representation)
-# "GET /test.html HTTP/1.1\r\nHost: threadgroup.org\r\n\r\n"
-send "tcp send -x 474554202F746573742E68746D6C20485454502F312E310D0A486F73743A2074687265616467726F75702E6F72670D0A0D0A\r\n"
-expect_line "Done"
-set timeout 15
-set http_success false
-expect {
-    -re "test-content-eth2" {
-        set http_success true
-        exp_continue
-    }
-    -re "TCP: Reached end of stream" {
-        # Done
-    }
-}
-send "tcp deinit\r\n"
-expect_line "Done"
+# Step 7: Reconfigure radvd on eth2-server to stop advertising default route
+send_user "Step 7: Reconfiguring radvd to stop advertising default route...\n"
+stop_radvd $eth2_server
+set radvd_conf_no_default "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  AdvDefaultLifetime 0;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+exec docker exec -i $eth2_server bash -c "echo '$radvd_conf_no_default' > /etc/radvd.conf"
+start_radvd $eth2_server
+sleep 4
 
-if {!$http_success} {
-    fail "HTTP GET to Internet Server failed"
-}
-send_user "HTTP GET to Internet Server verified successfully.\n"
-
-# Step 10: Ping Local Server (Eth_1) from ED_1
-send_user "Step 10: Verifying Ping to Local Server (Eth_1)...\n"
+# Step 8: Verify DUT *still* advertises default route in Thread Network Data
+send_user "Step 8: Verifying default route is still advertised in Thread Network Data...\n"
+verify_netdata $container
 
 # Get SLAAC IP of eth1-server
-# Poll until SLAAC IP is configured on eth1-server
 set eth1_slaac ""
 for {set i 0} {$i < 10} {incr i} {
     if {![catch {exec docker exec -i $eth1_server ip -6 addr show dev eth0 scope global} addrs]} {
@@ -496,7 +380,8 @@ send_user "Eth_1 SLAAC GUA: $eth1_slaac\n"
 # Configure static route on eth1-server for OMR prefix via OTBR
 exec docker exec -i $eth1_server ip -6 route replace $delegated_prefix via $otbr_ip dev eth0
 
-# Send ping from ED_1 to Eth_1 SLAAC IP
+# Step 9: Ping local server Eth_1 from ED_1
+send_user "Step 9: Verifying Ping to Local Host (Eth_1) works...\n"
 switch_node 4
 send "ping $eth1_slaac 56 5\r\n"
 set timeout 15
@@ -510,43 +395,115 @@ expect {
         # Finished
     }
     timeout {
-        send_user "Error: Ping to local server timed out\n"
+        send_user "Error: Ping to local host timed out\n"
     }
 }
 if {!$ping_success} {
-    fail "Ping from ED_1 to Local Server failed"
+    fail "Ping from ED_1 to Local Host failed"
 }
-send_user "Ping to Local Server verified successfully.\n"
+send_user "Ping to Local Host verified successfully.\n"
 
-# Step 11: HTTP GET to Local Server (Eth_1) from ED_1
-send_user "Step 11: Verifying HTTP GET to Local Server...\n"
-send "tcp init\r\n"
-expect_line "Done"
-send "tcp connect $eth1_slaac 80\r\n"
-expect_line "Done"
-expect "TCP: Connection established"
-# Send GET request (hex representation)
-# "GET /test2.html HTTP/1.1\r\nHost: localtest.org\r\n\r\n"
-send "tcp send -x 474554202F74657374322E68746D6C20485454502F312E310D0A486F73743A206C6F63616C746573742E6F72670D0A0D0A\r\n"
-expect_line "Done"
+# Step 10: Ping 2002:1234::1234 from ED_1. Ping response MUST NOT be received. Ping request MUST NOT be sent on AIL.
+send_user "Step 10: Verifying Ping to Internet Server does NOT work and is NOT forwarded...\n"
+
+# Start tcpdump on eth2-server to detect any ICMPv6 echo requests (line-buffered with -l)
+# Run in background via exec docker exec -d. Timeout in 8 seconds to allow ping tool to finish.
+exec docker exec -d $eth2_server bash -c "timeout 8 tcpdump -l -c 1 -i eth0 'icmp6 and icmp6\[0\] == 128' > /var/log/tcpdump.log 2>&1"
+sleep 1
+
+# Send ping from ED_1
+switch_node 4
+send "ping 2002:1234::1234 56 5\r\n"
 set timeout 15
-set http_success false
+set ping_received false
 expect {
-    -re "test-content-eth1" {
-        set http_success true
+    -re "bytes from" {
+        set ping_received true
         exp_continue
     }
-    -re "TCP: Reached end of stream" {
-        # Done
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        # Expected
     }
 }
-send "tcp deinit\r\n"
-expect_line "Done"
-
-if {!$http_success} {
-    fail "HTTP GET to Local Server failed"
+if {$ping_received} {
+    catch {
+        set radvd_log [exec docker exec -i $eth2_server cat /var/log/radvd.log]
+        send_user "\n=== radvd.log ===\n$radvd_log\n=== end of radvd.log ===\n"
+    }
+    fail "Ping from ED_1 to Internet Server succeeded, but it was expected to fail"
 }
-send_user "HTTP GET to Local Server verified successfully.\n"
+
+# Check if tcpdump captured any packet
+sleep 9
+set tcpdump_log [exec docker exec -i $eth2_server cat /var/log/tcpdump.log]
+send_user "tcpdump log on eth2-server:\n$tcpdump_log\n"
+if {![string match "*listening on*" $tcpdump_log]} {
+    fail "tcpdump failed to start on eth2-server: $tcpdump_log"
+}
+if {![regexp {\y0 packets captured} $tcpdump_log]} {
+    fail "Ping request was forwarded by DUT onto AIL or tcpdump failed to complete: $tcpdump_log"
+}
+send_user "Verified: Ping request was not forwarded to AIL and no response was received.\n"
+
+# Step 11: Reconfigure radvd on eth2-server to start advertising default route again
+send_user "Step 11: Reconfiguring radvd to start advertising default route again...\n"
+stop_radvd $eth2_server
+set radvd_conf_with_default "interface eth0\n{\n  AdvSendAdvert on;\n  MinRtrAdvInterval 3;\n  MaxRtrAdvInterval 10;\n  AdvDefaultLifetime 875;\n  prefix 2001:db8:1::/64\n  {\n    AdvOnLink on;\n    AdvAutonomous on;\n    AdvRouterAddr on;\n  };\n};"
+exec docker exec -i $eth2_server bash -c "echo '$radvd_conf_with_default' > /etc/radvd.conf"
+start_radvd $eth2_server
+sleep 4
+
+# Step 12: Verify default route is advertised in Thread Network Data
+send_user "Step 12: Verifying default route is advertised in Thread Network Data again...\n"
+verify_netdata $container
+
+# Step 13: Ping Internet Server (2002:1234::1234) from ED_1. Verify success.
+send_user "Step 13: Verifying Ping to Internet Server (2002:1234::1234) works again...\n"
+switch_node 4
+send "ping 2002:1234::1234 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to internet server timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Internet Server failed"
+}
+send_user "Ping to Internet Server verified successfully.\n"
+
+# Step 14: Ping local server Eth_1 from ED_1. Verify success.
+send_user "Step 14: Verifying Ping to Local Host (Eth_1) works again...\n"
+send "ping $eth1_slaac 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to local host timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Local Host failed"
+}
+send_user "Ping to Local Host verified successfully.\n"
 
 # Cleanup routing
 catch { exec ip -6 route del 2002:1234::1234 }
@@ -554,4 +511,4 @@ catch { exec ip -6 route del 2002:1234::1234 }
 # Cleanup containers
 send_user "Tearing down containers...\n"
 dispose_all
-send_user "# IPv6 Connectivity using DHCPv6-PD delegated OMR prefix integration test completed successfully!\n"
+send_user "# IPv6 default route advertisement (1_4_PIC_TC_3) integration test completed successfully!\n"

--- a/tests/scripts/expect/dind_1_4_pic_tc_4.exp
+++ b/tests/scripts/expect/dind_1_4_pic_tc_4.exp
@@ -1,0 +1,471 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+proc synthesize_ipv6 {prefix ip4} {
+    scan $ip4 "%d.%d.%d.%d" oct1 oct2 oct3 oct4
+    set hex_ip4 [format "%02x%02x:%02x%02x" $oct1 $oct2 $oct3 $oct4]
+    set prefix_val [lindex [split $prefix "/"] 0]
+    if {[string match "*::" $prefix_val]} {
+        set colons [regexp -all ":" $prefix_val]
+        if {$colons >= 7} {
+            set base [string range $prefix_val 0 [expr {[string length $prefix_val] - 2}]]
+            return "${base}${hex_ip4}"
+        }
+        return "${prefix_val}${hex_ip4}"
+    } elseif {[string match "*:" $prefix_val]} {
+        return "${prefix_val}${hex_ip4}"
+    } else {
+        return "${prefix_val}:${hex_ip4}"
+    }
+}
+
+set pty1 [create_socat_tcp 1 9000]
+set container "otbr-test-container"
+set eth2_server "eth2-server"
+set eth1_server "eth1-server"
+
+set dataset "0e080000000000010000000300001435060004001fffe002087d61eb42cdc48d6a0708fd0d07fca1b9f0500510ba088fc2bd6c3b3897f7a10f58263ff3030f4f70656e5468726561642d353234660102524f04109dc023ccd447b12b50997ef68020f19e0c0402a0f7f8"
+
+# 1. Start Eth_2 container (Gateway, simulated internet, DNS, HTTP)
+send_user "Starting Eth_2 container (CPE/DNS/Internet)...\n"
+track_container $eth2_server
+exec docker run -d \
+    --name $eth2_server \
+    --network infrastructure-link \
+    --ip 192.168.1.254 \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "sleep infinity"
+
+# Wait for container interface to stabilize
+sleep 2
+
+# Add loopback alias IP 38.106.217.165 to simulate the internet server threadv4.org
+exec docker exec -i $eth2_server ip addr add 38.106.217.165/32 dev lo
+
+# Start dnsmasq on eth2-server resolving threadv4.org to 38.106.217.165
+exec docker exec -d $eth2_server dnsmasq --address=/threadv4.org/38.106.217.165 --no-hosts --no-resolv --interface=eth0 --port=53
+
+# Start Python HTTP server serving testv4.html
+exec docker exec -i $eth2_server mkdir -p /var/www/html
+exec docker exec -i $eth2_server bash -c "echo 'test-content-eth2' > /var/www/html/testv4.html"
+exec docker exec -d $eth2_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind 38.106.217.165 >/tmp/http.log 2>&1"
+
+# Start Python UDP echo server on eth2-server
+exec docker exec -i $eth2_server bash -c {cat <<'EOF' > /tmp/udp_server.py
+import socket
+import sys
+try:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(('38.106.217.165', 7777))
+    print("Bound to 38.106.217.165:7777", flush=True)
+except Exception as e:
+    print(f"Bind failed: {e}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+while True:
+    try:
+        data, addr = s.recvfrom(1024)
+        print(f"Received {data} from {addr}", flush=True)
+        s.sendto(data, addr)
+        print(f"Sent reply to {addr}", flush=True)
+    except Exception as e:
+        print(f"Error during recv/send: {e}", file=sys.stderr, flush=True)
+EOF
+}
+exec docker exec -d $eth2_server bash -c "python3 /tmp/udp_server.py >/tmp/udp.log 2>&1"
+
+
+# 2. Start Eth_1 container (Local host server)
+send_user "Starting Eth_1 container (Local Server)...\n"
+track_container $eth1_server
+exec docker run -d \
+    --name $eth1_server \
+    --network infrastructure-link \
+    --ip 192.168.1.4 \
+    --cap-add=NET_ADMIN \
+    --privileged \
+    --entrypoint /bin/bash \
+    $::env(EXP_TEST_CLIENT_IMAGE) \
+    -c "sleep infinity"
+
+# Wait for container interface to stabilize
+sleep 2
+
+# Start Python HTTP server serving test2.html on local host eth1
+exec docker exec -i $eth1_server mkdir -p /var/www/html
+exec docker exec -i $eth1_server bash -c "echo 'test-content-eth1' > /var/www/html/test2.html"
+exec docker exec -d $eth1_server bash -c "cd /var/www/html && python3 -m http.server 80 --bind 192.168.1.4"
+
+# Configure routing on DinD host (so DinD runner knows to route 38.106.217.165 via eth2-server)
+send_user "Configuring routing for internet server on DinD host...\n"
+exec ip route replace 38.106.217.165 via 192.168.1.254
+
+# 3. Start Border Router in Docker (DUT)
+send_user "Starting OTBR Docker container...\n"
+start_otbr_docker_dind $container $::env(EXP_OT_RCP_PATH) 2 $pty1
+
+# Wait for otbr-agent to create the domain socket
+wait_for_otbr_agent [list $container]
+
+# Configure DNS nameserver of OTBR to use eth2-server's IPv4 address
+exec docker exec -i $container bash -c "echo nameserver 192.168.1.254 > /etc/resolv.conf"
+
+# Setup active dataset on OTBR via ot-ctl
+exec docker exec -i $container ot-ctl thread stop
+exec docker exec -i $container ot-ctl ifconfig down
+exec docker exec -i $container ot-ctl dataset set active ${dataset}
+exec docker exec -i $container ot-ctl ifconfig up
+exec docker exec -i $container ot-ctl thread start
+
+# Wait for OTBR to become leader
+wait_for_container_state $container "leader"
+
+# Enable NAT64 explicitly on the OTBR
+send_user "Enabling NAT64 on the OTBR...\n"
+exec docker exec -i $container ot-ctl nat64 enable
+
+# Verify NAT64 PrefixManager and Translator states are active
+set nat64_active false
+for {set i 0} {$i < 15} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl nat64 state} nat64_state]} {
+        set nat64_state [string trim $nat64_state]
+        send_user "NAT64 State (Attempt $i):\n$nat64_state\n"
+        if {[string match "*PrefixManager: Active*" $nat64_state] && [string match "*Translator: Active*" $nat64_state]} {
+            set nat64_active true
+            break
+        }
+    }
+    sleep 2
+}
+if {!$nat64_active} {
+    fail "NAT64 was not activated successfully on the Border Router"
+}
+
+# Retrieve the local NAT64 prefix from the Border Router
+set nat64_prefix ""
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl br nat64prefix local} prefix_out]} {
+        set prefix_out [string trim $prefix_out]
+        if {[regexp {([0-9a-fA-F:]+/96)} $prefix_out match prefix]} {
+            set nat64_prefix $prefix
+            break
+        }
+    }
+    sleep 2
+}
+if {$nat64_prefix == ""} {
+    fail "Failed to retrieve local NAT64 prefix from Border Router"
+}
+send_user "Discovered local NAT64 prefix: $nat64_prefix\n"
+
+# Verify NAT64 prefix length is 96 in Network Data
+set netdata_verified false
+for {set i 0} {$i < 10} {incr i} {
+    if {![catch {exec docker exec -i $container ot-ctl netdata show} netdata]} {
+        send_user "DUT Network Data (Attempt $i):\n$netdata\n"
+        # Search for routes: e.g. "fd00:db8:1:0:0:0:0:0/96 sn"
+        # Match prefix value and check prefix length field
+        if {[regexp {([0-9a-fA-F:]+)/96\s+sn} $netdata match route_prefix]} {
+            set netdata_verified true
+            break
+        }
+    }
+    sleep 2
+}
+if {!$netdata_verified} {
+    fail "NAT64 prefix in Network Data does not meet criteria (length /96)"
+}
+send_user "NAT64 prefix verified in Thread Network Data successfully.\n"
+
+# Get the running Border Router's active dataset dynamically to configure clients
+set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
+set active_dataset [lindex [split [string trim $active_dataset] "\n"] 0]
+
+# Get DUT ExtAddr
+set dut_extaddr [exec docker exec -i $container ot-ctl extaddr]
+set dut_extaddr [lindex [split [string trim $dut_extaddr] "\n"] 0]
+send_user "DUT ExtAddr: $dut_extaddr\n"
+
+# Spawn Router_1 (Node 3)
+send_user "Starting Router_1 (Node 3)...\n"
+spawn_node 3 cli $::env(EXP_OT_CLI_PATH)
+
+# Get Router_1 ExtAddr
+send "extaddr\r\n"
+expect_line "extaddr"
+set router_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "Router_1 ExtAddr: $router_extaddr\n"
+
+# Configure Router_1
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+
+# Spawn ED_1 (Node 4)
+send_user "Starting ED_1 (Node 4)...\n"
+spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
+
+# Get ED_1 ExtAddr
+send "extaddr\r\n"
+expect_line "extaddr"
+set ed_extaddr [expect_line {[0-9a-fA-F]{16}}]
+expect_line "Done"
+send_user "ED_1 ExtAddr: $ed_extaddr\n"
+
+# Configure ED_1
+send "dataset set active $active_dataset\n"
+expect_line "Done"
+send "mode rdn\r\n"
+expect_line "Done"
+send "routereligible disable\r\n"
+expect_line "Done"
+
+# Configure MAC filters to restrict topology: ED_1 (4) <-> Router_1 (3) <-> DUT (1)
+send_user "Configuring MAC filters for topology ED_1 <-> Router_1 <-> DUT...\n"
+
+# On ED_1 (Node 4), only allow Router_1 (Node 3)
+switch_node 4
+send "macfilter addr add $router_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr allowlist\r\n"
+expect_line "Done"
+
+# On Router_1 (Node 3), allow DUT and ED_1
+switch_node 3
+send "macfilter addr add $dut_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr add $ed_extaddr\r\n"
+expect_line "Done"
+send "macfilter addr allowlist\r\n"
+expect_line "Done"
+
+# On DUT (Node 1/container), only allow Router_1
+exec docker exec -i $container ot-ctl macfilter addr add $router_extaddr
+exec docker exec -i $container ot-ctl macfilter addr allowlist
+
+# Start Thread on Router_1 and wait for router state
+send_user "Starting Thread on Router_1...\n"
+switch_node 3
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "router"
+expect_line "Done"
+
+# Start Thread on ED_1 and wait for child state
+send_user "Starting Thread on ED_1...\n"
+switch_node 4
+send "ifconfig up\r\n"
+expect_line "Done"
+send "thread start\r\n"
+expect_line "Done"
+wait_for "state" "child"
+expect_line "Done"
+
+sleep 5
+
+# Retrieve DUT's RLOC address to use as DNS server on ED_1
+set otbr_rloc [get_rloc_dns_addr $container]
+send_user "OTBR RLOC IP: $otbr_rloc\n"
+
+# Configure DNS server on ED_1 (Node 4)
+switch_node 4
+send "dns config $otbr_rloc\r\n"
+expect_line "Done"
+
+# Synthesize target IPv6 addresses for DNS and ping verification
+set target_dns_ipv6 [synthesize_ipv6 $nat64_prefix "38.106.217.165"]
+set target_local_ipv6 [synthesize_ipv6 $nat64_prefix "192.168.1.4"]
+
+# Step 5-7: DNS resolution from ED_1
+send_user "Step 5-7: Resolving threadv4.org from ED_1...\n"
+send "dns resolve threadv4.org\r\n"
+set timeout 15
+set dns_resolved false
+expect {
+    -re "($target_dns_ipv6)" {
+        set dns_resolved true
+        exp_continue
+    }
+    -re "Done" {
+        # Succeeded
+    }
+    timeout {
+        fail "DNS resolution timed out"
+    }
+}
+if {!$dns_resolved} {
+    fail "DNS resolution failed to resolve threadv4.org to synthesized IPv6 address $target_dns_ipv6"
+}
+send_user "DNS resolution verified successfully.\n"
+
+# Step 8: Ping simulated Internet Server (38.106.217.165) via synthesized address
+send_user "Step 8: Verifying Ping to Internet Server ($target_dns_ipv6)...\n"
+send "ping $target_dns_ipv6 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to internet server timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Internet Server failed"
+}
+send_user "Ping to Internet Server verified successfully.\n"
+
+# Step 8a: Verify UDP ping via UDP echo server
+send_user "Step 8a: Verifying UDP communication with Internet Server...\n"
+send "udp open\r\n"
+expect_line "Done"
+send "udp connect $target_dns_ipv6 7777\r\n"
+expect_line "Done"
+send "udp send testudp\r\n"
+expect_line "Done"
+set timeout 10
+set udp_success false
+expect {
+    -re "7 bytes from .* 7777 testudp" {
+        set udp_success true
+    }
+    timeout {
+        send_user "Error: UDP echo request timed out\n"
+    }
+}
+send "udp close\r\n"
+expect_line "Done"
+if {!$udp_success} {
+    fail "UDP loopback test via NAT64 failed"
+}
+send_user "UDP loopback test verified successfully.\n"
+
+# Step 9: HTTP GET to Internet Server (threadv4.org) from ED_1
+send_user "Step 9: Verifying HTTP GET to Internet Server...\n"
+send "tcp init\r\n"
+expect_line "Done"
+send "tcp connect $target_dns_ipv6 80\r\n"
+expect_line "Done"
+expect "TCP: Connection established"
+# Send GET request (hex representation for "GET /testv4.html HTTP/1.1\r\nHost: threadv4.org\r\n\r\n")
+send "tcp send -x 474554202f7465737476342e68746d6c20485454502f312e310d0a486f73743a2074687265616476342e6f72670d0a0d0a\r\n"
+expect_line "Done"
+set timeout 15
+set http_success false
+expect {
+    -re "test-content-eth2" {
+        set http_success true
+        exp_continue
+    }
+    -re "TCP: Reached end of stream" {
+        # Done
+    }
+}
+send "tcp deinit\r\n"
+expect_line "Done"
+
+if {!$http_success} {
+    fail "HTTP GET to Internet Server failed"
+}
+send_user "HTTP GET to Internet Server verified successfully.\n"
+
+# Step 10: Ping local IPv4 server Eth_1 (192.168.1.4) via synthesized address
+send_user "Step 10: Verifying Ping to Local Host (Eth_1) works...\n"
+switch_node 4
+send "ping $target_local_ipv6 56 5\r\n"
+set timeout 15
+set ping_success false
+expect {
+    -re "bytes from" {
+        set ping_success true
+        exp_continue
+    }
+    -re "Done" {
+        # Finished
+    }
+    timeout {
+        send_user "Error: Ping to local host timed out\n"
+    }
+}
+if {!$ping_success} {
+    fail "Ping from ED_1 to Local Host failed"
+}
+send_user "Ping to Local Host verified successfully.\n"
+
+# Step 11: HTTP GET to local server Eth_1 (192.168.1.4) from ED_1
+send_user "Step 11: Verifying HTTP GET to Local Host...\n"
+send "tcp init\r\n"
+expect_line "Done"
+send "tcp connect $target_local_ipv6 80\r\n"
+expect_line "Done"
+expect "TCP: Connection established"
+# Send GET request (hex representation for "GET /test2.html HTTP/1.1\r\nHost: localv4.org\r\n\r\n")
+send "tcp send -x 474554202f74657374322e68746d6c20485454502f312e310d0a486f73743a206c6f63616c76342e6f72670d0a0d0a\r\n"
+expect_line "Done"
+set timeout 15
+set http_success false
+expect {
+    -re "test-content-eth1" {
+        set http_success true
+        exp_continue
+    }
+    -re "TCP: Reached end of stream" {
+        # Done
+    }
+}
+send "tcp deinit\r\n"
+expect_line "Done"
+
+if {!$http_success} {
+    fail "HTTP GET to Local Server failed"
+}
+send_user "HTTP GET to Local Server verified successfully.\n"
+
+# Cleanup routing
+catch { exec ip route del 38.106.217.165 }
+
+# Cleanup containers
+send_user "Tearing down containers...\n"
+dispose_all
+send_user "# IPv4 Connectivity using BR built-in NAT64 (1_4_PIC_TC_4) integration test completed successfully!\n"

--- a/tests/scripts/expect/dns_multi_question_query.py
+++ b/tests/scripts/expect/dns_multi_question_query.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2026, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import socket
+import sys
+import struct
+
+def build_query(domain):
+    # Header: ID=0x1234, Flags=0x0100 (RD=1), QDCOUNT=2, ANCOUNT=0, NSCOUNT=0, ARCOUNT=0
+    header = struct.pack('!HHHHHH', 0x1234, 0x0100, 2, 0, 0, 0)
+    
+    # Question 1: domain, QTYPE=SRV (33), QCLASS=IN (1)
+    parts = domain.strip('.').split('.')
+    q1_name = b''
+    for part in parts:
+        q1_name += bytes([len(part)]) + part.encode('ascii')
+    q1_name += b'\x00'
+    q1 = q1_name + struct.pack('!HH', 33, 1)
+    
+    # Question 2: domain (compressed pointing to offset 12), QTYPE=TXT (16), QCLASS=IN (1)
+    q2 = struct.pack('!H', 0xc00c) + struct.pack('!HH', 16, 1)
+    
+    return header + q1 + q2
+
+def parse_response(data):
+    if len(data) < 12:
+        return 'INVALID_LENGTH', 0
+    id_val, flags, qdcount, ancount, nscount, arcount = struct.unpack('!HHHHHH', data[:12])
+    rcode = flags & 0x000f
+    return rcode, ancount
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: dns_multi_question_query.py <dns_server_ip> <domain>")
+        sys.exit(1)
+        
+    server_ip = sys.argv[1]
+    domain = sys.argv[2]
+    
+    query = build_query(domain)
+    
+    # Send via UDP to port 53
+    s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    s.settimeout(5)
+    try:
+        s.sendto(query, (server_ip, 53))
+        resp, addr = s.recvfrom(512)
+    except Exception as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+        
+    rcode, ancount = parse_response(resp)
+    print(f"RCODE:{rcode}")
+    print(f"ANCOUNT:{ancount}")
+    
+    # Pass if RCODE is 1 (FormErr) or RCODE is 0 (NoError)
+    if rcode == 1:
+        print("SUCCESS")
+        sys.exit(0)
+    elif rcode == 0:
+        if ancount == 2:
+            print("SUCCESS")
+            sys.exit(0)
+        else:
+            print(f"FAILURE (Expected 2 answers, got {ancount})")
+            sys.exit(1)
+    else:
+        print(f"FAILURE (RCODE={rcode})")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tests/scripts/expect/dns_multi_question_query.py
+++ b/tests/scripts/expect/dns_multi_question_query.py
@@ -50,7 +50,7 @@ def build_query(domain):
 
 def parse_response(data):
     if len(data) < 12:
-        return 'INVALID_LENGTH', 0
+        raise ValueError("Response data too short")
     id_val, flags, qdcount, ancount, nscount, arcount = struct.unpack('!HHHHHH', data[:12])
     rcode = flags & 0x000f
     return rcode, ancount
@@ -66,16 +66,20 @@ def main():
     query = build_query(domain)
     
     # Send via UDP to port 53
-    s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-    s.settimeout(5)
-    try:
-        s.sendto(query, (server_ip, 53))
-        resp, addr = s.recvfrom(512)
-    except Exception as e:
-        print(f"ERROR: {e}")
-        sys.exit(1)
+    with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as s:
+        s.settimeout(5)
+        try:
+            s.sendto(query, (server_ip, 53))
+            resp, addr = s.recvfrom(512)
+        except Exception as e:
+            print(f"ERROR: {e}")
+            sys.exit(1)
         
-    rcode, ancount = parse_response(resp)
+    try:
+        rcode, ancount = parse_response(resp)
+    except ValueError as e:
+        print(f"FAILURE ({e})")
+        sys.exit(1)
     print(f"RCODE:{rcode}")
     print(f"ANCOUNT:{ancount}")
     

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -273,6 +273,9 @@ test_run()
 
     echo "--- Running IPv4 Connectivity using BR built-in NAT64 (1_4_PIC_TC_4) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_4.exp"
+
+    echo "--- Running Handling of multi-question DNS queries (1_4_DNS_TC_1) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_1_4_dns_tc_1.exp"
 }
 
 main()

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -141,7 +141,7 @@ test_setup()
     echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
     docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server dnsmasq python3-scapy radvd tcpdump --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["mdns-scan"]
 EOF
 
@@ -253,6 +253,9 @@ test_run()
 
     echo "--- Running Web UI integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_web.exp"
+
+    echo "--- Running IPv6 Connectivity using DHCPv6-PD (1_4_PIC_TC_1) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_1.exp"
 }
 
 main()

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -83,6 +83,7 @@ test_teardown()
     docker exec -i eth2-server cat /var/log/radvd.log || true
     docker exec -i eth2-server cat /var/log/tcpdump.log || true
     ip -6 route del 2002:1234::1234 || true
+    ip route del 38.106.217.165 || true
 
     echo "Agent logs:"
     for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web"; do
@@ -126,6 +127,11 @@ test_setup()
     echo "Adding iptables rule to allow ports 9000 to 9005 traffic..."
     iptables -I INPUT 1 -p tcp --dport 9000:9005 -j ACCEPT || true
 
+    if [[ -f "${REPO_ROOT}/ubuntu-24.04.tar" ]]; then
+        echo "Loading cached ubuntu:24.04 image..."
+        docker load -i "${REPO_ROOT}/ubuntu-24.04.tar"
+    fi
+
     # 1. Build the production Docker image
     local otbr_options="-DOTBR_DHCP6_PD=ON -DOTBR_DHCP6_PD_CLIENT=openthread"
     if [[ "$(uname)" == "Darwin" || "$(uname -r)" == *"linuxkit"* ]]; then
@@ -135,12 +141,12 @@ test_setup()
     docker build --build-arg OTBR_MDNS="${OTBR_MDNS}" --build-arg OTBR_OPTIONS="${otbr_options}" -t "${OTBR_DOCKER_IMAGE}" -f "${OTBR_DOCKER_FILE}" "${REPO_ROOT}"
 
     # 2. Create the IPv6-enabled Docker bridge network for infrastructure-link
-    if ! docker network inspect "${INFRA_NET_NAME}" >/dev/null 2>&1; then
-        echo "Creating ${INFRA_NET_NAME} Docker bridge network..."
-        docker network create --driver bridge --ipv6 --subnet fd00:db8:1::/64 "${INFRA_NET_NAME}"
-    else
-        echo "Network ${INFRA_NET_NAME} already exists."
+    if docker network inspect "${INFRA_NET_NAME}" >/dev/null 2>&1; then
+        echo "Removing existing ${INFRA_NET_NAME} Docker bridge network..."
+        docker network rm "${INFRA_NET_NAME}"
     fi
+    echo "Creating ${INFRA_NET_NAME} Docker bridge network..."
+    docker network create --driver bridge --subnet 192.168.1.0/24 --ipv6 --subnet fd00:db8:1::/64 "${INFRA_NET_NAME}"
 
     # 3. Build the test client image with mdns-scan and ping/ndisc6 tools
     echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
@@ -264,6 +270,9 @@ test_run()
 
     echo "--- Running IPv6 default route advertisement (1_4_PIC_TC_3) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_3.exp"
+
+    echo "--- Running IPv4 Connectivity using BR built-in NAT64 (1_4_PIC_TC_4) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_4.exp"
 }
 
 main()

--- a/tests/scripts/test_dind_dns_sd.sh
+++ b/tests/scripts/test_dind_dns_sd.sh
@@ -75,9 +75,14 @@ test_teardown()
     echo "Active and inactive containers:"
     docker ps -a || true
     echo "Container logs:"
-    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web" "test-client" "dhcp6-server"; do
+    for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web" "test-client" "dhcp6-server" "eth1-server" "eth2-server"; do
         docker logs "$c" || true
     done
+
+    echo "Radvd/Tcpdump logs on eth2-server:"
+    docker exec -i eth2-server cat /var/log/radvd.log || true
+    docker exec -i eth2-server cat /var/log/tcpdump.log || true
+    ip -6 route del 2002:1234::1234 || true
 
     echo "Agent logs:"
     for c in "${CONTAINER_NAME}" "otbr-test-container-1" "otbr-test-container-2" "otbr-test-container-3" "otbr-test-container-web"; do
@@ -141,7 +146,7 @@ test_setup()
     echo "Building test client image with mdns-scan and ping/ndisc6 tools..."
     docker build -t "${TEST_CLIENT_IMAGE}" - <<EOF
 FROM ubuntu:24.04
-RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server dnsmasq python3-scapy radvd tcpdump --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y mdns-scan iputils-ping ndisc6 python3-zeroconf iproute2 kea-dhcp6-server dnsmasq python3-scapy radvd tcpdump procps --no-install-recommends && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["mdns-scan"]
 EOF
 
@@ -256,6 +261,9 @@ test_run()
 
     echo "--- Running IPv6 Connectivity using DHCPv6-PD (1_4_PIC_TC_1) integration test ---"
     expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_1.exp"
+
+    echo "--- Running IPv6 default route advertisement (1_4_PIC_TC_3) integration test ---"
+    expect -df "${SCRIPT_DIR}/expect/dind_1_4_pic_tc_3.exp"
 }
 
 main()


### PR DESCRIPTION
Implement the integration test for '11.1 [1.3] [CERT] Handling of multi-question DNS queries' in the DinD framework.

- Add tests/scripts/expect/dns_multi_question_query.py, a Python helper to send DNS queries with multiple questions (QDCOUNT=2) and verify the returned RCODE (NoError or FormErr).
- Add tests/scripts/expect/dind_1_4_dns_tc_1.exp, the expect script coordinating nodes, registering services, and checking resolver outputs on simulated Thread networks.
- Integrate the expect script in tests/scripts/test_dind_dns_sd.sh.