### PR TITLE
[rest] add endpoints for Border Agent ephemeral key (ePSKc)

### DIFF
--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1884,6 +1884,92 @@ cJSON *CreateMetaCollection(uint32_t aOffset, uint32_t aLimit, uint32_t aTotal, 
     return meta;
 }
 
+#if OTBR_ENABLE_EPSKC
+static const char *EpskcStateToString(otBorderAgentEphemeralKeyState aState)
+{
+    const char *stateStr;
+
+    switch (aState)
+    {
+    case OT_BORDER_AGENT_STATE_DISABLED:
+        stateStr = "disabled";
+        break;
+    case OT_BORDER_AGENT_STATE_STOPPED:
+        stateStr = "stopped";
+        break;
+    case OT_BORDER_AGENT_STATE_STARTED:
+        stateStr = "started";
+        break;
+    case OT_BORDER_AGENT_STATE_CONNECTED:
+        stateStr = "connected";
+        break;
+    case OT_BORDER_AGENT_STATE_ACCEPTED:
+        stateStr = "accepted";
+        break;
+    default:
+        stateStr = "unknown";
+        break;
+    }
+
+    return stateStr;
+}
+
+std::string EpskcKeyStatus2JsonString(otBorderAgentEphemeralKeyState aState, uint16_t aPort)
+{
+    std::string ret;
+    cJSON      *root = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(root, "state", EpskcStateToString(aState));
+    cJSON_AddNumberToObject(root, "port", aPort);
+
+    ret = Json2String(root);
+    cJSON_Delete(root);
+
+    return ret;
+}
+
+std::string EpskcActivateResult2JsonString(const std::string &aTap, uint16_t aPort)
+{
+    std::string ret;
+    cJSON      *root = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(root, "tap", aTap.c_str());
+    cJSON_AddNumberToObject(root, "port", aPort);
+
+    ret = Json2String(root);
+    cJSON_Delete(root);
+
+    return ret;
+}
+
+bool JsonEpskcActivateParams(const std::string &aJson, uint32_t &aLifetime, uint16_t &aPort)
+{
+    cJSON *root;
+    cJSON *value;
+    bool   ret = true;
+
+    root = cJSON_Parse(aJson.c_str());
+    VerifyOrExit(root != nullptr, ret = false);
+    VerifyOrExit(cJSON_IsObject(root), ret = false);
+
+    value = cJSON_GetObjectItemCaseSensitive(root, "lifetime");
+    if (cJSON_IsNumber(value))
+    {
+        aLifetime = static_cast<uint32_t>(value->valueint);
+    }
+
+    value = cJSON_GetObjectItemCaseSensitive(root, "port");
+    if (cJSON_IsNumber(value))
+    {
+        aPort = static_cast<uint16_t>(value->valueint);
+    }
+
+exit:
+    cJSON_Delete(root);
+    return ret;
+}
+#endif // OTBR_ENABLE_EPSKC
+
 } // namespace Json
 } // namespace rest
 } // namespace otbr

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1955,13 +1955,15 @@ bool JsonEpskcActivateParams(const std::string &aJson, uint32_t &aLifetime, uint
     value = cJSON_GetObjectItemCaseSensitive(root, "lifetime");
     if (cJSON_IsNumber(value))
     {
-        aLifetime = static_cast<uint32_t>(value->valueint);
+        VerifyOrExit(value->valuedouble >= 0.0 && value->valuedouble <= UINT32_MAX, ret = false);
+        aLifetime = static_cast<uint32_t>(value->valuedouble);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(root, "port");
     if (cJSON_IsNumber(value))
     {
-        aPort = static_cast<uint16_t>(value->valueint);
+        VerifyOrExit(value->valuedouble >= 0.0 && value->valuedouble <= UINT16_MAX, ret = false);
+        aPort = static_cast<uint16_t>(value->valuedouble);
     }
 
 exit:

--- a/src/rest/json.cpp
+++ b/src/rest/json.cpp
@@ -1953,15 +1953,17 @@ bool JsonEpskcActivateParams(const std::string &aJson, uint32_t &aLifetime, uint
     VerifyOrExit(cJSON_IsObject(root), ret = false);
 
     value = cJSON_GetObjectItemCaseSensitive(root, "lifetime");
-    if (cJSON_IsNumber(value))
+    if (value != nullptr)
     {
+        VerifyOrExit(cJSON_IsNumber(value), ret = false);
         VerifyOrExit(value->valuedouble >= 0.0 && value->valuedouble <= UINT32_MAX, ret = false);
         aLifetime = static_cast<uint32_t>(value->valuedouble);
     }
 
     value = cJSON_GetObjectItemCaseSensitive(root, "port");
-    if (cJSON_IsNumber(value))
+    if (value != nullptr)
     {
+        VerifyOrExit(cJSON_IsNumber(value), ret = false);
         VerifyOrExit(value->valuedouble >= 0.0 && value->valuedouble <= UINT16_MAX, ret = false);
         aPort = static_cast<uint16_t>(value->valuedouble);
     }

--- a/src/rest/json.hpp
+++ b/src/rest/json.hpp
@@ -38,6 +38,7 @@
 
 #include <httplib.h>
 
+#include <openthread/border_agent_ephemeral_key.h>
 #include <openthread/dataset.h>
 #include <openthread/link.h>
 #include <openthread/thread_ftd.h>
@@ -386,6 +387,39 @@ otbrError StringDiscerner2Discerner(char *aString, otJoinerDiscerner &aDiscerner
 bool JsonJoinerInfoString2JoinerInfo(const std::string &aJsonJoinerInfo, otJoinerInfo &aJoinerInfo);
 
 std::string JoinerTable2JsonString(const std::vector<otJoinerInfo> &aJoinerTable);
+
+#if OTBR_ENABLE_EPSKC
+/**
+ * This method formats an ephemeral key (ePSKc) status to a Json object and serializes it to a string.
+ *
+ * @param[in] aState  The ephemeral key state.
+ * @param[in] aPort   The UDP port being used.
+ *
+ * @returns A string of serialized Json object.
+ */
+std::string EpskcKeyStatus2JsonString(otBorderAgentEphemeralKeyState aState, uint16_t aPort);
+
+/**
+ * This method formats an ephemeral key (ePSKc) activation result to a Json object and serializes it to a string.
+ *
+ * @param[in] aTap   The generated 9-digit Thread Administration Passcode (TAP).
+ * @param[in] aPort  The UDP port being used.
+ *
+ * @returns A string of serialized Json object.
+ */
+std::string EpskcActivateResult2JsonString(const std::string &aTap, uint16_t aPort);
+
+/**
+ * This method parses a Json string for ephemeral key (ePSKc) activation parameters.
+ *
+ * @param[in]  aJson      The Json string to be parsed.
+ * @param[out] aLifetime  The lifetime in milliseconds.
+ * @param[out] aPort      The UDP port.
+ *
+ * @returns If the Json string has been successfully parsed.
+ */
+bool JsonEpskcActivateParams(const std::string &aJson, uint32_t &aLifetime, uint16_t &aPort);
+#endif // OTBR_ENABLE_EPSKC
 
 /**
  * Converts a cJSON object to string.

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1734,8 +1734,9 @@ paths:
                   description: |-
                     The key lifetime in milliseconds. Defaults to
                     OT_BORDER_AGENT_DEFAULT_EPHEMERAL_KEY_TIMEOUT (2 minutes)
-                    when omitted or zero. Capped at
-                    OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT (10 minutes).
+                    when omitted or zero. Maximum value is
+                    OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT (10 minutes);
+                    values above the maximum are rejected with 400.
                   example: 120000
                 port:
                   type: integer

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1660,6 +1660,114 @@ paths:
                 type: string
                 description: Coprocessor version string
                 example: "OPENTHREAD/thread-reference-20200818-1740-g33cc75ed3; NRF52840; Jun  2 2022 14:25:49"
+  /node/ba-epskc/state:
+    get:
+      tags:
+        - node
+      summary: Get whether the Border Agent ephemeral key (ePSKc) feature is enabled.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                description: Whether the ephemeral key feature is enabled.
+                enum: ["enabled", "disabled"]
+                example: "enabled"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+    put:
+      tags:
+        - node
+      summary: Enable or disable the Border Agent ephemeral key (ePSKc) feature.
+      description: |-
+        The feature must be enabled before an ephemeral key can be activated
+        with a POST request to `/node/ba-epskc/key`.
+      responses:
+        "200":
+          description: Successful operation.
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+      requestBody:
+        description: New ephemeral key feature state.
+        content:
+          application/json:
+            schema:
+              type: string
+              description: Can be "enable" or "disable".
+              example: "enable"
+  /node/ba-epskc/key:
+    get:
+      tags:
+        - node
+      summary: Get the status of the Border Agent ephemeral key (ePSKc) session.
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpskcStatus"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+    post:
+      tags:
+        - node
+      summary: Generate and activate an ephemeral key (ePSKc).
+      description: |-
+        Generates a new 9-digit Thread Administration Passcode (TAP) and
+        starts listening for an external commissioner candidate to connect
+        using it. The ephemeral key feature must first be enabled with a PUT
+        request to `/node/ba-epskc/state`.
+      requestBody:
+        description: Optional activation parameters. An empty body uses the device defaults.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lifetime:
+                  type: integer
+                  description: |-
+                    The key lifetime in milliseconds. Defaults to
+                    OT_BORDER_AGENT_DEFAULT_EPHEMERAL_KEY_TIMEOUT (2 minutes)
+                    when omitted or zero. Capped at
+                    OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT (10 minutes).
+                  example: 120000
+                port:
+                  type: integer
+                  description: The UDP port to use. Defaults to the device's own default when omitted.
+                  example: 49152
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpskcActivateResult"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "409":
+          $ref: "#/components/responses/ConflictError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - node
+      summary: Deactivate the currently active ephemeral key (ePSKc), if any.
+      description: |-
+        Stops the ephemeral key use and disconnects any commissioner session
+        using it. Has no effect if there is no ephemeral key in use.
+      responses:
+        "200":
+          description: Successful operation.
+        "404":
+          $ref: "#/components/responses/NotFoundError"
 
 ### Components ##############################################################
 #############################################################################
@@ -2447,8 +2555,33 @@ components:
           example: "0xabc/12"
         timeout:
           type: integer
-          description: Joiner expiration time in milliseconds on response and seconds on request 
-          default: 60 
+          description: Joiner expiration time in milliseconds on response and seconds on request
+          default: 60
+
+    EpskcStatus:
+      type: object
+      properties:
+        state:
+          type: string
+          description: The Border Agent ephemeral key session state.
+          enum: ["disabled", "stopped", "started", "connected", "accepted"]
+          example: "started"
+        port:
+          type: integer
+          description: The UDP port used by the ephemeral key session, if active.
+          example: 49152
+
+    EpskcActivateResult:
+      type: object
+      properties:
+        tap:
+          type: string
+          description: The generated 9-digit Thread Administration Passcode (TAP).
+          example: "123456789"
+        port:
+          type: integer
+          description: The UDP port the border agent is listening on for the ePSKc session.
+          example: 49152
 
     WellKnownThread:
       type: object

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1098,7 +1098,7 @@ void RestWebServer::GetEpskcState(Response &aResponse) const
     aResponse.status = StatusCode::OK_200;
 }
 
-void RestWebServer::SetEpskcState(const Request &aRequest, Response &aResponse)
+void RestWebServer::SetEpskcState(const Request &aRequest, Response &aResponse) const
 {
     otbrError   error = OTBR_ERROR_NONE;
     std::string body;
@@ -1108,7 +1108,6 @@ void RestWebServer::SetEpskcState(const Request &aRequest, Response &aResponse)
 
     RunInMainLoop([this, &body]() {
         otBorderAgentEphemeralKeySetEnabled(GetInstance(), body == "enable");
-        return OTBR_ERROR_NONE;
     });
 
     aResponse.status = StatusCode::OK_200;
@@ -1120,7 +1119,7 @@ exit:
     }
 }
 
-void RestWebServer::EpskcState(const Request &aRequest, Response &aResponse)
+void RestWebServer::EpskcState(const Request &aRequest, Response &aResponse) const
 {
     switch (GetMethod(aRequest))
     {
@@ -1153,7 +1152,7 @@ void RestWebServer::GetEpskcKey(Response &aResponse) const
     aResponse.status = StatusCode::OK_200;
 }
 
-void RestWebServer::ActivateEpskcKey(const Request &aRequest, Response &aResponse)
+void RestWebServer::ActivateEpskcKey(const Request &aRequest, Response &aResponse) const
 {
     otbrError   error    = OTBR_ERROR_NONE;
     otError     errorOt  = OT_ERROR_NONE;
@@ -1168,7 +1167,8 @@ void RestWebServer::ActivateEpskcKey(const Request &aRequest, Response &aRespons
     }
     VerifyOrExit(lifetime <= OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT, error = OTBR_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = BorderAgent::CreateEphemeralKey(tap));
+    error = BorderAgent::CreateEphemeralKey(tap);
+    VerifyOrExit(error == OTBR_ERROR_NONE, error = OTBR_ERROR_REST);
     otbrLogInfo("Created Ephemeral Key for REST activation");
 
     SuccessOrExit(error = RunInMainLoop([this, &errorOt, &resultPort, &tap, lifetime, port]() {
@@ -1208,19 +1208,18 @@ exit:
     }
 }
 
-void RestWebServer::DeactivateEpskcKey(const Request &aRequest, Response &aResponse)
+void RestWebServer::DeactivateEpskcKey(const Request &aRequest, Response &aResponse) const
 {
     OT_UNUSED_VARIABLE(aRequest);
 
     RunInMainLoop([this]() {
         otBorderAgentEphemeralKeyStop(GetInstance());
-        return OTBR_ERROR_NONE;
     });
 
     aResponse.status = StatusCode::OK_200;
 }
 
-void RestWebServer::EpskcKey(const Request &aRequest, Response &aResponse)
+void RestWebServer::EpskcKey(const Request &aRequest, Response &aResponse) const
 {
     switch (GetMethod(aRequest))
     {

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -41,6 +41,12 @@
 
 #include <openthread/commissioner.h>
 
+#if OTBR_ENABLE_EPSKC
+#include <openthread/border_agent_ephemeral_key.h>
+
+#include "border_agent/border_agent.hpp"
+#endif
+
 #include "common/api_strings.hpp"
 #include "rest/json.hpp"
 
@@ -85,6 +91,8 @@
 #define OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER "/node/commissioner/joiner"
 #define OT_REST_RESOURCE_PATH_NODE_COPROCESSOR "/node/coprocessor"
 #define OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION "/node/coprocessor/version"
+#define OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE "/node/ba-epskc/state"
+#define OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY "/node/ba-epskc/key"
 #define OT_REST_RESOURCE_PATH_NETWORK "/networks"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT "/networks/current"
 #define OT_REST_RESOURCE_PATH_NETWORK_CURRENT_COMMISSION "/networks/commission"
@@ -168,6 +176,16 @@ RestWebServer::RestWebServer(Host::RcpHost &aHost)
     mServer.Delete(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
     mServer.Options(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
     mServer.Get(OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION, MakeHandler(&RestWebServer::CoprocessorVersion));
+
+#if OTBR_ENABLE_EPSKC
+    mServer.Get(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
+    mServer.Put(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
+    mServer.Options(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
+    mServer.Get(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    mServer.Post(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    mServer.Delete(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    mServer.Options(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+#endif
 
     mServer.set_error_handler(MakeHandler(&RestWebServer::RoutingErrorHandler));
     mServer.Get(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
@@ -1065,6 +1083,165 @@ void RestWebServer::CoprocessorVersion(const Request &aRequest, Response &aRespo
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
     }
 }
+
+#if OTBR_ENABLE_EPSKC
+void RestWebServer::GetEpskcState(Response &aResponse) const
+{
+    std::string state;
+
+    state = RunInMainLoop([this]() {
+        otBorderAgentEphemeralKeyState stateCode = otBorderAgentEphemeralKeyGetState(GetInstance());
+        return Json::String2JsonString(stateCode == OT_BORDER_AGENT_STATE_DISABLED ? "disabled" : "enabled");
+    });
+
+    aResponse.set_content(state, OT_REST_CONTENT_TYPE_JSON);
+    aResponse.status = StatusCode::OK_200;
+}
+
+void RestWebServer::SetEpskcState(const Request &aRequest, Response &aResponse)
+{
+    otbrError   error = OTBR_ERROR_NONE;
+    std::string body;
+
+    VerifyOrExit(Json::JsonString2String(aRequest.body, body), error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(body == "enable" || body == "disable", error = OTBR_ERROR_INVALID_ARGS);
+
+    RunInMainLoop([this, &body]() {
+        otBorderAgentEphemeralKeySetEnabled(GetInstance(), body == "enable");
+        return OTBR_ERROR_NONE;
+    });
+
+    aResponse.status = StatusCode::OK_200;
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        ErrorHandler(aResponse, StatusCode::BadRequest_400);
+    }
+}
+
+void RestWebServer::EpskcState(const Request &aRequest, Response &aResponse)
+{
+    switch (GetMethod(aRequest))
+    {
+    case HttpMethod::kGet:
+        GetEpskcState(aResponse);
+        break;
+    case HttpMethod::kPut:
+        SetEpskcState(aRequest, aResponse);
+        break;
+    case HttpMethod::kOptions:
+        aResponse.status = StatusCode::OK_200;
+        break;
+    default:
+        ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
+        break;
+    }
+}
+
+void RestWebServer::GetEpskcKey(Response &aResponse) const
+{
+    std::string body;
+
+    body = RunInMainLoop([this]() {
+        otBorderAgentEphemeralKeyState state = otBorderAgentEphemeralKeyGetState(GetInstance());
+        uint16_t                       port  = otBorderAgentEphemeralKeyGetUdpPort(GetInstance());
+        return Json::EpskcKeyStatus2JsonString(state, port);
+    });
+
+    aResponse.set_content(body, OT_REST_CONTENT_TYPE_JSON);
+    aResponse.status = StatusCode::OK_200;
+}
+
+void RestWebServer::ActivateEpskcKey(const Request &aRequest, Response &aResponse)
+{
+    otbrError   error    = OTBR_ERROR_NONE;
+    otError     errorOt  = OT_ERROR_NONE;
+    uint32_t    lifetime = OT_BORDER_AGENT_DEFAULT_EPHEMERAL_KEY_TIMEOUT;
+    uint16_t    port     = OTBR_CONFIG_BORDER_AGENT_MESHCOP_E_UDP_PORT;
+    std::string tap;
+    uint16_t    resultPort = 0;
+
+    if (!aRequest.body.empty())
+    {
+        VerifyOrExit(Json::JsonEpskcActivateParams(aRequest.body, lifetime, port), error = OTBR_ERROR_INVALID_ARGS);
+    }
+    VerifyOrExit(lifetime <= OT_BORDER_AGENT_MAX_EPHEMERAL_KEY_TIMEOUT, error = OTBR_ERROR_INVALID_ARGS);
+
+    SuccessOrExit(error = BorderAgent::CreateEphemeralKey(tap));
+    otbrLogInfo("Created Ephemeral Key for REST activation");
+
+    SuccessOrExit(error = RunInMainLoop([this, &errorOt, &resultPort, &tap, lifetime, port]() {
+                      errorOt = otBorderAgentEphemeralKeyStart(GetInstance(), tap.c_str(), lifetime, port);
+                      VerifyOrReturn(errorOt == OT_ERROR_NONE, OTBR_ERROR_OPENTHREAD);
+
+                      resultPort = otBorderAgentEphemeralKeyGetUdpPort(GetInstance());
+                      return OTBR_ERROR_NONE;
+                  }));
+
+    aResponse.set_content(Json::EpskcActivateResult2JsonString(tap, resultPort), OT_REST_CONTENT_TYPE_JSON);
+    aResponse.status = StatusCode::OK_200;
+
+exit:
+    if (error == OTBR_ERROR_INVALID_ARGS)
+    {
+        ErrorHandler(aResponse, StatusCode::BadRequest_400);
+    }
+    else if (error == OTBR_ERROR_OPENTHREAD)
+    {
+        if (errorOt == OT_ERROR_INVALID_STATE)
+        {
+            ErrorHandler(aResponse, StatusCode::Conflict_409);
+        }
+        else if (errorOt == OT_ERROR_INVALID_ARGS)
+        {
+            ErrorHandler(aResponse, StatusCode::BadRequest_400);
+        }
+        else
+        {
+            ErrorHandler(aResponse, StatusCode::InternalServerError_500);
+        }
+    }
+    else if (error != OTBR_ERROR_NONE)
+    {
+        ErrorHandler(aResponse, StatusCode::InternalServerError_500);
+    }
+}
+
+void RestWebServer::DeactivateEpskcKey(const Request &aRequest, Response &aResponse)
+{
+    OT_UNUSED_VARIABLE(aRequest);
+
+    RunInMainLoop([this]() {
+        otBorderAgentEphemeralKeyStop(GetInstance());
+        return OTBR_ERROR_NONE;
+    });
+
+    aResponse.status = StatusCode::OK_200;
+}
+
+void RestWebServer::EpskcKey(const Request &aRequest, Response &aResponse)
+{
+    switch (GetMethod(aRequest))
+    {
+    case HttpMethod::kGet:
+        GetEpskcKey(aResponse);
+        break;
+    case HttpMethod::kPost:
+        ActivateEpskcKey(aRequest, aResponse);
+        break;
+    case HttpMethod::kDelete:
+        DeactivateEpskcKey(aRequest, aResponse);
+        break;
+    case HttpMethod::kOptions:
+        aResponse.status = StatusCode::OK_200;
+        break;
+    default:
+        ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
+        break;
+    }
+}
+#endif // OTBR_ENABLE_EPSKC
 
 void RestWebServer::RoutingErrorHandler(const Request &aRequest, Response &aResponse)
 {

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1106,9 +1106,7 @@ void RestWebServer::SetEpskcState(const Request &aRequest, Response &aResponse) 
     VerifyOrExit(Json::JsonString2String(aRequest.body, body), error = OTBR_ERROR_INVALID_ARGS);
     VerifyOrExit(body == "enable" || body == "disable", error = OTBR_ERROR_INVALID_ARGS);
 
-    RunInMainLoop([this, &body]() {
-        otBorderAgentEphemeralKeySetEnabled(GetInstance(), body == "enable");
-    });
+    RunInMainLoop([this, &body]() { otBorderAgentEphemeralKeySetEnabled(GetInstance(), body == "enable"); });
 
     aResponse.status = StatusCode::OK_200;
 

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1212,9 +1212,7 @@ void RestWebServer::DeactivateEpskcKey(const Request &aRequest, Response &aRespo
 {
     OT_UNUSED_VARIABLE(aRequest);
 
-    RunInMainLoop([this]() {
-        otBorderAgentEphemeralKeyStop(GetInstance());
-    });
+    RunInMainLoop([this]() { otBorderAgentEphemeralKeyStop(GetInstance()); });
 
     aResponse.status = StatusCode::OK_200;
 }

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -1169,13 +1169,13 @@ void RestWebServer::ActivateEpskcKey(const Request &aRequest, Response &aRespons
 
     error = BorderAgent::CreateEphemeralKey(tap);
     VerifyOrExit(error == OTBR_ERROR_NONE, error = OTBR_ERROR_REST);
-    otbrLogInfo("Created Ephemeral Key for REST activation");
 
     SuccessOrExit(error = RunInMainLoop([this, &errorOt, &resultPort, &tap, lifetime, port]() {
                       errorOt = otBorderAgentEphemeralKeyStart(GetInstance(), tap.c_str(), lifetime, port);
                       VerifyOrReturn(errorOt == OT_ERROR_NONE, OTBR_ERROR_OPENTHREAD);
 
                       resultPort = otBorderAgentEphemeralKeyGetUdpPort(GetInstance());
+                      otbrLogInfo("Created Ephemeral Key for REST activation");
                       return OTBR_ERROR_NONE;
                   }));
 

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -137,6 +137,16 @@ private:
     void RemoveJoiner(const Request &aRequest, Response &aResponse) const;
     void GetCoprocessorVersion(Response &aResponse) const;
 
+#if OTBR_ENABLE_EPSKC
+    void EpskcState(const Request &aRequest, Response &aResponse);
+    void GetEpskcState(Response &aResponse) const;
+    void SetEpskcState(const Request &aRequest, Response &aResponse);
+    void EpskcKey(const Request &aRequest, Response &aResponse);
+    void GetEpskcKey(Response &aResponse) const;
+    void ActivateEpskcKey(const Request &aRequest, Response &aResponse);
+    void DeactivateEpskcKey(const Request &aRequest, Response &aResponse);
+#endif
+
     void ApiActionsHandler(const Request &aRequest, Response &aResponse);
     void ApiActionsGetHandler(const Request &aRequest, Response &aResponse);
     void ApiActionsItemGetHandler(const Request &aRequest, Response &aResponse);

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -138,13 +138,13 @@ private:
     void GetCoprocessorVersion(Response &aResponse) const;
 
 #if OTBR_ENABLE_EPSKC
-    void EpskcState(const Request &aRequest, Response &aResponse);
+    void EpskcState(const Request &aRequest, Response &aResponse) const;
     void GetEpskcState(Response &aResponse) const;
-    void SetEpskcState(const Request &aRequest, Response &aResponse);
-    void EpskcKey(const Request &aRequest, Response &aResponse);
+    void SetEpskcState(const Request &aRequest, Response &aResponse) const;
+    void EpskcKey(const Request &aRequest, Response &aResponse) const;
     void GetEpskcKey(Response &aResponse) const;
-    void ActivateEpskcKey(const Request &aRequest, Response &aResponse);
-    void DeactivateEpskcKey(const Request &aRequest, Response &aResponse);
+    void ActivateEpskcKey(const Request &aRequest, Response &aResponse) const;
+    void DeactivateEpskcKey(const Request &aRequest, Response &aResponse) const;
 #endif
 
     void ApiActionsHandler(const Request &aRequest, Response &aResponse);

--- a/tests/rest/test-rest-server
+++ b/tests/rest/test-rest-server
@@ -78,10 +78,20 @@ if {\$error != 0} {
     error "failed to run the test"
 }
 
-# Test that server can restart after abrupt shutdown (SO_REUSEADDR)
+# Stop the agent that ran the functional tests gracefully (SIGTERM) so that
+# coverage data is flushed on normal exit, instead of being discarded by the
+# SIGKILL used below to test abrupt shutdown.
+send_user "Stopping first agent gracefully to flush coverage data...\r\n"
+exec kill -TERM [exp_pid -i \$otbr_agent]
+expect -i \$otbr_agent eof
+
+# Test that server can restart after abrupt shutdown (SO_REUSEADDR), using a
+# disposable instance so the functional test coverage collected above isn't lost.
 send_user "Testing server restart after abrupt shutdown...\r\n"
-set agent_pid [exp_pid -i \$otbr_agent]
-exec kill -9 \$agent_pid
+spawn "${CMAKE_BINARY_DIR}/src/agent/otbr-agent" -d 7 -v -I wpan0 -B lo "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1"
+set otbr_agent \$spawn_id
+expect "RestWebServer listening on"
+exec kill -9 [exp_pid -i \$otbr_agent]
 expect -i \$otbr_agent eof
 
 spawn "${CMAKE_BINARY_DIR}/src/agent/otbr-agent" -d 7 -v -I wpan0 -B lo "spinel+hdlc+forkpty://$(command -v ot-rcp)?forkpty-arg=1"

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -500,15 +500,23 @@ def epskc_test():
     def get_key_status():
         return json.loads(urllib.request.urlopen(key_url).read())
 
+    def post_key(payload):
+        req = urllib.request.Request(key_url, data=json.dumps(payload).encode(), method='POST')
+        req.add_header('Content-Type', 'application/json')
+        return urllib.request.urlopen(req)
+
+    def expect_http_error(code, action):
+        try:
+            action()
+            raise AssertionError("expected HTTP {}".format(code))
+        except urllib.error.HTTPError as err:
+            assert err.code == code
+
     # Feature disabled: activation must be refused.
     put_state("disable")
     assert get_state() == "disabled"
 
-    try:
-        urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST'))
-        raise AssertionError("activating the ePSKc while disabled should fail")
-    except urllib.error.HTTPError as err:
-        assert err.code == 409
+    expect_http_error(409, lambda: urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST')))
 
     # Enable, activate, check, deactivate, disable.
     put_state("enable")
@@ -517,20 +525,26 @@ def epskc_test():
     status = get_key_status()
     assert status["state"] == "stopped"
 
-    req = urllib.request.Request(key_url, data=b'{}', method='POST')
+    # Invalid payloads must be rejected.
+    expect_http_error(400, lambda: post_key({"lifetime": "3600"}))
+    expect_http_error(400, lambda: post_key({"port": "49191"}))
+    expect_http_error(400, lambda: post_key({"lifetime": 4294967295}))
+
+    # Custom valid parameters should be accepted.
+    req = urllib.request.Request(
+        key_url,
+        data=json.dumps({"lifetime": 300, "port": status["port"]}).encode(),
+        method='POST',
+    )
     req.add_header('Content-Type', 'application/json')
     data = json.loads(urllib.request.urlopen(req).read())
-    assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] > 0
+    assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] == status["port"]
 
     status = get_key_status()
     assert status["state"] == "started" and status["port"] == data["port"]
 
     # A second activation attempt while one is already active must be refused.
-    try:
-        urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST'))
-        raise AssertionError("activating the ePSKc twice should fail")
-    except urllib.error.HTTPError as err:
-        assert err.code == 409
+    expect_http_error(409, lambda: urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST')))
 
     urllib.request.urlopen(urllib.request.Request(key_url, method='DELETE'))
     assert get_key_status()["state"] == "stopped"

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -485,6 +485,62 @@ def error_test(thread_num):
     print(" /v1/hello : all {}, valid {} ".format(thread_num, valid))
 
 
+def epskc_test():
+    state_url = rest_api_addr + "/node/ba-epskc/state"
+    key_url = rest_api_addr + "/node/ba-epskc/key"
+
+    def put_state(value):
+        req = urllib.request.Request(state_url, data=json.dumps(value).encode(), method='PUT')
+        req.add_header('Content-Type', 'application/json')
+        urllib.request.urlopen(req)
+
+    def get_state():
+        return json.loads(urllib.request.urlopen(state_url).read())
+
+    def get_key_status():
+        return json.loads(urllib.request.urlopen(key_url).read())
+
+    # Feature disabled: activation must be refused.
+    put_state("disable")
+    assert get_state() == "disabled"
+
+    try:
+        urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST'))
+        raise AssertionError("activating the ePSKc while disabled should fail")
+    except urllib.error.HTTPError as err:
+        assert err.code == 409
+
+    # Enable, activate, check, deactivate, disable.
+    put_state("enable")
+    assert get_state() == "enabled"
+
+    status = get_key_status()
+    assert status["state"] == "stopped"
+
+    req = urllib.request.Request(key_url, data=b'{}', method='POST')
+    req.add_header('Content-Type', 'application/json')
+    data = json.loads(urllib.request.urlopen(req).read())
+    assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] > 0
+
+    status = get_key_status()
+    assert status["state"] == "started" and status["port"] == data["port"]
+
+    # A second activation attempt while one is already active must be refused.
+    try:
+        urllib.request.urlopen(urllib.request.Request(key_url, data=b'{}', method='POST'))
+        raise AssertionError("activating the ePSKc twice should fail")
+    except urllib.error.HTTPError as err:
+        assert err.code == 409
+
+    urllib.request.urlopen(urllib.request.Request(key_url, method='DELETE'))
+    assert get_key_status()["state"] == "stopped"
+
+    put_state("disable")
+    assert get_state() == "disabled"
+
+    print(" /node/ba-epskc : OK")
+
+
 def main():
     node_test(200)
     node_rloc_test(200)
@@ -499,6 +555,7 @@ def main():
     node_coprocessor_version_test(200)
     # diagnostics_test(20)  # partly replaced with restjsonapi tests
     error_test(10)
+    epskc_test()
 
     return 0
 

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -533,7 +533,7 @@ def epskc_test():
     # Custom valid parameters should be accepted.
     req = urllib.request.Request(
         key_url,
-        data=json.dumps({"lifetime": 300, "port": status["port"]}).encode(),
+        data=json.dumps({"lifetime": 30000, "port": status["port"]}).encode(),
         method='POST',
     )
     req.add_header('Content-Type', 'application/json')


### PR DESCRIPTION
## Summary

- Adds `GET`/`PUT` `/node/ba-epskc/state` to query and toggle the Border Agent ephemeral key (ePSKc) feature.
- Adds `GET`/`POST`/`DELETE` `/node/ba-epskc/key` to query the ePSKc session status, generate and activate a new ephemeral key (Thread Administration Passcode), and deactivate the current one.
- Documents the new endpoints in `src/rest/openapi.yaml`.
- Adds an integration test (`epskc_test`) to `tests/rest/test_rest.py` covering enable/disable, activation while disabled (409), double activation (409), successful activation, status, and deactivation.

This is a rebase and adaptation of @puddly's original patch (https://github.com/puddly/ot-br-posix/commit/d8bd507e42a3e3a3a8517c7d7f55686cd024a25), which predates ~250 commits of drift on `main`, including the `openthread` submodule bump that moved the ephemeral key API from `otBorderAgentEphemeralKeyGenerateTap()` to the `BorderAgent::CreateEphemeralKey()` helper already used by the D-Bus `ActivateEphemeralKeyMode` method. I opened this on @puddly's behalf since they didn't have time to rebase it themselves; happy to have them take over review/authorship if preferred.

## Test plan

- [x] `cmake -DOTBR_REST=ON -DOT_PLATFORM=simulation ...` + `ninja otbr-agent` builds cleanly with `OTBR_ENABLE_EPSKC=1`.
- [x] `script/clang-format-check` passes (clang-format 19.1.7) on all changed C++ files.
- [x] Manually reproduced `tests/rest/test-rest-server` end-to-end without root, since `sudo`/`wpan0` weren't available in my sandbox: built an OpenThread simulation RCP (`OT_PLATFORM=simulation`), ran `otbr-agent` + `ot-rcp` + `ot-ctl` inside an unprivileged `unshare --user --net --mount` namespace (tmpfs over `/run` for the daemon socket, `--data-path` for settings), formed a Thread network, and ran the real `tests/rest/test_rest.py` against it. All pre-existing checks pass (`200/200` on every endpoint) and the new `epskc_test` passes end-to-end: 409 on activation while disabled, successful activation with a valid 9-digit TAP and port, status transitions (`stopped` → `started`), 409 on double activation, and deactivation back to `stopped`/`disabled`.
- [x] Also validated against real Thread radio hardware (Nabu Casa ZBT-2, Silicon Labs EFR32 RCP firmware `SL-OPENTHREAD/3.0.0.0_GitHub-61e43cffb`) over `spinel+hdlc+uart`, built with the same OpenThread core configuration as the Home Assistant [`openthread_border_router` add-on](https://github.com/home-assistant/addons/tree/master/openthread_border_router) (Thread 1.4, Border Agent, Backbone Router, TREL, `OPENTHREAD_CONFIG_BORDER_AGENT_MESHCOP_SERVICE_BASE_NAME`, etc.). The device formed a real Thread network (became `leader`) and `tests/rest/test_rest.py`, including `epskc_test`, passed end-to-end (`exit=0`) against the real hardware.
- [ ] CI `rest-check` / `check` / other GitHub Actions jobs — currently blocked on `action_required` pending a maintainer approval since this is a first-time external contribution; not something I can trigger myself.

