### PR TITLE
Correctly handle startup command lines without TREL parameters

### DIFF
--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -152,7 +152,7 @@ RcpHost::RcpHost(const char                      *aInterfaceName,
     {
         mConfig.mCoprocessorUrls.mUrls[mConfig.mCoprocessorUrls.mNum++] = url;
 
-        if (strncmp(url, "trel:", sizeof("trel:") - 1) == 0)
+        if (url != nullptr && strncmp(url, "trel:", sizeof("trel:") - 1) == 0)
         {
             mTrelUrlPresent = true;
         }

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -151,6 +151,11 @@ RcpHost::RcpHost(const char                      *aInterfaceName,
     for (const char *url : aRadioUrls)
     {
         mConfig.mCoprocessorUrls.mUrls[mConfig.mCoprocessorUrls.mNum++] = url;
+
+        if (strncmp(url, "trel:", sizeof("trel:") - 1) == 0)
+        {
+            mTrelUrlPresent = true;
+        }
     }
     mConfig.mSpeedUpFactor = 1;
 }
@@ -265,9 +270,19 @@ void RcpHost::Init(void)
         VerifyOrExit(result == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
     }
 
-#if OTBR_ENABLE_FEATURE_FLAGS && OTBR_ENABLE_TREL
-    // Enable/Disable trel according to feature flag default value.
-    otTrelSetEnabled(mInstance, featureFlagList.enable_trel());
+#if OTBR_ENABLE_TREL
+    if (!mTrelUrlPresent)
+    {
+        otTrelSetEnabled(mInstance, false);
+        otbrLogNotice("TREL is disabled because no trel:// radio URL was provided");
+    }
+#if OTBR_ENABLE_FEATURE_FLAGS
+    else
+    {
+        // Enable/Disable TREL according to the feature flag default value.
+        otTrelSetEnabled(mInstance, featureFlagList.enable_trel());
+    }
+#endif
 #endif
 
 #if OTBR_ENABLE_SRP_SERVER_AUTO_ENABLE_MODE && OTBR_ENABLE_SRP_SERVER_ON_INIT
@@ -332,7 +347,11 @@ otError RcpHost::ApplyFeatureFlagList(const FeatureFlagList &aFeatureFlagList)
     }
 
 #if OTBR_ENABLE_TREL
-    otTrelSetEnabled(mInstance, aFeatureFlagList.enable_trel());
+    if (aFeatureFlagList.enable_trel() && !mTrelUrlPresent)
+    {
+        otbrLogWarning("Ignoring TREL enable request because no trel:// radio URL was provided");
+    }
+    otTrelSetEnabled(mInstance, mTrelUrlPresent && aFeatureFlagList.enable_trel());
 #endif
 #if OTBR_ENABLE_DNS_UPSTREAM_QUERY
     otDnssdUpstreamQuerySetEnabled(mInstance, aFeatureFlagList.enable_dns_upstream_query());

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -285,6 +285,7 @@ private:
     otInstance *mInstance;
 
     otPlatformConfig                       mConfig;
+    bool                                   mTrelUrlPresent = false;
     std::unique_ptr<ThreadHelper>          mThreadHelper;
     std::vector<std::function<void(void)>> mResetHandlers;
     TaskRunner                             mTaskRunner;

--- a/tests/gtest/test_rcp_host_api.cpp
+++ b/tests/gtest/test_rcp_host_api.cpp
@@ -33,6 +33,12 @@
 
 #include <openthread/dataset.h>
 #include <openthread/dataset_ftd.h>
+#include <openthread/link.h>
+#include <openthread/trel.h>
+
+#if OTBR_ENABLE_FEATURE_FLAGS
+#include "proto/feature_flag.pb.h"
+#endif
 
 #include "common/mainloop.hpp"
 #include "common/mainloop_manager.hpp"
@@ -61,6 +67,36 @@ static void MainloopProcessUntil(otbr::MainloopContext    &aMainloop,
         otbr::MainloopManager::GetInstance().Process(aMainloop);
     }
 }
+
+#if OTBR_ENABLE_TREL
+TEST(RcpHostApi, TrelAvailabilityFollowsRadioUrlConfiguration)
+{
+    auto verifyTrelState = [](const std::vector<const char *> &aRadioUrls, bool aExpectedEnabled) {
+        otbr::Host::RcpHost host("wpan0", aRadioUrls, /* aBackboneInterfaceName */ "", /* aDryRun */ false,
+                                 /* aEnableAutoAttach */ false);
+
+        host.Init();
+
+#if OTBR_ENABLE_FEATURE_FLAGS
+        otbr::FeatureFlagList featureFlags;
+
+        featureFlags.set_enable_trel(true);
+        EXPECT_EQ(host.ApplyFeatureFlagList(featureFlags), OT_ERROR_NONE);
+#endif
+
+        otInstance *instance = host.GetInstance();
+
+        ASSERT_EQ(otLinkSetEnabled(instance, true), OT_ERROR_NONE);
+        EXPECT_EQ(otTrelIsEnabled(instance), aExpectedEnabled);
+        ASSERT_EQ(otLinkSetEnabled(instance, false), OT_ERROR_NONE);
+
+        host.Deinit();
+    };
+
+    verifyTrelState({"spinel+hdlc+uart:///dev/null"}, false);
+    verifyTrelState({"spinel+hdlc+uart:///dev/null", "trel://eth0"}, true);
+}
+#endif
 
 TEST(RcpHostApi, DeviceRoleChangesCorrectlyAfterSetThreadEnabled)
 {


### PR DESCRIPTION
When there is no TREL parameter in the startup parameters of otbr-agent, TREL is explicitly disabled.
Fixes #3495

Changes:
1. Explicitly disable TREL when no TREL URL provided;
2. Ignore TREL enable request when no TREL URL provided.
3. Add related test.