### PR TITLE
[rest] fix /.well-known/thread/br-rest content leakage

### DIFF
--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -32,6 +32,7 @@
 #include "rest/rest_web_server.hpp"
 
 #include <chrono>
+#include <regex>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -146,6 +147,15 @@ HttpMethod GetMethod(const Request &aRequest)
     return HttpMethod::kInvalidMethod;
 }
 
+// httplib compiles route paths registered via Server::Get/Post/... as regexes, so any regex
+// metacharacter in a path (e.g. the '.' in ".well-known") needs to be escaped here - otherwise
+// it would be interpreted as regex syntax instead of matching itself literally.
+std::string EscapeRegexMeta(const std::string &aPath)
+{
+    static const std::regex kSpecialChars(R"([.^$|()\[\]{}*+?\\])");
+    return std::regex_replace(aPath, kSpecialChars, R"(\$&)");
+}
+
 RestWebServer::RestWebServer(Host::RcpHost &aHost)
     : mHost(aHost)
 {
@@ -209,8 +219,9 @@ RestWebServer::RestWebServer(Host::RcpHost &aHost)
                    MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsItemDeleteHandler));
     mServer.Options(OT_REST_ROUTE_DIAGNOSTICS, MakeHandlerInMainLoop(&RestWebServer::ApiDiagnosticsHandler));
 
-    mServer.Get(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
-    mServer.Options(OT_REST_ROUTE_WELLKNOWN_THREAD, MakeHandler(&RestWebServer::WellKnownThreadHandler));
+    mServer.Get(EscapeRegexMeta(OT_REST_ROUTE_WELLKNOWN_THREAD), MakeHandler(&RestWebServer::WellKnownThreadHandler));
+    mServer.Options(EscapeRegexMeta(OT_REST_ROUTE_WELLKNOWN_THREAD),
+                    MakeHandler(&RestWebServer::WellKnownThreadHandler));
 }
 
 RestWebServer::~RestWebServer(void)

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -612,6 +612,27 @@ def well_known_thread_options_test():
         assert response.headers.get("Allow") == "GET, OPTIONS"
 
 
+def well_known_thread_route_not_regex_leaky_test():
+    """Regression test for https://github.com/openthread/ot-br-posix/issues/3547.
+
+    cpp-httplib compiles registered route paths as regexes, so the literal '.' in
+    '/.well-known/thread/br-rest' must be escaped - otherwise it matches ANY single
+    character there (regex '.' semantics), leaking the discovery endpoint's content
+    under unintended paths such as '/Awell-known/thread/br-rest'. That must 404.
+    """
+    url = rest_api_addr + "/Awell-known/thread/br-rest"
+
+    request = urllib.request.Request(url)
+
+    try:
+        urllib.request.urlopen(request)
+        assert False, "expected HTTP 404, but request succeeded"
+    except urllib.error.HTTPError as e:
+        assert e.code == 404, "expected HTTP 404, got {}".format(e.code)
+
+    print(" GET /Awell-known/thread/br-rest : status 404, expected 404 (route must not be regex-leaky)")
+
+
 def well_known_thread_method_not_allowed_test():
     """The discovery endpoint only supports GET and OPTIONS; any other method
     (e.g. DELETE, POST, PUT) must be rejected with 405.
@@ -639,6 +660,7 @@ def well_known_thread_test(thread_num=1):
     valid = [well_known_thread_check(data, expected_version) for data in response_data].count(True)
 
     well_known_thread_options_test()
+    well_known_thread_route_not_regex_leaky_test()
     well_known_thread_method_not_allowed_test()
 
     print(" /.well-known/thread/br-rest : all {}, valid {} (version {})".format(thread_num, valid, expected_version))


### PR DESCRIPTION
By escaping the `.` string literal before registering as a route in mServer.

This also introduces a simple regex special char escaper which can/should be reused with the method registry pattern converter in "per-route method registry" https://github.com/openthread/ot-br-posix/pull/3546 when merged.

Regression test for regex route leakiness

Fixes: #3547