### PR TITLE
[rest] fix PUT errors masked as 405 by RoutingErrorHandler

### DIFF
--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -72,7 +72,7 @@
 #endif
 
 #ifndef OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS
-#define OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS "DELETE, GET, OPTIONS, POST"
+#define OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS "DELETE, GET, OPTIONS, POST, PUT"
 #endif
 
 #define OT_REST_RESOURCE_PATH_NODE "/node"
@@ -1250,6 +1250,8 @@ void RestWebServer::RoutingErrorHandler(const Request &aRequest, Response &aResp
         // fallthrough
     case HttpMethod::kGet:
         // fallthrough
+    case HttpMethod::kPut:
+        // fallthrough
     case HttpMethod::kDelete:
         // fallthrough
     case HttpMethod::kOptions:
@@ -1257,7 +1259,7 @@ void RestWebServer::RoutingErrorHandler(const Request &aRequest, Response &aResp
     default:
         errorDetails = "method not supported";
         error        = StatusCode::MethodNotAllowed_405;
-        aResponse.set_header("Allow", "GET, POST, DELETE, OPTIONS");
+        aResponse.set_header("Allow", "GET, POST, PUT, DELETE, OPTIONS");
         break;
     }
 

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -389,6 +389,65 @@ def node_state_test_attached():
             time.sleep(1)
 
 
+def node_state_put_invalid_body_test():
+    """Regression test for https://github.com/openthread/ot-br-posix/issues/3522
+
+    A PUT request that fails to process (e.g. an invalid body) must return
+    its real error status (400 Bad Request here) instead of being masked as
+    405 Method Not Allowed by RoutingErrorHandler.
+    """
+    url = rest_api_addr + "/node/state"
+
+    # Not valid JSON (missing quotes around the string value), so the
+    # handler rejects it with 400 before touching any device state.
+    request = urllib.request.Request(url, data=b'enable', method='PUT')
+
+    try:
+        urllib.request.urlopen(request)
+        assert False
+    except urllib.error.HTTPError as e:
+        assert (e.code == 400)
+
+    print(" PUT /node/state (invalid body) : status {}, expected 400".format(400))
+
+
+def node_state_put_unsupported_method_test():
+    """A method that genuinely isn't supported (e.g. PATCH) on a PUT-capable
+    endpoint must still return 405.
+    """
+    url = rest_api_addr + "/node/state"
+
+    request = urllib.request.Request(url, method='PATCH')
+
+    try:
+        urllib.request.urlopen(request)
+        assert False
+    except urllib.error.HTTPError as e:
+        assert (e.code == 405)
+
+    print(" PATCH /node/state : status {}, expected 405".format(405))
+
+
+def node_ext_address_put_no_route_test():
+    """A PUT to an endpoint that never registers a PUT handler (e.g.
+    /node/ext-address, GET-only) returns 404, the same routing-miss status
+    POST and DELETE already return on that path. Full 404/405 semantics
+    (a per-resource Allow header, etc.) are tracked by
+    https://github.com/openthread/ot-br-posix/issues/3529.
+    """
+    url = rest_api_addr + "/node/ext-address"
+
+    request = urllib.request.Request(url, data=b'"0000000000000000"', method='PUT')
+
+    try:
+        urllib.request.urlopen(request)
+        assert False
+    except urllib.error.HTTPError as e:
+        assert (e.code == 404)
+
+    print(" PUT /node/ext-address (no route) : status {}, expected 404".format(404))
+
+
 def node_network_name_test(thread_num):
     url = rest_api_addr + "/node/network-name"
 
@@ -512,6 +571,10 @@ def epskc_test():
         except urllib.error.HTTPError as err:
             assert err.code == code
 
+    # Regression test for https://github.com/openthread/ot-br-posix/issues/3522: an invalid
+    # PUT body must return its real error status (400) rather than being masked as 405.
+    expect_http_error(400, lambda: put_state("toggle"))
+
     # Feature disabled: activation must be refused.
     put_state("disable")
     assert get_state() == "disabled"
@@ -561,6 +624,9 @@ def main():
     node_rloc16_test(200)
     node_ext_address_test(200)
     node_state_test(200)
+    node_state_put_invalid_body_test()
+    node_state_put_unsupported_method_test()
+    node_ext_address_put_no_route_test()
     node_network_name_test(200)
     node_state_test_attached()  # wait for attached state
     node_leader_data_test(200)


### PR DESCRIPTION
## Description

`RoutingErrorHandler` treats any `PUT` request as an unsupported method, forcing its status to `405`. Since `405` is only overridden when the handler's real status is *higher* than `405`, a genuine error below `405` (e.g. `400 Bad Request`) returned by a `PUT` handler such as `SetDataState` gets silently replaced by `405`, hiding the actual failure reason from the client.

```
$ curl -i -XPUT -d'enable' http://192.168.1.22:8081/node/state
HTTP/1.1 405 Method Not Allowed
...
{"title": "Method Not Allowed", "status": 405, "detail": "method not supported"}
```

`enable` here is invalid (must be the JSON string `"enable"`), so the correct response is `400 Bad Request`, not `405`.

## Changes

- Fold `kPut` into the same fallthrough group as `kGet`/`kPost`/`kDelete`/`kOptions` in `RoutingErrorHandler`, so it takes a plain `break` instead of falling into `default`. This lets a `PUT` with a real handler behind it (e.g. `/node/state`, `/node/dataset/active`, `/node/dataset/pending`, `/node/commissioner/state`, or `/node/ba-epskc/state` when `OTBR_ENABLE_EPSKC` is set) return whatever status that handler set, while a `PUT` to a path with no `PUT` route at all still falls through cpp-httplib's own routing-miss `404`, consistent with `GET`/`POST`/`DELETE` on the same kind of path.
- Add `PUT` to `OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS` and to the `Allow` header returned alongside a genuine `405`, since it's a legitimately supported method on the REST API.

Per-resource `Allow` headers and the broader `404`/`405`/`OPTIONS` semantics cleanup are tracked separately by #3529.

## Testing

- Verified with `curl` against a live `otbr-agent` (EFR32 RCP, real Thread network):
  - `PUT /node/state` with an invalid body -> `400` (was `405` before the fix)
  - `PUT /node/state` with a valid body -> `200`
  - `PATCH /node/state` (genuinely unsupported method) -> `405`
- Added regression tests in `tests/rest/test_rest.py` covering the above plus `PUT /node/ext-address` (GET-only, no `PUT` route registered) -> `404` (matches `POST`/`DELETE` on the same path); full suite passes against the same live setup (`python3 tests/rest/test_rest.py`).
- `script/clang-format-check src/rest/rest_web_server.cpp` passes.

Fixes #3522
