### PR TITLE
[ci] make release creation idempotent in monthly release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -102,10 +102,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Uses the built-in GitHub CLI to create the tag and release simultaneously
         run: |
-          gh release create "$TAG_NAME" "$TAR_NAME" \
-            --target "${GITHUB_REF_NAME}" \
-            --title "OpenThread Border Router $TAG_NAME" \
-            --generate-notes
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists, skipping release creation"
+            gh release upload "$TAG_NAME" "$TAR_NAME" --clobber || true
+          else
+            gh release create "$TAG_NAME" "$TAR_NAME" \
+              --target "${GITHUB_REF_NAME}" \
+              --title "OpenThread Border Router $TAG_NAME" \
+              --generate-notes
+          fi
 
   build-docker:
     needs: create-release


### PR DESCRIPTION
If the monthly-release workflow is re-triggered after a release or tag was already created (for example, to retry or resume a failed downstream job like Docker image creation), gh release create fails with an error because the release tag already exists.

This commit updates the release creation step in monthly-release.yml to check if the release already exists before calling gh release create. If it exists, it skips creation and uploads the source tarball asset with --clobber, making the workflow idempotent on re-runs.