### PR TITLE
[ncp] support the pending dataset under NCP mode

### DIFF
--- a/src/host/ncp_host.cpp
+++ b/src/host/ncp_host.cpp
@@ -53,6 +53,7 @@ NcpNetworkProperties::NcpNetworkProperties(void)
     : mDeviceRole(OT_DEVICE_ROLE_DISABLED)
 {
     memset(&mDatasetActiveTlvs, 0, sizeof(mDatasetActiveTlvs));
+    memset(&mDatasetPendingTlvs, 0, sizeof(mDatasetPendingTlvs));
     SetMeshLocalPrefix(kMeshLocalPrefixInit);
 }
 
@@ -90,10 +91,16 @@ void NcpNetworkProperties::GetDatasetActiveTlvs(otOperationalDatasetTlvs &aDatas
     memcpy(aDatasetTlvs.mTlvs, mDatasetActiveTlvs.mTlvs, mDatasetActiveTlvs.mLength);
 }
 
+void NcpNetworkProperties::SetDatasetPendingTlvs(const otOperationalDatasetTlvs &aPendingOpDatasetTlvs)
+{
+    mDatasetPendingTlvs.mLength = aPendingOpDatasetTlvs.mLength;
+    memcpy(mDatasetPendingTlvs.mTlvs, aPendingOpDatasetTlvs.mTlvs, aPendingOpDatasetTlvs.mLength);
+}
+
 void NcpNetworkProperties::GetDatasetPendingTlvs(otOperationalDatasetTlvs &aDatasetTlvs) const
 {
-    // TODO: Implement the method under NCP mode.
-    OTBR_UNUSED_VARIABLE(aDatasetTlvs);
+    aDatasetTlvs.mLength = mDatasetPendingTlvs.mLength;
+    memcpy(aDatasetTlvs.mTlvs, mDatasetPendingTlvs.mTlvs, mDatasetPendingTlvs.mLength);
 }
 
 void NcpNetworkProperties::SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix)

--- a/src/host/ncp_host.hpp
+++ b/src/host/ncp_host.hpp
@@ -70,10 +70,12 @@ private:
     // PropsObserver methods
     void SetDeviceRole(otDeviceRole aRole) override;
     void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) override;
+    void SetDatasetPendingTlvs(const otOperationalDatasetTlvs &aPendingOpDatasetTlvs) override;
     void SetMeshLocalPrefix(const otMeshLocalPrefix &aMeshLocalPrefix) override;
 
     otDeviceRole             mDeviceRole;
     otOperationalDatasetTlvs mDatasetActiveTlvs;
+    otOperationalDatasetTlvs mDatasetPendingTlvs;
     otMeshLocalPrefix        mMeshLocalPrefix;
 };
 

--- a/src/host/ncp_spinel.cpp
+++ b/src/host/ncp_spinel.cpp
@@ -79,6 +79,19 @@ void NcpSpinel::Init(ot::Spinel::SpinelDriver &aSpinelDriver, PropsObserver &aOb
     mPropsObserver = &aObserver;
     mIid           = mSpinelDriver->GetIid();
     mSpinelDriver->SetFrameHandler(&HandleReceivedFrame, &HandleSavedFrame, this);
+
+    // Get both datasets to have initial values: on startup against an
+    // already-provisioned NCP the caches would otherwise stay empty until the
+    // NCP next reports a change.
+    for (spinel_prop_key_t key : {SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS, SPINEL_PROP_THREAD_PENDING_DATASET_TLVS})
+    {
+        otError error = GetProperty(key);
+
+        if (error != OT_ERROR_NONE)
+        {
+            otbrLogWarning("Failed to get dataset property %u, %s", key, otThreadErrorToString(error));
+        }
+    }
 }
 
 void NcpSpinel::Deinit(void)
@@ -481,6 +494,28 @@ void NcpSpinel::HandleValueIs(spinel_prop_key_t aKey, const uint8_t *aBuffer, ui
         break;
     }
 
+    case SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS:
+    {
+        otOperationalDatasetTlvs datasetTlvs = {};
+
+        // The active dataset also changes without otbr asking for it, most
+        // notably when a pending dataset is applied at the end of a migration.
+        VerifyOrExit(ParseOperationalDatasetTlvs(aBuffer, aLength, datasetTlvs) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_PARSE);
+        mPropsObserver->SetDatasetActiveTlvs(datasetTlvs);
+        break;
+    }
+
+    case SPINEL_PROP_THREAD_PENDING_DATASET_TLVS:
+    {
+        otOperationalDatasetTlvs datasetTlvs = {};
+
+        VerifyOrExit(ParseOperationalDatasetTlvs(aBuffer, aLength, datasetTlvs) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_PARSE);
+        mPropsObserver->SetDatasetPendingTlvs(datasetTlvs);
+        break;
+    }
+
     case SPINEL_PROP_IPV6_ADDRESS_TABLE:
     {
         std::vector<Ip6AddressInfo> addressInfoTable;
@@ -863,6 +898,37 @@ otbrError NcpSpinel::HandleResponseForPropGet(spinel_tid_t      aTid,
         SuccessOrExit(decoder.ReadData(data, dataLen), error = OTBR_ERROR_PARSE);
 
         SafeInvoke(mBorderAgentMeshCoPServiceChangedCallback, isActive, port, data, dataLen);
+        break;
+    }
+
+    case SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS:
+    case SPINEL_PROP_THREAD_PENDING_DATASET_TLVS:
+    {
+        otOperationalDatasetTlvs datasetTlvs = {};
+
+        // A failed get comes back as LAST_STATUS with the error status as
+        // payload, which must not reach the TLV parser.
+        if (aKey == SPINEL_PROP_LAST_STATUS)
+        {
+            spinel_status_t status = SPINEL_STATUS_OK;
+
+            SuccessOrExit(error = SpinelDataUnpack(aData, aLength, SPINEL_DATATYPE_UINT_PACKED_S, &status));
+            otbrLogWarning("Failed to get dataset property %u: %s", mWaitingKeyTable[aTid],
+                           otThreadErrorToString(ot::Spinel::SpinelStatusToOtError(status)));
+            ExitNow();
+        }
+        VerifyOrExit(aKey == mWaitingKeyTable[aTid], error = OTBR_ERROR_INVALID_STATE);
+
+        VerifyOrExit(ParseOperationalDatasetTlvs(aData, aLength, datasetTlvs) == OT_ERROR_NONE,
+                     error = OTBR_ERROR_PARSE);
+        if (mWaitingKeyTable[aTid] == SPINEL_PROP_THREAD_ACTIVE_DATASET_TLVS)
+        {
+            mPropsObserver->SetDatasetActiveTlvs(datasetTlvs);
+        }
+        else
+        {
+            mPropsObserver->SetDatasetPendingTlvs(datasetTlvs);
+        }
         break;
     }
 

--- a/src/host/ncp_spinel.hpp
+++ b/src/host/ncp_spinel.hpp
@@ -87,6 +87,13 @@ public:
     virtual void SetDatasetActiveTlvs(const otOperationalDatasetTlvs &aActiveOpDatasetTlvs) = 0;
 
     /**
+     * Updates the pending dataset.
+     *
+     * @param[in] aPendingOpDatasetTlvs  The pending dataset tlvs.
+     */
+    virtual void SetDatasetPendingTlvs(const otOperationalDatasetTlvs &aPendingOpDatasetTlvs) = 0;
+
+    /**
      * Updates the mesh local prefix.
      *
      * @param[in] aMeshLocalPrefix  The mesh local prefix.


### PR DESCRIPTION
Split out of #3489, which is now the RCP-side half of the original series.

- `NcpSpinel` does not refresh its cached active dataset when the co-processor reports an unsolicited change, so callers read a stale dataset after the network changes underneath them.
- NCP mode has no pending-dataset path at all: `SetDatasetPendingTlvs` is added to the `NcpSpinel` interface and implemented in `NcpHost`, so `ScheduleMigration` works in NCP mode the way it already does under RCP.

**Testing:** compile-tested only (builds standalone against current main, unit tests pass). I do not have NCP-mode hardware — the co-processor type is chosen by `otSysInitCoprocessor()` from the firmware on the dongle, and mine reports RCP — so this half has not been exercised at runtime. Reviewers with an NCP setup are very welcome; the RCP counterpart of the same behaviour is in #3489.
