### PR TITLE
[tests] support container in dbus_join and wait_for_device_role

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -90,7 +90,7 @@ proc expect_line {line} {
 # the CI timing variance in leader/router formation instead of relying on a
 # single read after a fixed sleep, which races with attach and intermittently
 # fails with "Error org.freedesktop.DBus.Error.NoReply".
-proc wait_for_device_role {pattern {retries 30} {bus "--system"}} {
+proc wait_for_device_role {pattern {retries 30} {bus "--system"} {container ""}} {
     # spawn sets the global spawn_id, so the dbus-send calls below would
     # otherwise silently redirect any send/expect the caller does afterwards
     # on its own node. Save and restore it so this utility is transparent to
@@ -108,8 +108,12 @@ proc wait_for_device_role {pattern {retries 30} {bus "--system"}} {
 
     set success 0
     for {set i 0} {$i < $retries} {incr i} {
-        spawn dbus-send $bus --print-reply --reply-timeout=2000 --dest=io.openthread.BorderRouter.wpan0 \
-            /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole
+        set cmd [list dbus-send $bus --print-reply --reply-timeout=2000 --dest=io.openthread.BorderRouter.wpan0 \
+            /io/openthread/BorderRouter/wpan0 org.freedesktop.DBus.Properties.Get string:io.openthread.BorderRouter string:DeviceRole]
+        if {$container ne ""} {
+            set cmd [linsert $cmd 0 docker exec -i $container]
+        }
+        spawn {*}$cmd
         expect {
             -re $pattern {
                 expect eof
@@ -154,15 +158,19 @@ proc wait_for_device_role {pattern {retries 30} {bus "--system"}} {
 # gets its reply. Under CI runner load, this can take longer than dbus-send's
 # default 25s reply-timeout (especially when forming a network as leader).
 # Pass an explicit generous reply-timeout and expect timeout.
-proc dbus_join {dataset_dbus {bus "--system"}} {
+proc dbus_join {dataset_dbus {bus "--system"} {container ""}} {
     global spawn_id
     set has_spawn_id [info exists spawn_id]
     if {$has_spawn_id} {
         set backup_spawn_id $spawn_id
     }
 
-    spawn dbus-send $bus --print-reply --reply-timeout=60000 --dest=io.openthread.BorderRouter.wpan0 \
-        --type=method_call /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"
+    set cmd [list dbus-send $bus --print-reply --reply-timeout=60000 --dest=io.openthread.BorderRouter.wpan0 \
+        --type=method_call /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join "array:byte:${dataset_dbus}"]
+    if {$container ne ""} {
+        set cmd [linsert $cmd 0 docker exec -i $container]
+    }
+    spawn {*}$cmd
     expect -timeout 65 eof
     catch {close}
     catch {wait}

--- a/tests/scripts/expect/ncp_backbone_multicast_forwarding.exp
+++ b/tests/scripts/expect/ncp_backbone_multicast_forwarding.exp
@@ -53,9 +53,10 @@ try {
     sleep 5
 
     # Join a Thread network.
-    send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
-    expect "dbus-send"
-    expect "app#"
+    dbus_join $dataset_dbus "--system" $container
+    wait_for_device_role {leader} 30 "--system" $container
+
+    switch_node 3
     send "sysctl -w net.ipv6.icmp.echo_ignore_all=1\n"
     expect_line "net.ipv6.icmp.echo_ignore_all = 1"
     sleep 20

--- a/tests/scripts/expect/ncp_border_agent.exp
+++ b/tests/scripts/expect/ncp_border_agent.exp
@@ -67,10 +67,8 @@ try {
     check_common_txt $mdns_browse_result
 
     # Join a Thread network.
-    switch_node 3
-    send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
-    expect "dbus-send"
-    expect "app#"
+    dbus_join $dataset_dbus "--system" $container
+    wait_for_device_role {leader} 30 "--system" $container
     sleep 20
 
     # Browse after Thread network starts.

--- a/tests/scripts/expect/ncp_border_routing.exp
+++ b/tests/scripts/expect/ncp_border_routing.exp
@@ -51,9 +51,8 @@ send "thread start\r\n"
 expect_line "Done"
 wait_for "state" "leader"
 
-switch_node 3
-send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
-expect "app#"
+dbus_join $dataset_dbus "--system" $container
+wait_for_device_role {router|child} 30 "--system" $container
 sleep 20
 
 switch_node 4

--- a/tests/scripts/expect/ncp_epskc.exp
+++ b/tests/scripts/expect/ncp_epskc.exp
@@ -52,12 +52,11 @@ try {
     sleep 5
     
     # Join a Thread network.
-    switch_node 3
-    send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
-    expect "dbus-send"
-    expect "app#"
+    dbus_join $dataset_dbus "--system" $container
+    wait_for_device_role {leader} 30 "--system" $container
     sleep 20
 
+    switch_node 3
     # Activate Epskc and get the Ephemeral Key
     send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.ActivateEphemeralKeyMode \"uint32:${epskc_lifetime}\"\n"
     expect -re {string \"([0-9]{9})\"}

--- a/tests/scripts/expect/ncp_srp_server.exp
+++ b/tests/scripts/expect/ncp_srp_server.exp
@@ -40,8 +40,8 @@ start_otbr_docker $container $::env(EXP_OT_NCP_PATH) 2 $pty1 $pty2
 spawn_node 3 otbr-docker $container
 sleep 5
 
-send "dbus-send --system --dest=io.openthread.BorderRouter.wpan0 --type=method_call --print-reply /io/openthread/BorderRouter/wpan0 io.openthread.BorderRouter.Join \"array:byte:${dataset_dbus}\"\n"
-expect "app#"
+dbus_join $dataset_dbus "--system" $container
+wait_for_device_role {leader} 30 "--system" $container
 sleep 20
 
 spawn_node 4 cli $::env(EXP_OT_CLI_PATH)


### PR DESCRIPTION
In NCP mode integration tests running inside Docker containers (ncp_border_routing.exp, ncp_srp_server.exp, ncp_border_agent.exp, ncp_epskc.exp, and ncp_backbone_multicast_forwarding.exp), the tests previously sent raw 'dbus-send ... Join' commands to the interactive shell and waited for the shell prompt using the default 10s expect timeout, followed by fixed 'sleep 20' delays.

Under CI runner load, NcpHost::Join (which executes three sequential Spinel round-trips: DatasetSetActiveTlvs, Ip6SetEnabled, and ThreadSetEnabled) can exceed 10 seconds, causing expect to time out with exit code 1. Furthermore, fixed sleep intervals race with leader and router formation.

This commit updates dbus_join and wait_for_device_role in _common.exp to accept an optional container argument, and updates Docker-based NCP expect scripts to use these helpers for robust timeout management and polling.