### PR TITLE
[rest] avoid variable-length array in Bytes2HexJson

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -143,10 +143,7 @@ static cJSON *MeshChildrenIp62Json(const std::vector<DeviceIp6Addrs> &aChildrenI
 
 static cJSON *Bytes2HexJson(const uint8_t *aBytes, uint8_t aLength)
 {
-    char hex[2 * aLength + 1];
-
-    otbr::Utils::Bytes2Hex(aBytes, aLength, hex);
-    hex[2 * aLength] = '\0';
+    std::string hex = otbr::Utils::Bytes2Hex(aBytes, aLength);
 
     return cJSON_CreateString(StringUtils::ToLowercase(hex).c_str());
 }


### PR DESCRIPTION
In C++, variable-length arrays (VLAs) such as `char hex[2 * aLength + 1]` are a non-standard C99 extension that triggers -Wvla-cxx-extension warnings/errors when building with Clang under -Werror.

This commit replaces the VLA buffer in Bytes2HexJson with otbr::Utils::Bytes2Hex(aBytes, aLength), which returns a std::string. This ensures standard C++ compliance and resolves Clang build errors.