### PR TITLE
[tests] give NCP dbus-send Join calls a generous expect timeout

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -141,6 +141,33 @@ proc wait_for_device_role {pattern {retries 30} {bus "--system"}} {
     return 0
 }
 
+# Join the network via the D-Bus Join method, given a hex-encoded active
+# operational dataset TLV string as used with the "array:byte:" dbus-send
+# type.
+#
+# NcpHost::Join chains three sequential spinel round-trips to the NCP
+# (DatasetSetActiveTlvs, Ip6SetEnabled, ThreadSetEnabled) before dbus-send
+# gets its reply, which can exceed the default 10s expect timeout under CI
+# load well before dbus-send's own ~25s reply-timeout would trigger (see
+# #3512). Use a generous, explicit timeout just for this call.
+proc dbus_join {dataset_dbus {bus "--system"}} {
+    global spawn_id
+    set has_spawn_id [info exists spawn_id]
+    if {$has_spawn_id} {
+        set backup_spawn_id $spawn_id
+    }
+
+    spawn dbus-send $bus --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply \
+        /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
+    expect -timeout 30 eof
+
+    if {$has_spawn_id} {
+        set spawn_id $backup_spawn_id
+    } else {
+        unset -nocomplain spawn_id
+    }
+}
+
 # type: The type of the node.
 #   Possible values:
 #   1. cli: The cli app. ot-cli-ftd or ot-cli-mtd

--- a/tests/scripts/expect/ncp_join_leave.exp
+++ b/tests/scripts/expect/ncp_join_leave.exp
@@ -48,9 +48,7 @@ expect_line "Done"
 # Step 2. Start otbr-agent with a NCP and join the network by dbus join method
 spawn_node 2 otbr $::env(EXP_OT_NCP_PATH)
 sleep 1
-
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
-expect eof
+dbus_join $dataset_dbus
 
 # Step 3. Check if the otbr-agent has attached successfully. Poll instead of
 # a fixed sleep plus a single short-timeout read: attach timing varies in CI

--- a/tests/scripts/expect/ncp_netif_address_update.exp
+++ b/tests/scripts/expect/ncp_netif_address_update.exp
@@ -35,9 +35,7 @@ set dataset_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x03,0x
 # Step 1. Start otbr-agent with a NCP and join the network by dbus join method.
 spawn_node 2 otbr $::env(EXP_OT_NCP_PATH)
 sleep 1
-
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
-expect eof
+dbus_join $dataset_dbus
 
 # Step 2. Wait for it to become a leader. Poll instead of a fixed sleep plus
 # a single short-timeout read: leader formation timing varies in CI and the

--- a/tests/scripts/expect/ncp_netif_tx_rx.exp
+++ b/tests/scripts/expect/ncp_netif_tx_rx.exp
@@ -47,9 +47,7 @@ set dest_addr [get_ipaddr mleid]
 # Step 2. Start otbr-agent with a NCP and join the network by dbus join method
 spawn_node 2 otbr $::env(EXP_OT_NCP_PATH)
 sleep 1
-
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
-expect eof
+dbus_join $dataset_dbus
 
 # Step 3. Check if the otbr-agent has attached successfully. Poll instead of
 # a fixed sleep plus a single short-timeout read: attach timing varies in CI

--- a/tests/scripts/expect/ncp_schedule_migration.exp
+++ b/tests/scripts/expect/ncp_schedule_migration.exp
@@ -41,8 +41,7 @@ set dataset1_dbus "0x0e,0x08,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x03,0
 # Step 1. Start otbr-agent with a NCP and join the network by dbus join method
 spawn_node 1 otbr $::env(EXP_OT_NCP_PATH)
 sleep 1
-spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
-expect eof
+dbus_join $dataset_dbus
 
 # Step 2. Check if the otbr-agent has attached successfully. Poll instead of
 # a fixed sleep plus a single short-timeout read: attach timing varies in CI


### PR DESCRIPTION
## What

Give the initial `Join` D-Bus call in the `ncp_*.exp` test scripts a generous, explicit `expect` timeout.

## Why (#3512)

Several `ncp_*.exp` scripts join the network via D-Bus like this:

```tcl
spawn dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
expect eof
```

`expect eof` here inherits whatever `timeout` was last set (the implicit 10s default, or a leftover `set timeout 10` from a prior `expect_line` call) — there is no generous, explicit timeout for this specific call.

`NcpHost::Join` (`src/host/ncp_host.cpp`) chains three sequential spinel round-trips to the (simulated) NCP — `DatasetSetActiveTlvs` → `Ip6SetEnabled` → `ThreadSetEnabled` — and only replies to the D-Bus caller once all three complete. Under CI load this chain can take longer than the inherited ~10s `expect` timeout, well under `dbus-send`'s own default reply-timeout (~25s), so `expect eof` fires its `timeout { fail "Timed out" }` handler before `dbus-send` itself would time out — failing the whole script even though nothing is actually broken.

This is the same class of "fixed short wait window racing a variable-latency CI operation" as #3510 / #3511, but at a different call site (the initial `Join` RPC) that #3511 did not touch.

## Fix

Add an explicit `set timeout 30` immediately before each `spawn dbus-send ... Join ...` / `expect eof` pair — comfortably above `dbus-send`'s own ~25s default reply-timeout — and restore `set timeout 10` right after so later `expect`s in the same script are unaffected.

Applied to the four scripts listed in #3512:
- `tests/scripts/expect/ncp_netif_address_update.exp`
- `tests/scripts/expect/ncp_join_leave.exp`
- `tests/scripts/expect/ncp_schedule_migration.exp`
- `tests/scripts/expect/ncp_netif_tx_rx.exp`

Fixes #3512
