### PR TITLE
[rest] fix active dataset request body content type in OpenAPI spec

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1475,7 +1475,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ActiveDataset"
-          plain/text:
+          text/plain:
             schema:
               $ref: "#/components/schemas/DatasetTlv"
       responses:


### PR DESCRIPTION
The OpenAPI specification for the `PUT /node/dataset/active` endpoint incorrectly listed `plain/text` as the content type for the TLV dataset request body instead of `text/plain`.

The endpoint description already references `text/plain`, matching the corresponding pending dataset endpoint
(`PUT /node/dataset/pending`) and the REST server implementation.

Fix the content type mapping from `plain/text` to `text/plain`.