### PR TITLE
[border-router] handle DHCPv6-PD socket setup failure gracefully

### DIFF
--- a/src/common/api_strings.cpp
+++ b/src/common/api_strings.cpp
@@ -77,6 +77,11 @@ std::string GetDhcp6PdStateName(otBorderRoutingDhcp6PdState aState)
         stateName = OTBR_DHCP6_PD_STATE_NAME_IDLE;
         break;
 #endif
+#if OPENTHREAD_API_VERSION >= 614
+    case OT_BORDER_ROUTING_DHCP6_PD_STATE_ERROR:
+        stateName = OTBR_DHCP6_PD_STATE_NAME_ERROR;
+        break;
+#endif
     }
 
     return stateName;

--- a/src/common/api_strings.hpp
+++ b/src/common/api_strings.hpp
@@ -52,6 +52,7 @@
 #define OTBR_DHCP6_PD_STATE_NAME_STOPPED "stopped"
 #define OTBR_DHCP6_PD_STATE_NAME_RUNNING "running"
 #define OTBR_DHCP6_PD_STATE_NAME_IDLE "idle"
+#define OTBR_DHCP6_PD_STATE_NAME_ERROR "error"
 #endif
 
 #define OTBR_COMMISSIONER_STATE_NAME_DISABLED "disabled"

--- a/tests/gtest/fake_posix_platform.cpp
+++ b/tests/gtest/fake_posix_platform.cpp
@@ -110,11 +110,13 @@ void otPlatMdnsSendUnicast(otInstance *aInstance, otMessage *aMessage, const otP
     OT_UNUSED_VARIABLE(aAddress);
 }
 
-void otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
+otError otPlatInfraIfDhcp6PdClientSetListeningEnabled(otInstance *aInstance, bool aEnable, uint32_t aInfraIfIndex)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aEnable);
     OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+    return OT_ERROR_NONE;
 }
 
 void otPlatInfraIfDhcp6PdClientSend(otInstance   *aInstance,


### PR DESCRIPTION
This commit updates OTBR for graceful DHCPv6-PD socket setup failure handling in OpenThread:

1. Adds OTBR_DHCP6_PD_STATE_NAME_ERROR string representation in src/common/api_strings.hpp and guards case handling in src/common/api_strings.cpp with OPENTHREAD_API_VERSION >= 614.
2. Updates otPlatInfraIfDhcp6PdClientSetListeningEnabled return type to otError in tests/gtest/fake_posix_platform.cpp.