### PR TITLE
[tests] increase ping count in TREL_TC_4 expect script

### DIFF
--- a/tests/scripts/expect/dind_trel_tc_4.exp
+++ b/tests/scripts/expect/dind_trel_tc_4.exp
@@ -228,7 +228,7 @@ if {![string match "*Enabled*" $filter_status]} {
 send_user -- "--- Step 4: Trigger TREL disconnect detection (Router pings ED) ---\n"
 # To guarantee detection of disconnect, we will ping and check preference.
 # Router tries to send over TREL to DUT, but it fails.
-for {set i 0} {$i < 25} {incr i} {
+for {set i 0} {$i < 50} {incr i} {
     catch { exec docker exec -i $container2 ot-ctl ping $ed_mleid 500 1 } ping_res
     send_user "Router ping response ($i): $ping_res\n"
     after 100


### PR DESCRIPTION
The TREL Radio Link Rediscovery through Receive integration test (1_4_TREL_TC_4) can fail in CI due to the probabilistic nature of TREL background probes.

When the Router TREL filter is enabled, it drops TREL packets, causing a deferred ack timeout and reducing TREL preference to 155. The Router then falls back to 15.4 for subsequent pings because 15.4 has a higher preference (255).

Once fallback occurs, disconnect detection relies on probabilistic TREL probes (25% chance per transmitted message). To drop the TREL preference to 0 (which the test asserts), at least 2 probe failures are required. With only 25 pings, there is a 1.16% chance that fewer than 2 probes are sent, leaving TREL preference above 0 and failing the test.

This commit increases the ping count in the disconnect detection loop from 25 to 50, dropping the failure probability to 0.002% and making the test robust in CI environments.