### PR TITLE
[ci] fix source tarball creation in monthly release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Package Source Tarball
         run: |
           TAR_NAME="ot-br-posix-${TAG_NAME}.tar.gz"
-          tar --exclude-vcs --transform "s|^\.|ot-br-posix-${TAG_NAME}|" -czf "${TAR_NAME}" .
+          tar --exclude-vcs --transform "s|^\.|ot-br-posix-${TAG_NAME}|" -czf "../${TAR_NAME}" .
+          mv "../${TAR_NAME}" .
           echo "TAR_NAME=${TAR_NAME}" >> $GITHUB_ENV
 
       - name: Create GitHub Release


### PR DESCRIPTION
When packaging the source tarball in monthly-release.yml, tar was configured to write the output archive directly into the current working directory (`.`) being archived.

Because the archive file is created and written to inside `.`, GNU tar detects that the directory and file contents changed during traversal ("file changed as we read it") and exits with return code 1, causing the Package Source Tarball step to fail.

This commit creates the tarball in the parent directory (`../`) and moves it into the current directory after archiving completes.