### PR TITLE
[docker] declare secrets in workflow_call trigger

### DIFF
--- a/.github/workflows/docker-border-router.yml
+++ b/.github/workflows/docker-border-router.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      DOCKER_USERNAME:
+        required: false
+      DOCKER_PASSWORD:
+        required: false
 
 
 concurrency:


### PR DESCRIPTION
This commit adds DOCKER_USERNAME and DOCKER_PASSWORD under the workflow_call secrets declaration in docker-border-router.yml.

When monthly-release.yml invokes docker-border-router.yml as a reusable workflow via workflow_call, GitHub Actions validates that secrets referenced within the reusable workflow are explicitly declared in its workflow_call secrets section. Missing these declarations caused scheduled monthly release workflow runs to fail at startup with an invalid secret error.