### PR TITLE
[misc] replace instances of duplicated "the the" with "the"

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1461,7 +1461,7 @@ paths:
         - node
       summary: Creates or updates the active operational dataset
       description: |-
-        Creates or updates the the active operational dataset on the current node. Only allowed if the Thread node
+        Creates or updates the active operational dataset on the current node. Only allowed if the Thread node
         is inactive. If the Thread node is active, a pending dataset should be used to update the current active
         operational dataset.
       parameters:
@@ -1515,7 +1515,7 @@ paths:
         - node
       summary: Creates or updates the pending operational dataset
       description: |-
-        Creates or updates the the pending operational dataset on the current node. Delay needs to be set to let
+        Creates or updates the pending operational dataset on the current node. Delay needs to be set to let
         the pending dataset apply as active dataset in the near future.
       parameters:
         - $ref: "#/components/parameters/IfNoneMatchStar"

--- a/tests/scripts/meshcop
+++ b/tests/scripts/meshcop
@@ -584,7 +584,7 @@ test_meshcop_service()
     service="$(scan_meshcop_service)"
     grep "${OT_SERVICE_INSTANCE}._meshcop\._udp" <<<"${service}"
 
-    # Test if the the meshcop service is unpublished when otbr-agent stops.
+    # Test if the meshcop service is unpublished when otbr-agent stops.
     sudo "${OT_CTL}" ba disable
     sleep 2
     sudo killall "${OTBR_AGENT}"


### PR DESCRIPTION
Remove accidental duplicate "the" words across the codebase:

- src/rest/openapi.yaml: Remove duplicate "the" in descriptions for active and pending operational dataset endpoints.
- tests/scripts/meshcop: Remove duplicate "the" in comment within meshcop test script.