### PR TITLE
[docker] add die function in setup-host

### DIFF
--- a/etc/docker/border-router/setup-host
+++ b/etc/docker/border-router/setup-host
@@ -40,7 +40,7 @@ readonly SYSCTL_IP_FORWARD_FILE
 
 die()
 {
-    echo -e "${*}" 1>&2
+    echo >&2 "ERROR: $*"
     exit 1
 }
 

--- a/etc/docker/border-router/setup-host
+++ b/etc/docker/border-router/setup-host
@@ -38,6 +38,12 @@ readonly SYSCTL_ACCEPT_RA_FILE
 SYSCTL_IP_FORWARD_FILE="/etc/sysctl.d/60-otbr-ip-forward.conf"
 readonly SYSCTL_IP_FORWARD_FILE
 
+die()
+{
+    echo -e "${*}" 1>&2
+    exit 1
+}
+
 accept_ra_install()
 {
     sudo tee $SYSCTL_ACCEPT_RA_FILE <<EOF


### PR DESCRIPTION
Adding the function `die` prevents accidentally running the `die` binary
(if the `die` binary exists in the PATH) and also avoids printing the
confusing error message "die: command not found" (if the `die` binary
does not exist in the PATH).

Resolves https://github.com/openthread/ot-br-posix/issues/3451