### PR TITLE
[ubus] fix two memory-safety issues

### DIFF
--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -895,7 +895,7 @@ int UbusServer::UbusMgmtset(struct ubus_context      *aContext,
     {
         dataset.mComponents.mIsExtendedPanIdPresent = true;
         VerifyOrExit(Hex2Bin(blobmsg_get_string(tb[EXTPANID]), dataset.mExtendedPanId.m8,
-                             sizeof(dataset.mExtendedPanId.m8)) >= 0,
+                             sizeof(dataset.mExtendedPanId.m8)) == OT_EXT_PAN_ID_SIZE,
                      error = OT_ERROR_PARSE);
     }
     if (tb[PANID] != nullptr)
@@ -1512,7 +1512,8 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
         {
             otExtendedPanId extPanId;
             char           *input = blobmsg_get_string(tb[SETNETWORK]);
-            VerifyOrExit(Hex2Bin(input, extPanId.m8, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
+            VerifyOrExit(Hex2Bin(input, extPanId.m8, sizeof(extPanId.m8)) == OT_EXT_PAN_ID_SIZE,
+                         error = OT_ERROR_PARSE);
             error = otThreadSetExtendedPanId(mHost->GetInstance(), &extPanId);
         }
     }

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -1518,7 +1518,7 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
     }
     else if (!strcmp(aAction, "mode"))
     {
-        otLinkModeConfig  linkMode;
+        otLinkModeConfig  linkMode = {};
         struct blob_attr *tb[SET_NETWORK_MAX];
 
         blobmsg_parse(setModePolicy, SET_NETWORK_MAX, tb, blob_data(aMsg), blob_len(aMsg));

--- a/src/openwrt/ubus/otubus.cpp
+++ b/src/openwrt/ubus/otubus.cpp
@@ -895,7 +895,8 @@ int UbusServer::UbusMgmtset(struct ubus_context      *aContext,
     {
         dataset.mComponents.mIsExtendedPanIdPresent = true;
         VerifyOrExit(Hex2Bin(blobmsg_get_string(tb[EXTPANID]), dataset.mExtendedPanId.m8,
-                             sizeof(dataset.mExtendedPanId.m8)) >= 0,
+                             sizeof(dataset.mExtendedPanId.m8)) ==
+                         static_cast<int>(sizeof(dataset.mExtendedPanId.m8)),
                      error = OT_ERROR_PARSE);
     }
     if (tb[PANID] != nullptr)
@@ -1512,7 +1513,9 @@ int UbusServer::UbusSetInformation(struct ubus_context      *aContext,
         {
             otExtendedPanId extPanId;
             char           *input = blobmsg_get_string(tb[SETNETWORK]);
-            VerifyOrExit(Hex2Bin(input, extPanId.m8, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
+            VerifyOrExit(Hex2Bin(input, extPanId.m8, sizeof(extPanId.m8)) ==
+                             static_cast<int>(sizeof(extPanId.m8)),
+                         error = OT_ERROR_PARSE);
             error = otThreadSetExtendedPanId(mHost->GetInstance(), &extPanId);
         }
     }


### PR DESCRIPTION
Two independent fixes in the ubus integration:

1. `UbusSetInformation` read `otLinkModeConfig` fields from an uninitialized struct when the caller supplied a partial mode string; value-initialize it.
2. `UbusMgmtset` accepted a short hex string for the extended PAN ID and read past the parsed bytes; require the full length.

Both are reachable from unprivileged ubus callers on default OpenWrt ACLs. Found while integrating the ubus surface with a Matter network manager; tested on a Turris Omnia.