### PR TITLE
[ci] remove concurrency from monthly release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -41,10 +41,6 @@ on:
         required: false
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-br-posix' && github.run_id) || github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
When monthly-release.yml invokes docker-border-router.yml as a reusable workflow via workflow_call, ${{ github.workflow }} in the called workflow evaluates to the caller's workflow name ("Monthly CalVer Release"). Because both workflows defined top-level concurrency groups with identical keys, GitHub Actions detected a deadlock between the top-level workflow and the build-docker job and canceled the run.

monthly-release.yml is a scheduled release workflow rather than a CI test workflow and does not need cancel-in-progress concurrency. This commit removes the concurrency configuration from monthly-release.yml to prevent concurrency deadlocks when calling reusable workflows.