### PR TITLE
[ci] package and upload source tarball in monthly release

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          submodules: recursive
           persist-credentials: false
 
       - name: Generate CalVer Tag Name
@@ -88,12 +89,18 @@ jobs:
           echo "TAG_NAME=$CALVER_TAG" >> $GITHUB_OUTPUT
           echo "Generated tag: $CALVER_TAG"
 
+      - name: Package Source Tarball
+        run: |
+          TAR_NAME="ot-br-posix-${TAG_NAME}.tar.gz"
+          tar --exclude-vcs --transform "s|^\.|ot-br-posix-${TAG_NAME}|" -czf "${TAR_NAME}" .
+          echo "TAR_NAME=${TAR_NAME}" >> $GITHUB_ENV
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Uses the built-in GitHub CLI to create the tag and release simultaneously
         run: |
-          gh release create "$TAG_NAME" \
+          gh release create "$TAG_NAME" "$TAR_NAME" \
             --target "${GITHUB_REF_NAME}" \
             --title "OpenThread Border Router $TAG_NAME" \
             --generate-notes


### PR DESCRIPTION
GitHub's automatically generated source archives (.tar.gz and .zip) do not include Git submodules, leaving third_party/ submodules empty and making it impossible to build ot-br-posix directly from release archives.

This commit updates monthly-release.yml to checkout submodules recursively and package the source tree into a release tarball asset, which is attached to the GitHub release via gh release create.

Fixes #3496