### PR TITLE
[agent] use #if instead of #ifdef for OTBR_ENABLE_PLATFORM_ANDROID

### DIFF
--- a/src/agent/realmain.cpp
+++ b/src/agent/realmain.cpp
@@ -56,7 +56,7 @@
 #include "common/types.hpp"
 #include "host/thread_host.hpp"
 
-#ifdef OTBR_ENABLE_PLATFORM_ANDROID
+#if OTBR_ENABLE_PLATFORM_ANDROID
 #include <log/log.h>
 #ifndef __ANDROID__
 #error "OTBR_ENABLE_PLATFORM_ANDROID can be enabled for only Android devices"


### PR DESCRIPTION
OTBR_ENABLE_PLATFORM_ANDROID is a configuration macro defined as 0 or 1. Using '#ifdef' evaluates to true even when the macro is defined as 0, which causes compile errors when Android platform support is disabled.

This commit updates the preprocessor check in realmain.cpp from '#ifdef' to '#if' for consistency with the rest of the codebase.