### PR TITLE
[agent] enable max power table support for POSIX

### DIFF
--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -144,10 +144,18 @@ set(OT_MBEDTLS_CONFIG_FILE "\"${PROJECT_SOURCE_DIR}/third_party/openthread/mbedt
 
 add_subdirectory(repo EXCLUDE_FROM_ALL)
 
+# OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE is set here rather than in
+# openthread-otbr-posix-config.h, because it guards code in two libraries.
+# `src/posix/platform/radio.cpp` parses `max-power-table` from the radio URL and
+# reaches the config header through platform-posix.h, but the loop that restores
+# the table after an RCP reset lives in `src/lib/spinel/radio_spinel.cpp`, whose
+# only project config hook is OPENTHREAD_PROJECT_LIB_CONFIG_FILE. Defining it on
+# `ot-config` puts it on the command line of both.
 target_compile_definitions(ot-config INTERFACE
     "-DOPENTHREAD_CONFIG_LOG_CLI=1"
     "-DOPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS=3"
     "-DOPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE=1"
+    "-DOPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE=1"
     "-DOPENTHREAD_POSIX_CONFIG_FILE=\"${PROJECT_BINARY_DIR}/src/agent/openthread-otbr-posix-config.h\""
 )
 


### PR DESCRIPTION
Fixes #3520, as suggested there.

OpenThread's POSIX platform already parses `max-power-table` from the radio URL, but it is behind `OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE`, which defaults to `0`. This enables it, so the setting becomes reachable through `OT_RCP_DEVICE` with no extra moving parts at runtime:

```
OT_RCP_DEVICE=spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=460800&max-power-table=14
```

### Why not `openthread-otbr-posix-config.h.in`

That was the suggestion in #3520 and it is where I started, but it only covers half of the feature.

The macro guards code in two libraries:

| file | library | sees the config header? |
|---|---|---|
| `src/posix/platform/radio.cpp` — parses the URL value | `openthread-posix` | yes, via `platform-posix.h` |
| `src/lib/spinel/radio_spinel.cpp` — restores the table after an RCP reset | `openthread-radio-spinel` | **no** |

`radio_spinel.cpp`'s only project config hook is `OPENTHREAD_PROJECT_LIB_CONFIG_FILE`, from `OT_LIB_CONFIG`, which is not set anywhere in either repository. So a definition in the POSIX config header enables the parsing but silently leaves the restore path compiled out — the max power would be applied at startup and then lost on the next RCP reset, which is the failure mode hardest to notice.

Both libraries link `ot-config`, so defining it there covers both. There is precedent for exactly this in `src/posix/platform/CMakeLists.txt`, where `OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE` is lifted into `OT_PLATFORM_DEFINES` with a comment explaining that the core and POSIX libraries would otherwise disagree about the feature.

### This affects `OT_POSIX_MAX_POWER_TABLE` upstream too

Worth flagging separately: `-DOT_POSIX_MAX_POWER_TABLE=ON` puts the definition on `ot-posix-config`, which only `openthread-posix` links. `openthread-radio-spinel` links `ot-config` and `ot-lib-config`. As far as I can tell the restore-after-reset loop is therefore compiled out in openthread's own POSIX builds as well, including `script/cmake-build posix`. I have not filed anything in openthread/openthread yet — happy to, if you agree with the reading.

### Why it is safe for everyone else

- The parser is `VerifyOrExit(aRadioUrl.GetValue("max-power-table") != nullptr)` — it returns before touching the radio when the URL carries no such value.
- `MaxPowerTable` initialises every channel to `kPowerDefault` (30 dBm), so `GetSupportedChannelMask()` still returns every channel and the mask in `radio_spinel.cpp` is unaffected.
- An RCP that does not implement the property is already handled: `SetChannelMaxTransmitPower` returning `OT_ERROR_NOT_IMPLEMENTED` is tolerated and logged as a warning.

### Verification

Checked against the pinned submodule (`7b6ed71`) that the value actually arrives, rather than assuming the include order works out:

```
with this change:    OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE = 1
without:             OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE = 0
```

Behaviour was confirmed on real hardware before this change, by setting the same value at runtime through `ot-ctl txpower`: a mains-powered plug 8.5 m from the border router could not attach at 0 dBm and attached within a minute at 14 dBm. Details and the neighbour-table measurements are in #3520.

### Note on scope

`max-power-table` is a per-channel list, and a single value applies to every channel from the first onwards ("use the last power if omitted"). That is OpenThread's existing semantics; this PR only makes it reachable.
