### PR TITLE
[tests] fix epskc_test() port assertion against a real ephemeral port

### DIFF
--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -530,15 +530,10 @@ def epskc_test():
     expect_http_error(400, lambda: post_key({"port": "49191"}))
     expect_http_error(400, lambda: post_key({"lifetime": 4294967295}))
 
-    # Custom valid parameters should be accepted.
-    req = urllib.request.Request(
-        key_url,
-        data=json.dumps({"lifetime": 30000, "port": status["port"]}).encode(),
-        method='POST',
-    )
-    req.add_header('Content-Type', 'application/json')
-    data = json.loads(urllib.request.urlopen(req).read())
-    assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] == status["port"]
+    # Custom valid parameters (custom lifetime with auto-assigned port).
+    data = json.loads(post_key({"lifetime": 30000, "port": 0}).read())
+    assert len(data["tap"]) == 9 and data["tap"].isdigit()
+    assert 0 < data["port"] <= 65535
 
     status = get_key_status()
     assert status["state"] == "started" and status["port"] == data["port"]


### PR DESCRIPTION
## Description

`epskc_test()` asserts that the port returned by activating the ephemeral key equals the port read *before* activation:

```python
status = get_key_status()
assert status["state"] == "stopped"
...
data = json.loads(urllib.request.urlopen(req).read())
assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] == status["port"]
```

While the feature is `stopped`, `GET /node/ba-epskc/key` reports `port: 0` (not yet assigned). The test then activates with that same `port: 0` in the request body, which `otBorderAgentEphemeralKeyStart()` treats as "auto-assign a port" - so the server picks a real ephemeral port and returns it. Comparing that freshly-assigned port to the `0` placeholder captured while stopped only matches by coincidence.

This reproduced consistently against a real EFR32-based RCP (`otbr-agent` returned port `49157` while the pre-activation placeholder was `0`), while apparently passing in CI against the simulated `ot-rcp`.

## Changes

- Replace the `data["port"] == status["port"]` comparison with a check that the returned port is a valid, non-zero UDP port.
- The existing post-activation check (`status["port"] == data["port"]`, right after) already covers the comparison that actually matters: that the *started* status reports the same port the activation response returned.
- Per review feedback, reuse the existing `post_key()` helper and pass `port: 0` directly instead of routing through the pre-activation `status` dict - this makes the "auto-assign a port" intent explicit and drops the data dependency on `status`:

```python
# Custom valid parameters (custom lifetime with auto-assigned port).
data = json.loads(post_key({"lifetime": 30000, "port": 0}).read())
assert len(data["tap"]) == 9 and data["tap"].isdigit()
assert 0 < data["port"] <= 65535
```

## Testing

Ran the full REST test suite twice in a row against a real border agent + EFR32 RCP (Home Assistant Connect ZBT-2):

```
$ python3 tests/rest/test_rest.py
...
 /node/ba-epskc : OK
```

Both runs exited 0. Without this fix, the suite consistently failed with:
```
AssertionError
  File "tests/rest/test_rest.py", line 541, in epskc_test
    assert len(data["tap"]) == 9 and data["tap"].isdigit() and data["port"] == status["port"]
```

Fixes #3525
