### PR TITLE
[tests] fix provisioning URL mismatch in dbus test-client

### DIFF
--- a/tests/dbus/test-client
+++ b/tests/dbus/test-client
@@ -275,7 +275,7 @@ EOF
     sudo dbus-send --system --dest=io.openthread.BorderRouter.wpan0 \
         --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 \
         io.openthread.BorderRouter.JoinerStart \
-        string:ABCDEF string:mock string:mock \
+        string:ABCDEF string:"" string:mock \
         string:mock string:mock string:mock
     sleep 10
     ot_ctl state | grep router


### PR DESCRIPTION
In tests/dbus/test-client, the commissioner node adds the joiner via `commissioner joiner add * ABCDEF` without configuring a provisioning URL (leaving it empty). However, the DBus test called `JoinerStart` passing "mock" as the provisioning URL argument.

Previously, OpenThread's Joiner implementation ignored the rejection State TLV in JOIN_FIN.rsp and proceeded to adopt the credentials, masking the URL mismatch. Following OpenThread PR #13418 (which enforces commissioner rejection on provisioning URL mismatch), the joiner correctly rejects the credentials and fails to join the network.

This commit updates the `JoinerStart` DBus invocation in test-client to pass an empty string for the provisioning URL, matching the commissioner's configuration.