### PR TITLE
[tests] increase timeout in ncp_version.exp to prevent CI flakiness

### DIFF
--- a/tests/scripts/expect/ncp_version.exp
+++ b/tests/scripts/expect/ncp_version.exp
@@ -26,7 +26,7 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-set timeout 1
+set timeout 10
 
 # Spawn the otbr-agent with NCP in Dry Run mode
 spawn $::env(EXP_OTBR_AGENT_PATH) -I $::env(EXP_TUN_NAME) -v -d7 --vendor-name="OpenThreadTest" --model-name="BorderRouter" --radio-version "spinel+hdlc+forkpty://$::env(EXP_OT_NCP_PATH)?forkpty-arg=$::env(EXP_LEADER_NODE_ID)"


### PR DESCRIPTION
This commit increases the expect timeout in ncp_version.exp from 1 second to 10 seconds.

Spawning `otbr-agent`, launching `ot-ncp-ftd` over PTY via forkpty, performing Spinel protocol initialization, querying version string, and flushing stdout can occasionally take longer than 1 second when GitHub Actions runner VMs experience CPU scheduling load spikes.

Increasing the timeout to 10 seconds matches standard helper timeout configurations in expect tests and prevents spurious timeout failures.