### PR TITLE
[rest] bump REST API version to 0.5.0 for ePSKc endpoints

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -2751,7 +2751,7 @@ components:
             $ref: "#/components/schemas/WellKnownThread"
           example:
             api:
-              version: 0.3.0
+              version: 0.5.0
               base: /api/
             links:
               - href: /.well-known/thread/br-rest

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: BSD 3-Clause
     url: https://github.com/openthread/ot-br-posix/blob/main/LICENSE
-  version: 0.4.0
+  version: 0.5.0
 servers:
   - url: "{protocol}://{host}:{port}"
     description: Configurable Border Router destination.

--- a/src/rest/version.hpp
+++ b/src/rest/version.hpp
@@ -40,6 +40,6 @@
  * - MINOR: New features (backward compatible) or breaking changes during 0.x
  * - PATCH: Bug fixes (backward compatible)
  */
-#define OTBR_REST_API_VERSION "0.4.0"
+#define OTBR_REST_API_VERSION "0.5.0"
 
 #endif // OTBR_REST_VERSION_HPP_


### PR DESCRIPTION
## Description

`OTBR_REST_API_VERSION` (`version.hpp`) and the OpenAPI `info.version` were left at `0.4.0` after #3480 added the Border Agent ephemeral key (ePSKc) REST endpoints (`/node/ba-epskc/state`, `/node/ba-epskc/key`).

The version discovery mechanism introduced in #3330 exists precisely so clients can detect server capabilities via `/.well-known/thread/br-rest` instead of probing an endpoint and handling failure. Adding ePSKc support is new, backward-compatible REST API surface, so per the semver rules documented in `version.hpp` this is a MINOR bump, not a PATCH.

This PR bumps both `version.hpp` and `openapi.yaml` from `0.4.0` to `0.5.0` to keep them in sync.

## Question

Is there a changelog somewhere in this project that should also be updated for this kind of change? I couldn't find one (no `CHANGELOG*` file in the repo), just checking before assuming there isn't one.
