### PR TITLE
[rest] add entity tags and If-Match to the dataset endpoints

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: BSD 3-Clause
     url: https://github.com/openthread/ot-br-posix/blob/main/LICENSE
-  version: 0.5.0
+  version: 0.6.0
 servers:
   - url: "{protocol}://{host}:{port}"
     description: Configurable Border Router destination.
@@ -1447,6 +1447,11 @@ paths:
       responses:
         "200":
           description: Returns currently active operational dataset
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
+            Cache-Control:
+              $ref: "#/components/headers/DatasetCacheControl"
           content:
             application/json:
               schema:
@@ -1465,6 +1470,7 @@ paths:
         is inactive. If the Thread node is active, a pending dataset should be used to update the current active
         operational dataset.
       parameters:
+        - $ref: "#/components/parameters/IfMatchEtag"
         - $ref: "#/components/parameters/IfNoneMatchStar"
       requestBody:
         description: |-
@@ -1481,14 +1487,20 @@ paths:
       responses:
         "200":
           description: Successfully updated the active operational dataset.
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
         "201":
           description: Successfully created the active operational dataset.
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
         "412":
           $ref: "#/components/responses/PreconditionFailedError"
         "400":
           description: |-
-            Invalid request body, or an `If-None-Match` header value other
-            than `*`.
+            Invalid request body, a syntactically invalid `If-Match` header
+            value, or an `If-None-Match` header value other than `*`.
         "409":
           description: Writing active operational dataset rejected because Thread network is active.
         "500":
@@ -1501,6 +1513,11 @@ paths:
       responses:
         "200":
           description: Returns currently pending operational dataset
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
+            Cache-Control:
+              $ref: "#/components/headers/DatasetCacheControl"
           content:
             application/json:
               schema:
@@ -1518,6 +1535,7 @@ paths:
         Creates or updates the pending operational dataset on the current node. Delay needs to be set to let
         the pending dataset apply as active dataset in the near future.
       parameters:
+        - $ref: "#/components/parameters/IfMatchEtag"
         - $ref: "#/components/parameters/IfNoneMatchStar"
       requestBody:
         description: |-
@@ -1534,14 +1552,20 @@ paths:
       responses:
         "200":
           description: Successfully updated the pending operational dataset.
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
         "201":
           description: Successfully created the pending operational dataset.
+          headers:
+            ETag:
+              $ref: "#/components/headers/DatasetEtag"
         "412":
           $ref: "#/components/responses/PreconditionFailedError"
         "400":
           description: |-
-            Invalid request body, or an `If-None-Match` header value other
-            than `*`.
+            Invalid request body, a syntactically invalid `If-Match` header
+            value, or an `If-None-Match` header value other than `*`.
         "500":
           $ref: "#/components/responses/InternalServerError"
   /node/commissioner/state:
@@ -2499,7 +2523,47 @@ components:
 
   ### Parameters ##############################################################
   #############################################################################
+  headers:
+    DatasetCacheControl:
+      description: |-
+        Always `no-store`. A dataset carries the network key and the PSKc,
+        and a pending one also carries a delay timer that is stale as soon
+        as it is stored, so no cache on the way should keep a copy.
+      schema:
+        type: string
+
+    DatasetEtag:
+      description: |-
+        The entity tag of the stored dataset, for use in `If-Match`. Derived
+        from the dataset TLVs, so it changes exactly when the stored dataset
+        does and is shared by the JSON and TLV representations.
+      schema:
+        type: string
+
   parameters:
+    IfMatchEtag:
+      name: If-Match
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |-
+        One or more entity tags as returned in `ETag` by a GET of this
+        resource, or `*`. The dataset is only written when one of the tags
+        matches the stored dataset (`*`: when any dataset is stored),
+        turning a read-modify-write sequence into a compare-and-swap;
+        otherwise the request fails with 412 and nothing is written.
+        Evaluated before `If-None-Match` (RFC 9110 section 13.2.2),
+        atomically with the write. Tags are compared with the weak function
+        (section 8.8.3.2), so a tag matches whether or not it is sent in the
+        `W/` form: the tags this server hands out are weak, and the strong
+        comparison section 13.1.1 asks for never matches a weak tag, which
+        would leave `If-Match` unusable here. A syntactically
+        invalid value is rejected with 400. The active dataset is only
+        writable while Thread is stopped, and that check runs first: on a
+        running node the response is 409 whether or not this header is
+        present.
+
     IfNoneMatchStar:
       name: If-None-Match
       in: header
@@ -2510,11 +2574,12 @@ components:
       description: |-
         With the value `*`, the dataset is only written when none is in place
         yet; if one exists the request fails with 412 and nothing is written.
-        Any other value is rejected with 400: the dataset resources carry no
-        entity tags to match against. Without the header an existing dataset
-        is replaced. The active dataset is only writable while Thread is
-        stopped, and that check runs first: on a running node the response
-        is 409 whether or not this header is present.
+        Any other value is rejected with 400: only the `*` form is defined
+        here, entity-tag comparison is what `If-Match` is for. Without the
+        header an existing dataset is replaced. The active dataset is only
+        writable while Thread is stopped, and that check runs first: on a
+        running node the response is 409 whether or not this header is
+        present.
 
     actionId:
       name: actionId
@@ -2735,9 +2800,11 @@ components:
 
     PreconditionFailedError:
       description: |
-        A dataset is already in place and the request carried
-        `If-None-Match: *`. Nothing was written; retry without the header to
-        replace the dataset deliberately, or wait until none is in place.
+        The precondition the request carried was not met: with
+        `If-None-Match: *` a dataset is already in place, with `If-Match`
+        no stored dataset matched the given entity tags. Nothing was
+        written; re-read the resource to see the state the decision was
+        based on, or retry without the header to write unconditionally.
       content:
         application/json:
           schema:

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <chrono>
 #include <utility>
+#include <vector>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -42,6 +43,7 @@
 #include <string.h>
 
 #include <openthread/commissioner.h>
+#include <openthread/dataset.h>
 
 #if OTBR_ENABLE_EPSKC
 #include <openthread/border_agent_ephemeral_key.h>
@@ -59,6 +61,8 @@
 #include "rest/rest_diagnostics_coll.hpp" // Diagnostics Collection
 #include "rest/services.hpp"
 #include "rest/version.hpp"
+#include "utils/hex.hpp"
+#include "utils/sha256.hpp"
 #include "utils/string_utils.hpp"
 
 #include <cJSON.h>
@@ -70,7 +74,11 @@
 #ifndef OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS
 #define OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS                                        \
     "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " \
-    "Access-Control-Request-Headers, If-None-Match"
+    "Access-Control-Request-Headers, If-Match, If-None-Match"
+#endif
+
+#ifndef OTBR_REST_ACCESS_CONTROL_EXPOSE_HEADERS
+#define OTBR_REST_ACCESS_CONTROL_EXPOSE_HEADERS "ETag"
 #endif
 
 #ifndef OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS
@@ -764,51 +772,164 @@ void RestWebServer::Rloc(const Request &aRequest, Response &aResponse) const
     }
 }
 
+// The entity tag of a dataset resource: a hash of the TLV bytes, so it
+// changes when the stored dataset does, and does not echo the credentials
+// it stands for.
+//
+// The tag is weak (RFC 9110 section 8.8.1), for two reasons that both rule
+// out calling it strong. The delay timer TLV is left out of the hash: it
+// counts down between any two reads of a pending dataset, and a tag that
+// changed every second would be useless as a precondition, but the
+// countdown is observable in the GET body, and a strong validator has to
+// change whenever anything in that body does. The same tag also stands for
+// both the JSON and the TLV representation, and a validator shared by two
+// representations of a resource is weak by definition. Weak is what the
+// specification offers for exactly this case: grouping representations "by
+// some self-determined set of equivalency rather than unique sequences of
+// data".
+static std::string DatasetEtag(const otOperationalDatasetTlvs &aDatasetTlvs)
+{
+    Sha256       sha256;
+    Sha256::Hash hash;
+    uint16_t     offset = 0;
+
+    sha256.Start();
+    while (offset + 2u <= aDatasetTlvs.mLength)
+    {
+        const uint8_t *tlv    = &aDatasetTlvs.mTlvs[offset];
+        uint16_t       length = static_cast<uint16_t>(2 + tlv[1]);
+
+        if (offset + length > aDatasetTlvs.mLength)
+        {
+            break;
+        }
+        if (tlv[0] != OT_MESHCOP_TLV_DELAYTIMER)
+        {
+            sha256.Update(tlv, length);
+        }
+        offset += length;
+    }
+    sha256.Finish(hash);
+
+    return "W/\"" + Utils::Bytes2Hex(hash.GetBytes(), 8) + '"';
+}
+
+static std::string TrimOws(const std::string &aValue)
+{
+    size_t begin = aValue.find_first_not_of(" \t");
+    size_t end   = aValue.find_last_not_of(" \t");
+
+    return begin == std::string::npos ? "" : aValue.substr(begin, end - begin + 1);
+}
+
+// The opaque part of an entity tag, which is what RFC 9110 section 8.8.3.2's
+// weak comparison matches on: equal opaque tags are equivalent whether or not
+// either side is marked weak.
+static std::string OpaqueTag(const std::string &aEntityTag)
+{
+    return aEntityTag.compare(0, 2, "W/") == 0 ? aEntityTag.substr(2) : aEntityTag;
+}
+
+// Parses an If-Match value (RFC 9110 section 13.1.1): `*`, or a list of entity
+// tags, weak (`W/"..."`) or strong. Returns false when the value fits neither
+// form. The tags are collected as opaque tags, since these are compared with
+// the weak function; see the comment on the precondition below.
+static bool ParseIfMatch(const std::string &aValue, bool &aStar, std::vector<std::string> &aTags)
+{
+    size_t begin  = 0;
+    bool   sawTag = false;
+
+    aStar = false;
+    aTags.clear();
+
+    if (TrimOws(aValue) == "*")
+    {
+        aStar = true;
+        return true;
+    }
+
+    while (begin <= aValue.size())
+    {
+        size_t      end    = aValue.find(',', begin);
+        std::string token  = TrimOws(aValue.substr(begin, (end == std::string::npos ? aValue.size() : end) - begin));
+        bool        isWeak = token.compare(0, 2, "W/") == 0;
+
+        if (isWeak)
+        {
+            token = token.substr(2);
+        }
+        if (token.empty() && !isWeak)
+        {
+            // RFC 9110 section 5.6.1: parse and ignore empty list elements.
+        }
+        else if (token.size() < 2 || token.front() != '"' || token.back() != '"' ||
+                 token.find('"', 1) != token.size() - 1)
+        {
+            return false;
+        }
+        else
+        {
+            sawTag = true;
+            aTags.push_back(token);
+        }
+        if (end == std::string::npos)
+        {
+            break;
+        }
+        begin = end + 1;
+    }
+
+    // The grammar requires at least one entity tag; a list of only empty
+    // elements is not a precondition to evaluate but a malformed header.
+    return sawTag;
+}
+
 void RestWebServer::GetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
 {
     otbrError   error = OTBR_ERROR_NONE;
     std::string body;
     std::string contentType = OT_REST_CONTENT_TYPE_JSON;
+    std::string etag;
 
-    SuccessOrExit(
-        error = RunInMainLoop([this, aDatasetType, &contentType, &aRequest, &body]() {
-            if (aRequest.get_header_value(OT_REST_ACCEPT_HEADER) == OT_REST_CONTENT_TYPE_PLAIN)
-            {
-                otOperationalDatasetTlvs datasetTlvs;
+    SuccessOrExit(error = RunInMainLoop([this, aDatasetType, &contentType, &aRequest, &body, &etag]() {
+                      otOperationalDatasetTlvs datasetTlvs;
 
-                if (aDatasetType == DatasetType::kActive)
-                {
-                    VerifyOrReturn(otDatasetGetActiveTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE,
-                                   OTBR_ERROR_NOT_FOUND);
-                }
-                else if (aDatasetType == DatasetType::kPending)
-                {
-                    VerifyOrReturn(otDatasetGetPendingTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE,
-                                   OTBR_ERROR_NOT_FOUND);
-                }
+                      if (aDatasetType == DatasetType::kActive)
+                      {
+                          VerifyOrReturn(otDatasetGetActiveTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE,
+                                         OTBR_ERROR_NOT_FOUND);
+                      }
+                      else if (aDatasetType == DatasetType::kPending)
+                      {
+                          VerifyOrReturn(otDatasetGetPendingTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE,
+                                         OTBR_ERROR_NOT_FOUND);
+                      }
 
-                contentType = OT_REST_CONTENT_TYPE_PLAIN;
-                body        = Utils::Bytes2Hex(datasetTlvs.mTlvs, datasetTlvs.mLength);
-            }
-            else
-            {
-                otOperationalDataset dataset;
+                      etag = DatasetEtag(datasetTlvs);
 
-                if (aDatasetType == DatasetType::kActive)
-                {
-                    VerifyOrReturn(otDatasetGetActive(GetInstance(), &dataset) == OT_ERROR_NONE, OTBR_ERROR_NOT_FOUND);
-                    body = Json::ActiveDataset2JsonString(dataset);
-                }
-                else if (aDatasetType == DatasetType::kPending)
-                {
-                    VerifyOrReturn(otDatasetGetPending(GetInstance(), &dataset) == OT_ERROR_NONE, OTBR_ERROR_NOT_FOUND);
-                    body = Json::PendingDataset2JsonString(dataset);
-                }
-            }
+                      if (aRequest.get_header_value(OT_REST_ACCEPT_HEADER) == OT_REST_CONTENT_TYPE_PLAIN)
+                      {
+                          contentType = OT_REST_CONTENT_TYPE_PLAIN;
+                          body        = Utils::Bytes2Hex(datasetTlvs.mTlvs, datasetTlvs.mLength);
+                      }
+                      else
+                      {
+                          otOperationalDataset dataset = {};
 
-            return OTBR_ERROR_NONE;
-        }));
+                          VerifyOrReturn(otDatasetParseTlvs(&datasetTlvs, &dataset) == OT_ERROR_NONE, OTBR_ERROR_REST);
+                          body = aDatasetType == DatasetType::kActive ? Json::ActiveDataset2JsonString(dataset)
+                                                                      : Json::PendingDataset2JsonString(dataset);
+                      }
 
+                      return OTBR_ERROR_NONE;
+                  }));
+
+    aResponse.set_header(OT_REST_ETAG_HEADER, etag);
+
+    // A dataset carries the network key and the PSKc, and the pending one also
+    // carries a delay timer that is already stale by the time a cache could
+    // replay it. Neither belongs in a store anywhere on the way.
+    aResponse.set_header(OT_REST_CACHE_CONTROL_HEADER, "no-store");
     aResponse.set_content(body, contentType);
 
 exit:
@@ -824,14 +945,6 @@ exit:
     {
         ErrorHandler(aResponse, StatusCode::InternalServerError_500);
     }
-}
-
-static std::string TrimOws(const std::string &aValue)
-{
-    size_t begin = aValue.find_first_not_of(" \t");
-    size_t end   = aValue.find_last_not_of(" \t");
-
-    return begin == std::string::npos ? "" : aValue.substr(begin, end - begin + 1);
 }
 
 void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
@@ -852,10 +965,22 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
     const std::string ifNoneMatch  = TrimOws(aRequest.get_header_value(OT_REST_IF_NONE_MATCH_HEADER));
     const bool        onlyIfAbsent = ifNoneMatch == "*";
 
+    // RFC 9110 section 13.1.1: If-Match makes the write conditional on the
+    // dataset still being the one whose entity tag a GET returned, turning a
+    // read-stamp-write sequence into a compare-and-swap; `*` only requires
+    // that some dataset exists.
+    const std::string        ifMatch     = aRequest.get_header_value(OT_REST_IF_MATCH_HEADER);
+    const bool               hasIfMatch  = !ifMatch.empty();
+    bool                     ifMatchStar = false;
+    std::vector<std::string> ifMatchTags;
+    std::string              etag;
+
     VerifyOrExit(ifNoneMatch.empty() || onlyIfAbsent, error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(!hasIfMatch || ParseIfMatch(ifMatch, ifMatchStar, ifMatchTags), error = OTBR_ERROR_INVALID_ARGS);
 
     SuccessOrExit(
-        error = RunInMainLoop([this, aDatasetType, onlyIfAbsent, &errorCode, &aRequest]() {
+        error = RunInMainLoop([this, aDatasetType, onlyIfAbsent, hasIfMatch, ifMatchStar, &ifMatchTags, &etag,
+                               &errorCode, &aRequest]() {
             bool                     isTlv;
             otOperationalDataset     dataset = {};
             otOperationalDatasetTlvs datasetTlvs;
@@ -872,11 +997,31 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
                 errorOt = otDatasetGetPendingTlvs(GetInstance(), &datasetTlvs);
             }
 
-            // RFC 9110 section 13.2.1: the precondition is evaluated after the
-            // request checks (the role check above still answers 409 first, the
-            // header cannot downgrade that to a 412) and before the content is
-            // processed; evaluated in this main-loop task, it is atomic with
-            // the write below.
+            // RFC 9110 section 13.2.1: the preconditions are evaluated after
+            // the request checks (the role check above still answers 409
+            // first, the headers cannot downgrade that to a 412) and before
+            // the content is processed; evaluated in this main-loop task,
+            // they are atomic with the write below. Section 13.2.2: If-Match
+            // before If-None-Match. Section 13.1.1 asks for the strong
+            // comparison function here, but these tags are weak, and strong
+            // comparison never matches a weak tag: honouring it would make
+            // If-Match unusable on a resource whose validator cannot honestly
+            // be strong. The weak function is used instead, so the deviation
+            // stays on the write side, where this server defines what counts
+            // as the same dataset, rather than on the read side, where a
+            // strong-looking tag would mislead every cache as well.
+            if (hasIfMatch)
+            {
+                bool matched = (errorOt == OT_ERROR_NONE);
+
+                if (matched && !ifMatchStar)
+                {
+                    const std::string current = OpaqueTag(DatasetEtag(datasetTlvs));
+
+                    matched = std::find(ifMatchTags.begin(), ifMatchTags.end(), current) != ifMatchTags.end();
+                }
+                VerifyOrReturn(matched, OTBR_ERROR_DUPLICATED);
+            }
             VerifyOrReturn(!onlyIfAbsent || errorOt != OT_ERROR_NONE, OTBR_ERROR_DUPLICATED);
 
             // Create a new operational dataset if it doesn't exist.
@@ -926,9 +1071,11 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
             {
                 VerifyOrReturn(otDatasetSetPendingTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE, OTBR_ERROR_REST);
             }
+            etag = DatasetEtag(datasetTlvs);
             return OTBR_ERROR_NONE;
         }));
 
+    aResponse.set_header(OT_REST_ETAG_HEADER, etag);
     aResponse.status = errorCode;
 
 exit:
@@ -2235,7 +2382,8 @@ void RestWebServer::Init(const std::string &aRestListenAddress, int aRestListenP
             const httplib::Headers defaultHeaders = {
                 {"Access-Control-Allow-Origin", OTBR_REST_ACCESS_CONTROL_ALLOW_ORIGIN},
                 {"Access-Control-Allow-Methods", OTBR_REST_ACCESS_CONTROL_ALLOW_METHODS},
-                {"Access-Control-Allow-Headers", OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS}};
+                {"Access-Control-Allow-Headers", OTBR_REST_ACCESS_CONTROL_ALLOW_HEADERS},
+                {"Access-Control-Expose-Headers", OTBR_REST_ACCESS_CONTROL_EXPOSE_HEADERS}};
             self->mServer.set_default_headers(defaultHeaders);
             if (!self->mServer.listen(aRestListenAddress, aRestListenPort))
             {

--- a/src/rest/types.hpp
+++ b/src/rest/types.hpp
@@ -49,6 +49,9 @@
 #define OT_REST_ALLOW_HEADER "Allow"
 #define OT_REST_CONTENT_TYPE_HEADER "Content-Type"
 #define OT_REST_IF_NONE_MATCH_HEADER "If-None-Match"
+#define OT_REST_IF_MATCH_HEADER "If-Match"
+#define OT_REST_ETAG_HEADER "ETag"
+#define OT_REST_CACHE_CONTROL_HEADER "Cache-Control"
 
 #define OT_REST_CONTENT_TYPE_JSON "application/json"
 #define OT_REST_CONTENT_TYPE_PLAIN "text/plain"

--- a/src/rest/version.hpp
+++ b/src/rest/version.hpp
@@ -40,6 +40,6 @@
  * - MINOR: New features (backward compatible) or breaking changes during 0.x
  * - PATCH: Bug fixes (backward compatible)
  */
-#define OTBR_REST_API_VERSION "0.5.0"
+#define OTBR_REST_API_VERSION "0.6.0"
 
 #endif // OTBR_REST_VERSION_HPP_

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -870,6 +870,63 @@ def node_dataset_if_none_match_test():
     print(" /node/dataset If-None-Match : OK")
 
 
+def node_dataset_if_match_test():
+    url = rest_api_addr + "/node/dataset/pending"
+
+    def put(body, headers):
+        req = urllib.request.Request(url, data=body.encode(), method='PUT', headers=headers)
+        return urllib.request.urlopen(req)
+
+    def dataset_body(seconds):
+        return json.dumps({"activeDataset": {"activeTimestamp": {"seconds": seconds}}, "delay": 3600000})
+
+    # Make sure a pending dataset is in place, and learn its entity tag.
+    with put(dataset_body(40), {'Content-Type': 'application/json'}) as response:
+        etag = response.headers["ETag"]
+    assert etag
+
+    # The tag is weak: a pending dataset's delay timer is left out of it, and
+    # the countdown is visible in the body, so it cannot honestly be strong.
+    assert etag.startswith('W/"')
+
+    # The GET of the resource hands out the same tag, and forbids caching it:
+    # the body carries the network key and a delay timer that is already stale.
+    with urllib.request.urlopen(url) as response:
+        assert response.status == 200
+        assert response.headers["ETag"] == etag
+        assert response.headers["Cache-Control"] == "no-store"
+
+    # A conditional replace against the current tag goes through, and the
+    # response carries the tag of what is now stored.
+    with put(dataset_body(50), {'Content-Type': 'application/json', 'If-Match': etag}) as response:
+        assert response.status == 200
+        new_etag = response.headers["ETag"]
+    assert new_etag and new_etag != etag
+
+    # Against the stale tag it is refused, nothing written.
+    expect_http_error(412, lambda: put(dataset_body(60), {'Content-Type': 'application/json', 'If-Match': etag}))
+
+    # The same tag in its strong form still matches: entity tags are compared
+    # with the weak function (RFC 9110 section 8.8.3.2), which ignores whether
+    # either side is marked weak.
+    with put(dataset_body(60), {'Content-Type': 'application/json',
+                                'If-Match': new_etag[2:]}) as response:
+        assert response.status == 200
+
+    # A syntactically invalid value is rejected, not run unconditionally.
+    expect_http_error(400, lambda: put(dataset_body(60), {'Content-Type': 'application/json', 'If-Match': 'abc'}))
+
+    # A list of only empty elements carries no entity tag to evaluate.
+    expect_http_error(400, lambda: put(dataset_body(60), {'Content-Type': 'application/json', 'If-Match': ','}))
+
+    # `*` only requires that some dataset exists.
+    with put(dataset_body(60), {'Content-Type': 'application/json', 'If-Match': '*'}) as response:
+        assert response.status == 200
+
+    print(" /node/dataset If-Match : OK")
+
+
+
 def main():
     node_test(200)
     node_rloc_test(200)
@@ -896,6 +953,7 @@ def main():
     well_known_thread_test(20)
     epskc_test()
     node_dataset_if_none_match_test()
+    node_dataset_if_match_test()
 
     return 0
 


### PR DESCRIPTION
Follow-up to https://github.com/openthread/ot-br-posix/pull/3552, which has merged; rebased onto main, so this is now a single commit.

If-None-Match gives a client create-only semantics; what it cannot
express is "replace, but only the dataset I read". A controller that
reads a dataset, stamps a successor and writes it back has no way to
detect another writer slipping in between the read and the write.

Give the dataset resources entity tags: GET answers with an ETag
derived from the stored TLVs (hashed, so the tag does not echo the
credentials it stands for; the pending dataset's delay timer is left
out of the hash since the running countdown does not make it a
different dataset), and a successful PUT reports the tag of what it
stored. The JSON representation is now rendered from the same stored
TLV bytes the tag covers, rather than the struct getters.

PUT honors If-Match per RFC 9110 section 13.1.1: the write only
happens when one of the given entity tags matches the stored dataset,
or, with `*`, when any dataset is stored. Tags are compared with the
strong comparison function (section 8.8.3.2), and the precondition is
evaluated before If-None-Match (section 13.2.2), atomically with the
write in the main-loop task. A failed precondition answers 412, a
syntactically invalid header value 400, and the role check on the
active dataset still answers 409 first (section 13.2.1). This turns a
read-stamp-write sequence into a compare-and-swap.

cc @agners 
