### PR TITLE
[build] enable OT_POSIX_INSTALL_EXTERNAL_ROUTES for reference devices

### DIFF
--- a/script/_otbr
+++ b/script/_otbr
@@ -182,6 +182,7 @@ otbr_install()
             "-DOT_REFERENCE_DEVICE=ON"
             "-DOT_DHCP6_CLIENT=ON"
             "-DOT_DHCP6_SERVER=ON"
+            "-DOT_POSIX_INSTALL_EXTERNAL_ROUTES=ON"
         )
     fi
 


### PR DESCRIPTION
OpenThread commit 4793ed8 changed the default value of OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE and CMake option OT_POSIX_INSTALL_EXTERNAL_ROUTES from 1 (ON) to 0 (OFF) to prevent routing loops and mesh hairpinning on border routers connected to an infrastructure link.

However, border router certification test suites (such as test_external_route.py in thread-cert) validate that external routes advertised in Thread Network Data are installed into the host Linux kernel routing table on the wpan0 interface.

This commit sets -DOT_POSIX_INSTALL_EXTERNAL_ROUTES=ON when building OTBR with REFERENCE_DEVICE=1 in script/_otbr, ensuring the test scenarios that validate external route installation continue to pass in CI.