### PR TITLE
[utils] add nullptr guards to Bytes2Hex overloads

### DIFF
--- a/src/utils/hex.cpp
+++ b/src/utils/hex.cpp
@@ -38,6 +38,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "common/code_utils.hpp"
+
 namespace otbr {
 
 namespace Utils {
@@ -94,31 +96,37 @@ int Hex2Bytes(const char *aHex, uint8_t *aBytes, uint16_t aBytesLength)
 
 size_t Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength, char *aHex)
 {
-    char byteHex[3];
+    static const char kHexChars[] = "0123456789ABCDEF";
+    size_t            len         = 0;
 
-    // Make sure strcat appends at the beginning of the output buffer even
-    // if uninitialized.
+    VerifyOrExit(aHex != nullptr);
+
     aHex[0] = '\0';
 
-    for (int i = 0; i < aBytesLength; i++)
-    {
-        snprintf(byteHex, sizeof(byteHex), "%02X", aBytes[i]);
-        strcat(aHex, byteHex);
-    }
+    VerifyOrExit(aBytes != nullptr);
 
-    return strlen(aHex);
+    for (uint16_t i = 0; i < aBytesLength; i++)
+    {
+        aHex[len++] = kHexChars[aBytes[i] >> 4];
+        aHex[len++] = kHexChars[aBytes[i] & 0x0F];
+    }
+    aHex[len] = '\0';
+
+exit:
+    return len;
 }
 
 std::string Bytes2Hex(const uint8_t *aBytes, const uint16_t aBytesLength)
 {
-    char       *hex = new char[2 * aBytesLength + 1];
     std::string s;
-    size_t      len;
 
-    len = Bytes2Hex(aBytes, aBytesLength, hex);
-    s   = std::string(hex, len);
-    delete[] hex;
+    VerifyOrExit(aBytes != nullptr && aBytesLength > 0);
 
+    s.resize(2 * aBytesLength + 1);
+    Bytes2Hex(aBytes, aBytesLength, &s[0]);
+    s.resize(2 * aBytesLength);
+
+exit:
     return s;
 }
 

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(otbr-gtest-unit
     test_async_task.cpp
     test_common_types.cpp
     test_dns_utils.cpp
+    test_hex.cpp
     test_logging.cpp
     test_once_callback.cpp
     test_pskc.cpp

--- a/tests/gtest/test_hex.cpp
+++ b/tests/gtest/test_hex.cpp
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "utils/hex.hpp"
+
+TEST(Hex, Bytes2HexBuffer)
+{
+    const uint8_t bytes[] = {0x12, 0x34, 0xab, 0xcd, 0xef, 0x00, 0xff};
+    char          hexBuf[2 * sizeof(bytes) + 1];
+
+    EXPECT_EQ(otbr::Utils::Bytes2Hex(nullptr, sizeof(bytes), hexBuf), 0u);
+    EXPECT_STREQ(hexBuf, "");
+
+    EXPECT_EQ(otbr::Utils::Bytes2Hex(bytes, 0, hexBuf), 0u);
+    EXPECT_STREQ(hexBuf, "");
+
+    EXPECT_EQ(otbr::Utils::Bytes2Hex(bytes, sizeof(bytes), nullptr), 0u);
+
+    size_t len = otbr::Utils::Bytes2Hex(bytes, sizeof(bytes), hexBuf);
+    EXPECT_EQ(len, 14u);
+    EXPECT_STREQ(hexBuf, "1234ABCDEF00FF");
+}
+
+TEST(Hex, Bytes2HexString)
+{
+    const uint8_t bytes[] = {0x12, 0x34, 0xab, 0xcd, 0xef, 0x00, 0xff};
+
+    EXPECT_EQ(otbr::Utils::Bytes2Hex(nullptr, sizeof(bytes)), "");
+    EXPECT_EQ(otbr::Utils::Bytes2Hex(bytes, 0), "");
+
+    std::string hexStr = otbr::Utils::Bytes2Hex(bytes, sizeof(bytes));
+    EXPECT_EQ(hexStr, "1234ABCDEF00FF");
+}


### PR DESCRIPTION
This commit adds nullptr checks to otbr::Utils::Bytes2Hex overloads in src/utils/hex.cpp using VerifyOrExit and the exit: label convention to handle null pointers safely across the codebase.