### PR TITLE
[mdns] allow resolving IPv4 address for host or service with mDNSResponder

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -131,6 +131,39 @@ void Ip6Address::CopyTo(otIp6Address &aAddress) const
     memcpy(aAddress.mFields.m8, m8, sizeof(aAddress.mFields.m8));
 }
 
+otbrError Ip6Address::CopyFrom(const struct sockaddr &aSockAddr)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    if (aSockAddr.sa_family == AF_INET6)
+    {
+        CopyFrom(*reinterpret_cast<const struct sockaddr_in6 *>(&aSockAddr));
+    }
+    else if (aSockAddr.sa_family == AF_INET)
+    {
+        CopyFrom(*reinterpret_cast<const struct sockaddr_in *>(&aSockAddr));
+    }
+    else
+    {
+        error = OTBR_ERROR_INVALID_ARGS;
+    }
+
+    return error;
+}
+
+void Ip6Address::CopyFrom(const struct sockaddr_in &aSockAddr)
+{
+    CopyFrom(aSockAddr.sin_addr);
+}
+
+void Ip6Address::CopyFrom(const struct in_addr &aInAddr)
+{
+    memset(m8, 0, 10);
+    m8[10] = 0xff;
+    m8[11] = 0xff;
+    memcpy(&m8[12], &aInAddr.s_addr, sizeof(aInAddr.s_addr));
+}
+
 otbrError Ip6Address::FromString(const char *aStr, Ip6Address &aAddr)
 {
     int ret;

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -213,6 +213,14 @@ public:
     std::string ToString(void) const;
 
     /**
+     * This method indicates whether or not the Ip6 address is an IPv4-mapped IPv6 address.
+     *
+     * @retval TRUE   If the Ip6 address is an IPv4-mapped IPv6 address.
+     * @retval FALSE  If the Ip6 address is not an IPv4-mapped IPv6 address.
+     */
+    bool IsIp4Mapped(void) const { return (m64[0] == 0 && m16[4] == 0 && m16[5] == 0xffff); }
+
+    /**
      * This method indicates whether or not the Ip6 address is the Unspecified Address.
      *
      * @retval TRUE   If the Ip6 address is the Unspecified Address.
@@ -318,6 +326,30 @@ public:
      * @param[out] aAddress  The `otIp6Address` structure to copy the Ip6 address to.
      */
     void CopyTo(otIp6Address &aAddress) const;
+
+    /**
+     * This method copies the Ip6 address from a `sockaddr` structure (supporting AF_INET6 and AF_INET).
+     *
+     * @param[in] aSockAddr  The `sockaddr` structure to copy the Ip6 address from.
+     *
+     * @retval OTBR_ERROR_NONE          Successfully copied the address.
+     * @retval OTBR_ERROR_INVALID_ARGS  The address family is neither AF_INET6 nor AF_INET.
+     */
+    otbrError CopyFrom(const struct sockaddr &aSockAddr);
+
+    /**
+     * This method copies the Ip6 address from a `sockaddr_in` structure (as an IPv4-mapped IPv6 address).
+     *
+     * @param[in] aSockAddr  The `sockaddr_in` structure to copy the Ip6 address from.
+     */
+    void CopyFrom(const struct sockaddr_in &aSockAddr);
+
+    /**
+     * This method copies the Ip6 address from an `in_addr` structure (as an IPv4-mapped IPv6 address).
+     *
+     * @param[in] aInAddr  The `in_addr` structure to copy the Ip6 address from.
+     */
+    void CopyFrom(const struct in_addr &aInAddr);
 
     union
     {

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -1472,17 +1472,25 @@ void PublisherMDnsSd::ServiceInstanceResolution::HandleGetAddrInfoResult(DNSServ
     OTBR_UNUSED_VARIABLE(aInterfaceIndex);
 
     Ip6Address address;
-    bool       isAdd      = (aFlags & kDNSServiceFlagsAdd) != 0;
-    bool       moreComing = (aFlags & kDNSServiceFlagsMoreComing) != 0;
+    bool       isAdd;
+    bool       moreComing = false;
 
-    otbrLog(aErrorCode == kDNSServiceErr_NoError ? OTBR_LOG_INFO : OTBR_LOG_WARNING, OTBR_LOG_TAG,
-            "DNSServiceGetAddrInfo reply: flags=%" PRIu32 ", host=%s, sa_family=%u, error=%" PRId32, aFlags, aHostName,
-            static_cast<unsigned int>(aAddress->sa_family), aErrorCode);
+    if (aErrorCode != kDNSServiceErr_NoError)
+    {
+        otbrLogWarning("DNSServiceGetAddrInfo failed: host=%s, error=%" PRId32, aHostName, aErrorCode);
+        ExitNow();
+    }
 
-    VerifyOrExit(aErrorCode == kDNSServiceErr_NoError);
-    VerifyOrExit(aAddress->sa_family == AF_INET6);
+    isAdd      = (aFlags & kDNSServiceFlagsAdd) != 0;
+    moreComing = (aFlags & kDNSServiceFlagsMoreComing) != 0;
 
-    address.CopyFrom(*reinterpret_cast<const struct sockaddr_in6 *>(aAddress));
+    VerifyOrExit(aAddress != nullptr, otbrLogWarning("DNSServiceGetAddrInfo reply has null address"));
+
+    otbrLogInfo("DNSServiceGetAddrInfo reply: flags=%" PRIu32 ", host=%s, sa_family=%u", aFlags, aHostName,
+                static_cast<unsigned int>(aAddress->sa_family));
+
+    SuccessOrExit(address.CopyFrom(*aAddress), otbrLogWarning("DNSServiceGetAddrInfo unsupported sa_family %u",
+                                                              static_cast<unsigned int>(aAddress->sa_family)));
     VerifyOrExit(!address.IsUnspecified() && !address.IsMulticast() && !address.IsLoopback(),
                  otbrLogDebug("DNSServiceGetAddrInfo ignores address %s", address.ToString().c_str()));
 
@@ -1572,17 +1580,27 @@ void PublisherMDnsSd::HostSubscription::HandleResolveResult(DNSServiceRef       
     OTBR_UNUSED_VARIABLE(aServiceRef);
 
     Ip6Address address;
-    bool       isAdd      = (aFlags & kDNSServiceFlagsAdd) != 0;
-    bool       moreComing = (aFlags & kDNSServiceFlagsMoreComing) != 0;
+    bool       isAdd;
+    bool       moreComing = false;
 
-    otbrLog(aErrorCode == kDNSServiceErr_NoError ? OTBR_LOG_INFO : OTBR_LOG_WARNING, OTBR_LOG_TAG,
-            "DNSServiceGetAddrInfo reply: flags=%" PRIu32 ", host=%s, sa_family=%u, error=%" PRId32, aFlags, aHostName,
-            static_cast<unsigned int>(aAddress->sa_family), aErrorCode);
+    if (aErrorCode != kDNSServiceErr_NoError)
+    {
+        otbrLogWarning("DNSServiceGetAddrInfo failed: host=%s, error=%" PRId32, aHostName, aErrorCode);
+        ExitNow();
+    }
 
-    VerifyOrExit(aErrorCode == kDNSServiceErr_NoError);
-    VerifyOrExit(aAddress->sa_family == AF_INET6);
+    isAdd      = (aFlags & kDNSServiceFlagsAdd) != 0;
+    moreComing = (aFlags & kDNSServiceFlagsMoreComing) != 0;
 
-    address.CopyFrom(*reinterpret_cast<const struct sockaddr_in6 *>(aAddress));
+    VerifyOrExit(aAddress != nullptr, otbrLogWarning("DNSServiceGetAddrInfo reply has null address"));
+
+    otbrLogInfo("DNSServiceGetAddrInfo reply: flags=%" PRIu32 ", host=%s, sa_family=%u", aFlags, aHostName,
+                static_cast<unsigned int>(aAddress->sa_family));
+
+    SuccessOrExit(address.CopyFrom(*aAddress), otbrLogWarning("DNSServiceGetAddrInfo unsupported sa_family %u",
+                                                              static_cast<unsigned int>(aAddress->sa_family)));
+    VerifyOrExit(!address.IsUnspecified() && !address.IsMulticast() && !address.IsLoopback(),
+                 otbrLogDebug("DNSServiceGetAddrInfo ignores address %s", address.ToString().c_str()));
 
     otbrLogInfo("DNSServiceGetAddrInfo reply: %s address=%s, ttl=%" PRIu32, isAdd ? "add" : "remove",
                 address.ToString().c_str(), aTtl);

--- a/tests/gtest/test_common_types.cpp
+++ b/tests/gtest/test_common_types.cpp
@@ -26,13 +26,83 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arpa/inet.h>
+
 #include <gtest/gtest.h>
 
 #include "common/types.hpp"
 
 //-------------------------------------------------------------
 // Test for Ip6Address
-// TODO: Add Ip6Address tests
+
+TEST(Ip6Address, Ipv4MappedAddress)
+{
+    using otbr::Ip6Address;
+
+    struct sockaddr_in sockAddr;
+    memset(&sockAddr, 0, sizeof(sockAddr));
+    sockAddr.sin_family = AF_INET;
+    ASSERT_EQ(inet_pton(AF_INET, "192.168.1.100", &sockAddr.sin_addr), 1);
+
+    Ip6Address address;
+    EXPECT_EQ(address.CopyFrom(reinterpret_cast<const struct sockaddr &>(sockAddr)), OTBR_ERROR_NONE);
+    EXPECT_TRUE(address.IsIp4Mapped());
+    EXPECT_STREQ(address.ToString().c_str(), "::ffff:192.168.1.100");
+
+    Ip6Address addressFromSockAddrIn;
+    addressFromSockAddrIn.CopyFrom(sockAddr);
+    EXPECT_TRUE(addressFromSockAddrIn.IsIp4Mapped());
+    EXPECT_STREQ(addressFromSockAddrIn.ToString().c_str(), "::ffff:192.168.1.100");
+
+    struct in_addr inAddr;
+    ASSERT_EQ(inet_pton(AF_INET, "10.0.0.1", &inAddr), 1);
+
+    Ip6Address addressFromInAddr;
+    addressFromInAddr.CopyFrom(inAddr);
+    EXPECT_TRUE(addressFromInAddr.IsIp4Mapped());
+    EXPECT_STREQ(addressFromInAddr.ToString().c_str(), "::ffff:10.0.0.1");
+
+    struct sockaddr_in6 sockAddr6;
+    memset(&sockAddr6, 0, sizeof(sockAddr6));
+    sockAddr6.sin6_family = AF_INET6;
+    ASSERT_EQ(inet_pton(AF_INET6, "fd00::1", &sockAddr6.sin6_addr), 1);
+
+    Ip6Address address6;
+    EXPECT_EQ(address6.CopyFrom(reinterpret_cast<const struct sockaddr &>(sockAddr6)), OTBR_ERROR_NONE);
+    EXPECT_FALSE(address6.IsIp4Mapped());
+    EXPECT_STREQ(address6.ToString().c_str(), "fd00::1");
+
+    struct sockaddr invalidSockAddr;
+    memset(&invalidSockAddr, 0, sizeof(invalidSockAddr));
+    invalidSockAddr.sa_family = AF_UNSPEC;
+    EXPECT_EQ(address.CopyFrom(invalidSockAddr), OTBR_ERROR_INVALID_ARGS);
+
+    // Negative matches
+    EXPECT_FALSE(Ip6Address("::").IsIp4Mapped());
+    EXPECT_FALSE(Ip6Address("::1").IsIp4Mapped());
+    EXPECT_FALSE(Ip6Address("::ffff:0:0:0").IsIp4Mapped());
+    EXPECT_FALSE(Ip6Address("::1.2.3.4").IsIp4Mapped());
+    EXPECT_FALSE(Ip6Address("ffff::").IsIp4Mapped());
+    EXPECT_FALSE(Ip6Address("::fffe:0:0").IsIp4Mapped());
+
+    // Boundary positive matches
+    EXPECT_TRUE(Ip6Address("::ffff:0:0").IsIp4Mapped());
+    EXPECT_TRUE(Ip6Address("::ffff:0.0.0.0").IsIp4Mapped());
+    EXPECT_STREQ(Ip6Address("::ffff:0:0").ToString().c_str(), "::ffff:0.0.0.0");
+    EXPECT_TRUE(Ip6Address("::ffff:255.255.255.255").IsIp4Mapped());
+    EXPECT_TRUE(Ip6Address("::ffff:ffff:ffff").IsIp4Mapped());
+    EXPECT_STREQ(Ip6Address("::ffff:ffff:ffff").ToString().c_str(), "::ffff:255.255.255.255");
+
+    inAddr.s_addr = INADDR_ANY;
+    addressFromInAddr.CopyFrom(inAddr);
+    EXPECT_TRUE(addressFromInAddr.IsIp4Mapped());
+    EXPECT_STREQ(addressFromInAddr.ToString().c_str(), "::ffff:0.0.0.0");
+
+    inAddr.s_addr = INADDR_NONE;
+    addressFromInAddr.CopyFrom(inAddr);
+    EXPECT_TRUE(addressFromInAddr.IsIp4Mapped());
+    EXPECT_STREQ(addressFromInAddr.ToString().c_str(), "::ffff:255.255.255.255");
+}
 
 //-------------------------------------------------------------
 // Test for Ip6Prefix


### PR DESCRIPTION
In mdns_mdnssd.cpp, DNSServiceGetAddrInfo is called with `kDNSServiceProtocol_IPv6 | kDNSServiceProtocol_IPv4` for both service instance resolution and host subscription resolution. This indicates that either an IPv6 or an IPv4 address is explicitly expected and allowed from the mDNS responder.

However, the callback handlers `HandleGetAddrInfoResult` and `HandleResolveResult` previously discarded all non-IPv6 addresses with `VerifyOrExit(aAddress->sa_family == AF_INET6)`. This was a bug that caused hosts and services advertising only IPv4 A records to be ignored rather than resolved.

This change fixes the bug by:
- Accepting both AF_INET and AF_INET6 address families in `PublisherMDnsSd::ServiceInstanceResolution::HandleGetAddrInfoResult` and `PublisherMDnsSd::HostSubscription::HandleResolveResult`.
- Extending `Ip6Address` with `CopyFrom(const struct sockaddr &)`, `CopyFrom(const struct sockaddr_in &)` and `CopyFrom(const struct in_addr &)` to convert resolved IPv4 addresses into IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`), consistent with OpenThread's DNS-SD / discovery proxy specification.
- Adding unit test for `Ip6Address` covering IPv4-mapped addresses.