### PR TITLE
[github-actions] remove MATN test jobs from workflow

### DIFF
--- a/.github/workflows/border_router.yml
+++ b/.github/workflows/border_router.yml
@@ -77,20 +77,6 @@ jobs:
             otbr_mdns: "mDNSResponder"
             cert_scripts: ./tests/scripts/thread-cert/border_router/*.py
             packet_verification: 2
-          - name: "Border Router MATN (OT mDNS)"
-            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
-            border_routing: 1
-            internet: 0
-            otbr_mdns: "openthread"
-            cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py
-            packet_verification: 1
-          - name: "Border Router MATN (mDNSResponder)"
-            otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF"
-            border_routing: 1
-            internet: 0
-            otbr_mdns: "mDNSResponder"
-            cert_scripts: ./tests/scripts/thread-cert/border_router/MATN/*.py
-            packet_verification: 1
           - name: "Border Router Internet Access Features (OT mDNS)"
             otbr_options: "-DOTBR_COVERAGE=ON -DOTBR_TREL=OFF -DOTBR_DHCP6_PD=ON"
             border_routing: 1


### PR DESCRIPTION
This commit removes the MATN test jobs from the border router GitHub Actions workflow because equivalent integration tests now exist under the tests/scripts/expect directory using the docker-in-docker framework.

Specifically, the multicast forwarding and BBR tests are covered by tests/scripts/expect/dind_multicast.exp which runs in the DinD integration suite.

Equivalent tests path:
https://github.com/openthread/ot-br-posix/tree/main/tests/scripts/expect