### PR TITLE
[rest] add per-route method registry to fix 404/405/OPTIONS handling

### DIFF
--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -31,7 +31,9 @@
 
 #include "rest/rest_web_server.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <utility>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -149,68 +151,60 @@ HttpMethod GetMethod(const Request &aRequest)
 RestWebServer::RestWebServer(Host::RcpHost &aHost)
     : mHost(aHost)
 {
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE, MakeHandler(&RestWebServer::NodeInfo));
-    mServer.Delete(OT_REST_RESOURCE_PATH_NODE, MakeHandler(&RestWebServer::NodeInfo));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_BAID, MakeHandler(&RestWebServer::BaId));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
-    mServer.Put(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_EXTADDRESS, MakeHandler(&RestWebServer::ExtendedAddr));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_NETWORKNAME, MakeHandler(&RestWebServer::NetworkName));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_RLOC16, MakeHandler(&RestWebServer::Rloc16));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_LEADERDATA, MakeHandler(&RestWebServer::LeaderData));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER, MakeHandler(&RestWebServer::NumOfRoute));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_EXTPANID, MakeHandler(&RestWebServer::ExtendedPanId));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_RLOC, MakeHandler(&RestWebServer::Rloc));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, MakeHandler(&RestWebServer::DatasetActive));
-    mServer.Put(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, MakeHandler(&RestWebServer::DatasetActive));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, MakeHandler(&RestWebServer::DatasetActive));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, MakeHandler(&RestWebServer::DatasetPending));
-    mServer.Put(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, MakeHandler(&RestWebServer::DatasetPending));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, MakeHandler(&RestWebServer::DatasetPending));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, MakeHandler(&RestWebServer::CommissionerState));
-    mServer.Put(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, MakeHandler(&RestWebServer::CommissionerState));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, MakeHandler(&RestWebServer::CommissionerState));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
-    mServer.Post(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
-    mServer.Delete(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION, MakeHandler(&RestWebServer::CoprocessorVersion));
+    // OPTIONS are handled generically for all routes.
+    mServer.set_pre_routing_handler(MakePreRoutingHandler(&RestWebServer::OptionsHandler));
+    mServer.set_error_handler(MakeHandler(&RestWebServer::RoutingErrorHandler));
+
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE, MakeHandler(&RestWebServer::NodeInfo));
+    RegisterDelete(OT_REST_RESOURCE_PATH_NODE, MakeHandler(&RestWebServer::NodeInfo));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_BAID, MakeHandler(&RestWebServer::BaId));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
+    RegisterPut(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_EXTADDRESS, MakeHandler(&RestWebServer::ExtendedAddr));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_NETWORKNAME, MakeHandler(&RestWebServer::NetworkName));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_RLOC16, MakeHandler(&RestWebServer::Rloc16));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_LEADERDATA, MakeHandler(&RestWebServer::LeaderData));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER, MakeHandler(&RestWebServer::NumOfRoute));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_EXTPANID, MakeHandler(&RestWebServer::ExtendedPanId));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_RLOC, MakeHandler(&RestWebServer::Rloc));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, MakeHandler(&RestWebServer::DatasetActive));
+    RegisterPut(OT_REST_RESOURCE_PATH_NODE_DATASET_ACTIVE, MakeHandler(&RestWebServer::DatasetActive));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, MakeHandler(&RestWebServer::DatasetPending));
+    RegisterPut(OT_REST_RESOURCE_PATH_NODE_DATASET_PENDING, MakeHandler(&RestWebServer::DatasetPending));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, MakeHandler(&RestWebServer::CommissionerState));
+    RegisterPut(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_STATE, MakeHandler(&RestWebServer::CommissionerState));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
+    RegisterPost(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
+    RegisterDelete(OT_REST_RESOURCE_PATH_NODE_COMMISSIONER_JOINER, MakeHandler(&RestWebServer::CommissionerJoiner));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_COPROCESSOR_VERSION, MakeHandler(&RestWebServer::CoprocessorVersion));
 
 #if OTBR_ENABLE_EPSKC
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
-    mServer.Put(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
-    mServer.Get(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
-    mServer.Post(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
-    mServer.Delete(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
-    mServer.Options(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
+    RegisterPut(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_STATE, MakeHandler(&RestWebServer::EpskcState));
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    RegisterPost(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
+    RegisterDelete(OT_REST_RESOURCE_PATH_NODE_BA_EPSKC_KEY, MakeHandler(&RestWebServer::EpskcKey));
 #endif
 
-    mServer.set_error_handler(MakeHandler(&RestWebServer::RoutingErrorHandler));
-    mServer.Get(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
-    mServer.Get(OT_REST_ROUTE_ACTIONS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiActionsItemGetHandler));
-    mServer.Post(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
-    mServer.Delete(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
-    mServer.Delete(OT_REST_ROUTE_ACTIONS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiActionsItemDeleteHandler));
-    mServer.Options(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
+    RegisterGet(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
+    RegisterGet(OT_REST_ROUTE_ACTIONS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiActionsItemGetHandler));
+    RegisterPost(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
+    RegisterDelete(OT_REST_ROUTE_ACTIONS, MakeHandlerInMainLoop(&RestWebServer::ApiActionsHandler));
+    RegisterDelete(OT_REST_ROUTE_ACTIONS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiActionsItemDeleteHandler));
 
-    mServer.Get(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
-    mServer.Get(OT_REST_ROUTE_DEVICES_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesItemGetHandler));
-    mServer.Get(OT_REST_ROUTE_NODE, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesSelfGetHandler));
-    mServer.Delete(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
-    mServer.Delete(OT_REST_ROUTE_DEVICES_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesItemDeleteHandler));
-    mServer.Options(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
+    RegisterGet(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
+    RegisterGet(OT_REST_ROUTE_DEVICES_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesItemGetHandler));
+    RegisterGet(OT_REST_ROUTE_NODE, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesSelfGetHandler));
+    RegisterDelete(OT_REST_ROUTE_DEVICES, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesHandler));
+    RegisterDelete(OT_REST_ROUTE_DEVICES_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDevicesItemDeleteHandler));
 
-    mServer.Get(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
-    mServer.Get(OT_REST_ROUTE_DIAGNOSTICS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemGetHandler));
-    mServer.Delete(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
-    mServer.Delete(OT_REST_ROUTE_DIAGNOSTICS_ID,
+    RegisterGet(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
+    RegisterGet(OT_REST_ROUTE_DIAGNOSTICS_ID, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemGetHandler));
+    RegisterDelete(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
+    RegisterDelete(OT_REST_ROUTE_DIAGNOSTICS_ID,
                    MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemDeleteHandler));
-    mServer.Options(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
 
-    mServer.Get(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
-    mServer.Options(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
+    RegisterGet(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
 }
 
 RestWebServer::~RestWebServer(void)
@@ -223,6 +217,151 @@ RestWebServer::~RestWebServer(void)
     {
         mServerThread.join();
     }
+}
+
+void RestWebServer::RegisterGet(const std::string &aPattern, httplib::Server::Handler aHandler)
+{
+    mServer.Get(aPattern, aHandler);
+    mRouteRegistry.Add(aPattern, HttpMethod::kGet);
+}
+
+void RestWebServer::RegisterPost(const std::string &aPattern, httplib::Server::Handler aHandler)
+{
+    mServer.Post(aPattern, aHandler);
+    mRouteRegistry.Add(aPattern, HttpMethod::kPost);
+}
+
+void RestWebServer::RegisterPut(const std::string &aPattern, httplib::Server::Handler aHandler)
+{
+    mServer.Put(aPattern, aHandler);
+    mRouteRegistry.Add(aPattern, HttpMethod::kPut);
+}
+
+void RestWebServer::RegisterDelete(const std::string &aPattern, httplib::Server::Handler aHandler)
+{
+    mServer.Delete(aPattern, aHandler);
+    mRouteRegistry.Add(aPattern, HttpMethod::kDelete);
+}
+
+bool RestWebServer::RouteRegistry::MatchPath(const std::string &aPattern, const std::string &aPath)
+{
+    bool   matched    = false;
+    size_t patternPos = 0;
+    size_t pathPos    = 0;
+    while (patternPos < aPattern.size() && pathPos < aPath.size())
+    {
+        size_t      nextPatternSlash = aPattern.find('/', patternPos);
+        size_t      nextPathSlash    = aPath.find('/', pathPos);
+        std::string patternSeg       = aPattern.substr(patternPos, nextPatternSlash - patternPos);
+        std::string pathSeg          = aPath.substr(pathPos, nextPathSlash - pathPos);
+        if (!patternSeg.empty() && patternSeg[0] == ':')
+        {
+            VerifyOrExit(!pathSeg.empty());
+        }
+        else
+        {
+            VerifyOrExit(patternSeg == pathSeg);
+        }
+        VerifyOrExit((nextPatternSlash == std::string::npos) == (nextPathSlash == std::string::npos));
+        if (nextPatternSlash == std::string::npos)
+        {
+            patternPos = aPattern.size();
+            pathPos    = aPath.size();
+            break;
+        }
+        patternPos = nextPatternSlash + 1;
+        pathPos    = nextPathSlash + 1;
+    }
+    matched = (patternPos == aPattern.size() && pathPos == aPath.size());
+exit:
+    return matched;
+}
+
+RestWebServer::RouteRegistry::RouteMethods RestWebServer::RouteRegistry::MethodBit(HttpMethod aMethod)
+{
+    return static_cast<RouteMethods>(1u << static_cast<uint8_t>(aMethod));
+}
+
+void RestWebServer::RouteRegistry::Add(const std::string &aPattern, HttpMethod aMethod)
+{
+    auto it = std::find_if(mRoutes.begin(), mRoutes.end(),
+                           [&aPattern](const Route &aRoute) { return aRoute.mPattern == aPattern; });
+
+    if (it == mRoutes.end())
+    {
+        Route route;
+
+        route.mPattern    = aPattern;
+        route.mMethodMask = MethodBit(aMethod);
+        mRoutes.push_back(std::move(route));
+    }
+    else
+    {
+        it->mMethodMask |= MethodBit(aMethod);
+    }
+}
+
+RestWebServer::RouteRegistry::RouteMethods RestWebServer::RouteRegistry::GetMethods(const std::string &aPath) const
+{
+    const Route *route = nullptr;
+
+    for (const auto &r : mRoutes)
+    {
+        if (MatchPath(r.mPattern, aPath))
+        {
+            route = &r;
+            break;
+        }
+    }
+
+    return (route != nullptr) ? route->mMethodMask : 0;
+}
+
+bool RestWebServer::RouteRegistry::MatchMethod(RouteMethods aMethods, HttpMethod aMethod)
+{
+    return (aMethods & MethodBit(aMethod)) != 0;
+}
+
+bool RestWebServer::RouteRegistry::AnyMethod(RouteMethods aMethods)
+{
+    return aMethods != 0;
+}
+
+std::string RestWebServer::RouteRegistry::BuildMethodsString(RouteMethods aMethods)
+{
+    std::string methodsString = "";
+
+    if (aMethods == 0)
+    {
+        return methodsString;
+    }
+
+    if (aMethods & MethodBit(HttpMethod::kGet))
+        methodsString += "GET, ";
+    if (aMethods & MethodBit(HttpMethod::kPost))
+        methodsString += "POST, ";
+    if (aMethods & MethodBit(HttpMethod::kPut))
+        methodsString += "PUT, ";
+    if (aMethods & MethodBit(HttpMethod::kDelete))
+        methodsString += "DELETE, ";
+
+    return methodsString + "OPTIONS";
+}
+
+httplib::Server::HandlerResponse RestWebServer::OptionsHandler(const Request &aRequest, Response &aResponse)
+{
+    if (GetMethod(aRequest) == HttpMethod::kOptions)
+    {
+        RouteRegistry::RouteMethods methods = mRouteRegistry.GetMethods(aRequest.path);
+        if (RouteRegistry::AnyMethod(methods))
+        {
+            aResponse.status = StatusCode::NoContent_204;
+            aResponse.set_header(OT_REST_ALLOW_HEADER, RouteRegistry::BuildMethodsString(methods));
+            return httplib::Server::HandlerResponse::Handled;
+        }
+    }
+
+    return httplib::Server::HandlerResponse::Unhandled;
 }
 
 void RestWebServer::ErrorHandler(Response &aResponse, StatusCode aErrorCode) const
@@ -457,9 +596,6 @@ void RestWebServer::State(const Request &aRequest, Response &aResponse) const
         break;
     case HttpMethod::kPut:
         SetDataState(aRequest, aResponse);
-        break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
         break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
@@ -792,9 +928,6 @@ void RestWebServer::Dataset(DatasetType aDatasetType, const Request &aRequest, R
     case HttpMethod::kPut:
         SetDataset(aDatasetType, aRequest, aResponse);
         break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
-        break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
         break;
@@ -876,9 +1009,6 @@ void RestWebServer::CommissionerState(const Request &aRequest, Response &aRespon
         break;
     case HttpMethod::kPut:
         SetCommissionerState(aRequest, aResponse);
-        break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
         break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
@@ -1051,10 +1181,6 @@ void RestWebServer::CommissionerJoiner(const Request &aRequest, Response &aRespo
     case HttpMethod::kDelete:
         RemoveJoiner(aRequest, aResponse);
         break;
-
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
-        break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
         break;
@@ -1126,9 +1252,6 @@ void RestWebServer::EpskcState(const Request &aRequest, Response &aResponse) con
         break;
     case HttpMethod::kPut:
         SetEpskcState(aRequest, aResponse);
-        break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
         break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
@@ -1228,9 +1351,6 @@ void RestWebServer::EpskcKey(const Request &aRequest, Response &aResponse) const
     case HttpMethod::kDelete:
         DeactivateEpskcKey(aRequest, aResponse);
         break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::OK_200;
-        break;
     default:
         ErrorHandler(aResponse, StatusCode::MethodNotAllowed_405);
         break;
@@ -1240,37 +1360,28 @@ void RestWebServer::EpskcKey(const Request &aRequest, Response &aResponse) const
 
 void RestWebServer::RoutingErrorHandler(const Request &aRequest, Response &aResponse)
 {
-    httplib::StatusCode error = StatusCode::OK_200;
-    std::string         errorDetails;
+    httplib::StatusCode status = StatusCode(aResponse.status);
 
-    // handle methods not used or not supported by cpp-httplib
-    switch (GetMethod(aRequest))
+    if (status == StatusCode::NotFound_404 || status == StatusCode::MethodNotAllowed_405)
     {
-    case HttpMethod::kPost:
-        // fallthrough
-    case HttpMethod::kGet:
-        // fallthrough
-    case HttpMethod::kPut:
-        // fallthrough
-    case HttpMethod::kDelete:
-        // fallthrough
-    case HttpMethod::kOptions:
-        break;
-    default:
-        errorDetails = "method not supported";
-        error        = StatusCode::MethodNotAllowed_405;
-        aResponse.set_header("Allow", "GET, POST, PUT, DELETE, OPTIONS");
-        break;
+        RouteRegistry::RouteMethods methods = mRouteRegistry.GetMethods(aRequest.path);
+
+        if (RouteRegistry::AnyMethod(methods) && !RouteRegistry::MatchMethod(methods, GetMethod(aRequest)))
+        {
+            status = StatusCode::MethodNotAllowed_405;
+        }
+
+        if (status == StatusCode::MethodNotAllowed_405)
+        {
+            aResponse.set_header(OT_REST_ALLOW_HEADER, RouteRegistry::BuildMethodsString(methods));
+            ErrorHandler(aResponse, status, "method not supported");
+            return;
+        }
     }
 
-    if (error != StatusCode::OK_200 || aResponse.status >= StatusCode::MultipleChoices_300)
+    if (aResponse.body.empty())
     {
-        if (error < aResponse.status)
-        {
-            error = StatusCode(aResponse.status);
-        }
-        otbrLogWarning("%s:%d Error (%d) - %s", __FILE__, __LINE__, error, errorDetails.c_str());
-        ErrorHandler(aResponse, error, errorDetails);
+        ErrorHandler(aResponse, status);
     }
 }
 
@@ -1322,10 +1433,6 @@ void RestWebServer::ApiActionsHandler(const Request &aRequest, Response &aRespon
         break;
     case HttpMethod::kDelete:
         ApiActionsDeleteHandler(aRequest, aResponse);
-        break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::NoContent_204;
-        aResponse.set_header("Allow", "GET, POST, DELETE, OPTIONS");
         break;
     default:
         errorDetails = "not supported";
@@ -1693,10 +1800,6 @@ void RestWebServer::ApiDiagnosticsHandler(const Request &aRequest, Response &aRe
     case HttpMethod::kDelete:
         ApiDiagnosticsDeleteHandler(aRequest, aResponse);
         break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::NoContent_204;
-        aResponse.set_header("Allow", "GET, DELETE, OPTIONS");
-        break;
     case HttpMethod::kPost:
     default:
         errorDetails = "not supported";
@@ -1724,10 +1827,6 @@ void RestWebServer::ApiDevicesHandler(const Request &aRequest, Response &aRespon
         break;
     case HttpMethod::kGet:
         ApiDevicesGetHandler(aRequest, aResponse);
-        break;
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::NoContent_204;
-        aResponse.set_header("Allow", "GET, DELETE, OPTIONS");
         break;
     default:
         errorDetails = "not supported";
@@ -2000,11 +2099,6 @@ void RestWebServer::WellKnownThreadHandler(const Request &aRequest, Response &aR
     {
     case HttpMethod::kGet:
         WellKnownThreadGetHandler(aRequest, aResponse);
-        break;
-
-    case HttpMethod::kOptions:
-        aResponse.status = StatusCode::NoContent_204;
-        aResponse.set_header("Allow", "GET, OPTIONS");
         break;
 
     default:

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -42,9 +42,6 @@
 #include <netinet/ip.h>
 #include <sys/socket.h>
 
-#include <functional>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include <openthread/border_agent.h>

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -42,7 +42,9 @@
 #include <netinet/ip.h>
 #include <sys/socket.h>
 
+#include <functional>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <openthread/border_agent.h>
@@ -97,6 +99,63 @@ private:
     {
         kActive,  ///< Active Dataset
         kPending, ///< Pending Dataset
+    };
+
+    /**
+     * Tracks, for every registered route pattern, which HTTP methods it was
+     * registered under.
+     *
+     * cpp-httplib routes each method (GET/POST/PUT/DELETE) independently and has no notion of
+     * "this path exists but not for that method" - an unmatched method simply falls through to
+     * a generic 404. This class lets RestWebServer tell an unknown path (status 404) apart from
+     * a known path used with an unsupported method (status 405).
+     */
+    class RouteRegistry
+    {
+    public:
+        /**
+         * Bitmask of the HTTP methods (see HttpMethod) registered for a route.
+         */
+        using RouteMethods = uint8_t;
+
+        /**
+         * Records that aPattern was registered for aMethod.
+         */
+        void Add(const std::string &aPattern, HttpMethod aMethod);
+
+        /**
+         * Returns the methods registered for the route matching aPath, or 0 if no route matches.
+         */
+        RouteMethods GetMethods(const std::string &aPath) const;
+
+        /**
+         * Returns whether aMethod is supported by aMethods.
+         */
+        static bool MatchMethod(RouteMethods aMethods, HttpMethod aMethod);
+
+        /**
+         * Returns whether aMethods has any methods at all.
+         */
+        static bool AnyMethod(RouteMethods aMethods);
+
+        /**
+         * Formats aMethods as a comma-separated Allow-header value (e.g. "GET, POST, OPTIONS"),
+         * or "" if aMethods has no methods.
+         */
+        static std::string BuildMethodsString(RouteMethods aMethods);
+
+    private:
+        struct Route
+        {
+            std::string  mPattern;
+            RouteMethods mMethodMask = 0;
+        };
+
+        static bool MatchPath(const std::string &aPattern, const std::string &aPath);
+
+        static RouteMethods MethodBit(HttpMethod aMethod);
+
+        std::vector<Route> mRoutes;
     };
 
     void NodeInfo(const Request &aRequest, Response &aResponse) const;
@@ -176,6 +235,13 @@ private:
                                                             const std::set<std::string> &aContainedTypes) const;
     otError                            HasValidChars(const Request &aRequest, std::string &aErrorDetails) const;
 
+    void RegisterGet(const std::string &aPattern, httplib::Server::Handler aHandler);
+    void RegisterPost(const std::string &aPattern, httplib::Server::Handler aHandler);
+    void RegisterPut(const std::string &aPattern, httplib::Server::Handler aHandler);
+    void RegisterDelete(const std::string &aPattern, httplib::Server::Handler aHandler);
+
+    httplib::Server::HandlerResponse OptionsHandler(const Request &aRequest, Response &aResponse);
+
     otInstance *GetInstance(void) const { return mHost.GetThreadHelper()->GetInstance(); }
 
     void ErrorHandler(Response &aResponse, StatusCode aErrorCode) const;
@@ -191,6 +257,14 @@ private:
     auto RunInMainLoop(Milliseconds aDelay, Call aCall, Args... aArgs) const -> decltype(aCall(aArgs...))
     {
         return mHost.GetTaskRunner().PostAndWait<decltype(aCall(aArgs...))>([&]() { return aCall(aArgs...); }, aDelay);
+    }
+
+    httplib::Server::HandlerWithResponse MakePreRoutingHandler(
+        httplib::Server::HandlerResponse (RestWebServer::*aHandler)(const Request &, Response &))
+    {
+        return [this, aHandler](const Request &aRequest, Response &aResponse) {
+            return (this->*aHandler)(aRequest, aResponse);
+        };
     }
 
     template <typename HandlerType> httplib::Server::Handler MakeHandler(HandlerType aHandler)
@@ -211,6 +285,8 @@ private:
 
     httplib::Server mServer;
     std::thread     mServerThread;
+
+    RouteRegistry mRouteRegistry;
 
     Services mServices;
 };

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -429,11 +429,12 @@ def node_state_put_unsupported_method_test():
     print(" PATCH /node/state : status {}, expected 405".format(405))
 
 
-def node_ext_address_put_no_route_test():
+def node_ext_address_put_method_not_allowed_test():
     """A PUT to an endpoint that never registers a PUT handler (e.g.
-    /node/ext-address, GET-only) returns 404, the same routing-miss status
-    POST and DELETE already return on that path. Full 404/405 semantics
-    (a per-resource Allow header, etc.) are tracked by
+    /node/ext-address, GET-only) is a genuinely unsupported method on a
+    route that does exist, so RouteRegistry must report it as 405 with an
+    Allow header listing the methods that are actually registered - not a
+    plain 404. Regression test for
     https://github.com/openthread/ot-br-posix/issues/3529.
     """
     url = rest_api_addr + "/node/ext-address"
@@ -444,9 +445,121 @@ def node_ext_address_put_no_route_test():
         urllib.request.urlopen(request)
         assert False
     except urllib.error.HTTPError as e:
-        assert (e.code == 404)
+        assert (e.code == 405)
+        assert (e.headers.get("Allow") == "GET, OPTIONS")
+        assert e.headers.get("Content-Type") == "application/json"
+        body = json.loads(e.read().decode('utf-8'))
+        assert body["status"] == 405
+        assert body["title"] == "Method Not Allowed"
+        assert body.get("detail") == "method not supported"
 
-    print(" PUT /node/ext-address (no route) : status {}, expected 404".format(404))
+    print(" PUT /node/ext-address (registered route, wrong method) : status {}, expected 405".format(405))
+
+
+def node_state_delete_method_not_allowed_test():
+    """DELETE on /node/state (which only registers GET and PUT) must be
+    rejected with 405, and the Allow header must list every method actually
+    registered on that route, not just the one that was tried.
+    """
+    request = urllib.request.Request(rest_api_addr + "/node/state", method='DELETE')
+
+    try:
+        urllib.request.urlopen(request)
+        assert False
+    except urllib.error.HTTPError as e:
+        assert (e.code == 405)
+        assert (e.headers.get("Allow") == "GET, PUT, OPTIONS")
+        assert e.headers.get("Content-Type") == "application/json"
+        body = json.loads(e.read().decode('utf-8'))
+        assert body["status"] == 405
+        assert body["title"] == "Method Not Allowed"
+        assert body.get("detail") == "method not supported"
+
+    print(" DELETE /node/state : status {}, expected 405, Allow 'GET, PUT, OPTIONS'".format(405))
+
+
+def node_state_options_test():
+    """OPTIONS on a route with more than one registered method must report
+    all of them via the Allow header (in GET/POST/PUT/DELETE order), plus
+    OPTIONS itself.
+    """
+    req = urllib.request.Request(rest_api_addr + "/node/state", method='OPTIONS')
+    with urllib.request.urlopen(req) as response:
+        assert response.status == 204
+        assert response.headers.get("Allow") == "GET, PUT, OPTIONS"
+
+    print(" OPTIONS /node/state : status 204, Allow 'GET, PUT, OPTIONS'")
+
+
+def node_ext_address_options_test():
+    """OPTIONS on a GET-only route must report only GET plus OPTIONS."""
+    req = urllib.request.Request(rest_api_addr + "/node/ext-address", method='OPTIONS')
+    with urllib.request.urlopen(req) as response:
+        assert response.status == 204
+        assert response.headers.get("Allow") == "GET, OPTIONS"
+
+    print(" OPTIONS /node/ext-address : status 204, Allow 'GET, OPTIONS'")
+
+
+def node_options_test():
+    """OPTIONS on /node (GET+DELETE) exercises the DELETE branch of
+    RouteRegistry::BuildMethodsString directly, so coverage of that branch
+    doesn't depend on some other, unrelated test suite (e.g. schemathesis
+    against /api/*) happening to touch a DELETE-bearing route.
+    """
+    req = urllib.request.Request(rest_api_addr + "/node", method='OPTIONS')
+    with urllib.request.urlopen(req) as response:
+        assert response.status == 204
+        assert response.headers.get("Allow") == "GET, DELETE, OPTIONS"
+
+    print(" OPTIONS /node : status 204, Allow 'GET, DELETE, OPTIONS'")
+
+
+def api_actions_item_not_found_test():
+    """GET /api/actions/unknown UUID: the route AND the method
+    match a registered handler (ApiActionsItemGetHandler), but the item itself
+    doesn't exist, so the handler legitimately returns 404 on its own - this must
+    NOT be rewritten or otherwise touched by RoutingErrorHandler's routing-miss
+    logic, which only applies to routes/methods that were never registered.
+    """
+    url = rest_api_addr + "/api/actions/unknown-uuid"
+    request = urllib.request.Request(url, headers={'Accept': 'application/vnd.api+json'})
+
+    try:
+        urllib.request.urlopen(request)
+        assert False, "expected HTTP 404, but request succeeded"
+    except urllib.error.HTTPError as e:
+        assert e.code == 404, "expected HTTP 404, got {}".format(e.code)
+        assert e.headers.get("Content-Type") == "application/json"
+        body = json.loads(e.read().decode('utf-8'))
+        assert body["status"] == 404
+        assert body["title"] == "Not Found"
+
+    print(" GET /api/actions/unknown-uuid : status 404, expected 404 (matched route/method, app-level miss)")
+
+
+def unknown_route_test():
+    """A path with no registered route at all is a real 404, regardless of
+    method (including OPTIONS, which must not be handled generically since
+    RouteRegistry has no route to report methods for), and must not carry
+    an Allow header.
+    """
+    url = rest_api_addr + "/node/this-path-does-not-exist"
+
+    for method in ("GET", "OPTIONS", "POST", "PUT", "DELETE"):
+        request = urllib.request.Request(url, method=method)
+        try:
+            urllib.request.urlopen(request)
+            assert False, "expected HTTP 404 for {}, but request succeeded".format(method)
+        except urllib.error.HTTPError as e:
+            assert e.code == 404, "expected HTTP 404 for {}, got {}".format(method, e.code)
+            assert e.headers.get("Content-Type") == "application/json"
+            body = json.loads(e.read().decode('utf-8'))
+            assert body["status"] == 404
+            assert body["title"] == "Not Found"
+            assert e.headers.get("Allow") is None, "unexpected Allow header on a real 404 for {}".format(method)
+
+        print(" {} /node/this-path-does-not-exist : status 404, no Allow header".format(method))
 
 
 def node_network_name_test(thread_num):
@@ -721,7 +834,13 @@ def main():
     node_state_test(200)
     node_state_put_invalid_body_test()
     node_state_put_unsupported_method_test()
-    node_ext_address_put_no_route_test()
+    node_ext_address_put_method_not_allowed_test()
+    node_state_delete_method_not_allowed_test()
+    node_state_options_test()
+    node_ext_address_options_test()
+    node_options_test()
+    api_actions_item_not_found_test()
+    unknown_route_test()
     node_network_name_test(200)
     node_state_test_attached()  # wait for attached state
     node_leader_data_test(200)


### PR DESCRIPTION
Tracks, for each registered route, which HTTP methods it supports. This lets the routing error handler and a new pre-routing OPTIONS handler tell an unknown path (404) apart from a known path used with an unsupported method (405), and report the Allow header for the specific resource instead of a static server-wide method list.

Replaces the ad hoc per-handler OPTIONS cases and the PUT-only 404/405 workaround from https://github.com/openthread/ot-br-posix/pull/3524 with a single generic mechanism covering GET/POST/PUT/DELETE on every route.

Addresses https://github.com/openthread/ot-br-posix/issues/3529

Since OTBR REST endpoints are strictly defined by OpenAPI specifications the registry features a regex-free path matcher.

Co-authored-by: Jonathan Hui <jonhui@google.com>