### PR TITLE
[docker] make IPv4 firewall rules idempotent and remove them on exit

### DIFF
--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -30,6 +30,9 @@
 OT_THREAD_IF="${OT_THREAD_IF:-wpan0}"
 readonly OT_THREAD_IF
 
+OT_INFRA_IF="${OT_INFRA_IF:-wlan0}"
+readonly OT_INFRA_IF
+
 OT_FORWARD_INGRESS_CHAIN="OT_FORWARD_INGRESS"
 readonly OT_FORWARD_INGRESS_CHAIN
 
@@ -48,8 +51,25 @@ ipset_destroy_if_exist()
     done
 }
 
-while ip6tables -C FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null; do
-    ip6tables -D FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}"
+# Remove every copy of an iptables rule. Older images appended these rules
+# without checking for duplicates, so a host may carry several of them.
+#
+# `-w` keeps a busy xtables lock from ending the loop early, and `|| break`
+# catches everything else: without it a failing `-D` leaves the rule in place,
+# `-C` keeps succeeding, and this spins forever -- hanging container shutdown,
+# since finish runs on the way out.
+iptables_delete_all()
+{
+    local table="$1"
+    shift
+
+    while iptables -t "${table}" -w -C "$@" 2> /dev/null; do
+        iptables -t "${table}" -w -D "$@" || break
+    done
+}
+
+while ip6tables -w -C FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null; do
+    ip6tables -w -D FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" || break
 done
 
 if ip6tables -L "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null; then
@@ -61,6 +81,11 @@ ipset_destroy_if_exist otbr-ingress-deny-src
 ipset_destroy_if_exist otbr-ingress-deny-src-swap
 ipset_destroy_if_exist otbr-ingress-allow-dst
 ipset_destroy_if_exist otbr-ingress-allow-dst-swap
+
+iptables_delete_all mangle PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
+iptables_delete_all nat POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
+iptables_delete_all filter FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
+iptables_delete_all filter FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
 
 echo "OpenThread firewall rules removed."
 

--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -60,6 +60,24 @@ die()
     exit 1
 }
 
+# Add an iptables rule unless an identical one is already present.
+#
+# With `--network host` these rules are created in the host's netfilter
+# namespace and outlive the container, so a plain `-A` appends another copy on
+# every start of this service. `finish` removes them again, but it does not run
+# when the container is killed rather than stopped.
+#
+# `-w` is required, not cosmetic: without it a busy xtables lock makes `-C`
+# fail, which is indistinguishable from "rule not present" and falls through to
+# `-A` -- the guard would then create the very duplicate it exists to prevent.
+iptables_add_if_missing()
+{
+    local table="$1"
+    shift
+
+    iptables -t "${table}" -w -C "$@" 2> /dev/null || iptables -t "${table}" -w -A "$@"
+}
+
 mkdir -p /data/thread && ln -sft /var/lib /data/thread || die "Could not create directory /var/lib/thread to store Thread data."
 
 echo "Configuring OpenThread firewall..."
@@ -69,21 +87,28 @@ ipset create -exist otbr-ingress-deny-src-swap hash:net family inet6
 ipset create -exist otbr-ingress-allow-dst hash:net family inet6
 ipset create -exist otbr-ingress-allow-dst-swap hash:net family inet6
 
-ip6tables -N "${OT_FORWARD_INGRESS_CHAIN}"
-ip6tables -I FORWARD 1 -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}"
+# Create the chain, or empty it if a previous run left it behind. The rules
+# below are appended unconditionally, so a surviving chain would end up holding
+# two copies of each of them.
+ip6tables -w -N "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null ||
+    ip6tables -w -F "${OT_FORWARD_INGRESS_CHAIN}"
 
-ip6tables -A "${OT_FORWARD_INGRESS_CHAIN}" -m pkttype --pkt-type unicast -i "${OT_THREAD_IF}" -j DROP
-ip6tables -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-deny-src src -j DROP
-ip6tables -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
-ip6tables -A "${OT_FORWARD_INGRESS_CHAIN}" -m pkttype --pkt-type unicast -j DROP
-ip6tables -A "${OT_FORWARD_INGRESS_CHAIN}" -j ACCEPT
+# The jump into that chain lives in FORWARD and outlives the container as well.
+ip6tables -w -C FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null ||
+    ip6tables -w -I FORWARD 1 -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}"
+
+ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m pkttype --pkt-type unicast -i "${OT_THREAD_IF}" -j DROP
+ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-deny-src src -j DROP
+ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
+ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m pkttype --pkt-type unicast -j DROP
+ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -j ACCEPT
 
 echo "Configuring OpenThread NAT64..."
 
-iptables -t mangle -A PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
-iptables -t nat -A POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
-iptables -t filter -A FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
-iptables -t filter -A FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
+iptables_add_if_missing mangle PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
+iptables_add_if_missing nat POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
+iptables_add_if_missing filter FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
+iptables_add_if_missing filter FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
 
 echo "Starting otbr-agent..."
 


### PR DESCRIPTION
Fixes #3516.

### Problem

`etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run` appends four IPv4 rules for NAT64 with `-A` and no `-C` check:

```sh
iptables -t mangle -A PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
iptables -t nat -A POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
iptables -t filter -A FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
iptables -t filter -A FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
```

The matching `finish` cleans up only the ip6tables chain and the ipsets — that cleanup was added for #1286 (PR #1287) and the IPv4 rules were not included.

With `--network host` these rules live in the host's netfilter namespace and outlive the container, so every start of the service appends another copy — including in-container restarts by s6, not just container restarts.

On the deployment where this surfaced:

```
iptables -t filter -S FORWARD     | grep -c 'enp2s0 -j ACCEPT'   ->  250
iptables -t nat    -S POSTROUTING | grep -c '0x1001'             ->  125
iptables -t mangle -S PREROUTING  | grep -c '0x1001'             ->  125
```

Functionally harmless — the first match wins — but unbounded, traversed by every forwarded IPv4 packet, and the chains become unreadable when diagnosing something else.

### Change

- `run`: add `iptables_add_if_missing`, guarding each rule with `-C`.
- `finish`: add `iptables_delete_all`, mirroring the `while ip6tables -C … do -D done` loop already used for the ingress chain jump, and remove the four rules.
- `finish` now also defines `OT_INFRA_IF` (same default as `run`), which it needs for the two `filter FORWARD` rules.

The removal loop deletes *every* copy, so a host carrying duplicates from an earlier image is cleaned up on the first graceful stop.

The `-C` guard matters independently of the cleanup: `finish` does not run when the container is killed rather than stopped (`docker kill` sends SIGKILL), and a plain `-A` would duplicate the rules on the next start. This is also what #1286 originally asked for — tolerating a previous unclean shutdown.

### Testing

`shellcheck -s bash run finish` reports nothing for the changed lines. (It flags one pre-existing `SC2015` on the unrelated `mkdir … && … || die` line, left untouched.)

Functional check of both helpers against real `iptables` in an isolated network namespace:

```
--- old behaviour: plain -A three times ---
filter FORWARD : 3     (expected 3)
nat POSTROUTING: 3     (expected 3)
--- iptables_delete_all ---
filter FORWARD : 0     (expected 0)
nat POSTROUTING: 0     (expected 0)
--- new behaviour: iptables_add_if_missing three times ---
mangle PREROUTING: 1   (expected 1)
nat POSTROUTING  : 1   (expected 1)
filter FORWARD   : 2   (expected 2, one per direction)
--- finish path ---
all chains        : 0  (expected 0)
```

The second block covers the upgrade path: the loop removes duplicates left behind by an older image.

### Not in this PR

`run` also creates the ip6tables chain with a bare `ip6tables -N` / `-I FORWARD 1 … -j OT_FORWARD_INGRESS`, which duplicates the same way after an unclean shutdown. Happy to extend this PR to cover that if you would like it in the same change.