### PR TITLE
[docker] add stable tag to border-router Docker image

### DIFF
--- a/.github/workflows/docker-border-router.yml
+++ b/.github/workflows/docker-border-router.yml
@@ -180,6 +180,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short
             type=raw,value=${{ inputs.release_tag || 'none' }},enable=${{ inputs.release_tag != '' && inputs.release_tag != null }}
+            type=raw,value=stable,enable=${{ inputs.release_tag != '' && inputs.release_tag != null }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
The `latest` tag on [`openthread/border-router`](https://hub.docker.com/r/openthread/border-router) currently tracks every push to `main`, so it can point at unreleased commits in between monthly CalVer releases. Users who want a released image must therefore track the exact CalVer tag (e.g. `v2026.08.0`), and have no fixed rollback target once `latest` regresses — a gap called out by a user in #3463:

> Docker Hub publishes only `openthread/otbr:latest` (no version tags), so downstream users have no clean rollback target once `:latest` regresses.

This PR adds a `stable` tag to the border-router image, applied under the same condition as the CalVer `release_tag` input, so that it only moves when `monthly-release.yml` cuts a release.

## Changes

- Add a `type=raw,value=stable` entry to `docker/metadata-action` in the `merge` job, enabled only when the `release_tag` input is provided.

## Resulting tag behaviour

| Trigger | Tags pushed |
| --- | --- |
| Push to `main` | `main`, `latest`, `sha-<short>` |
| Push to other branch | `<branch>`, `sha-<short>` |
| Manual `v*` tag push | `v2026.08.1`, `sha-<short>` |
| Monthly release (cron or `workflow_dispatch` + `tag_override`) | `main`, `latest`, `sha-<short>`, `v2026.09.0`, **`stable`** |

On release day `latest` and `stable` briefly point at the same digest; `latest` then moves ahead with the next merge to `main` while `stable` stays pinned until the next monthly cut.

## Note for reviewers

A manually pushed `v*` tag deliberately does **not** move `stable`, since the documented release path — including ad-hoc releases via `monthly-release.yml`'s `tag_override` dispatch — always flows through the `release_tag` input. If you would prefer hand-pushed tags to advance `stable` as well, the condition can be widened to:

```yaml
type=raw,value=stable,enable=${{ github.ref_type == 'tag' || (inputs.release_tag != '' && inputs.release_tag != null) }}
```

(the `push:` filter already restricts this workflow to `v*` tags, so `ref_type` alone is sufficient). Happy to make that change if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)