### PR TITLE
[docker] accept IPv6 traffic leaving the Thread network

### DIFF
--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/finish
@@ -36,6 +36,9 @@ readonly OT_INFRA_IF
 OT_FORWARD_INGRESS_CHAIN="OT_FORWARD_INGRESS"
 readonly OT_FORWARD_INGRESS_CHAIN
 
+OT_DOCKER_USER_CHAIN="DOCKER-USER"
+readonly OT_DOCKER_USER_CHAIN
+
 if test "$1" -eq 256 ; then
   e=$((128 + $2))
 else
@@ -44,35 +47,44 @@ fi
 
 echo "otbr-agent exited with code ${1} (by signal ${2})."
 
+# `|| break` rather than `|| true`: a destroy that keeps failing leaves the set
+# in place, `ipset list -n` keeps succeeding, and the loop never ends -- hanging
+# container shutdown, since finish runs on the way out.
 ipset_destroy_if_exist()
 {
     while ipset list -n "$1" 2> /dev/null; do
-        ipset destroy "$1" || true
+        ipset destroy "$1" || break
     done
 }
 
-# Remove every copy of an iptables rule. Older images appended these rules
-# without checking for duplicates, so a host may carry several of them.
+# Remove every copy of a rule, for either address family. Older images appended
+# some of these without checking for duplicates, so a host may carry several.
 #
 # `-w` keeps a busy xtables lock from ending the loop early, and `|| break`
 # catches everything else: without it a failing `-D` leaves the rule in place,
 # `-C` keeps succeeding, and this spins forever -- hanging container shutdown,
 # since finish runs on the way out.
-iptables_delete_all()
+xtables_delete_all()
 {
-    local table="$1"
-    shift
+    local cmd="$1"
+    local table="$2"
+    shift 2
 
-    while iptables -t "${table}" -w -C "$@" 2> /dev/null; do
-        iptables -t "${table}" -w -D "$@" || break
+    while "${cmd}" -t "${table}" -w -C "$@" 2> /dev/null; do
+        "${cmd}" -t "${table}" -w -D "$@" || break
     done
 }
 
-while ip6tables -w -C FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null; do
-    ip6tables -w -D FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}" || break
+xtables_delete_all ip6tables filter FORWARD -o "${OT_THREAD_IF}" -j "${OT_FORWARD_INGRESS_CHAIN}"
+
+# The egress rule. Both chains are tried because which one run picked depends on
+# whether DOCKER-USER existed at the time, and that can differ between start and
+# stop.
+for chain in "${OT_DOCKER_USER_CHAIN}" FORWARD; do
+    xtables_delete_all ip6tables filter "${chain}" -i "${OT_THREAD_IF}" -o "${OT_INFRA_IF}" -j ACCEPT
 done
 
-if ip6tables -L "${OT_FORWARD_INGRESS_CHAIN}" 2> /dev/null; then
+if ip6tables -w -L "${OT_FORWARD_INGRESS_CHAIN}" -n > /dev/null 2>&1; then
     ip6tables -w -F "${OT_FORWARD_INGRESS_CHAIN}"
     ip6tables -w -X "${OT_FORWARD_INGRESS_CHAIN}"
 fi
@@ -82,10 +94,10 @@ ipset_destroy_if_exist otbr-ingress-deny-src-swap
 ipset_destroy_if_exist otbr-ingress-allow-dst
 ipset_destroy_if_exist otbr-ingress-allow-dst-swap
 
-iptables_delete_all mangle PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
-iptables_delete_all nat POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
-iptables_delete_all filter FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
-iptables_delete_all filter FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
+xtables_delete_all iptables mangle PREROUTING -i "${OT_THREAD_IF}" -j MARK --set-mark 0x1001
+xtables_delete_all iptables nat POSTROUTING -m mark --mark 0x1001 -j MASQUERADE
+xtables_delete_all iptables filter FORWARD -o "${OT_INFRA_IF}" -j ACCEPT
+xtables_delete_all iptables filter FORWARD -i "${OT_INFRA_IF}" -j ACCEPT
 
 echo "OpenThread firewall rules removed."
 

--- a/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
+++ b/etc/docker/border-router/rootfs/etc/s6-overlay/s6-rc.d/otbr-agent/run
@@ -54,6 +54,9 @@ readonly OT_REST_LISTEN_PORT
 OT_FORWARD_INGRESS_CHAIN="OT_FORWARD_INGRESS"
 readonly OT_FORWARD_INGRESS_CHAIN
 
+OT_DOCKER_USER_CHAIN="DOCKER-USER"
+readonly OT_DOCKER_USER_CHAIN
+
 die()
 {
     echo >&2 "ERROR: $*"
@@ -102,6 +105,26 @@ ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-de
 ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m set --match-set otbr-ingress-allow-dst dst -j ACCEPT
 ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -m pkttype --pkt-type unicast -j DROP
 ip6tables -w -A "${OT_FORWARD_INGRESS_CHAIN}" -j ACCEPT
+
+# Traffic leaving the Thread network needs an explicit accept. The ingress chain
+# above only filters what the host already forwards; it does nothing for the
+# other direction, which until now relied on the FORWARD policy being ACCEPT.
+# That does not hold under Docker, which manages ip6tables and sets the policy
+# to DROP. The result is a one-directional, silent failure: requests into the
+# mesh work, every reply out of it is dropped, and the border router looks
+# perfectly healthy throughout.
+#
+# DOCKER-USER is the chain Docker reserves for user rules and does not rewrite
+# when it rebuilds its own; fall back to FORWARD where it does not exist.
+if ip6tables -w -L "${OT_DOCKER_USER_CHAIN}" -n > /dev/null 2>&1; then
+    egress_chain="${OT_DOCKER_USER_CHAIN}"
+else
+    egress_chain="FORWARD"
+fi
+readonly egress_chain
+
+ip6tables -w -C "${egress_chain}" -i "${OT_THREAD_IF}" -o "${OT_INFRA_IF}" -j ACCEPT 2> /dev/null ||
+    ip6tables -w -I "${egress_chain}" 1 -i "${OT_THREAD_IF}" -o "${OT_INFRA_IF}" -j ACCEPT
 
 echo "Configuring OpenThread NAT64..."
 


### PR DESCRIPTION
Fixes #3515, following @jwhui's direction in https://github.com/openthread/ot-br-posix/issues/3515#issuecomment-5298669158 — explicit forward rules for the Thread and infrastructure interfaces, `DOCKER-USER` with a `FORWARD` fallback.

> ⚠️ **Stacked on #3517.** Both change the same two scripts, so this branch is based on that PR to keep the diff applicable. It carries #3517's commit as its parent; please merge that one first, or say the word and I will rebase onto main once it lands.

### Problem

`run` installs the ingress chain, which filters traffic going *into* the Thread network. There is nothing for the other direction — egress has relied on the ip6tables FORWARD policy being ACCEPT. That holds on a bare host. It does not hold under Docker, which manages ip6tables and sets the policy to DROP:

```
# ip6tables -S FORWARD
-P FORWARD DROP
-A FORWARD -j DOCKER-USER
```

The failure is one-directional and completely silent. Requests into the mesh work, because the ingress chain accepts them; every reply out of it is dropped. Meanwhile `ot-ctl state` reports `leader`, the REST API answers, mDNS is fine, devices attach and show good link quality. Only the application layer fails — in our case every Matter node went `unavailable` while Thread itself was flawless. It cost most of a day before we thought to look at the FORWARD counters.

The IPv4 path does not have this problem because it adds its own `filter FORWARD` ACCEPT rules explicitly. This is the missing IPv6 counterpart.

### Change

`run`:

```sh
if ip6tables -w -L "${OT_DOCKER_USER_CHAIN}" -n > /dev/null 2>&1; then
    egress_chain="${OT_DOCKER_USER_CHAIN}"
else
    egress_chain="FORWARD"
fi

ip6tables -w -C "${egress_chain}" -i "${OT_THREAD_IF}" -o "${OT_INFRA_IF}" -j ACCEPT 2> /dev/null ||
    ip6tables -w -I "${egress_chain}" 1 -i "${OT_THREAD_IF}" -o "${OT_INFRA_IF}" -j ACCEPT
```

`finish` removes it from **both** chains, because which one `run` picked depends on whether `DOCKER-USER` existed at that moment, and that can differ between start and stop.

The rule is narrow on purpose — `-i <thread> -o <infra>` rather than the broader `-o <infra>` used on the IPv4 side. Aligning IPv4 with that would be a separate discussion; this PR only adds what is missing.

### Testing

`shellcheck -s bash run finish` is clean for the changed lines (it flags one pre-existing `SC2015` on the unrelated `mkdir … && … || die` line, left untouched).

Functional test against real `ip6tables` in an isolated network namespace, exercising both chain scenarios and the transition between them:

```
### case A: DOCKER-USER exists ###
  DOCKER-USER: 1   FORWARD: 0     (add run three times — idempotent)
  rule sits ahead of the chain's RETURN
  after finish: DOCKER-USER=0  FORWARD=0

### case B: no DOCKER-USER ###
  FORWARD: 1                      (add run twice — idempotent)
  after finish: FORWARD=0

### case C: added to FORWARD, DOCKER-USER appears afterwards ###
  before finish: DOCKER-USER=0  FORWARD=1
  after finish:  DOCKER-USER=0  FORWARD=0
```

Case C is why `finish` tries both.

### Environment this was found on

| | |
|---|---|
| Image | `openthread/border-router:latest`, built 2026-08-10 |
| Host | Debian 12, kernel 6.1, x86-64, Docker 27.4.1 |
| Compose | `network_mode: host`, `privileged: true` |
| RCP | SMLIGHT SLZB-06M (EFR32MG21) over USB |