### PR TITLE
[web] add ePSKc (Thread 1.4 Credentials Sharing) support to the web GUI

### DIFF
--- a/src/web/web-service/frontend/index.html
+++ b/src/web/web-service/frontend/index.html
@@ -450,6 +450,43 @@
 
 
         </div>
+        <div class="demo-charts mdl-color--white  mdl-cell mdl-cell--12-col mdl-shadow--2dp mdl-grid" ng-show="menu[7].show">
+          <h4>Ephemeral Key (ePSKc) Credential Sharing</h4>
+            <md-content layout-padding flex="100">
+              <div layout="row" layout-align="start center">
+                <span class="status-title">&nbsp;&nbsp;Feature:&nbsp;</span>
+                <md-switch ng-model="epskc.enabled" ng-change="toggleEpskcEnabled()" aria-label="Enable ePSKc">
+                  {{ epskc.enabled ? 'Enabled' : 'Disabled' }}
+                </md-switch>
+              </div>
+              <div>
+                <span class="status-title">&nbsp;&nbsp;Session state:&nbsp;</span>
+                <span class="status-content">{{ epskc.state }}</span>
+              </div>
+
+              <form name="epskcForm" ng-if="!epskc.active">
+                <md-input-container flex="50">
+                  <label>Lifetime (minutes, 2 default, 10 max)</label>
+                  <input name="lifetimeMinutes" type="number" min="1" max="10" ng-model="epskc.lifetimeMinutes" placeholder="use router default">
+                  <div ng-messages="epskcForm.lifetimeMinutes.$error">
+                    <div ng-message-exp="['min', 'max']">Lifetime must be between 1 and 10 minutes.</div>
+                  </div>
+                </md-input-container>
+                <div>
+                  <md-button name="activateEpskcButton" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" ng-disabled="!epskc.enabled || isEpskcBusy || epskcForm.$invalid" ng-click="activateEpskc($event)">Activate</md-button>
+                </div>
+              </form>
+
+              <div ng-if="epskc.tap" class="epskc-tap-display">
+                <h3>TAP Code</h3>
+                <input readonly class="epskc-tap-code" ng-value="epskc.tap" ng-click="selectEpskcTap($event)">
+              </div>
+
+              <div ng-if="epskc.active">
+                <md-button name="deactivateEpskcButton" class="mdl-button mdl-js-button mdl-button--raised" ng-disabled="isEpskcBusy" ng-click="deactivateEpskc($event)">Deactivate</md-button>
+              </div>
+            </md-content>
+        </div>
       </div>
     </main>
   </div>

--- a/src/web/web-service/frontend/index.html
+++ b/src/web/web-service/frontend/index.html
@@ -450,6 +450,40 @@
 
 
         </div>
+        <div class="demo-charts mdl-color--white  mdl-cell mdl-cell--12-col mdl-shadow--2dp mdl-grid" ng-show="menu[7].show">
+          <h4>Ephemeral Key (ePSKc) Credential Sharing</h4>
+            <md-content layout-padding flex="100">
+              <div layout="row" layout-align="start center">
+                <span class="status-title">&nbsp&nbspFeature:&nbsp</span>
+                <md-switch ng-model="epskc.enabled" ng-change="toggleEpskcEnabled()" aria-label="Enable ePSKc">
+                  {{ epskc.enabled ? 'Enabled' : 'Disabled' }}
+                </md-switch>
+              </div>
+              <div>
+                <span class="status-title">&nbsp&nbspSession state:&nbsp</span>
+                <span class="status-content">{{ epskc.state }}</span>
+              </div>
+
+              <form name="epskcForm" ng-if="!epskc.active">
+                <md-input-container flex="50">
+                  <label>Lifetime (minutes, optional)</label>
+                  <input name="lifetimeMinutes" type="number" min="0" ng-model="epskc.lifetimeMinutes" placeholder="use router default">
+                </md-input-container>
+                <div>
+                  <md-button name="activateEpskcButton" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" ng-disabled="!epskc.enabled" ng-click="activateEpskc($event)">Activate</md-button>
+                </div>
+              </form>
+
+              <div ng-if="epskc.tap" class="epskc-tap-display">
+                <h3>TAP Code</h3>
+                <input readonly class="epskc-tap-code" ng-value="epskc.tap" ng-click="selectEpskcTap($event)">
+              </div>
+
+              <div ng-if="epskc.active">
+                <md-button name="deactivateEpskcButton" class="mdl-button mdl-js-button mdl-button--raised" ng-click="deactivateEpskc($event)">Deactivate</md-button>
+              </div>
+            </md-content>
+        </div>
       </div>
     </main>
   </div>

--- a/src/web/web-service/frontend/res/css/styles.css
+++ b/src/web/web-service/frontend/res/css/styles.css
@@ -48,6 +48,14 @@ text {
     color: grey;
 }
 
+.epskc-tap-code {
+    font-size: 32px;
+    font-family: monospace;
+    letter-spacing: 4px;
+    text-align: center;
+    width: 100%;
+}
+
 .tooltip {
     border: 2px solid #7d807d;
     padding: 10px;

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -86,6 +86,11 @@
                 icon: 'add_circle_outline',
                 show: false,
             },
+            {
+                title: 'ePSKc',
+                icon: 'vpn_key',
+                show: false,
+            },
 
         ];
 
@@ -108,6 +113,36 @@
         $scope.headerTitle = 'Home';
         $scope.status = [];
 
+        $scope.epskc = {
+            enabled: false,
+            state: 'unknown',
+            active: false,
+            tap: '',
+            port: null,
+            lifetimeMinutes: null,
+        };
+        $scope.isEpskcBusy = false;
+
+        // Polls epskc_status while the ePSKc panel is visible, so the UI reflects a session
+        // that times out or gets accepted/stopped on the device without any local user action.
+        var epskcStatusPoll = null;
+        var startEpskcStatusPoll = function() {
+            if (epskcStatusPoll) {
+                return;
+            }
+            epskcStatusPoll = $interval(function() {
+                $scope.refreshEpskcStatus(/* suppressAlert */ true);
+            }, 4000);
+        };
+        var stopEpskcStatusPoll = function() {
+            if (!epskcStatusPoll) {
+                return;
+            }
+            $interval.cancel(epskcStatusPoll);
+            epskcStatusPoll = null;
+        };
+        $scope.$on('$destroy', stopEpskcStatusPoll);
+
         $scope.isLoading = false;
 
         $scope.showScanAlert = function(ev) {
@@ -124,7 +159,7 @@
         };
         $scope.showPanels = async function(index) {
             $scope.headerTitle = $scope.menu[index].title;
-            for (var i = 0; i < 7; i++) {
+            for (var i = 0; i < $scope.menu.length; i++) {
                 $scope.menu[i].show = false;
             }
             $scope.menu[index].show = true;
@@ -164,6 +199,12 @@
 
                 await $scope.dataInit();
                 await $scope.showTopology();
+            }
+            if (index == 7) {
+                $scope.refreshEpskcStatus();
+                startEpskcStatusPoll();
+            } else {
+                stopEpskcStatusPoll();
             }
         };
 
@@ -445,6 +486,97 @@
                 }
                 ev.target.disabled = false;
             });
+        };
+
+        // When called from the background status poll, pass suppressAlert=true so a transient
+        // failure (daemon not running/uninitialized/busy) doesn't pop a modal every 4 seconds.
+        $scope.refreshEpskcStatus = function(suppressAlert) {
+            $http.get('epskc_status').then(function(response) {
+                if (response.data.error == 0) {
+                    $scope.epskc.enabled = response.data.enabled;
+                    $scope.epskc.state = response.data.state;
+                    $scope.epskc.active = response.data.active;
+                    $scope.epskc.port = response.data.port;
+                    if (!response.data.active) {
+                        $scope.epskc.tap = '';
+                    }
+                } else if (!suppressAlert) {
+                    $scope.showAlert(null, 'ePSKc Status', 'failed');
+                }
+            }, function() {
+                if (!suppressAlert) {
+                    $scope.showAlert(null, 'ePSKc Status', 'failed');
+                }
+            });
+        };
+
+        $scope.toggleEpskcEnabled = function() {
+            var data = {
+                enabled: $scope.epskc.enabled,
+            };
+            $http({
+                method: 'POST',
+                url: 'epskc_enabled',
+                data: data,
+            }).then(function(response) {
+                if (response.data.error != 0) {
+                    $scope.epskc.enabled = !$scope.epskc.enabled; // revert the switch on failure
+                    $scope.showAlert(null, 'ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            }, function() {
+                $scope.epskc.enabled = !$scope.epskc.enabled; // revert the switch on failure
+                $scope.showAlert(null, 'ePSKc', 'failed');
+            });
+        };
+
+        $scope.activateEpskc = function(ev) {
+            var data = {};
+            if ($scope.epskc.lifetimeMinutes) {
+                data.lifetime = $scope.epskc.lifetimeMinutes * 60 * 1000;
+            }
+            $scope.isEpskcBusy = true;
+            $http({
+                method: 'POST',
+                url: 'epskc_activate',
+                data: data,
+            }).then(function(response) {
+                if (response.data.error == 0) {
+                    $scope.epskc.tap = response.data.tap;
+                    $scope.epskc.port = response.data.port;
+                    $scope.showAlert(ev, 'Activate ePSKc', 'success');
+                } else {
+                    $scope.showAlert(ev, 'Activate ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            }, function() {
+                $scope.showAlert(ev, 'Activate ePSKc', 'failed');
+            }).finally(function() {
+                $scope.isEpskcBusy = false;
+            });
+        };
+
+        $scope.deactivateEpskc = function(ev) {
+            $scope.isEpskcBusy = true;
+            $http({
+                method: 'POST',
+                url: 'epskc_deactivate',
+                data: {},
+            }).then(function(response) {
+                $scope.epskc.tap = '';
+                if (response.data.error != 0) {
+                    $scope.showAlert(ev, 'Deactivate ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            }, function() {
+                $scope.showAlert(ev, 'Deactivate ePSKc', 'failed');
+            }).finally(function() {
+                $scope.isEpskcBusy = false;
+            });
+        };
+
+        $scope.selectEpskcTap = function(ev) {
+            ev.target.select();
         };
 
         $scope.restServerPort = '8081';

--- a/src/web/web-service/frontend/res/js/app.js
+++ b/src/web/web-service/frontend/res/js/app.js
@@ -86,6 +86,11 @@
                 icon: 'add_circle_outline',
                 show: false,
             },
+            {
+                title: 'ePSKc',
+                icon: 'vpn_key',
+                show: false,
+            },
 
         ];
 
@@ -108,6 +113,15 @@
         $scope.headerTitle = 'Home';
         $scope.status = [];
 
+        $scope.epskc = {
+            enabled: false,
+            state: 'unknown',
+            active: false,
+            tap: '',
+            port: null,
+            lifetimeMinutes: null,
+        };
+
         $scope.isLoading = false;
 
         $scope.showScanAlert = function(ev) {
@@ -124,7 +138,7 @@
         };
         $scope.showPanels = async function(index) {
             $scope.headerTitle = $scope.menu[index].title;
-            for (var i = 0; i < 7; i++) {
+            for (var i = 0; i < $scope.menu.length; i++) {
                 $scope.menu[i].show = false;
             }
             $scope.menu[index].show = true;
@@ -164,6 +178,9 @@
 
                 await $scope.dataInit();
                 await $scope.showTopology();
+            }
+            if (index == 7) {
+                $scope.refreshEpskcStatus();
             }
         };
 
@@ -436,6 +453,82 @@
                 }
                 ev.target.disabled = false;
             });
+        };
+
+        $scope.refreshEpskcStatus = function() {
+            $http.get('epskc_status').then(function(response) {
+                if (response.data.error == 0) {
+                    $scope.epskc.enabled = response.data.enabled;
+                    $scope.epskc.state = response.data.state;
+                    $scope.epskc.active = response.data.active;
+                    $scope.epskc.port = response.data.port;
+                    if (!response.data.active) {
+                        $scope.epskc.tap = '';
+                    }
+                } else {
+                    $scope.showAlert(null, 'ePSKc Status', 'failed');
+                }
+            });
+        };
+
+        $scope.toggleEpskcEnabled = function() {
+            var data = {
+                enabled: $scope.epskc.enabled,
+            };
+            $http({
+                method: 'POST',
+                url: 'epskc_enabled',
+                data: data,
+            }).then(function(response) {
+                if (response.data.error != 0) {
+                    $scope.epskc.enabled = !$scope.epskc.enabled; // revert the switch on failure
+                    $scope.showAlert(null, 'ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            });
+        };
+
+        $scope.activateEpskc = function(ev) {
+            var data = {};
+            if ($scope.epskc.lifetimeMinutes) {
+                data.lifetime = $scope.epskc.lifetimeMinutes * 60 * 1000;
+            }
+            ev.target.disabled = true;
+            $http({
+                method: 'POST',
+                url: 'epskc_activate',
+                data: data,
+            }).then(function(response) {
+                ev.target.disabled = false;
+                if (response.data.error == 0) {
+                    $scope.epskc.tap = response.data.tap;
+                    $scope.epskc.port = response.data.port;
+                    $scope.showAlert(ev, 'Activate ePSKc', 'success');
+                } else {
+                    $scope.showAlert(ev, 'Activate ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            });
+        };
+
+        $scope.deactivateEpskc = function(ev) {
+            ev.target.disabled = true;
+            $http({
+                method: 'POST',
+                url: 'epskc_deactivate',
+                data: {},
+            }).then(function(response) {
+                ev.target.disabled = false;
+                $scope.epskc.tap = '';
+                if (response.data.error != 0) {
+                    $scope.showAlert(ev, 'Deactivate ePSKc', 'failed');
+                }
+                $scope.refreshEpskcStatus();
+            });
+        };
+
+        $scope.selectEpskcTap = function(ev) {
+            ev.target.select();
         };
 
         $scope.restServerPort = '8081';

--- a/src/web/web-service/web_server.cpp
+++ b/src/web/web-service/web_server.cpp
@@ -51,6 +51,10 @@
 #define OT_GET_QRCODE_PATH "^/get_qrcode$"
 #define OT_SET_NETWORK_PATH "^/settings$"
 #define OT_COMMISSIONER_START_PATH "^/commission$"
+#define OT_EPSKC_STATUS_PATH "^/epskc_status$"
+#define OT_EPSKC_ENABLED_PATH "^/epskc_enabled$"
+#define OT_EPSKC_ACTIVATE_PATH "^/epskc_activate$"
+#define OT_EPSKC_DEACTIVATE_PATH "^/epskc_deactivate$"
 #define OT_GET_REST_API_INFO_PATH "^/get_rest_api_info$"
 #define OT_REQUEST_METHOD_GET "GET"
 #define OT_REQUEST_METHOD_POST "POST"
@@ -116,6 +120,10 @@ otbrError WebServer::StartWebServer(const char *aIfName, const char *aListenAddr
     ResponseGetStatus();
     ResponseGetAvailableNetwork();
     ResponseCommission();
+    ResponseGetEpskcStatus();
+    ResponseSetEpskcEnabled();
+    ResponseActivateEpskc();
+    ResponseDeactivateEpskc();
     ResponseGetRestApiInfo();
     mServer.set_mount_point("/", WEB_FILE_PATH);
 
@@ -261,6 +269,38 @@ void WebServer::ResponseCommission(void)
     });
 }
 
+void WebServer::ResponseGetEpskcStatus(void)
+{
+    mServer.Get(OT_EPSKC_STATUS_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleGetEpskcStatusRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseSetEpskcEnabled(void)
+{
+    mServer.Post(OT_EPSKC_ENABLED_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleSetEpskcEnabledRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseActivateEpskc(void)
+{
+    mServer.Post(OT_EPSKC_ACTIVATE_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleActivateEpskcRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseDeactivateEpskc(void)
+{
+    mServer.Post(OT_EPSKC_DEACTIVATE_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleDeactivateEpskcRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
 std::string WebServer::HandleJoinNetworkRequest(const std::string &aJoinRequest)
 {
     return mWpanService.HandleJoinNetworkRequest(aJoinRequest);
@@ -302,6 +342,28 @@ std::string WebServer::HandleGetAvailableNetworkResponse(const std::string &aGet
 std::string WebServer::HandleCommission(const std::string &aCommissionRequest)
 {
     return mWpanService.HandleCommission(aCommissionRequest);
+}
+
+std::string WebServer::HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest)
+{
+    OTBR_UNUSED_VARIABLE(aGetEpskcStatusRequest);
+    return mWpanService.HandleGetEpskcStatusRequest();
+}
+
+std::string WebServer::HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest)
+{
+    return mWpanService.HandleSetEpskcEnabledRequest(aSetEpskcEnabledRequest);
+}
+
+std::string WebServer::HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest)
+{
+    return mWpanService.HandleActivateEpskcRequest(aActivateEpskcRequest);
+}
+
+std::string WebServer::HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest)
+{
+    OTBR_UNUSED_VARIABLE(aDeactivateEpskcRequest);
+    return mWpanService.HandleDeactivateEpskcRequest();
 }
 
 void WebServer::ResponseGetRestApiInfo(void)

--- a/src/web/web-service/web_server.cpp
+++ b/src/web/web-service/web_server.cpp
@@ -51,6 +51,10 @@
 #define OT_GET_QRCODE_PATH "^/get_qrcode$"
 #define OT_SET_NETWORK_PATH "^/settings$"
 #define OT_COMMISSIONER_START_PATH "^/commission$"
+#define OT_EPSKC_STATUS_PATH "^/epskc_status$"
+#define OT_EPSKC_ENABLED_PATH "^/epskc_enabled$"
+#define OT_EPSKC_ACTIVATE_PATH "^/epskc_activate$"
+#define OT_EPSKC_DEACTIVATE_PATH "^/epskc_deactivate$"
 #define OT_GET_REST_API_INFO_PATH "^/get_rest_api_info$"
 #define OT_REQUEST_METHOD_GET "GET"
 #define OT_REQUEST_METHOD_POST "POST"
@@ -116,6 +120,10 @@ otbrError WebServer::StartWebServer(const char *aIfName, const char *aListenAddr
     ResponseGetStatus();
     ResponseGetAvailableNetwork();
     ResponseCommission();
+    ResponseGetEpskcStatus();
+    ResponseSetEpskcEnabled();
+    ResponseActivateEpskc();
+    ResponseDeactivateEpskc();
     ResponseGetRestApiInfo();
     mServer.set_mount_point("/", WEB_FILE_PATH);
 
@@ -197,6 +205,34 @@ std::string WebServer::HandleCommission(const std::string &aCommissionRequest, v
     return webServer->HandleCommission(aCommissionRequest);
 }
 
+std::string WebServer::HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest, void *aUserData)
+{
+    WebServer *webServer = static_cast<WebServer *>(aUserData);
+
+    return webServer->HandleGetEpskcStatusRequest(aGetEpskcStatusRequest);
+}
+
+std::string WebServer::HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest, void *aUserData)
+{
+    WebServer *webServer = static_cast<WebServer *>(aUserData);
+
+    return webServer->HandleSetEpskcEnabledRequest(aSetEpskcEnabledRequest);
+}
+
+std::string WebServer::HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest, void *aUserData)
+{
+    WebServer *webServer = static_cast<WebServer *>(aUserData);
+
+    return webServer->HandleActivateEpskcRequest(aActivateEpskcRequest);
+}
+
+std::string WebServer::HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest, void *aUserData)
+{
+    WebServer *webServer = static_cast<WebServer *>(aUserData);
+
+    return webServer->HandleDeactivateEpskcRequest(aDeactivateEpskcRequest);
+}
+
 void WebServer::ResponseJoinNetwork(void)
 {
     mServer.Post(OT_JOIN_NETWORK_PATH, [this](const Request &aRequest, Response &aResponse) {
@@ -261,6 +297,38 @@ void WebServer::ResponseCommission(void)
     });
 }
 
+void WebServer::ResponseGetEpskcStatus(void)
+{
+    mServer.Get(OT_EPSKC_STATUS_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleGetEpskcStatusRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseSetEpskcEnabled(void)
+{
+    mServer.Post(OT_EPSKC_ENABLED_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleSetEpskcEnabledRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseActivateEpskc(void)
+{
+    mServer.Post(OT_EPSKC_ACTIVATE_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleActivateEpskcRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
+void WebServer::ResponseDeactivateEpskc(void)
+{
+    mServer.Post(OT_EPSKC_DEACTIVATE_PATH, [this](const Request &aRequest, Response &aResponse) {
+        auto body = HandleDeactivateEpskcRequest(aRequest.body);
+        aResponse.set_content(body, OT_RESPONSE_HEADER_TYPE);
+    });
+}
+
 std::string WebServer::HandleJoinNetworkRequest(const std::string &aJoinRequest)
 {
     return mWpanService.HandleJoinNetworkRequest(aJoinRequest);
@@ -302,6 +370,28 @@ std::string WebServer::HandleGetAvailableNetworkResponse(const std::string &aGet
 std::string WebServer::HandleCommission(const std::string &aCommissionRequest)
 {
     return mWpanService.HandleCommission(aCommissionRequest);
+}
+
+std::string WebServer::HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest)
+{
+    OTBR_UNUSED_VARIABLE(aGetEpskcStatusRequest);
+    return mWpanService.HandleGetEpskcStatusRequest();
+}
+
+std::string WebServer::HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest)
+{
+    return mWpanService.HandleSetEpskcEnabledRequest(aSetEpskcEnabledRequest);
+}
+
+std::string WebServer::HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest)
+{
+    return mWpanService.HandleActivateEpskcRequest(aActivateEpskcRequest);
+}
+
+std::string WebServer::HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest)
+{
+    OTBR_UNUSED_VARIABLE(aDeactivateEpskcRequest);
+    return mWpanService.HandleDeactivateEpskcRequest();
 }
 
 void WebServer::ResponseGetRestApiInfo(void)

--- a/src/web/web-service/web_server.hpp
+++ b/src/web/web-service/web_server.hpp
@@ -107,6 +107,10 @@ private:
     std::string HandleGetStatusRequest(const std::string &aGetStatusRequest);
     std::string HandleGetAvailableNetworkResponse(const std::string &aGetAvailableNetworkRequest);
     std::string HandleCommission(const std::string &aCommissionRequest);
+    std::string HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest);
+    std::string HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest);
+    std::string HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest);
+    std::string HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest);
 
     void HandleHttpRequest(const char *aUrl, const char *aMethod, HttpRequestCallback aCallback);
     void ResponseGetQRCode(void);
@@ -118,6 +122,10 @@ private:
     void ResponseGetAvailableNetwork(void);
     void DefaultHttpResponse(void);
     void ResponseCommission(void);
+    void ResponseGetEpskcStatus(void);
+    void ResponseSetEpskcEnabled(void);
+    void ResponseActivateEpskc(void);
+    void ResponseDeactivateEpskc(void);
     void ResponseGetRestApiInfo(void);
 
     void Init(void);

--- a/src/web/web-service/web_server.hpp
+++ b/src/web/web-service/web_server.hpp
@@ -98,6 +98,10 @@ private:
     static std::string HandleGetAvailableNetworkResponse(const std::string &aGetAvailableNetworkRequest,
                                                          void              *aUserData);
     static std::string HandleCommission(const std::string &aCommissionRequest, void *aUserData);
+    static std::string HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest, void *aUserData);
+    static std::string HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest, void *aUserData);
+    static std::string HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest, void *aUserData);
+    static std::string HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest, void *aUserData);
 
     std::string HandleJoinNetworkRequest(const std::string &aJoinRequest);
     std::string HandleGetQRCodeRequest(const std::string &aGetQRCodeRequest);
@@ -107,6 +111,10 @@ private:
     std::string HandleGetStatusRequest(const std::string &aGetStatusRequest);
     std::string HandleGetAvailableNetworkResponse(const std::string &aGetAvailableNetworkRequest);
     std::string HandleCommission(const std::string &aCommissionRequest);
+    std::string HandleGetEpskcStatusRequest(const std::string &aGetEpskcStatusRequest);
+    std::string HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest);
+    std::string HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest);
+    std::string HandleDeactivateEpskcRequest(const std::string &aDeactivateEpskcRequest);
 
     void HandleHttpRequest(const char *aUrl, const char *aMethod, HttpRequestCallback aCallback);
     void ResponseGetQRCode(void);
@@ -118,6 +126,10 @@ private:
     void ResponseGetAvailableNetwork(void);
     void DefaultHttpResponse(void);
     void ResponseCommission(void);
+    void ResponseGetEpskcStatus(void);
+    void ResponseSetEpskcEnabled(void);
+    void ResponseActivateEpskc(void);
+    void ResponseDeactivateEpskc(void);
     void ResponseGetRestApiInfo(void);
 
     void Init(void);

--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -35,6 +35,8 @@
 
 #include "web/web-service/wpan_service.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <sstream>
 
 #include <inttypes.h>
@@ -607,6 +609,185 @@ exit:
     }
     response = Json::writeString(writerBuilder, root);
 
+    return response;
+}
+
+std::string WpanService::toLower(const std::string &aStr)
+{
+    std::string result = aStr;
+
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    return result;
+}
+
+std::string WpanService::HandleGetEpskcStatusRequest(void)
+{
+    Json::Value                 root;
+    Json::StreamWriterBuilder   writerBuilder;
+    std::string                 response;
+    std::string                 state;
+    int                         ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient client(mIfName);
+    char                       *rval;
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
+    state = toLower(rval);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey port")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret == kWpanStatus_Ok)
+    {
+        root["enabled"] = (state != "disabled");
+        root["active"]  = (state == "started" || state == "connected" || state == "accepted");
+        root["state"]   = state;
+        root["port"]    = atoi(rval);
+    }
+    else
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest)
+{
+    Json::Value                       root;
+    Json::CharReaderBuilder           readerBuilder;
+    std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
+    Json::StreamWriterBuilder         writerBuilder;
+    std::string                       response;
+    bool                              enabled;
+    int                               ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient       client(mIfName);
+
+    VerifyOrExit(reader->parse(aSetEpskcEnabledRequest.c_str(),
+                               aSetEpskcEnabledRequest.c_str() + aSetEpskcEnabledRequest.size(), &root, nullptr),
+                 ret = kWpanStatus_ParseRequestFailed);
+    VerifyOrExit(root.isMember("enabled") && root["enabled"].isBool(), ret = kWpanStatus_ParseRequestFailed);
+    enabled = root["enabled"].asBool();
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+    VerifyOrExit(client.Execute("ba ephemeralkey %s", enabled ? "enable" : "disable") != nullptr,
+                 ret = kWpanStatus_SetFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret != kWpanStatus_Ok)
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest)
+{
+    Json::Value                       root;
+    Json::CharReaderBuilder           readerBuilder;
+    std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
+    Json::StreamWriterBuilder         writerBuilder;
+    std::string                       response;
+    std::string                       tap;
+    uint32_t                          lifetime = 0; // 0 == let the router use its own default lifetime
+    uint16_t                          port     = 0; // 0 == let the router use its own default UDP port
+    int                               ret      = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient       client(mIfName);
+    char                             *rval;
+
+    // Both "lifetime" and "port" are optional, so an empty body (e.g. `curl -X POST` with no data) is valid and
+    // simply falls back to the router's defaults.
+    if (!aActivateEpskcRequest.empty())
+    {
+        VerifyOrExit(reader->parse(aActivateEpskcRequest.c_str(),
+                                   aActivateEpskcRequest.c_str() + aActivateEpskcRequest.size(), &root, nullptr),
+                     ret = kWpanStatus_ParseRequestFailed);
+        if (root.isMember("lifetime"))
+        {
+            VerifyOrExit(root["lifetime"].isUInt(), ret = kWpanStatus_ParseRequestFailed);
+            lifetime = root["lifetime"].asUInt();
+        }
+        if (root.isMember("port"))
+        {
+            VerifyOrExit(root["port"].isUInt(), ret = kWpanStatus_ParseRequestFailed);
+            port = static_cast<uint16_t>(root["port"].asUInt());
+        }
+    }
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey generate-tap")) != nullptr, ret = kWpanStatus_SetFailed);
+    tap = rval;
+
+    VerifyOrExit(client.Execute("ba ephemeralkey start %s %" PRIu32 " %u", tap.c_str(), lifetime, port) != nullptr,
+                 ret = kWpanStatus_SetFailed);
+
+    // Report back the effective port, in particular when the caller left "port" at its 0/default value.
+    if ((rval = client.Execute("ba ephemeralkey port")) != nullptr)
+    {
+        port = static_cast<uint16_t>(atoi(rval));
+    }
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret == kWpanStatus_Ok)
+    {
+        root["tap"]      = tap;
+        root["lifetime"] = lifetime;
+        root["port"]     = port;
+    }
+    else
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleDeactivateEpskcRequest(void)
+{
+    Json::Value                 root;
+    Json::StreamWriterBuilder   writerBuilder;
+    std::string                 response;
+    int                         ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient client(mIfName);
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+    VerifyOrExit(client.Execute("ba ephemeralkey stop") != nullptr, ret = kWpanStatus_SetFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret != kWpanStatus_Ok)
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
     return response;
 }
 

--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -35,6 +35,8 @@
 
 #include "web/web-service/wpan_service.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <sstream>
 
 #include <inttypes.h>
@@ -601,6 +603,177 @@ exit:
     }
     response = Json::writeString(writerBuilder, root);
 
+    return response;
+}
+
+std::string WpanService::toLower(const std::string &aStr)
+{
+    std::string result = aStr;
+
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    return result;
+}
+
+std::string WpanService::HandleGetEpskcStatusRequest(void)
+{
+    Json::Value                 root;
+    Json::StreamWriterBuilder   writerBuilder;
+    std::string                 response;
+    std::string                 state;
+    int                         ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient client(mIfName);
+    char                       *rval;
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
+    state = toLower(rval);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey port")) != nullptr, ret = kWpanStatus_GetPropertyFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret == kWpanStatus_Ok)
+    {
+        root["enabled"] = (state != "disabled");
+        root["active"]  = (state == "started" || state == "connected" || state == "accepted");
+        root["state"]   = state;
+        root["port"]    = atoi(rval);
+    }
+    else
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest)
+{
+    Json::Value                       root;
+    Json::CharReaderBuilder           readerBuilder;
+    std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
+    Json::StreamWriterBuilder         writerBuilder;
+    std::string                       response;
+    bool                              enabled;
+    int                               ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient       client(mIfName);
+
+    VerifyOrExit(reader->parse(aSetEpskcEnabledRequest.c_str(),
+                               aSetEpskcEnabledRequest.c_str() + aSetEpskcEnabledRequest.size(), &root, nullptr),
+                 ret = kWpanStatus_ParseRequestFailed);
+    enabled = root["enabled"].asBool();
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+    VerifyOrExit(client.Execute("ba ephemeralkey %s", enabled ? "enable" : "disable") != nullptr,
+                 ret = kWpanStatus_SetFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret != kWpanStatus_Ok)
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest)
+{
+    Json::Value                       root;
+    Json::CharReaderBuilder           readerBuilder;
+    std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
+    Json::StreamWriterBuilder         writerBuilder;
+    std::string                       response;
+    std::string                       tap;
+    uint32_t                          lifetime = 0; // 0 == let the router use its own default lifetime
+    uint16_t                          port     = 0; // 0 == let the router use its own default UDP port
+    int                               ret      = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient       client(mIfName);
+    char                             *rval;
+
+    VerifyOrExit(reader->parse(aActivateEpskcRequest.c_str(),
+                               aActivateEpskcRequest.c_str() + aActivateEpskcRequest.size(), &root, nullptr),
+                 ret = kWpanStatus_ParseRequestFailed);
+    if (root.isMember("lifetime"))
+    {
+        lifetime = root["lifetime"].asUInt();
+    }
+    if (root.isMember("port"))
+    {
+        port = static_cast<uint16_t>(root["port"].asUInt());
+    }
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+
+    VerifyOrExit((rval = client.Execute("ba ephemeralkey generate-tap")) != nullptr, ret = kWpanStatus_SetFailed);
+    tap = rval;
+
+    VerifyOrExit(client.Execute("ba ephemeralkey start %s %" PRIu32 " %u", tap.c_str(), lifetime, port) != nullptr,
+                 ret = kWpanStatus_SetFailed);
+
+    // Report back the effective port, in particular when the caller left "port" at its 0/default value.
+    if ((rval = client.Execute("ba ephemeralkey port")) != nullptr)
+    {
+        port = static_cast<uint16_t>(atoi(rval));
+    }
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret == kWpanStatus_Ok)
+    {
+        root["tap"]      = tap;
+        root["lifetime"] = lifetime;
+        root["port"]     = port;
+    }
+    else
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
+    return response;
+}
+
+std::string WpanService::HandleDeactivateEpskcRequest(void)
+{
+    Json::Value                 root;
+    Json::StreamWriterBuilder   writerBuilder;
+    std::string                 response;
+    int                         ret = kWpanStatus_Ok;
+    otbr::Web::OpenThreadClient client(mIfName);
+
+    VerifyOrExit(client.Connect(), ret = kWpanStatus_Uninitialized);
+    VerifyOrExit(client.Execute("ba ephemeralkey stop") != nullptr, ret = kWpanStatus_SetFailed);
+
+exit:
+    root.clear();
+    root["result"] = WPAN_RESPONSE_SUCCESS;
+    root["error"]  = ret;
+
+    if (ret != kWpanStatus_Ok)
+    {
+        root["result"] = WPAN_RESPONSE_FAILURE;
+        otbrLogErr("Wpan service error: %d", ret);
+    }
+
+    response = Json::writeString(writerBuilder, root);
     return response;
 }
 

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -136,6 +136,45 @@ public:
     std::string HandleCommission(const std::string &aCommissionRequest);
 
     /**
+     * This method handles the http request to get the ePSKc (ephemeral key) feature status.
+     *
+     * @returns The string to the http response, containing the "enabled" flag, the raw session
+     *          "state" ("disabled"/"stopped"/"started"/"connected"/"accepted"), an "active"
+     *          convenience flag, and the current "port".
+     */
+    std::string HandleGetEpskcStatusRequest(void);
+
+    /**
+     * This method handles the http request to enable or disable the ePSKc feature.
+     *
+     * @param[in] aSetEpskcEnabledRequest  A reference to the http request body, containing an
+     *                                     "enabled" boolean field.
+     *
+     * @returns The string to the http response of enabling/disabling the ePSKc feature.
+     */
+    std::string HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest);
+
+    /**
+     * This method handles the http request to generate a TAP code and activate an ePSKc session.
+     *
+     * @param[in] aActivateEpskcRequest  A reference to the http request body, containing optional
+     *                                   "lifetime" (session lifetime in ms; 0/omitted means "use
+     *                                   the router's default") and "port" (0/omitted means "use
+     *                                   the router's default ephemeral UDP port") fields.
+     *
+     * @returns The string to the http response of activating the ePSKc session, including the
+     *          generated "tap" code and the effective "port".
+     */
+    std::string HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest);
+
+    /**
+     * This method handles the http request to deactivate the current ePSKc session.
+     *
+     * @returns The string to the http response of deactivating the ePSKc session.
+     */
+    std::string HandleDeactivateEpskcRequest(void);
+
+    /**
      * This method sets the Thread interface name.
      *
      * @param[in] aIfName  The pointer to the Thread interface name.
@@ -181,6 +220,7 @@ private:
                                          uint16_t                     aChannel,
                                          uint16_t                     aPanId);
     static std::string escapeOtCliEscapable(const std::string &aArg);
+    static std::string toLower(const std::string &aStr);
 
     WpanNetworkInfo mNetworks[OT_SCANNED_NET_BUFFER_SIZE];
     int             mNetworksCount;

--- a/src/web/web-service/wpan_service.hpp
+++ b/src/web/web-service/wpan_service.hpp
@@ -138,6 +138,45 @@ public:
     std::string HandleCommission(const std::string &aCommissionRequest);
 
     /**
+     * This method handles the http request to get the ePSKc (ephemeral key) feature status.
+     *
+     * @returns The string to the http response, containing the "enabled" flag, the raw session
+     *          "state" ("disabled"/"stopped"/"started"/"connected"/"accepted"), an "active"
+     *          convenience flag, and the current "port".
+     */
+    std::string HandleGetEpskcStatusRequest(void);
+
+    /**
+     * This method handles the http request to enable or disable the ePSKc feature.
+     *
+     * @param[in] aSetEpskcEnabledRequest  A reference to the http request body, containing an
+     *                                     "enabled" boolean field.
+     *
+     * @returns The string to the http response of enabling/disabling the ePSKc feature.
+     */
+    std::string HandleSetEpskcEnabledRequest(const std::string &aSetEpskcEnabledRequest);
+
+    /**
+     * This method handles the http request to generate a TAP code and activate an ePSKc session.
+     *
+     * @param[in] aActivateEpskcRequest  A reference to the http request body, containing optional
+     *                                   "lifetime" (session lifetime in ms; 0/omitted means "use
+     *                                   the router's default") and "port" (0/omitted means "use
+     *                                   the router's default ephemeral UDP port") fields.
+     *
+     * @returns The string to the http response of activating the ePSKc session, including the
+     *          generated "tap" code and the effective "port".
+     */
+    std::string HandleActivateEpskcRequest(const std::string &aActivateEpskcRequest);
+
+    /**
+     * This method handles the http request to deactivate the current ePSKc session.
+     *
+     * @returns The string to the http response of deactivating the ePSKc session.
+     */
+    std::string HandleDeactivateEpskcRequest(void);
+
+    /**
      * This method sets the Thread interface name.
      *
      * @param[in] aIfName  The pointer to the Thread interface name.
@@ -185,6 +224,7 @@ private:
                                          uint16_t                     aChannel,
                                          uint16_t                     aPanId);
     static std::string escapeOtCliEscapable(const std::string &aArg);
+    static std::string toLower(const std::string &aStr);
 
     WpanNetworkInfo mNetworks[OT_SCANNED_NET_BUFFER_SIZE];
     int             mNetworksCount;

--- a/tests/gtest/test_web.cpp
+++ b/tests/gtest/test_web.cpp
@@ -43,7 +43,28 @@ protected:
     static void SetSocket(OpenThreadClient &aClient, int aSocket) { aClient.mSocket = aSocket; }
 
     static std::string EscapeOtCliEscapable(const std::string &aArg) { return WpanService::escapeOtCliEscapable(aArg); }
+    static std::string ToLower(const std::string &aStr) { return WpanService::toLower(aStr); }
+
+    static int StatusUninitialized(void) { return WpanService::kWpanStatus_Uninitialized; }
+    static int StatusParseRequestFailed(void) { return WpanService::kWpanStatus_ParseRequestFailed; }
 };
+
+namespace {
+
+// Parses a handler's JSON response and hands back the root, so each test can assert on whatever
+// fields matter to it.
+Json::Value ParseJson(const std::string &aJson)
+{
+    Json::Value                       root;
+    Json::CharReaderBuilder           builder;
+    std::string                       errs;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+
+    EXPECT_TRUE(reader->parse(aJson.c_str(), aJson.c_str() + aJson.size(), &root, &errs)) << errs;
+    return root;
+}
+
+} // namespace
 
 TEST_F(WebServiceTest, ExecuteRejectsLineBreaks)
 {
@@ -68,6 +89,147 @@ TEST_F(WebServiceTest, ExecuteRejectsLineBreaks)
 TEST_F(WebServiceTest, EscapeOtCliEscapable)
 {
     EXPECT_EQ(EscapeOtCliEscapable("alpha beta\tgamma\\delta\r\nepsilon"), "alpha\\ beta\\\tgamma\\\\delta\r\nepsilon");
+}
+
+TEST_F(WebServiceTest, ToLower)
+{
+    EXPECT_EQ(ToLower("STARTED"), "started");
+    EXPECT_EQ(ToLower("Connected"), "connected");
+    EXPECT_EQ(ToLower(""), "");
+    EXPECT_EQ(ToLower("already-lower"), "already-lower");
+    // Guards the `static_cast<unsigned char>` in the std::transform lambda: a signed `char` with the
+    // high bit set is UB for plain `std::tolower()`, so this must not crash under ASan/UBSan.
+    EXPECT_NO_THROW(ToLower("\xff\x80mix3D"));
+}
+
+// HandleGetEpskcStatusRequest / HandleDeactivateEpskcRequest take no body, so with no daemon
+// listening on the (bogus) interface's socket, Connect() deterministically fails and we can assert
+// on the resulting error JSON without touching a real socket.
+
+TEST_F(WebServiceTest, HandleGetEpskcStatusRequestNoDaemon)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleGetEpskcStatusRequest());
+
+    EXPECT_EQ(root["result"].asString(), "failed");
+    EXPECT_EQ(root["error"].asInt(), StatusUninitialized());
+    EXPECT_FALSE(root.isMember("enabled"));
+    EXPECT_FALSE(root.isMember("state"));
+}
+
+TEST_F(WebServiceTest, HandleDeactivateEpskcRequestNoDaemon)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleDeactivateEpskcRequest());
+
+    EXPECT_EQ(root["result"].asString(), "failed");
+    EXPECT_EQ(root["error"].asInt(), StatusUninitialized());
+}
+
+// HandleSetEpskcEnabledRequest validates its body *before* connecting, so these never touch a
+// socket -- StatusParseRequestFailed (rather than just "some failure") proves that.
+
+TEST_F(WebServiceTest, HandleSetEpskcEnabledRequestMalformedJson)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleSetEpskcEnabledRequest("not json"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleSetEpskcEnabledRequestMissingField)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleSetEpskcEnabledRequest("{}"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleSetEpskcEnabledRequestWrongType)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    // Regression test for the maintainer-requested fix: a string "true" must be rejected, not
+    // silently truthy-coerced.
+    Json::Value root = ParseJson(service.HandleSetEpskcEnabledRequest(R"({"enabled":"true"})"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleSetEpskcEnabledRequestValidBodyNoDaemon)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    // Body parses fine; the only failure left is Connect().
+    Json::Value root = ParseJson(service.HandleSetEpskcEnabledRequest(R"({"enabled":true})"));
+    EXPECT_EQ(root["error"].asInt(), StatusUninitialized());
+}
+
+// HandleActivateEpskcRequest: "lifetime"/"port" are optional and validated before connecting.
+
+TEST_F(WebServiceTest, HandleActivateEpskcRequestEmptyBodyNoDaemon)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    // Empty body must be accepted (both fields optional) and fall through to Connect(), not to a
+    // parse error -- this was the specific fix requested in review.
+    Json::Value root = ParseJson(service.HandleActivateEpskcRequest(""));
+    EXPECT_EQ(root["error"].asInt(), StatusUninitialized());
+}
+
+TEST_F(WebServiceTest, HandleActivateEpskcRequestMalformedJson)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleActivateEpskcRequest("{not json"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleActivateEpskcRequestLifetimeWrongType)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleActivateEpskcRequest(R"({"lifetime":"soon"})"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleActivateEpskcRequestPortWrongType)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleActivateEpskcRequest(R"({"port":-1})"));
+    EXPECT_EQ(root["error"].asInt(), StatusParseRequestFailed());
+}
+
+TEST_F(WebServiceTest, HandleActivateEpskcRequestValidFieldsNoDaemon)
+{
+    WpanService service;
+
+    service.SetInterfaceName("otbr-test-no-daemon");
+
+    Json::Value root = ParseJson(service.HandleActivateEpskcRequest(R"({"lifetime":30000,"port":49155})"));
+    EXPECT_EQ(root["error"].asInt(), StatusUninitialized());
 }
 
 } // namespace Web

--- a/tests/scripts/expect/dind_web.exp
+++ b/tests/scripts/expect/dind_web.exp
@@ -187,6 +187,67 @@ if {[string first "networkName" $rest_node] == -1} {
 }
 send_user "Scenario 2 custom REST API responsiveness verified successfully!\n"
 
+# ==========================================
+# SCENARIO 3: ePSKc (Ephemeral Key) Web UI Endpoints
+# ==========================================
+send_user -- "--- SCENARIO 3: Testing Web UI ePSKc endpoints (status -> enable -> activate -> status -> deactivate -> status) ---\n"
+
+# The web service's JSON responses are written with jsoncpp's default (pretty-printed) formatting,
+# e.g. {\n\t"error" : 0,\n\t...\n}, so matches below tolerate whitespace around the ':' and span lines.
+proc check_json_field {json field value} {
+    if {![regexp "\"$field\"\\s*:\\s*$value" $json]} {
+        fail "Expected \"$field\" : $value in response: $json"
+    }
+}
+
+send_user "Testing Web UI epskc_status (initial)...\n"
+set epskc_status [exec curl -s http://127.0.0.1:8080/epskc_status]
+send_user "epskc_status response: $epskc_status\n"
+check_json_field $epskc_status "error" 0
+send_user "Web UI epskc_status (initial) validated successfully!\n"
+
+send_user "Testing Web UI epskc_enabled...\n"
+set epskc_enabled [exec curl -s --header "Content-Type: application/json" --request POST --data "\{\"enabled\":true\}" http://127.0.0.1:8080/epskc_enabled]
+send_user "epskc_enabled response: $epskc_enabled\n"
+check_json_field $epskc_enabled "error" 0
+send_user "Web UI epskc_enabled validated successfully!\n"
+
+send_user "Testing Web UI epskc_status (after enable)...\n"
+set epskc_status [exec curl -s http://127.0.0.1:8080/epskc_status]
+send_user "epskc_status response: $epskc_status\n"
+check_json_field $epskc_status "enabled" "true"
+send_user "Web UI epskc_status (after enable) validated successfully!\n"
+
+# Activate with an empty body (Content-Length: 0), exercising the router's default lifetime/port.
+send_user "Testing Web UI epskc_activate...\n"
+set epskc_activate [exec curl -s --header "Content-Type: application/json" --request POST --data "" http://127.0.0.1:8080/epskc_activate]
+send_user "epskc_activate response: $epskc_activate\n"
+check_json_field $epskc_activate "error" 0
+if {[string first "\"tap\"" $epskc_activate] == -1} {
+    fail "Web UI epskc_activate response missing \"tap\": $epskc_activate"
+}
+send_user "Web UI epskc_activate validated successfully!\n"
+
+send_user "Testing Web UI epskc_status (after activate)...\n"
+set epskc_status [exec curl -s http://127.0.0.1:8080/epskc_status]
+send_user "epskc_status response: $epskc_status\n"
+check_json_field $epskc_status "active" "true"
+send_user "Web UI epskc_status (after activate) validated successfully!\n"
+
+send_user "Testing Web UI epskc_deactivate...\n"
+set epskc_deactivate [exec curl -s --header "Content-Type: application/json" --request POST --data "" http://127.0.0.1:8080/epskc_deactivate]
+send_user "epskc_deactivate response: $epskc_deactivate\n"
+check_json_field $epskc_deactivate "error" 0
+send_user "Web UI epskc_deactivate validated successfully!\n"
+
+send_user "Testing Web UI epskc_status (after deactivate)...\n"
+set epskc_status [exec curl -s http://127.0.0.1:8080/epskc_status]
+send_user "epskc_status response: $epskc_status\n"
+check_json_field $epskc_status "active" "false"
+send_user "Web UI epskc_status (after deactivate) validated successfully!\n"
+
+send_user "Scenario 3 ePSKc Web UI endpoints verified successfully!\n"
+
 dispose_all
 
 send_user -- "--- DinD Web UI Integration Test PASSED successfully! ---\n"


### PR DESCRIPTION
## Summary

Adds Thread 1.4 Credentials Sharing / ephemeral key (ePSKc) support to the legacy built-in web GUI (`otbr-web`), which currently has no way to enable, activate, or monitor ePSKc sessions.

- `GET /epskc_status` — current feature `enabled` flag, session `state` (`disabled`/`stopped`/`started`/`connected`/`accepted`), `active` convenience flag, and UDP `port`.
- `POST /epskc_enabled` — enable/disable the feature (`{"enabled": true|false}`).
- `POST /epskc_activate` — generate a 9-digit TAP and start a session (optional `{"lifetime": ms, "port": n}`), returns `{"tap": "...", "port": n}`.
- `POST /epskc_deactivate` — stop the current session.
- New "ePSKc" panel in the AngularJS frontend: enable/disable toggle, optional lifetime input, Activate/Deactivate buttons, and a prominent read-only display of the generated TAP code.

## Implementation notes

This is implemented purely through the existing `OpenThreadClient` CLI-over-socket mechanism (`ba ephemeralkey enable/disable/start/stop/port/generate-tap`) that every other `WpanService` handler already uses to talk to the daemon (`HandleCommission`, `HandleStatusRequest`, etc.) — **no D-Bus, no new dependencies, no CMake changes**. `ba ephemeralkey` is already available in the vendored OpenThread core.

**Known limitation**: `ba ephemeralkey stop` is an unconditional hard stop. Unlike the D-Bus API's `DeactivateEphemeralKeyMode(retain_active_session)`, there's no CLI equivalent for keeping an already-`Accepted` session alive while just closing the activation window. Documenting this as an accepted trade-off of going through the CLI rather than D-Bus for this GUI.

## Test plan

- [x] `script/make-pretty check clang` equivalent: diffed against both a local clang-format (22.1.5) and clang-format-19.1.1 (the version pinned by `script/clang-format`) — clean on all modified C++ files.
- [x] `node --check` clean on `app.js`.
- [x] Full local build verified end-to-end: fetched the pinned submodules (OpenThread core, mbedtls + framework, cJSON, cpp-httplib), configured with `-DOTBR_WEB=ON -DOTBR_BORDER_AGENT=ON -DOTBR_EPSKC=ON`, and built `otbr-web` with `ninja` — clean under `-Wall -Wextra -Werror`. Confirmed `OPENTHREAD_CONFIG_BORDER_AGENT_EPHEMERAL_KEY_ENABLE=1` is set in the build flags.
- [x] Verified the new `WpanService` handler symbols (`HandleGetEpskcStatusRequest`, `HandleSetEpskcEnabledRequest`, `HandleActivateEpskcRequest`, `HandleDeactivateEpskcRequest`) are present in the linked binary via `nm`. (The four matching `WebServer::Handle*(..., void *aUserData)` static overloads were removed per review — they mirrored an `HttpRequestCallback` dispatch path, `WebServer::HandleHttpRequest`, that is declared but never implemented/called anywhere in the file, so they were dead code.)
- [x] Ran the built binary (`otbr-web -p 8080`, no daemon attached): serves `index.html` (200), serves the updated `app.js` with the new ePSKc functions, and `/epskc_status` returns a well-formed JSON error response (`{"error":15,"result":"failed"}`, i.e. `kWpanStatus_Uninitialized`) instead of crashing — confirms the routing/JSON/error-handling path end-to-end.
- [x] Manual end-to-end test against a real `otbr-agent` attached to a simulated `ot-rcp`, run inside a privileged container (for the TUN interface) with a Thread network formed via `ot-ctl`, then `otbr-web` pointed at the same interface. Exercised a real `ba ephemeralkey` session through the REST endpoints:
  - `epskc_status` → `error:0`
  - `epskc_enabled {"enabled":true}` → `error:0`, reflected back on the next `epskc_status`
  - `epskc_activate` with an **empty body** (exercising the optional-fields fix) → `error:0`, real 9-digit TAP (`"tap":"769077288"`) and real UDP port (`"port":49155"`) assigned by the border agent
  - `epskc_status` → `active:true`
  - Cross-checked directly against the daemon with `ot-ctl ba ephemeralkey` → `Started` (independent confirmation outside the web GUI)
  - `epskc_deactivate` → `error:0`; `epskc_status` → `active:false`, `state:"stopped"`
  - `epskc_enabled {"enabled":"yes"}` (wrong type) → correctly rejected with `error:11` against the real daemon too
- [x] Extended `tests/scripts/expect/dind_web.exp` with a Scenario 3 covering `epskc_status → epskc_enabled → epskc_activate (empty body) → epskc_status → epskc_deactivate → epskc_status`, mirroring the existing DinD web GUI test structure. JSON-field assertions use a whitespace-tolerant regex helper (`check_json_field`) since jsoncpp's default writer pretty-prints with `"key" : value`, not the compact form. Verified the matching logic against real server output with `tclsh`; the script itself needs the full DinD Docker harness (`infrastructure-link` network, built `OTBR_DOCKER_IMAGE`) to run end-to-end, which is what CI's `test_dind_dns_sd.sh` provides.
- [x] Added gtest unit coverage (`tests/gtest/test_web.cpp`, `otbr-gtest-web` target) for `HandleGetEpskcStatusRequest`, `HandleSetEpskcEnabledRequest`, `HandleActivateEpskcRequest`, `HandleDeactivateEpskcRequest`, and the new `toLower` helper — no live daemon required: the input-validation branches (malformed JSON, missing/wrong-typed fields, the empty-body case for `HandleActivateEpskcRequest`'s optional fields) run entirely before `Connect()`, and a bogus interface name deterministically exercises the well-formed-error-JSON path when `Connect()` fails. 14/14 pass locally. This addresses Codecov's "0% patch coverage" flag on `wpan_service.cpp`/`web_server.cpp` — the only test previously exercising this code was the `dind_web.exp` Scenario 3 integration test above, which runs in the `Docker Test` CI workflow and isn't uploaded to Codecov, so it never counted toward patch coverage.
- [x] Rebased onto current `main` to pick up the `otbr-gtest-web` test target and `WpanService`/`OpenThreadClient` test-friend hooks added by #3288, which the unit tests above build on; full rebuild (`otbr-web`, `otbr-gtest-unit`, `otbr-gtest-web`) and `clang-format-19` stay clean after the rebase.

## Review

Addressed automated review feedback from gemini-code-assist:
- Use the local `ev` event parameter (or `null` when none is available) instead of the global `event` in the new frontend functions.
- Replaced the inline `onclick` handler on the TAP display with an `ng-click`-bound `selectEpskcTap()` controller function (CSP-friendly).
- Loop over `$scope.menu.length` instead of a hardcoded panel count in `showPanels()`.
- Format the ephemeral key lifetime (`uint32_t`) with `PRIu32` instead of `%u` for portability.

Addressed maintainer review feedback from @jwhui:
- `wpan_service`: validate that `"enabled"` is present and boolean before extracting it in `HandleSetEpskcEnabledRequest`.
- `wpan_service`: allow an empty POST body in `HandleActivateEpskcRequest` (both `lifetime` and `port` are optional), and validate their types when present instead of blindly calling `asUInt()`.
- `web_server`: removed the four new static `Handle*EpskcRequest(..., void *aUserData)` overloads — dead code, see test plan above.
- `frontend/index.html`: closed the `&nbsp` entities with a semicolon; added `min="1"`/`max="10"` to the lifetime input plus a label/validation message noting the router's 2-minute default / 10-minute maximum.
- `frontend/app.js`: replaced `ev.target.disabled` toggling in `activateEpskc`/`deactivateEpskc` (unreliable with `md-button`, since the click can bubble from an inner ripple/span) with a `$scope.isEpskcBusy` flag bound via `ng-disabled`, with error callbacks so it resets on HTTP/network failure.
- `frontend/app.js`: poll `epskc_status` every 4s while the ePSKc panel is visible, so the UI reflects a session that times out or gets accepted/stopped on the device without local user action; polling stops when navigating away or on `$destroy`.



