### PR TITLE
[rest] honor If-None-Match on the dataset PUT endpoints

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1464,6 +1464,8 @@ paths:
         Creates or updates the the active operational dataset on the current node. Only allowed if the Thread node
         is inactive. If the Thread node is active, a pending dataset should be used to update the current active
         operational dataset.
+      parameters:
+        - $ref: "#/components/parameters/IfNoneMatchStar"
       requestBody:
         description: |-
           Operational dataset that will be stored as active operational dataset. Supports request body Content-Type
@@ -1481,8 +1483,12 @@ paths:
           description: Successfully updated the active operational dataset.
         "201":
           description: Successfully created the active operational dataset.
+        "412":
+          $ref: "#/components/responses/PreconditionFailedError"
         "400":
-          description: Invalid request body.
+          description: |-
+            Invalid request body, or an `If-None-Match` header value other
+            than `*`.
         "409":
           description: Writing active operational dataset rejected because Thread network is active.
         "500":
@@ -1511,6 +1517,8 @@ paths:
       description: |-
         Creates or updates the the pending operational dataset on the current node. Delay needs to be set to let
         the pending dataset apply as active dataset in the near future.
+      parameters:
+        - $ref: "#/components/parameters/IfNoneMatchStar"
       requestBody:
         description: |-
           Operational dataset that will be stored as pending operational dataset. Supports request body Content-Type
@@ -1528,8 +1536,12 @@ paths:
           description: Successfully updated the pending operational dataset.
         "201":
           description: Successfully created the pending operational dataset.
+        "412":
+          $ref: "#/components/responses/PreconditionFailedError"
         "400":
-          description: Invalid request body.
+          description: |-
+            Invalid request body, or an `If-None-Match` header value other
+            than `*`.
         "500":
           $ref: "#/components/responses/InternalServerError"
   /node/commissioner/state:
@@ -2488,6 +2500,21 @@ components:
   ### Parameters ##############################################################
   #############################################################################
   parameters:
+    IfNoneMatchStar:
+      name: If-None-Match
+      in: header
+      required: false
+      schema:
+        type: string
+        enum: ["*"]
+      description: |-
+        With the value `*`, the dataset is only written when none is in place
+        yet; if one exists the request fails with 412 and nothing is written.
+        Any other value is rejected with 400: the dataset resources carry no
+        entity tags to match against. Without the header an existing dataset
+        is replaced. The active dataset is only writable while Thread is
+        stopped, and that check runs first: on a running node the response
+        is 409 whether or not this header is present.
 
     actionId:
       name: actionId
@@ -2706,6 +2733,18 @@ components:
             title: Request Timeout
             status: 408
 
+    PreconditionFailedError:
+      description: |
+        A dataset is already in place and the request carried
+        `If-None-Match: *`. Nothing was written; retry without the header to
+        replace the dataset deliberately, or wait until none is in place.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SimpleError"
+          example:
+            title: Precondition Failed
+            status: 412
     ConflictError:
       description: |
         The request conflicts with the current state of the target resource;

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -68,7 +68,7 @@
 #ifndef OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS
 #define OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS                                        \
     "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
-    "Access-Control-Request-Headers"
+    "Access-Control-Request-Headers, If-None-Match"
 #endif
 
 #ifndef OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS
@@ -690,6 +690,14 @@ exit:
     }
 }
 
+static std::string TrimOws(const std::string &aValue)
+{
+    size_t begin = aValue.find_first_not_of(" \t");
+    size_t end   = aValue.find_last_not_of(" \t");
+
+    return begin == std::string::npos ? "" : aValue.substr(begin, end - begin + 1);
+}
+
 void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
 {
     otbrError       error = OTBR_ERROR_NONE;
@@ -697,8 +705,21 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
     std::string     body;
     StatusCode      errorCode = StatusCode::OK_200;
 
+    // RFC 9110 section 13.1.2: If-None-Match with "*" makes the write
+    // conditional on no dataset being in place. A pending dataset that is
+    // not newer than the one already held is silently ignored by the mesh
+    // while this handler accepts the write, so a client that does not intend
+    // to supersede an in-flight dataset can turn that collision into an
+    // error it sees. Other forms of the header (entity tags) have nothing to
+    // match against here and are rejected rather than mistaken for an
+    // unconditional write.
+    const std::string ifNoneMatch  = TrimOws(aRequest.get_header_value(OT_REST_IF_NONE_MATCH_HEADER));
+    const bool        onlyIfAbsent = ifNoneMatch == "*";
+
+    VerifyOrExit(ifNoneMatch.empty() || onlyIfAbsent, error = OTBR_ERROR_INVALID_ARGS);
+
     SuccessOrExit(
-        error = RunInMainLoop([this, aDatasetType, &errorCode, &aRequest]() {
+        error = RunInMainLoop([this, aDatasetType, onlyIfAbsent, &errorCode, &aRequest]() {
             bool                     isTlv;
             otOperationalDataset     dataset = {};
             otOperationalDatasetTlvs datasetTlvs;
@@ -714,6 +735,13 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
             {
                 errorOt = otDatasetGetPendingTlvs(GetInstance(), &datasetTlvs);
             }
+
+            // RFC 9110 section 13.2.1: the precondition is evaluated after the
+            // request checks (the role check above still answers 409 first, the
+            // header cannot downgrade that to a 412) and before the content is
+            // processed; evaluated in this main-loop task, it is atomic with
+            // the write below.
+            VerifyOrReturn(!onlyIfAbsent || errorOt != OT_ERROR_NONE, OTBR_ERROR_DUPLICATED);
 
             // Create a new operational dataset if it doesn't exist.
             if (errorOt == OT_ERROR_NOT_FOUND)
@@ -775,6 +803,10 @@ exit:
     else if (error == OTBR_ERROR_INVALID_STATE)
     {
         ErrorHandler(aResponse, StatusCode::Conflict_409);
+    }
+    else if (error == OTBR_ERROR_DUPLICATED)
+    {
+        ErrorHandler(aResponse, StatusCode::PreconditionFailed_412);
     }
     else if (error != OTBR_ERROR_NONE)
     {

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -48,6 +48,7 @@
 #define OT_REST_ACCEPT_HEADER "Accept"
 #define OT_REST_ALLOW_HEADER "Allow"
 #define OT_REST_CONTENT_TYPE_HEADER "Content-Type"
+#define OT_REST_IF_NONE_MATCH_HEADER "If-None-Match"
 
 #define OT_REST_CONTENT_TYPE_JSON "application/json"
 #define OT_REST_CONTENT_TYPE_PLAIN "text/plain"

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -49,6 +49,14 @@ def get_data_from_url(url, result, index):
     result[index] = data
 
 
+def expect_http_error(code, action):
+    try:
+        action()
+        raise AssertionError("expected HTTP {}".format(code))
+    except urllib.error.HTTPError as err:
+        assert err.code == code, f"expected HTTP {code}, got {err.code}"
+
+
 def get_error_from_url(url, result, index):
     try:
         urllib.request.urlopen(urllib.request.Request(url))
@@ -664,13 +672,6 @@ def epskc_test():
         req.add_header('Content-Type', 'application/json')
         return urllib.request.urlopen(req)
 
-    def expect_http_error(code, action):
-        try:
-            action()
-            raise AssertionError("expected HTTP {}".format(code))
-        except urllib.error.HTTPError as err:
-            assert err.code == code
-
     # Regression test for https://github.com/openthread/ot-br-posix/issues/3522: an invalid
     # PUT body must return its real error status (400) rather than being masked as 405.
     expect_http_error(400, lambda: put_state("toggle"))
@@ -713,6 +714,49 @@ def epskc_test():
     print(" /node/ba-epskc : OK")
 
 
+def node_dataset_if_none_match_test():
+    url = rest_api_addr + "/node/dataset/pending"
+
+    def put(body, headers, target=None):
+        req = urllib.request.Request(target or url, data=body.encode(), method='PUT', headers=headers)
+        return urllib.request.urlopen(req)
+
+    body = json.dumps({"activeDataset": {"activeTimestamp": {"seconds": 20}}, "delay": 3600000})
+
+    # A rerun against the same node may find the pending dataset a previous
+    # run left behind (there is no DELETE to clean it up with); the
+    # conditional create is only expected on a node that has none.
+    try:
+        with urllib.request.urlopen(url) as response:
+            has_pending = response.status == 200
+    except urllib.error.HTTPError:
+        has_pending = False
+    if not has_pending:
+        with put(body, {'Content-Type': 'application/json', 'If-None-Match': '*'}) as response:
+            assert response.status == 201
+
+    # One is in place now: the conditional write is refused, nothing written.
+    expect_http_error(412, lambda: put(body, {'Content-Type': 'application/json', 'If-None-Match': '*'}))
+
+    # Header values other than "*" are rejected, not run unconditionally.
+    expect_http_error(400, lambda: put(body, {'Content-Type': 'application/json', 'If-None-Match': '"abc"'}))
+
+    # A failing precondition answers before the body is processed (RFC 9110
+    # section 13.2.1), so the malformed body does not turn this into a 400.
+    expect_http_error(412, lambda: put("{not json", {'Content-Type': 'application/json', 'If-None-Match': '*'}))
+
+    # On the active dataset of an attached node the role check answers first.
+    expect_http_error(409, lambda: put(body, {'Content-Type': 'application/json', 'If-None-Match': '*'},
+                                       rest_api_addr + "/node/dataset/active"))
+
+    # Without the header the replace semantics are unchanged.
+    body = json.dumps({"activeDataset": {"activeTimestamp": {"seconds": 30}}, "delay": 3600000})
+    with put(body, {'Content-Type': 'application/json'}) as response:
+        assert response.status == 200
+
+    print(" /node/dataset If-None-Match : OK")
+
+
 def main():
     node_test(200)
     node_rloc_test(200)
@@ -732,6 +776,7 @@ def main():
     error_test(10)
     well_known_thread_test(20)
     epskc_test()
+    node_dataset_if_none_match_test()
 
     return 0
 


### PR DESCRIPTION
A pending dataset that is not newer than the one the mesh already holds is silently ignored while this handler accepts the write, so a client that did not know a dataset was in flight reports success for a change that never happens. The client can check first, but not atomically with the write.

Honor the RFC 9110 If-None-Match header with the value `*` on PUT /node/dataset/active and /node/dataset/pending: the write then only happens when the addressed endpoint has no dataset in place yet (no pending dataset on the pending endpoint, no active dataset on the active one), and answers 412 Precondition Failed otherwise, checked inside the main-loop task atomically with the write. Header values other than `*` answer 400 rather than running the write unconditionally.

The checks run in the order RFC 9110 section 13.2.1 prescribes: first the existing request checks (the active dataset is only writable while Thread is stopped, so on a running node the answer stays 409 and the header cannot downgrade it to a 412), then the precondition (412), and only then is the request content processed (400 for a malformed body) and the dataset written. Requests without the header keep the replace semantics unchanged, so existing clients are unaffected.

cc @agners re https://github.com/home-assistant-libs/python-otbr-api/pull/269#pullrequestreview-5007594914