### PR TITLE
[misc] fix cmake install manifest spelling

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -95,9 +95,9 @@ otbr_uninstall()
     sudo killall otbr-web otbr-agent || true
 
     (
-        if cd "${OTBR_TOP_BUILDDIR}"; then
-            # shellcheck disable=SC2024
-            sudo xargs rm <install_manifests.txt || true
+        if cd "${OTBR_TOP_BUILDDIR}" 2>/dev/null && [ -f install_manifest.txt ]; then
+            sudo xargs -a install_manifest.txt -r rm -f || true
+            rm -f install_manifest.txt
         fi
     )
     if have systemctl; then


### PR DESCRIPTION
Change from install_manifests.txt to install_manifest.txt
This fixes uninstall of otbr