### PR TITLE
[ci] allow uploads endpoint for monthly release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -67,6 +67,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             github.com:443
+            uploads.github.com:443
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
When uploading the source tarball asset to a release, gh release create connects to uploads.github.com:443. Because harden-runner was configured with egress-policy: block and only permitted api.github.com:443 and github.com:443, outbound connections to the asset upload endpoint were blocked, causing the release creation step to fail.

This commit adds uploads.github.com:443 to the allowed-endpoints list in monthly-release.yml.