### PR TITLE
[agent] add option to exit on platform reset

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -187,6 +187,16 @@ if(OTBR_NOTIFY_UPSTART)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_NOTIFY_UPSTART=1)
 endif()
 
+# When OTBR_PLATFORM_RESET_EXIT is enabled, the daemon exits with status 0 on
+# platform reset. Ensure the service supervisor is configured to restart on clean
+# exits as well (e.g. systemd Restart=always).
+option(OTBR_PLATFORM_RESET_EXIT "Exit on platform reset instead of restarting in-place" OFF)
+if(OTBR_PLATFORM_RESET_EXIT)
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_PLATFORM_RESET_EXIT=1)
+else()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_PLATFORM_RESET_EXIT=0)
+endif()
+
 set(OTBR_NAT64_DEFAULT OFF)
 if (OTBR_BORDER_ROUTING)
     set(OTBR_NAT64_DEFAULT ON)

--- a/src/agent/realmain.cpp
+++ b/src/agent/realmain.cpp
@@ -61,7 +61,13 @@
 #ifndef __ANDROID__
 #error "OTBR_ENABLE_PLATFORM_ANDROID can be enabled for only Android devices"
 #endif
-#define OTBR_ENABLE_PLATFORM_RESET_EXIT
+#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#define OTBR_ENABLE_PLATFORM_RESET_EXIT 1
+#endif
+#endif
+
+#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#define OTBR_ENABLE_PLATFORM_RESET_EXIT 0
 #endif
 
 #define DEFAULT_INTERFACE_NAME "wpan0"
@@ -94,7 +100,7 @@ enum
 #endif
 };
 
-#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#if !OTBR_ENABLE_PLATFORM_RESET_EXIT
 static jmp_buf sResetJump;
 #endif
 static otbr::Application *gApp = nullptr;
@@ -139,7 +145,7 @@ exit:
     return successful;
 }
 
-#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#if !OTBR_ENABLE_PLATFORM_RESET_EXIT
 static constexpr char kAutoAttachDisableArg[] = "--auto-attach=0";
 static char           sAutoAttachDisableArgStorage[sizeof(kAutoAttachDisableArg)];
 
@@ -466,14 +472,14 @@ void otPlatReset(otInstance *aInstance)
     gApp->Deinit();
     gApp = nullptr;
 
-#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#if !OTBR_ENABLE_PLATFORM_RESET_EXIT
     longjmp(sResetJump, 1);
     assert(false);
 #else
     otbrLogNotice("Exit for platform reset!");
 
-    // Exits immediately. The system server will receive the
-    // signal and decide whether (and how) to restart the ot-daemon
+    // Exits immediately. The service supervisor (or Android system server) will
+    // decide whether (and how) to restart the daemon.
     exit(0);
 #endif
 }
@@ -482,7 +488,7 @@ int otbr::RealMain(int argc, char *argv[])
 {
     int ret;
 
-#ifndef OTBR_ENABLE_PLATFORM_RESET_EXIT
+#if !OTBR_ENABLE_PLATFORM_RESET_EXIT
     if (setjmp(sResetJump))
     {
         std::vector<char *> args = AppendAutoAttachDisableArg(argc, argv);


### PR DESCRIPTION
## Motivation

On platform reset (e.g. `ot-ctl reset` / factory reset), otbr-agent currently re-executes itself in place on Linux (`longjmp` + `execvp`), so the process keeps its PID. For deployments running under a service supervisor (systemd, s6, dinit, ...) this hides the restart from the supervisor: it cannot apply restart policies/limits, re-run per-start setup (firewall rules, notification file descriptors), or observe a fresh readiness cycle (see #3478).

Android builds already handle this differently: `OTBR_ENABLE_PLATFORM_RESET_EXIT` makes the agent simply `exit(0)` and leaves the restart decision to the system server. This PR exposes that existing behavior as a CMake option, `OTBR_PLATFORM_RESET_EXIT` (default `OFF`), so supervised Linux deployments can opt in.

The default keeps today's in-place re-exec behavior. The in-file `#define` for Android is guarded with `#ifndef` to avoid a macro redefinition when the option is also enabled.

## Testing

- Built with the option `OFF` (default; macro not defined, behavior unchanged) and `ON` (macro defined).
- Verified formatting with clang-format 19.1.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)