### PR TITLE
[tests] fix flaky ncp DeviceRole checks by polling instead of fixed sleep

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -84,6 +84,63 @@ proc expect_line {line} {
     return $expect_out(1,string)
 }
 
+# Poll the otbr-agent DeviceRole D-Bus property until it matches `pattern`,
+# retrying up to `retries` times (roughly one attempt per second). Each
+# individual dbus-send call keeps a short reply-timeout, but polling absorbs
+# the CI timing variance in leader/router formation instead of relying on a
+# single read after a fixed sleep, which races with attach and intermittently
+# fails with "Error org.freedesktop.DBus.Error.NoReply".
+proc wait_for_device_role {pattern {retries 30} {bus "--system"}} {
+    # spawn sets the global spawn_id, so the dbus-send calls below would
+    # otherwise silently redirect any send/expect the caller does afterwards
+    # on its own node. Save and restore it so this utility is transparent to
+    # the caller's spawn state.
+    global spawn_id
+    set has_spawn_id [info exists spawn_id]
+    if {$has_spawn_id} {
+        set backup_spawn_id $spawn_id
+    }
+
+    # Localize the timeout so a hung dbus-send can't inherit whatever
+    # timeout was active in the calling script, and so a genuine timeout
+    # (as opposed to a clean eof) still closes the spawned process below.
+    set timeout 2
+
+    set success 0
+    for {set i 0} {$i < $retries} {incr i} {
+        spawn dbus-send $bus --print-reply --reply-timeout=1000 --dest=io.openthread.BorderRouter.wpan0 \
+            /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
+        expect {
+            -re $pattern {
+                expect eof
+                set success 1
+                break
+            }
+            eof {
+                # NoReply, wrong role, or another transient D-Bus error: retry.
+            }
+            timeout {
+                # dbus-send hung instead of replying or closing; kill it off
+                # before retrying.
+                catch {close}
+                catch {wait}
+            }
+        }
+        sleep 1
+    }
+
+    if {$has_spawn_id} {
+        set spawn_id $backup_spawn_id
+    } else {
+        unset -nocomplain spawn_id
+    }
+
+    if {!$success} {
+        fail "Timed out waiting for DeviceRole matching '$pattern'"
+    }
+    return 0
+}
+
 # type: The type of the node.
 #   Possible values:
 #   1. cli: The cli app. ot-cli-ftd or ot-cli-mtd

--- a/tests/scripts/expect/ncp_get_device_role.exp
+++ b/tests/scripts/expect/ncp_get_device_role.exp
@@ -32,13 +32,7 @@ spawn_node 1 otbr $::env(EXP_OT_NCP_PATH)
 
 sleep 1
 
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {disabled} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+wait_for_device_role {disabled}
 
 # Shut down otbr-agent
 switch_node 1

--- a/tests/scripts/expect/ncp_join_leave.exp
+++ b/tests/scripts/expect/ncp_join_leave.exp
@@ -52,25 +52,14 @@ sleep 1
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
 expect eof
 
-# Step 3. Wait 10 seconds, check if the otbr-agent has attached successfully
-sleep 10
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {router|child} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+# Step 3. Check if the otbr-agent has attached successfully. Poll instead of
+# a fixed sleep plus a single short-timeout read: attach timing varies in CI
+# and the fixed wait intermittently races with it (see #3510).
+wait_for_device_role {router|child}
 
 # Step 4. Use dbus leave method to let otbr-agent leave the network
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.LeaveNetwork
 expect eof
 
 # Step 5. Verify the state of otbr-agent is 'disabled'
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {disabled} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+wait_for_device_role {disabled}

--- a/tests/scripts/expect/ncp_netif_address_update.exp
+++ b/tests/scripts/expect/ncp_netif_address_update.exp
@@ -39,15 +39,10 @@ sleep 1
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
 expect eof
 
-# Step 2. Wait 10 seconds for it becomes a leader.
-sleep 10
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {leader} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+# Step 2. Wait for it to become a leader. Poll instead of a fixed sleep plus
+# a single short-timeout read: leader formation timing varies in CI and the
+# fixed wait intermittently races with it (see #3510).
+wait_for_device_role {leader}
 
 # Step 3. Verify the addresses on wpan.
 # There should be:

--- a/tests/scripts/expect/ncp_netif_tx_rx.exp
+++ b/tests/scripts/expect/ncp_netif_tx_rx.exp
@@ -51,15 +51,10 @@ sleep 1
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
 expect eof
 
-# Step 3. Wait 10 seconds, check if the otbr-agent has attached successfully
-sleep 10
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {router|child} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+# Step 3. Check if the otbr-agent has attached successfully. Poll instead of
+# a fixed sleep plus a single short-timeout read: attach timing varies in CI
+# and the fixed wait intermittently races with it (see #3510).
+wait_for_device_role {router|child}
 
 # Step 4. Verify pinging from otbr-agent NCP to the cli node
 spawn ping6 -c 10 ${dest_addr}

--- a/tests/scripts/expect/ncp_schedule_migration.exp
+++ b/tests/scripts/expect/ncp_schedule_migration.exp
@@ -44,15 +44,10 @@ sleep 1
 spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
 expect eof
 
-# Step 2. Wait 10 seconds, check if the otbr-agent has attached successfully
-sleep 10
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --print-reply --reply-timeout=1000 /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
-expect -re {leader} {
-} timeout {
-    puts "timeout!"
-    exit 1
-}
-expect eof
+# Step 2. Check if the otbr-agent has attached successfully. Poll instead of
+# a fixed sleep plus a single short-timeout read: attach timing varies in CI
+# and the fixed wait intermittently races with it (see #3510).
+wait_for_device_role {leader}
 
 # Step 3. Start a Thread node and create a Thread network
 spawn_node 2 cli $::env(EXP_OT_CLI_PATH)


### PR DESCRIPTION
### Description

Fixes the flaky `NcpMode` CI failure reported in #3510: several `expect` scripts wait a fixed `sleep 10`, then read the `DeviceRole` D-Bus property **once** with a 1000ms reply-timeout. When attach/leader formation takes slightly longer than the fixed window (or otbr-agent's D-Bus dispatch is briefly busy), the read fails with:

```
Error org.freedesktop.DBus.Error.NoReply: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
```

...failing the whole script (`expect eof` then errors with `spawn id ... not open`).

Same class of "fixed wait window" timing race already addressed for `RcpHostApi.StateChangesCorrectlyAfterJoin`.

### Change

- Add `wait_for_device_role {pattern} {retries} {bus}` to `tests/scripts/expect/_common.exp`: polls the `DeviceRole` property (bounded, ~30 retries spaced ~1s apart), keeping the same short per-call `reply-timeout`, but tolerating transient `NoReply`/wrong-role reads instead of asserting on a single racy one.
- Apply it to the four scripts sharing the fixed-sleep + single-read pattern:
  - `tests/scripts/expect/ncp_netif_address_update.exp`
  - `tests/scripts/expect/ncp_join_leave.exp`
  - `tests/scripts/expect/ncp_schedule_migration.exp`
  - `tests/scripts/expect/ncp_netif_tx_rx.exp`

### Testing

**Update:** since opening this PR, the fix has also been validated locally against the *real* stack (not just the fake D-Bus service described below), in a privileged Docker container running systemd/dbus/avahi and mirroring the `NcpMode` CI job (`tests/scripts/bootstrap.sh` + `script/cmake-build` + `tests/scripts/ncp_mode build_ot_sim expect ...`) — real `otbr-agent` built from this branch, talking over D-Bus to a real simulated NCP (`ot-ncp-ftd`) via `spinel+hdlc+forkpty`, no mocks:

```
PASS tests/scripts/expect/ncp_netif_address_update.exp
PASS tests/scripts/expect/ncp_join_leave.exp
PASS tests/scripts/expect/ncp_schedule_migration.exp
PASS tests/scripts/expect/ncp_netif_tx_rx.exp
```

In the `ncp_netif_address_update.exp` run, the log shows `wait_for_device_role` polling through several consecutive `DeviceRole = "detached"` reads before the node reaches `leader` — the exact race window this PR's fix is meant to absorb.

Original validation (from before sudo/docker were available in the sandbox used to prepare this change):

CI here doesn't have sudo/docker available in the sandbox used to prepare this change, so instead of the full otbr-agent + simulated NCP stack, the fix was validated against a minimal fake `io.openthread.BorderRouter` D-Bus service that reproduces the exact race:

- Replies to `Properties.Get(DeviceRole)` take 2s (> the 1000ms `reply-timeout`) until a configurable point in time, then reply immediately with the target role (`leader` / `router|child` / `disabled`, matching each script's assertion).
- **Old logic** (fixed `sleep 10` + single read) against this fake service: fails with the **identical** `NoReply` error seen in CI.
- **New logic** (`wait_for_device_role`): retries through the `NoReply`s and succeeds once the role becomes available.
- **Negative case**: when the role never matches, `wait_for_device_role` still fails deterministically after exhausting its bounded retries (no infinite loop).

Also confirmed the modified `_common.exp` sources without syntax errors.

Fixes #3510
