### PR TITLE
[web] generate QR codes on webUI client instead of remote API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ src/agent/otbr-agent.conf
 src/web/otbr-web
 src/web/otbr-web.service
 src/web/otbr-web.init
+src/web/web-service/frontend/node_modules
 
 # Test code.
 tests/mdns/otbr-test-mdns

--- a/src/web/web-service/frontend/.gitignore
+++ b/src/web/web-service/frontend/.gitignore
@@ -1,2 +1,0 @@
-# Dependency directories
-node_modules/

--- a/src/web/web-service/frontend/.gitignore
+++ b/src/web/web-service/frontend/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules/

--- a/src/web/web-service/frontend/CMakeLists.txt
+++ b/src/web/web-service/frontend/CMakeLists.txt
@@ -38,6 +38,7 @@ set(NPM_JS_DEPENDENCIES
     ${CMAKE_CURRENT_BINARY_DIR}/node_modules/angular/angular.min.js
     ${CMAKE_CURRENT_BINARY_DIR}/node_modules/d3/d3.min.js
     ${CMAKE_CURRENT_BINARY_DIR}/node_modules/material-design-lite/material.min.js
+    ${CMAKE_CURRENT_BINARY_DIR}/node_modules/qrcode-generator/dist/qrcode.js
 )
 
 add_custom_target(otbr-web-frontend

--- a/src/web/web-service/frontend/CMakeLists.txt
+++ b/src/web/web-service/frontend/CMakeLists.txt
@@ -46,8 +46,11 @@ add_custom_target(otbr-web-frontend
 
 add_custom_command(OUTPUT ${NPM_CSS_DEPENDENCIES} ${NPM_JS_DEPENDENCIES}
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/package.json .
+    COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json .
     COMMAND npm install
-    DEPENDS package.json)
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/package.json
+        ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json)
 
 install(FILES index.html join.dialog.html
     DESTINATION ${OTBR_WEB_DATADIR}/frontend)

--- a/src/web/web-service/frontend/index.html
+++ b/src/web/web-service/frontend/index.html
@@ -460,6 +460,7 @@
   <script src="res/js/angular-aria.min.js"></script>
   <script src="res/js/angular-material.min.js"></script>
   <script src="res/js/angular-messages.min.js"></script>
+  <script src="res/js/qrcode.js"></script>
   <script src="res/js/app.js"></script>
   <script src="res/js/d3.min.js"></script>
 </body>

--- a/src/web/web-service/frontend/package-lock.json
+++ b/src/web/web-service/frontend/package-lock.json
@@ -20,48 +20,56 @@
       }
     },
     "node_modules/angular": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
-      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg==",
-      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.3.tgz",
+      "integrity": "sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
+      "license": "MIT"
     },
     "node_modules/angular-animate": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.6.4.tgz",
-      "integrity": "sha1-0+uQbTmDTy373Zgua416O02QAdI=",
-      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.8.3.tgz",
+      "integrity": "sha512-/LtTKvy5sD6MZbV0v+nHgOIpnFF0mrUp+j5WIxVprVhcrJriYpuCZf4S7Owj1o76De/J0eRzANUozNJ6hVepnQ==",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
+      "license": "MIT"
     },
     "node_modules/angular-aria": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.6.4.tgz",
-      "integrity": "sha1-yGg2ZqzhlmaPaOciCBG9z8nhBuQ=",
-      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.8.3.tgz",
+      "integrity": "sha512-qTXclmTW/KGw5JNKKQPcCKKq6hCBZ39jYINmLgMsjUHBAoxULaMRRTaRj/L2VTOjKvK5f9enkx+EUqRqzXDSFQ==",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
+      "license": "MIT"
     },
     "node_modules/angular-material": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.1.4.tgz",
-      "integrity": "sha1-J941ZG9UzNMgCArwxwjhtDivh/Y=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.2.5.tgz",
+      "integrity": "sha512-bTTDV0vszpfms1tAMzhLntxBiNMCk/I3Mx/vhbtfhijJILODjpDBfWah0nvWrniFIcxMLcsb1tcPri13hZEaew==",
       "deprecated": "For the actively supported Angular Material, see https://www.npmjs.com/package/@angular/material. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
+      "license": "MIT",
       "peerDependencies": {
-        "angular": ">=1.3 <1.7",
-        "angular-animate": ">=1.3 <1.7",
-        "angular-aria": ">=1.3 <1.7"
+        "angular": "^1.7.2",
+        "angular-animate": "^1.7.2",
+        "angular-aria": "^1.7.2",
+        "angular-messages": "^1.7.2"
       }
     },
     "node_modules/angular-messages": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.6.4.tgz",
-      "integrity": "sha1-nsnBOTKTsU3lQWHS+El3ZInpgP4="
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.8.3.tgz",
+      "integrity": "sha512-f/ywtg32lqzX8FnXkBJOyn13lbCbo333/xy/5TTFcsH/gZdXoiuERj+dLTOs8xHCkOeFQhFx0VD0DgtMgSag7A==",
+      "license": "MIT"
     },
     "node_modules/d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+      "integrity": "sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/material-design-lite": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
-      "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=",
+      "integrity": "sha512-ao76b0bqSTKcEMt7Pui+J/S3eVF0b3GWfuKUwfe2lP5DKlLZOwBq37e0/bXEzxrw7/SuHAuYAdoCwY6mAYhrsg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.12.0"
       }

--- a/src/web/web-service/frontend/package-lock.json
+++ b/src/web/web-service/frontend/package-lock.json
@@ -1,43 +1,76 @@
 {
   "name": "otbr-web",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "angular": {
+  "packages": {
+    "": {
+      "name": "otbr-web",
+      "version": "1.0.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "angular": "^1.8.0",
+        "angular-animate": "^1.6.4",
+        "angular-aria": "^1.6.4",
+        "angular-material": "^1.1.4",
+        "angular-messages": "^1.6.4",
+        "d3": "^3.5.17",
+        "material-design-lite": "^1.3.0",
+        "qrcode-generator": "^2.0.4"
+      }
+    },
+    "node_modules/angular": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
-      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
+      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg==",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
     },
-    "angular-animate": {
+    "node_modules/angular-animate": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.6.4.tgz",
-      "integrity": "sha1-0+uQbTmDTy373Zgua416O02QAdI="
+      "integrity": "sha1-0+uQbTmDTy373Zgua416O02QAdI=",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
     },
-    "angular-aria": {
+    "node_modules/angular-aria": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.6.4.tgz",
-      "integrity": "sha1-yGg2ZqzhlmaPaOciCBG9z8nhBuQ="
+      "integrity": "sha1-yGg2ZqzhlmaPaOciCBG9z8nhBuQ=",
+      "deprecated": "For the actively supported Angular, see https://www.npmjs.com/package/@angular/core. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward."
     },
-    "angular-material": {
+    "node_modules/angular-material": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.1.4.tgz",
-      "integrity": "sha1-J941ZG9UzNMgCArwxwjhtDivh/Y="
+      "integrity": "sha1-J941ZG9UzNMgCArwxwjhtDivh/Y=",
+      "deprecated": "For the actively supported Angular Material, see https://www.npmjs.com/package/@angular/material. AngularJS support has officially ended. For extended AngularJS support options, see https://goo.gle/angularjs-path-forward.",
+      "peerDependencies": {
+        "angular": ">=1.3 <1.7",
+        "angular-animate": ">=1.3 <1.7",
+        "angular-aria": ">=1.3 <1.7"
+      }
     },
-    "angular-messages": {
+    "node_modules/angular-messages": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.6.4.tgz",
       "integrity": "sha1-nsnBOTKTsU3lQWHS+El3ZInpgP4="
     },
-    "d3": {
+    "node_modules/d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
     },
-    "material-design-lite": {
+    "node_modules/material-design-lite": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/material-design-lite/-/material-design-lite-1.3.0.tgz",
-      "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM="
+      "integrity": "sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+      "license": "MIT"
     }
   }
 }

--- a/src/web/web-service/frontend/package.json
+++ b/src/web/web-service/frontend/package.json
@@ -15,6 +15,7 @@
     "angular-material": "^1.1.4",
     "angular-messages": "^1.6.4",
     "d3": "^3.5.17",
-    "material-design-lite": "^1.3.0"
+    "material-design-lite": "^1.3.0",
+    "qrcode-generator": "^2.0.4"
   }
 }

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -287,11 +287,20 @@
                     console.log(response);
                     $scope.res = response.data.result;
                     if (response.data.result == 'successful') {
-                        var image = "http://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=v%3D1%26%26eui%3D" + response.data.eui64 +"%26%26cc%3D" + $scope.thread.pskd +"&amp;qzone=1&amp;margin=0&amp;size=400x400&amp;ecc=L";
-                        $scope.showQRCode(event, image);
+                        try {
+                            var qrData = "v=1&&eui=" + response.data.eui64 + "&&cc=" + $scope.thread.pskd;
+                            var qr = qrcode(0, 'L');
+                            qr.addData(qrData);
+                            qr.make();
+                            var image = qr.createDataURL(10, 0);
+                            $scope.showQRCode(event, image);
+                        } catch (err) {
+                            console.error("QR Generation failed:", err);
+                            $scope.showQRAlert(event, "sorry, can not generate the QR code.");
+                        }
                     } else {
-                        $scope.showQRAlert(event, "sorry, can not generate the QR code.");
-                    }   
+                        $scope.showQRAlert(event, "sorry, server returned an error.");
+                    }
                     $scope.isDisplay = true;       
                     
                 });

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -292,7 +292,7 @@
                             var qr = qrcode(0, 'L');
                             qr.addData(qrData);
                             qr.make();
-                            var image = qr.createDataURL(10, 0);
+                            var image = qr.createDataURL(10, 2);
                             $scope.showQRCode(event, image);
                         } catch (err) {
                             console.error("QR Generation failed:", err);

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -287,11 +287,20 @@
                     console.log(response);
                     $scope.res = response.data.result;
                     if (response.data.result == 'successful') {
-                        var image = "https://api.qrserver.com/v1/create-qr-code/?color=000000&amp;bgcolor=FFFFFF&amp;data=v%3D1%26%26eui%3D" + response.data.eui64 +"%26%26cc%3D" + $scope.thread.pskd +"&amp;qzone=1&amp;margin=0&amp;size=400x400&amp;ecc=L";
-                        $scope.showQRCode(event, image);
+                        try {
+                            var qrData = "v=1&&eui=" + response.data.eui64 + "&&cc=" + $scope.thread.pskd;
+                            var qr = qrcode(0, 'L');
+                            qr.addData(qrData);
+                            qr.make();
+                            var image = qr.createDataURL(10, 0);
+                            $scope.showQRCode(event, image);
+                        } catch (err) {
+                            console.error("QR Generation failed:", err);
+                            $scope.showQRAlert(event, "sorry, can not generate the QR code.");
+                        }
                     } else {
-                        $scope.showQRAlert(event, "sorry, can not generate the QR code.");
-                    }   
+                        $scope.showQRAlert(event, "sorry, server returned an error.");
+                    }
                     $scope.isDisplay = true;       
                     
                 });


### PR DESCRIPTION
Adding one client-executed QR-code generator script to replace the `api.qrserver.com` call. It didn't seem great or necessary to send `thread.pskd` out in the existing implementation.

## Demo
<img width="1437" height="872" alt="with change" src="https://github.com/user-attachments/assets/d09f76f5-1b4f-4361-b095-0fce4f02584d" />