### PR TITLE
[dnssd] deduplicate service instance updates

### DIFF
--- a/src/trel_dnssd/trel_dnssd.cpp
+++ b/src/trel_dnssd/trel_dnssd.cpp
@@ -289,8 +289,7 @@ void TrelDnssd::OnTrelServiceInstanceAdded(const Mdns::Publisher::DiscoveredInst
     Ip6Address         selectedAddress;
     otPlatTrelPeerInfo peerInfo;
 
-    // Remove any existing TREL service instance before adding
-    OnTrelServiceInstanceRemoved(instanceName);
+    memset(&peerInfo, 0, sizeof(peerInfo));
 
     otbrLogDebug("Peer discovered: %s hostname %s addresses %zu port %d priority %d "
                  "weight %d",
@@ -330,6 +329,25 @@ void TrelDnssd::OnTrelServiceInstanceAdded(const Mdns::Publisher::DiscoveredInst
         Peer peer(aInstanceInfo.mTxtData, peerInfo.mSockAddr);
 
         VerifyOrExit(peer.mValid, otbrLogWarning("Peer %s is invalid", aInstanceInfo.mName.c_str()));
+
+        auto it = mPeers.find(instanceName);
+        if (it != mPeers.end())
+        {
+            if (it->second.Matches(peer))
+            {
+                it->second.mDiscoverTime = Clock::now();
+                ExitNow();
+            }
+
+            if (memcmp(&it->second.mExtAddr, &peer.mExtAddr, sizeof(otExtAddress)) != 0)
+            {
+                OnTrelServiceInstanceRemoved(instanceName);
+            }
+            else
+            {
+                mPeers.erase(it);
+            }
+        }
 
         otPlatTrelHandleDiscoveredPeerInfo(mHost.GetInstance(), &peerInfo);
 
@@ -386,6 +404,8 @@ exit:
 void TrelDnssd::NotifyRemovePeer(const Peer &aPeer)
 {
     otPlatTrelPeerInfo peerInfo;
+
+    memset(&peerInfo, 0, sizeof(peerInfo));
 
     peerInfo.mRemoved   = true;
     peerInfo.mTxtData   = aPeer.mTxtData.data();
@@ -466,7 +486,8 @@ uint16_t TrelDnssd::CountDuplicatePeers(const TrelDnssd::Peer &aPeer)
             continue;
         }
 
-        if (!memcmp(&entry.second.mSockAddr, &aPeer.mSockAddr, sizeof(otSockAddr)) &&
+        if ((entry.second.mSockAddr.mPort == aPeer.mSockAddr.mPort) &&
+            !memcmp(&entry.second.mSockAddr.mAddress, &aPeer.mSockAddr.mAddress, sizeof(otIp6Address)) &&
             !memcmp(&entry.second.mExtAddr, &aPeer.mExtAddr, sizeof(otExtAddress)))
         {
             count++;

--- a/src/trel_dnssd/trel_dnssd.hpp
+++ b/src/trel_dnssd/trel_dnssd.hpp
@@ -39,6 +39,7 @@
 #if OTBR_ENABLE_TREL_DNSSD
 
 #include <assert.h>
+#include <string.h>
 #include <utility>
 
 #include <openthread/instance.h>
@@ -140,6 +141,13 @@ private:
         }
 
         void ReadExtAddrFromTxtData(void);
+
+        bool Matches(const Peer &aOther) const
+        {
+            return (mSockAddr.mPort == aOther.mSockAddr.mPort) &&
+                   (memcmp(&mSockAddr.mAddress, &aOther.mSockAddr.mAddress, sizeof(otIp6Address)) == 0) &&
+                   (mTxtData == aOther.mTxtData);
+        }
 
         Clock::time_point    mDiscoverTime;
         std::vector<uint8_t> mTxtData;


### PR DESCRIPTION
When OTBR_MDNS=mDNSResponder is enabled, redundant service browse and resolve callbacks can occur for already discovered TREL peers. Because TrelDnssd::OnTrelServiceInstanceAdded unconditionally called OnTrelServiceInstanceRemoved right at the start of the function, each duplicate mDNS update triggered peer removal (kDnssdRemoved) followed by peer re-addition (kReAdded).

This continuous state cycling in OpenThread's TrelPeerTable caused unnecessary multi-radio link probing and out-of-order fragment delivery between 15.4 and TREL interfaces, leading to kErrorDuplicated drops on valid ICMPv6 Echo Reply fragments during integration tests.

Before calling OnTrelServiceInstanceRemoved, check if the peer entry already exists with identical socket address and TXT data. If unchanged, update mDiscoverTime and exit without triggering peer removal or re-addition in OpenThread.