### PR TITLE
[tests] fix ED_1 state after reset in dind_srp_tc_11 script

### DIFF
--- a/tests/scripts/expect/dind_srp_tc_11.exp
+++ b/tests/scripts/expect/dind_srp_tc_11.exp
@@ -148,8 +148,10 @@ set netdata_before [exec docker exec -i $container ot-ctl netdata show]
 check_string_contains $netdata_before "44970 5d"
 
 # Get the running Border Router's active dataset dynamically to configure clients
-set active_dataset [exec docker exec -i $container ot-ctl dataset active -x]
-set active_dataset [string trim $active_dataset]
+set active_dataset_raw [exec docker exec -i $container ot-ctl dataset active -x]
+if {![regexp -nocase {[0-9a-f]{32,}} $active_dataset_raw active_dataset]} {
+    fail "Failed to parse active dataset hex from: $active_dataset_raw"
+}
 
 # Enable ED_1 (Node 4)
 spawn_node 4 cli $::env(EXP_OT_CLI_PATH)
@@ -239,6 +241,8 @@ expect_line "Done"
 
 # Step 9: ED_1 sends SRP Update, as in step 4
 send_user "Step 9: ED_1 starting Thread and re-configuring SRP...\n"
+send "routereligible disable\r\n"
+expect_line "Done"
 send "ifconfig up\r\n"
 expect_line "Done"
 send "thread start\r\n"


### PR DESCRIPTION
Fix an integration test failure in dind_srp_tc_11.exp caused by two issues:

1. Software reset in Step 8 clears non-persistent runtime configurations on Node 4 (ED_1), resetting routereligible back to enabled. In Step 9, when starting Thread, Node 4 promotes itself to a router, causing wait_for "state" "child" to time out and fail. Re-apply routereligible disable before starting Thread in Step 9.

2. ot-ctl dataset active -x appends \nDone to the output. Parsing the whole output caused dataset set active to pass Done on a new line to the OpenThread CLI, causing Error 35: InvalidCommand and desynchronizing the expect response matching queue. Clean dataset output to extract only the hex string.