### PR TITLE
[rest] add a generic Server-Sent Events streaming component

### DIFF
--- a/src/rest/CMakeLists.txt
+++ b/src/rest/CMakeLists.txt
@@ -39,12 +39,14 @@ add_library(otbr-rest
     diagnostic_types.cpp
     json.cpp
     network_diag_handler.cpp
+    network_diag_sse.cpp
     rest_devices_coll.cpp
     rest_diagnostics_coll.cpp
     rest_generic_collection.cpp
     rest_server_common.cpp
     rest_web_server.cpp
     services.cpp
+    sse_handler.cpp
     timestamp.cpp
     uuid.cpp
 )

--- a/src/rest/actions/action.cpp
+++ b/src/rest/actions/action.cpp
@@ -70,6 +70,12 @@ BasicActions::~BasicActions()
         cJSON_Delete(mJson);
         mJson = nullptr;
     }
+
+    if (mRelationships != nullptr)
+    {
+        cJSON_Delete(mRelationships);
+        mRelationships = nullptr;
+    }
 }
 
 std::string BasicActions::ToJsonString(std::set<std::string> aKeys)
@@ -215,12 +221,54 @@ void BasicActions::SetResult(const std::string &aType, const std::string &aUuid)
 
     cJSON_AddItemToObject(result, "data", data);
 
-    if (mRelationships != nullptr)
+    if (mRelationships == nullptr)
+    {
+        mRelationships = cJSON_CreateObject();
+    }
+
+    cJSON_DeleteItemFromObjectCaseSensitive(mRelationships, "result");
+    cJSON_AddItemToObject(mRelationships, "result", result);
+}
+
+void BasicActions::SetRelatedLink(const std::string &aName, const std::string &aHref)
+{
+    /* Example:
+    "relationships": {
+        "stream": {
+          "links": {
+            "related": "/api/diagnostics/stream?actionId=0a97ef16-1997-43dd-91c4-7fbcb1ec6713"
+          }
+        }
+    */
+    cJSON *relation = cJSON_CreateObject();
+    cJSON *links    = cJSON_CreateObject();
+
+    cJSON_AddStringToObject(links, "related", aHref.c_str());
+    cJSON_AddItemToObject(relation, "links", links);
+
+    if (mRelationships == nullptr)
+    {
+        mRelationships = cJSON_CreateObject();
+    }
+
+    cJSON_DeleteItemFromObjectCaseSensitive(mRelationships, aName.c_str());
+    cJSON_AddItemToObject(mRelationships, aName.c_str(), relation);
+}
+
+void BasicActions::ClearRelation(const std::string &aName)
+{
+    VerifyOrExit(mRelationships != nullptr);
+
+    cJSON_DeleteItemFromObjectCaseSensitive(mRelationships, aName.c_str());
+
+    if (cJSON_GetArraySize(mRelationships) == 0)
     {
         cJSON_Delete(mRelationships);
+        mRelationships = nullptr;
     }
-    mRelationships = cJSON_CreateObject();
-    cJSON_AddItemToObject(mRelationships, "result", result);
+
+exit:
+    return;
 }
 
 const char *BasicActions::StatusToString(ActionStatus aStatus)

--- a/src/rest/actions/action.hpp
+++ b/src/rest/actions/action.hpp
@@ -54,6 +54,13 @@ enum ActionStatus
     kActionStatusFailed,
 };
 
+#define KEY_STATUS "status"
+#define KEY_TIMEOUT "timeout"
+#define KEY_DESTINATION "destination"
+#define KEY_DESTINATION_TYPE "destinationType"
+#define KEY_TYPES "types"
+#define KEY_STREAM "stream"
+
 /**
  * @brief This virtual class implements a general json:api item for holding action attributes.
  */
@@ -156,7 +163,7 @@ public:
      * @retval  True   If now is after the timeout of this action.
      * @retval  False  If now is before or equal the timeout of this action.
      */
-    bool IsBeyondTimeout(void) const { return mCreatedSteady + mTimeout < Clock::now(); }
+    virtual bool IsBeyondTimeout(void) const { return mCreatedSteady + mTimeout < Clock::now(); }
 
     /**
      * Get the status of the action.
@@ -179,6 +186,17 @@ public:
      * @retval False If the action is not pending or active.
      */
     bool IsPendingOrActive(void) const { return mStatus == kActionStatusPending || mStatus == kActionStatusActive; }
+
+    /**
+     * Does this action publish its results on an SSE channel while they arrive?
+     *
+     * Each streaming domain owns its own broadcaster, so at most one streaming
+     * action per action type may be in flight at a time.
+     *
+     * @retval True  If the action was created with streaming enabled.
+     * @retval False If the action only exposes its results once it finished.
+     */
+    virtual bool IsStreaming(void) const { return false; }
 
     /**
      * Convert the status of the action to string.
@@ -240,6 +258,23 @@ protected:
      * Set the relationship to the result of this action.
      */
     void SetResult(const std::string &aType, const std::string &aUuid);
+
+    /**
+     * Set a relationship holding a `related` link, e.g. to a stream endpoint.
+     *
+     * @param[in] aName  The name of the relationship.
+     * @param[in] aHref  The link target, may be relative to the server root.
+     */
+    void SetRelatedLink(const std::string &aName, const std::string &aHref);
+
+    /**
+     * Remove a relationship, e.g. when the linked resource ceased to exist.
+     *
+     * Does nothing if no relationship of that name is set.
+     *
+     * @param[in] aName  The name of the relationship.
+     */
+    void ClearRelation(const std::string &aName);
 
     /**
      * The steady_clock created timepoint of the action.

--- a/src/rest/actions/network_diagnostic.cpp
+++ b/src/rest/actions/network_diagnostic.cpp
@@ -46,17 +46,22 @@ namespace otbr {
 namespace rest {
 namespace actions {
 
+static constexpr const char *kNetworkDiagStreamPath = "/api/diagnostics/stream";
+
 NetworkDiagnostic::NetworkDiagnostic(const cJSON &aJson, Services &aServices)
     : BasicActions(aJson, aServices)
+    , mStream(false)
 {
     cJSON            *item;
     uint8_t           id;
     std::set<uint8_t> tlvs;
 
-    cJSON *types = cJSON_GetObjectItemCaseSensitive(mJson, KEY_TYPES);
+    cJSON *types  = cJSON_GetObjectItemCaseSensitive(mJson, KEY_TYPES);
+    cJSON *stream = cJSON_GetObjectItemCaseSensitive(mJson, KEY_STREAM);
 
     // Were guaranteed that Validate has run already
     mDestination = ReadDestination(*mJson, mDestinationType);
+    mStream      = cJSON_IsTrue(stream);
 
     cJSON_ArrayForEach(item, types)
     {
@@ -93,10 +98,22 @@ void NetworkDiagnostic::Update(void)
         otIp6Address address;
         SuccessOrExit(mServices.LookupAddress(mDestination, mDestinationType, address));
 
+        // The handler serves a single request at a time. While another one is
+        // running this stays pending, and must not touch the shared broadcaster.
         if (mServices.GetNetworkDiagHandler().StartDiagnosticsRequest(address, mTypeList, mTypeCount, mTimeout) ==
             OT_ERROR_NONE)
         {
             mStatus = kActionStatusActive;
+
+            if (mStream)
+            {
+                // Re-open the channel, a previous streaming action may have closed it.
+                mServices.GetNetworkDiagHandler().GetSseBroadcaster().Reset();
+                mServices.GetNetworkDiagHandler().SetStreaming(true);
+
+                // Advertise where the client can consume the stream of this action.
+                SetRelatedLink(KEY_STREAM, std::string(kNetworkDiagStreamPath) + "?actionId=" + mUuid.ToString());
+            }
         }
     }
 
@@ -122,8 +139,23 @@ void NetworkDiagnostic::Update(void)
         if (mStatus != kActionStatusActive)
         {
             mServices.GetNetworkDiagHandler().StopDiagnosticsRequest();
+            StopStreaming();
         }
     }
+
+exit:
+    return;
+}
+
+void NetworkDiagnostic::StopStreaming(void)
+{
+    VerifyOrExit(mStream);
+
+    mServices.GetNetworkDiagHandler().SetStreaming(false);
+    // Wakes all connected SSE clients so they terminate their response.
+    mServices.GetNetworkDiagHandler().GetSseBroadcaster().Close();
+    // The stream endpoint no longer serves this action, stop advertising it.
+    ClearRelation(KEY_STREAM);
 
 exit:
     return;
@@ -139,6 +171,7 @@ void NetworkDiagnostic::Stop(void)
 
     case kActionStatusActive:
         mServices.GetNetworkDiagHandler().StopDiagnosticsRequest();
+        StopStreaming();
         mStatus = kActionStatusStopped;
         break;
 
@@ -171,6 +204,11 @@ cJSON *NetworkDiagnostic::Jsonify(std::set<std::string> aFieldset)
         cJSON_AddItemToObject(attributes, KEY_TYPES, types);
     }
 
+    if (hasKey(aFieldset, KEY_STREAM))
+    {
+        cJSON_AddBoolToObject(attributes, KEY_STREAM, mStream);
+    }
+
     if (IsPendingOrActive())
     {
         if (hasKey(aFieldset, KEY_TIMEOUT))
@@ -196,10 +234,14 @@ bool NetworkDiagnostic::Validate(const cJSON &aJson)
     cJSON      *item;
     uint8_t     id;
 
-    cJSON *types = cJSON_GetObjectItemCaseSensitive(&aJson, KEY_TYPES);
+    cJSON *types  = cJSON_GetObjectItemCaseSensitive(&aJson, KEY_TYPES);
+    cJSON *stream = cJSON_GetObjectItemCaseSensitive(&aJson, KEY_STREAM);
 
     errormsg = KEY_TIMEOUT;
     SuccessOrExit(ReadTimeout(aJson, timeout));
+
+    errormsg = KEY_STREAM;
+    VerifyOrExit(stream == nullptr || cJSON_IsBool(stream));
 
     errormsg = KEY_DESTINATION;
     VerifyOrExit(ReadDestination(aJson, type) != nullptr);

--- a/src/rest/actions/network_diagnostic.hpp
+++ b/src/rest/actions/network_diagnostic.hpp
@@ -90,9 +90,18 @@ public:
      */
     static bool Validate(const cJSON &aJson);
 
+    /**
+     * Whether responses of this action are published on the network
+     * diagnostics SSE channel while they arrive.
+     */
+    bool IsStreaming(void) const override { return mStream; }
+
 private:
+    void StopStreaming(void);
+
     const char *mDestination; ///< Pointer to string in mJson
     AddressType mDestinationType;
+    bool        mStream; ///< If true, responses are broadcast as they arrive
 
     uint8_t  mTypeList[DiagnosticTypes::kMaxTotalCount];
     uint32_t mTypeCount;

--- a/src/rest/actions_list.cpp
+++ b/src/rest/actions_list.cpp
@@ -71,6 +71,61 @@ void ActionsCollection::GetPendingOrActive(uint32_t &aPending) const
     }
 }
 
+bool ActionsCollection::HasStreamingAction(const std::string &aTypeName) const
+{
+    otbr::rest::actions::BasicActions *action;
+
+    for (auto &it : mCollection)
+    {
+        action = static_cast<otbr::rest::actions::BasicActions *>(it.second.get());
+        if (action->IsStreaming() && action->IsPendingOrActive() && action->GetTypeName() == aTypeName)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool ActionsCollection::EvictOldestInactiveItem(void)
+{
+    bool                               evicted = false;
+    std::string                        evictKey;
+    otbr::rest::actions::BasicActions *evictAction = nullptr;
+
+    // Find the oldest inactive action. Pending or active actions are never
+    // evicted, because dropping them while they still own resources has
+    // undesired side effects.
+    for (const auto &key : mAgeSortedItemIds)
+    {
+        auto collIt = mCollection.find(key);
+        if (collIt == mCollection.end())
+        {
+            continue;
+        }
+
+        auto *action = static_cast<otbr::rest::actions::BasicActions *>(collIt->second.get());
+
+        if (!action->IsPendingOrActive())
+        {
+            evictKey    = key;
+            evictAction = action;
+            break;
+        }
+    }
+
+    if (evictAction != nullptr)
+    {
+        otbrLogInfo("EvictOldestInactiveItem: evicting %s", evictKey.c_str());
+        DecrHoldsTypes(evictAction->GetTypeName());
+        mCollection.erase(evictKey);
+        mAgeSortedItemIds.remove(evictKey);
+        evicted = true;
+    }
+
+    return evicted;
+}
+
 void ActionsCollection::AddItem(std::unique_ptr<otbr::rest::actions::BasicActions> aItem)
 {
     if (!aItem)
@@ -79,10 +134,21 @@ void ActionsCollection::AddItem(std::unique_ptr<otbr::rest::actions::BasicAction
         return;
     }
 
-    // do not exceed a max size of the collection
+    // Do not exceed the max size of the collection. Only inactive actions may be
+    // evicted. If all actions are pending or active the new item is rejected.
     while (mCollection.size() >= MAX_ACTIONS_COLLECTION_ITEMS)
     {
-        EvictOldestItem();
+        if (!EvictOldestInactiveItem())
+        {
+            break;
+        }
+    }
+
+    if (mCollection.size() >= MAX_ACTIONS_COLLECTION_ITEMS)
+    {
+        otbrLogWarning("%s:%d - %s - collection full of pending or active actions, item not added", __FILE__, __LINE__,
+                       __func__);
+        return;
     }
 
     // add to mHoldsTypes
@@ -95,7 +161,6 @@ void ActionsCollection::AddItem(std::unique_ptr<otbr::rest::actions::BasicAction
         mAgeSortedItemIds.push_back(aItem->mUuid.ToString());
     }
 
-    otbrLogWarning("%s:%d - %s - %s", __FILE__, __LINE__, __func__, aItem->mUuid.ToString().c_str());
     auto result = mCollection.emplace(aItem->mUuid.ToString(), std::move(aItem));
     if (!result.second)
     {
@@ -131,7 +196,14 @@ ActionsList::~ActionsList()
 
 size_t ActionsList::FreeCapacity(void) const
 {
-    return mMaxActions > mCollection.size() ? mMaxActions - mCollection.size() : 0;
+    uint32_t pendingOrActive = 0;
+
+    // Completed, stopped and failed actions can be evicted to make room for a
+    // new action, pending or active ones can not. Hence the free capacity is
+    // what is left after the pending or active actions.
+    GetPendingOrActive(pendingOrActive);
+
+    return mMaxActions > pendingOrActive ? mMaxActions - pendingOrActive : 0;
 }
 
 bool ActionsList::ValidateRequest(const cJSON *aJson)
@@ -188,6 +260,9 @@ otError ActionsList::CreateAction(const cJSON *aJson, std::string &aUuid)
 
     handler = actions::FindHandler(type->valuestring);
     VerifyOrExit(handler != nullptr, error = OT_ERROR_INVALID_ARGS);
+
+    // Reject the new action rather than evicting a pending or active one.
+    VerifyOrExit(FreeCapacity() > 0, error = OT_ERROR_NO_BUFS);
 
     action = handler->Create(*attributes, mServices);
     aUuid  = action.get()->mUuid.ToString();

--- a/src/rest/actions_list.hpp
+++ b/src/rest/actions_list.hpp
@@ -98,7 +98,35 @@ public:
     void GetPendingOrActive(uint32_t &aPending) const;
 
     /**
+     * Is a streaming action of a given type currently pending or active?
+     *
+     * Each streaming domain owns its own SSE broadcaster, so streams of
+     * different types may run concurrently. A second stream of the same type
+     * however would take the channel away from the first one.
+     *
+     * @param[in] aTypeName  The action type name to check.
+     *
+     * @retval true   A pending or active action of that type is streaming.
+     * @retval false  No action of that type is currently streaming.
+     */
+    bool HasStreamingAction(const std::string &aTypeName) const;
+
+    /**
+     * Evict the oldest action that is neither pending nor active.
+     *
+     * Pending or active actions are never evicted, evicting them can cause
+     * undesired side effects.
+     *
+     * @retval true   An inactive action was evicted.
+     * @retval false  All actions are pending or active, nothing was evicted.
+     */
+    bool EvictOldestInactiveItem(void);
+
+    /**
      * Add a item to the collection.
+     *
+     * The item is not added if the collection is full and holds
+     * pending or active actions only.
      *
      * @param[in] aItem  The item to add.
      */
@@ -134,6 +162,9 @@ public:
 
     /**
      * The remaining capacity of the collection.
+     *
+     * Only pending or active actions occupy capacity permanently, all other
+     * actions can be evicted to make room for a new action.
      */
     size_t FreeCapacity(void) const;
 
@@ -148,6 +179,8 @@ public:
      * Create an action from a json object.
      *
      * Returns OT_ERROR_NONE on success, or an error code on failure.
+     * Returns OT_ERROR_NO_BUFS if the collection is full of pending or
+     * active actions.
      * aUuid is the Uuid of the action that was created.
      */
     otError CreateAction(const cJSON *aJson, std::string &aUuid);

--- a/src/rest/network_diag_handler.cpp
+++ b/src/rest/network_diag_handler.cpp
@@ -190,6 +190,7 @@ NetworkDiagHandler::NetworkDiagHandler(Services &aServices, otInstance *aInstanc
     , mServices{aServices}
     , mRequestState{RequestState::kIdle}
     , mDiagQueryRequestState{RequestState::kIdle}
+    , mStreaming{false}
 {
 }
 
@@ -851,6 +852,11 @@ void NetworkDiagHandler::UpdateDiag(uint16_t aKey, std::vector<otNetworkDiagTlv>
     mDiagSet[aKey] = value;
     otbrLogDebug("%s:%d - %s - updated DiagSet for 0x%04x with %zu TLVs.", __FILE__, __LINE__, __func__, aKey,
                  value.mDiagContent.size());
+
+    if (mStreaming)
+    {
+        mSseBroadcaster.Broadcast(std::make_shared<const std::vector<otNetworkDiagTlv>>(value.mDiagContent));
+    }
 }
 
 bool NetworkDiagHandler::HandleNextDiagQuery()

--- a/src/rest/network_diag_handler.hpp
+++ b/src/rest/network_diag_handler.hpp
@@ -47,9 +47,11 @@ Include necessary headers for OpenThread functions, REST utilities, and JSON pro
 #include <openthread/border_router.h>
 
 #include "json.hpp"
+#include "network_diag_sse.hpp"
 #include "rest_devices_coll.hpp"
 #include "rest_diagnostics_coll.hpp"
 #include "services.hpp"
+#include "sse_handler.hpp"
 #include "common/api_strings.hpp"
 #include "host/thread_helper.hpp"
 #include "openthread/dataset.h"
@@ -122,6 +124,25 @@ public:
     /**
      */
     void StopDiagnosticsRequest(void);
+
+    /**
+     * The SSE channel owned by this domain.
+     *
+     * Each streaming domain owns its own broadcaster so several domains can
+     * stream concurrently without sharing a payload channel.
+     */
+    SseBroadcaster &GetSseBroadcaster(void) { return mSseBroadcaster; }
+
+    /**
+     * Enable or disable broadcasting of incoming diagnostic responses.
+     *
+     * While enabled every updated device entry is published on the SSE
+     * channel as soon as its response arrives, instead of only being
+     * available once the whole request completed.
+     *
+     * @param[in] aEnable  Whether responses are broadcast.
+     */
+    void SetStreaming(bool aEnable) { mStreaming = aEnable; }
 
     /**
      * @brief Continue a ongoing request assuring retries and completeness of responses.
@@ -240,6 +261,10 @@ private:
     uint16_t     mDiagQueryRequestRloc;  // destination of the DiagQuery
 
     std::string mResultUuid;
+
+    // SSE channel for this domain and whether responses are published on it.
+    SseBroadcaster mSseBroadcaster;
+    bool           mStreaming;
 
     /**
      * @brief Reset router entries in mDiagSet buffer.

--- a/src/rest/network_diag_sse.cpp
+++ b/src/rest/network_diag_sse.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Network-diagnostics-specific SSE payload formatting.
+ */
+
+#include "rest/network_diag_sse.hpp"
+
+#include <sstream>
+
+#include "rest/json.hpp"
+#include "rest/rest_diagnostics_coll.hpp" // NWK_DIAG_TYPE_NAME
+
+namespace otbr {
+namespace rest {
+
+std::string FormatNetworkDiagSsePayload(const std::vector<otNetworkDiagTlv> &aTlvs,
+                                        const std::string                   &aActionId,
+                                        uint64_t                            &aNextId)
+{
+    std::ostringstream ss;
+    std::string        attributes;
+
+    if (aTlvs.empty())
+    {
+        return std::string();
+    }
+
+    // Same serialisation as the diagnostics collection item, so a streaming
+    // client and a polling client see identical attributes.
+    attributes = Json::DiagSet2JsonString(aTlvs, {}, {}, {}, {}, {});
+
+    ss << "id: " << aNextId++ << "\n"
+       << "event: network.diag.update\n"
+       << "data: " << Json::jsonStr2JsonApiItem(aActionId, NWK_DIAG_TYPE_NAME, attributes) << "\n"
+       << "\n";
+
+    return ss.str();
+}
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/network_diag_sse.hpp
+++ b/src/rest/network_diag_sse.hpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Network-diagnostics-specific SSE payload formatting.
+ *
+ *   This is the domain adapter for the generic SseBroadcaster: it defines the
+ *   payload that NetworkDiagHandler broadcasts and turns it into the SSE wire
+ *   format. The streaming engine itself stays domain-neutral.
+ */
+
+#ifndef OTBR_REST_NETWORK_DIAG_SSE_HPP_
+#define OTBR_REST_NETWORK_DIAG_SSE_HPP_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <openthread/netdiag.h>
+
+namespace otbr {
+namespace rest {
+
+/**
+ * Format one diagnostic response as a single SSE event, using the JSON:API
+ * shape also returned by GET /api/diagnostics/{uuid}.
+ *
+ * The payload broadcast on this domain's channel is the set of TLVs currently
+ * known for one device; the responding device is identified by the short
+ * address TLV, which is always part of the request.
+ *
+ *   id: <counter>
+ *   event: network.diag.update
+ *   data: {"id":"<actionId>","type":"networkDiagnostics","attributes":{...}}
+ *
+ * @param[in]     aTlvs      All TLVs known so far for the responding device.
+ * @param[in]     aActionId  Action ID the stream belongs to, used for correlation.
+ * @param[in,out] aNextId    Monotonic SSE event id counter (per client).
+ *
+ * @returns  The SSE-formatted event, or an empty string if @p aTlvs is empty.
+ */
+std::string FormatNetworkDiagSsePayload(const std::vector<otNetworkDiagTlv> &aTlvs,
+                                        const std::string                   &aActionId,
+                                        uint64_t                            &aNextId);
+
+} // namespace rest
+} // namespace otbr
+
+#endif // OTBR_REST_NETWORK_DIAG_SSE_HPP_

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -32,6 +32,7 @@
 #include "rest/rest_web_server.hpp"
 
 #include <chrono>
+#include <map>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -49,8 +50,11 @@
 
 #include "common/api_strings.hpp"
 #include "rest/json.hpp"
+#include "rest/network_diag_sse.hpp"
+#include "rest/sse_handler.hpp"
 
-#include "rest/actions_list.hpp" // Actions Collection
+#include "rest/actions/network_diagnostic.hpp" // NetworkDiagnostic, NETWORK_DIAG_ACTION_TYPE_NAME
+#include "rest/actions_list.hpp"               // Actions Collection
 #include "rest/commissioner_manager.hpp"
 #include "rest/network_diag_handler.hpp"
 #include "rest/rest_devices_coll.hpp"     // Devices Collection
@@ -118,6 +122,7 @@
 
 #define OT_REST_ROUTE_DIAGNOSTICS "/api/diagnostics"
 #define OT_REST_ROUTE_DIAGNOSTICS_ID "/api/diagnostics/:id"
+#define OT_REST_ROUTE_DIAGNOSTICS_STREAM "/api/diagnostics/stream"
 
 #define OT_REST_ROUTE_WELLKNOWN_THREAD "/.well-known/thread/br-rest"
 
@@ -203,6 +208,7 @@ RestWebServer::RestWebServer(Host::RcpHost &aHost)
     mServer.Options(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
 
     mServer.Get(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
+    mServer.Get(OT_REST_ROUTE_DIAGNOSTICS_STREAM, MakeHandler(&RestWebServer::ApiDiagnosticsStreamHandler));
     mServer.Get(OT_REST_ROUTE_DIAGNOSTICS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemGetHandler));
     mServer.Delete(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
     mServer.Delete(OT_REST_ROUTE_DIAGNOSTICS_ID,
@@ -1344,7 +1350,6 @@ void RestWebServer::ApiActionsPostHandler(const Request &aRequest, Response &aRe
 {
     ActionsList &actions = mServices.GetActionsList();
     std::string  responseMessage;
-    uint32_t     taskQueueMax;
     std::string  errorCode;
     StatusCode   statusCode = StatusCode::OK_200;
     cJSON       *root       = nullptr;
@@ -1382,13 +1387,40 @@ void RestWebServer::ApiActionsPostHandler(const Request &aRequest, Response &aRe
                      statusCode = StatusCode::UnprocessableContent_422);
     }
 
-    // Check queueing all tasks does not exceed the max number of tasks we can have queued
-    // older completed tasks can be omitted from the queue
-    actions.GetPendingOrActive(taskQueueMax);
-    taskQueueMax -= actions.GetMaxCollectionSize();
+    // Check queueing all tasks does not exceed the max number of tasks we can have queued.
+    // Older inactive tasks can be evicted from the queue, pending or active ones can not.
     VerifyOrExit(cJSON_GetArraySize(dataArray) >= 0 &&
-                     taskQueueMax >= static_cast<uint32_t>(cJSON_GetArraySize(dataArray)),
+                     actions.FreeCapacity() >= static_cast<size_t>(cJSON_GetArraySize(dataArray)),
                  statusCode = StatusCode::ServiceUnavailable_503);
+
+    // Each streaming domain owns a single shared SSE broadcaster, so only one
+    // stream per action type may be in flight. Streams of different types may
+    // run concurrently. Reject the whole request rather than silently taking
+    // the channel away from an action a client is consuming.
+    {
+        std::map<std::string, int> streamsPerType;
+
+        for (int idx = 0; idx < cJSON_GetArraySize(dataArray); idx++)
+        {
+            datum = cJSON_GetArrayItem(dataArray, idx);
+
+            cJSON *attributes = cJSON_GetObjectItemCaseSensitive(datum, "attributes");
+
+            if (cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(attributes, KEY_STREAM)))
+            {
+                std::string typeName = cJSON_GetObjectItemCaseSensitive(datum, "type")->valuestring;
+                int        &streams  = streamsPerType[typeName];
+
+                if (streams == 0 && actions.HasStreamingAction(typeName))
+                {
+                    streams++;
+                }
+
+                streams++;
+                VerifyOrExit(streams <= 1, statusCode = StatusCode::Conflict_409);
+            }
+        }
+    }
 
     // Queue the tasks and prepare response data
     resp_data = cJSON_CreateArray();
@@ -1709,6 +1741,154 @@ exit:
         otbrLogWarning("%s:%d Error (%d)", __FILE__, __LINE__, statusCode);
         ErrorHandler(aResponse, statusCode, errorDetails);
     }
+}
+
+void RestWebServer::ApiDiagnosticsStreamHandler(const Request &aRequest, Response &aResponse)
+{
+    // Single SSE entry point for every diagnostics streaming domain.
+    //
+    // The 'actionId' query parameter selects the domain: the type of the
+    // referenced action determines which producer the client is attached to.
+    // Domain specific query parameters are handled by the domain handler.
+    std::string actionId;
+    std::string typeName;
+
+    if (!aRequest.has_param("actionId"))
+    {
+        ErrorHandler(aResponse, StatusCode::BadRequest_400, "Missing required 'actionId' query parameter");
+        return;
+    }
+
+    actionId = aRequest.get_param_value("actionId");
+
+    RunInMainLoop([this, &actionId, &typeName]() {
+        actions::BasicActions *action = mServices.GetActionsList().GetItem(actionId);
+
+        if (action != nullptr)
+        {
+            typeName = action->GetTypeName();
+        }
+    });
+
+    if (typeName == NETWORK_DIAG_ACTION_TYPE_NAME)
+    {
+        ApiNetworkDiagStreamHandler(aResponse, actionId);
+    }
+    else
+    {
+        otbrLogWarning("SSE: rejecting stream actionId=%s (unknown or non-streamable action)", actionId.c_str());
+        ErrorHandler(aResponse, StatusCode::NotFound_404, "Action not found, not streaming, or not active");
+    }
+}
+
+void RestWebServer::ApiNetworkDiagStreamHandler(Response &aResponse, const std::string &aActionId)
+{
+    // SSE stream for network diagnostics. Each diagnostic response is published
+    // as soon as it arrives, instead of only being readable once the action
+    // completed.
+    //
+    // Requires the actionId of a 'getNetworkDiagnosticTask' started with
+    // "stream": true.
+    std::string actionId    = aActionId;
+    bool        actionValid = false;
+    std::string rejectDetails;
+    int         slot = SseBroadcaster::kInvalidSlot;
+
+    RunInMainLoop([this, &actionId, &actionValid, &rejectDetails]() {
+        actions::BasicActions *item = mServices.GetActionsList().GetItem(actionId);
+
+        // The dispatcher already resolved the type, but the action may have
+        // been evicted in the meantime.
+        if (item == nullptr || item->GetTypeName() != NETWORK_DIAG_ACTION_TYPE_NAME)
+        {
+            rejectDetails = "Action not found";
+            ExitNow();
+        }
+
+        if (!static_cast<actions::NetworkDiagnostic *>(item)->IsStreaming())
+        {
+            rejectDetails = "Action was not started with \"stream\": true";
+            ExitNow();
+        }
+
+        if (!item->IsPendingOrActive())
+        {
+            // A network diagnostic action is short lived: it ends as soon as
+            // all responses arrived or its timeout expired. Connecting after
+            // that is too late.
+            rejectDetails = "Action already finished, no stream to attach to";
+            ExitNow();
+        }
+
+        actionValid = true;
+
+    exit:
+        return;
+    });
+
+    if (!actionValid)
+    {
+        otbrLogWarning("SSE: rejecting netdiag stream actionId=%s (%s)", actionId.c_str(), rejectDetails.c_str());
+        ErrorHandler(aResponse, StatusCode::NotFound_404, rejectDetails);
+        return;
+    }
+
+    if (!mServices.GetNetworkDiagHandler().GetSseBroadcaster().AddClient(slot))
+    {
+        otbrLogWarning("SSE: failed to add netdiag client for actionId=%s (max clients reached)", actionId.c_str());
+        ErrorHandler(aResponse, StatusCode::ServiceUnavailable_503, "Max SSE clients reached");
+        return;
+    }
+
+    aResponse.set_header("Cache-Control", "no-cache");
+    aResponse.set_header("Connection", "keep-alive");
+    aResponse.set_header("X-Accel-Buffering", "no");
+    aResponse.set_header("Access-Control-Allow-Origin", OTBR_REST_ACCESS_CONTROL_ALLOW_ORIGIN);
+
+    // State for the chunked provider lambda, one instance per connected client.
+    struct SseClientState
+    {
+        int         mEventId;
+        uint64_t    mNextSseId;
+        std::string mActionId;
+    };
+    auto state        = std::make_shared<SseClientState>();
+    state->mEventId   = -1;
+    state->mNextSseId = 0;
+    state->mActionId  = actionId;
+
+    aResponse.set_chunked_content_provider(
+        "text/event-stream",
+        [this, state, slot](size_t /*offset*/, httplib::DataSink &sink) -> bool {
+            std::shared_ptr<const void> payloadPtr;
+
+            if (!mServices.GetNetworkDiagHandler().GetSseBroadcaster().WaitEvent(slot, state->mEventId, payloadPtr))
+            {
+                // Broadcaster closed: end the chunked response properly, so the
+                // client sees a completed transfer instead of an aborted one.
+                sink.done();
+                return true;
+            }
+
+            // Propagate write failures so httplib terminates the provider once
+            // the client is gone, instead of looping on a dead connection.
+            if (!payloadPtr)
+            {
+                const char *heartbeat = "event: heartbeat\ndata: {}\n\n";
+                return sink.write(heartbeat, strlen(heartbeat));
+            }
+
+            const auto &tlvs = *std::static_pointer_cast<const std::vector<otNetworkDiagTlv>>(payloadPtr);
+
+            std::string payload = FormatNetworkDiagSsePayload(tlvs, state->mActionId, state->mNextSseId);
+            if (!payload.empty())
+            {
+                return sink.write(payload.data(), payload.size());
+            }
+
+            return true;
+        },
+        [this, slot](bool /*success*/) { mServices.GetNetworkDiagHandler().GetSseBroadcaster().RemoveClient(slot); });
 }
 
 void RestWebServer::ApiDevicesHandler(const Request &aRequest, Response &aResponse)

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -57,6 +57,7 @@
 #include "rest/rest_devices_coll.hpp"
 #include "rest/rest_diagnostics_coll.hpp"
 #include "rest/services.hpp"
+#include "rest/sse_handler.hpp"
 #include "rest/types.hpp"
 
 namespace otbr {
@@ -167,6 +168,8 @@ private:
     void ApiDiagnosticsItemGetHandler(const Request &aRequest, Response &aResponse);
     void ApiDiagnosticsDeleteHandler(const Request &aRequest, Response &aResponse);
     void ApiDiagnosticsItemDeleteHandler(const Request &aRequest, Response &aResponse);
+    void ApiDiagnosticsStreamHandler(const Request &aRequest, Response &aResponse);
+    void ApiNetworkDiagStreamHandler(Response &aResponse, const std::string &aActionId);
 
     void WellKnownThreadHandler(const Request &aRequest, Response &aResponse) const;
     void WellKnownThreadGetHandler(const Request &aRequest, Response &aResponse) const;

--- a/src/rest/sse_handler.cpp
+++ b/src/rest/sse_handler.cpp
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Generic Server-Sent Events broadcaster.
+ */
+
+#define OTBR_LOG_TAG "REST"
+
+#include "sse_handler.hpp"
+
+#include "common/logging.hpp"
+
+namespace otbr {
+namespace rest {
+
+// ─────────────────────────────────────────────────────────────────────
+//  SseBroadcaster static constexpr definitions
+// ─────────────────────────────────────────────────────────────────────
+constexpr uint8_t SseBroadcaster::kMaxClients;
+constexpr int     SseBroadcaster::kHeartbeatIntervalS;
+constexpr int     SseBroadcaster::kInvalidSlot;
+
+// ─────────────────────────────────────────────────────────────────────
+//  SseBroadcaster implementation
+// ─────────────────────────────────────────────────────────────────────
+
+SseBroadcaster::SseBroadcaster(void)
+    : mEventId(0)
+    , mLastEventId(-1)
+    , mClientCount(0)
+    , mClosed(false)
+{
+    for (uint8_t i = 0; i < kMaxClients; i++)
+    {
+        mSlots[i].mActive       = false;
+        mSlots[i].mClosePending = false;
+    }
+}
+
+void SseBroadcaster::Broadcast(std::shared_ptr<const void> aPayload)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    mLastEventId    = mEventId++;
+    mCurrentPayload = std::move(aPayload);
+    otbrLogDebug("SSE: broadcast eventId=%d clients=%u", mLastEventId, mClientCount);
+    mCv.notify_all();
+}
+
+bool SseBroadcaster::WaitEvent(int aSlot, int &aClientEventId, std::shared_ptr<const void> &aPayload)
+{
+    std::unique_lock<std::mutex> lock(mMutex);
+    bool                         valid = (aSlot >= 0 && aSlot < kMaxClients);
+
+    bool got = mCv.wait_for(lock, std::chrono::seconds(kHeartbeatIntervalS), [this, aSlot, valid, aClientEventId] {
+        return mLastEventId != aClientEventId || mClosed || (valid && mSlots[aSlot].mClosePending);
+    });
+
+    // A client of a closed session must terminate even when a new session
+    // already called Reset() and cleared mClosed in the meantime.
+    if (valid && mSlots[aSlot].mClosePending)
+    {
+        mSlots[aSlot].mClosePending = false;
+        otbrLogDebug("SSE: WaitEvent exiting, slot=%d belongs to a closed session", aSlot);
+        return false;
+    }
+
+    if (mClosed)
+    {
+        otbrLogDebug("SSE: WaitEvent exiting because broadcaster is closed");
+        return false;
+    }
+
+    if (!got)
+    {
+        // Timeout — caller sends heartbeat (null payload = heartbeat signal)
+        aPayload.reset();
+        otbrLogDebug("SSE: heartbeat timeout fired for client eventId=%d", aClientEventId);
+        return true;
+    }
+
+    aClientEventId = mLastEventId;
+    aPayload       = mCurrentPayload;
+    otbrLogDebug("SSE: client woke on eventId=%d", aClientEventId);
+    return true;
+}
+
+bool SseBroadcaster::AddClient(int &aSlot)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    if (mClientCount >= kMaxClients)
+    {
+        aSlot = kInvalidSlot;
+        return false;
+    }
+
+    for (uint8_t i = 0; i < kMaxClients; i++)
+    {
+        if (!mSlots[i].mActive)
+        {
+            mSlots[i].mActive       = true;
+            mSlots[i].mClosePending = false;
+            mClientCount++;
+            aSlot = static_cast<int>(i);
+            otbrLogInfo("SSE: client added slot=%d total_clients=%u", aSlot, mClientCount);
+            return true;
+        }
+    }
+
+    // Should not happen if mClientCount is accurate
+    aSlot = kInvalidSlot;
+    return false;
+}
+
+void SseBroadcaster::RemoveClient(int aSlot)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    if (aSlot >= 0 && aSlot < kMaxClients && mSlots[aSlot].mActive)
+    {
+        mSlots[aSlot].mActive       = false;
+        mSlots[aSlot].mClosePending = false;
+        if (mClientCount > 0)
+        {
+            mClientCount--;
+        }
+        otbrLogInfo("SSE: client removed slot=%d total_clients=%u", aSlot, mClientCount);
+    }
+}
+
+uint8_t SseBroadcaster::GetClientCount(void) const
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    return mClientCount;
+}
+
+void SseBroadcaster::Close(void)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    mClosed = true;
+
+    // Flag the clients of this session individually. A Reset() for the next
+    // session clears mClosed, but must not hand these clients over to it.
+    for (uint8_t i = 0; i < kMaxClients; i++)
+    {
+        if (mSlots[i].mActive)
+        {
+            mSlots[i].mClosePending = true;
+        }
+    }
+
+    otbrLogInfo("SSE: broadcaster closed");
+    mCv.notify_all();
+}
+
+void SseBroadcaster::Reset(void)
+{
+    std::lock_guard<std::mutex> lock(mMutex);
+    mClosed = false;
+    mCurrentPayload.reset();
+    mEventId     = 0;
+    mLastEventId = -1;
+    otbrLogDebug("SSE: broadcaster reset (clients preserved=%u)", mClientCount);
+    // Client slots are NOT cleared, but clients flagged by a preceding Close()
+    // still terminate on their next WaitEvent().
+}
+
+} // namespace rest
+} // namespace otbr

--- a/src/rest/sse_handler.hpp
+++ b/src/rest/sse_handler.hpp
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2026, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Generic Server-Sent Events broadcaster.
+ */
+
+#ifndef OTBR_REST_SSE_HANDLER_HPP_
+#define OTBR_REST_SSE_HANDLER_HPP_
+
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+
+namespace otbr {
+namespace rest {
+
+class SseBroadcaster
+{
+public:
+    static constexpr uint8_t kMaxClients         = 4;
+    static constexpr int     kHeartbeatIntervalS = 30;
+    static constexpr int     kInvalidSlot        = -1;
+
+    SseBroadcaster(void);
+
+    // ── Producer API (mainloop thread) ───────────────────────────────
+
+    /**
+     * Broadcast an opaque payload to all connected SSE clients.
+     *
+     * The payload type is owned by the domain (e.g. a vector of
+     * otNetworkDiagTlv); the engine only forwards the pointer and
+     * signals that a new event is available.
+     *
+     * @param[in] aPayload  Domain payload, shared with all consumers.
+     */
+    void Broadcast(std::shared_ptr<const void> aPayload);
+
+    // ── Consumer API (httplib worker threads) ────────────────────────
+
+    /**
+     * Block until a new payload is available, the stream is closed, or
+     * the heartbeat timeout expires.
+     *
+     * @param[in]     aSlot           Slot returned by AddClient().
+     * @param[in,out] aClientEventId  Caller's last-seen event ID (stack var). Updated.
+     * @param[out]    aPayload        Domain payload to format (nullptr on heartbeat).
+     *
+     * @returns  true  → aPayload valid (or heartbeat — aPayload nullptr).
+     *           false → stream closed, consumer should exit.
+     */
+    bool WaitEvent(int aSlot, int &aClientEventId, std::shared_ptr<const void> &aPayload);
+
+    /**
+     * Register a new SSE client.
+     *
+     * @param[out] aSlot    Assigned slot index (0..kMaxClients-1).
+     *
+     * @returns true if accepted, false if all slots full.
+     */
+    bool AddClient(int &aSlot);
+
+    /**
+     * Unregister an SSE client by slot.
+     *
+     * @param[in] aSlot  Slot returned by AddClient().
+     */
+    void RemoveClient(int aSlot);
+
+    uint8_t GetClientCount(void) const;
+
+    /**
+     * Close all streams. Wakes all WaitEvent() callers.
+     */
+    void Close(void);
+
+    /**
+     * Reset for reuse (new streaming session).
+     * Client slots are NOT cleared, but clients of a previously closed
+     * session still terminate on their next WaitEvent().
+     */
+    void Reset(void);
+
+private:
+    struct ClientSlot
+    {
+        bool mActive;
+        bool mClosePending; ///< Set by Close(), survives Reset().
+    };
+
+    mutable std::mutex      mMutex;
+    std::condition_variable mCv;
+
+    // Current broadcast payload (opaque; shared by all consumers)
+    std::shared_ptr<const void> mCurrentPayload;
+    int                         mEventId;     ///< Bumped on each Broadcast()
+    int                         mLastEventId; ///< ID of current payload
+
+    ClientSlot mSlots[kMaxClients];
+    uint8_t    mClientCount;
+    bool       mClosed;
+};
+
+} // namespace rest
+} // namespace otbr
+
+#endif // OTBR_REST_SSE_HANDLER_HPP_


### PR DESCRIPTION
## Summary

Adds a small, domain-neutral push channel to the `otbr-agent` REST server, so long-running observations can reach clients as they happen instead of only being readable once an action has finished.

Three layers:

| Layer | File | Knows about |
|---|---|---|
| Engine | `src/rest/sse_handler.{hpp,cpp}` | nothing domain-specific |
| Adapter | `src/rest/network_diag_sse.{hpp,cpp}` | one domain's payload → SSE wire format |
| Producer | `NetworkDiagHandler` | when to publish |

The engine (`SseBroadcaster`) passes an opaque `std::shared_ptr<const void>` and never includes an OpenThread header. Adding another streaming domain means adding a producer hook and a formatter, the engine stays untouched.

No new dependency as this is built on the `set_chunked_content_provider()` API `cpp-httplib` already has.

## Why network diagnostics is only the example

The `getNetworkDiagnosticTask` wiring is here to prove the component works end-to-end, not because network diagnostics needs streaming. Network diagnostics is request/response with a bounded lifetime. There's no  continuous source behind it.

The real motivation is mesh monitor, which is genuinely continuous (see [Mesh Monitor](https://github.com/openthread/openthread/pull/13045)).

## Relation to #3382

This is a small step toward the streaming capability discussed in [#3382] and it touches both problems listed there.

**Threading model.** Not solved. Handlers still marshal through `RunInMainLoop`, including the stream handler. What this PR does add is a concrete data point for the argument: **each connected SSE client parks one `cpp-httplib` worker thread for the whole life of the connection**, blocked in `WaitEvent()` doing nothing.

**Push delivery.** [#3382] says `cpp-httplib` "does not natively support WebSockets or Server-Sent Events (SSE)". For WebSockets that's true and stays true. For SSE it turns out not to be a blocker: SSE isn't a protocol upgrade, just a chunked `text/event-stream` response and `set_chunked_content_provider()` covers it.

[#3382]: https://github.com/openthread/ot-br-posix/issues/3382
