### PR TITLE
[RFC] [host] preserve host configuration across reset

### DIFF
--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -32,6 +32,7 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <net/if.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -40,8 +41,10 @@
 #include <openthread/border_routing.h>
 #include <openthread/dataset.h>
 #include <openthread/dnssd_server.h>
+#include <openthread/link.h>
 #include <openthread/link_metrics.h>
 #include <openthread/logging.h>
+#include <openthread/mdns.h>
 #include <openthread/nat64.h>
 #include <openthread/netdiag.h>
 #include <openthread/srp_server.h>
@@ -474,17 +477,154 @@ void RcpHost::SetBackboneRouterStateChangedCallback(BackboneRouterStateChangedCa
 
 void RcpHost::Reset(void)
 {
+    HostConfig hostConfig;
+
     gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
+
+    SaveHostConfig(hostConfig);
 
     otSysDeinit();
     mInstance = nullptr;
 
     Init();
+    RestoreHostConfig(hostConfig);
+
     for (auto &handler : mResetHandlers)
     {
         handler();
     }
     mEnableAutoAttach = true;
+}
+
+void RcpHost::SaveHostConfig(HostConfig &aHostConfig) const
+{
+#ifndef OTBR_VENDOR_NAME
+    aHostConfig.mVendorName = otThreadGetVendorName(mInstance);
+#endif
+#ifndef OTBR_PRODUCT_NAME
+    aHostConfig.mVendorModel = otThreadGetVendorModel(mInstance);
+#endif
+
+#if OTBR_ENABLE_MDNS_OPENTHREAD
+    {
+        const char         *localHostName                                         = otMdnsGetLocalHostName(mInstance);
+        const otExtAddress *extAddress                                            = otLinkGetExtendedAddress(mInstance);
+        char                generatedName[sizeof("ot") + OT_EXT_ADDRESS_SIZE * 2] = "ot";
+
+        // In the auto-enable mode the mDNS module follows the infrastructure interface state on its own, only an
+        // explicitly enabled mDNS module needs to be restored.
+        aHostConfig.mMdnsEnabled = otMdnsIsEnabled(mInstance) && !otMdnsGetAutoEnableMode(mInstance);
+
+        // The auto-generated local host name is "ot" followed by the extended address. It is generated again from
+        // the (possibly new) extended address after the reset, any other name was set explicitly and is preserved.
+        for (uint8_t byte : extAddress->m8)
+        {
+            snprintf(generatedName + strlen(generatedName), sizeof("00"), "%02x", byte);
+        }
+
+        if (strcmp(localHostName, generatedName) != 0)
+        {
+            aHostConfig.mMdnsLocalHostName = localHostName;
+        }
+    }
+#endif
+
+#if OTBR_ENABLE_NAT64
+    aHostConfig.mNat64Enabled = otNat64GetTranslatorState(mInstance) != OT_NAT64_STATE_DISABLED;
+#endif
+#if OTBR_ENABLE_DNS_UPSTREAM_QUERY
+    aHostConfig.mDnsUpstreamQueryEnabled = otDnssdUpstreamQueryIsEnabled(mInstance);
+#endif
+#if OTBR_ENABLE_DHCP6_PD && OTBR_ENABLE_BORDER_ROUTING
+    aHostConfig.mDhcp6PdEnabled =
+        otBorderRoutingDhcp6PdGetState(mInstance) != OT_BORDER_ROUTING_DHCP6_PD_STATE_DISABLED;
+#endif
+#if OTBR_ENABLE_TREL
+    aHostConfig.mTrelEnabled = otTrelIsEnabled(mInstance);
+#endif
+
+    aHostConfig.mTxPowerValid = otPlatRadioGetTransmitPower(mInstance, &aHostConfig.mTxPower) == OT_ERROR_NONE;
+}
+
+void RcpHost::RestoreHostConfig(const HostConfig &aHostConfig)
+{
+#ifndef OTBR_VENDOR_NAME
+    if (!aHostConfig.mVendorName.empty())
+    {
+        ThreadHelper::LogOpenThreadResult("Restore vendor name",
+                                          otThreadSetVendorName(mInstance, aHostConfig.mVendorName.c_str()));
+    }
+#endif
+#ifndef OTBR_PRODUCT_NAME
+    if (!aHostConfig.mVendorModel.empty())
+    {
+        ThreadHelper::LogOpenThreadResult("Restore vendor model",
+                                          otThreadSetVendorModel(mInstance, aHostConfig.mVendorModel.c_str()));
+    }
+#endif
+
+#if OTBR_ENABLE_FEATURE_FLAGS
+    if (!mAppliedFeatureFlagListBytes.empty())
+    {
+        FeatureFlagList featureFlagList;
+
+        if (featureFlagList.ParseFromString(mAppliedFeatureFlagListBytes))
+        {
+            ThreadHelper::LogOpenThreadResult("Restore feature flags", ApplyFeatureFlagList(featureFlagList));
+        }
+        else
+        {
+            otbrLogWarning("Failed to parse the applied feature flags");
+        }
+    }
+#endif
+
+#if OTBR_ENABLE_NAT64
+    otNat64SetEnabled(mInstance, aHostConfig.mNat64Enabled);
+#endif
+#if OTBR_ENABLE_DNS_UPSTREAM_QUERY
+    otDnssdUpstreamQuerySetEnabled(mInstance, aHostConfig.mDnsUpstreamQueryEnabled);
+#endif
+#if OTBR_ENABLE_DHCP6_PD && OTBR_ENABLE_BORDER_ROUTING
+    otBorderRoutingDhcp6PdSetEnabled(mInstance, aHostConfig.mDhcp6PdEnabled);
+#endif
+#if OTBR_ENABLE_TREL
+    otTrelSetEnabled(mInstance, aHostConfig.mTrelEnabled);
+#endif
+
+    if (aHostConfig.mTxPowerValid)
+    {
+        ThreadHelper::LogOpenThreadResult("Restore transmit power",
+                                          otPlatRadioSetTransmitPower(mInstance, aHostConfig.mTxPower));
+    }
+
+#if OTBR_ENABLE_MDNS_OPENTHREAD
+    // The local host name can only be set while the mDNS module is disabled.
+    if (!aHostConfig.mMdnsLocalHostName.empty())
+    {
+        ThreadHelper::LogOpenThreadResult("Restore mDNS local host name",
+                                          otMdnsSetLocalHostName(mInstance, aHostConfig.mMdnsLocalHostName.c_str()));
+    }
+
+    if (aHostConfig.mMdnsEnabled)
+    {
+        uint32_t infraIfIndex = 0;
+
+        if (mConfig.mBackboneInterfaceName != nullptr)
+        {
+            infraIfIndex = if_nametoindex(mConfig.mBackboneInterfaceName);
+        }
+
+        if (infraIfIndex != 0)
+        {
+            ThreadHelper::LogOpenThreadResult("Restore mDNS", otMdnsSetEnabled(mInstance, true, infraIfIndex));
+        }
+        else
+        {
+            otbrLogWarning("Failed to restore mDNS: unknown infrastructure interface");
+        }
+    }
+#endif
 }
 
 const char *RcpHost::GetThreadVersion(void)

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -283,6 +283,44 @@ private:
 
     otError SetOtbrAndOtLogLevel(otbrLogLevel aLevel);
 
+    /**
+     * Represents the host configuration preserved across a host reset.
+     *
+     * A reset re-creates the OpenThread instance, which clears all volatile state. A reset is meant to clear the
+     * Thread network state, not the configuration of the host, so the latter is saved before and restored after
+     * the instance is re-created.
+     */
+    struct HostConfig
+    {
+#ifndef OTBR_VENDOR_NAME
+        std::string mVendorName;
+#endif
+#ifndef OTBR_PRODUCT_NAME
+        std::string mVendorModel;
+#endif
+#if OTBR_ENABLE_MDNS_OPENTHREAD
+        bool        mMdnsEnabled = false; ///< Whether mDNS was enabled explicitly (not by the auto-enable mode).
+        std::string mMdnsLocalHostName;   ///< Explicitly set mDNS local host name, empty when auto-generated.
+#endif
+#if OTBR_ENABLE_NAT64
+        bool mNat64Enabled = false;
+#endif
+#if OTBR_ENABLE_DNS_UPSTREAM_QUERY
+        bool mDnsUpstreamQueryEnabled = false;
+#endif
+#if OTBR_ENABLE_DHCP6_PD && OTBR_ENABLE_BORDER_ROUTING
+        bool mDhcp6PdEnabled = false;
+#endif
+#if OTBR_ENABLE_TREL
+        bool mTrelEnabled = false;
+#endif
+        bool   mTxPowerValid = false; ///< Whether the transmit power could be read from the radio.
+        int8_t mTxPower      = 0;     ///< The transmit power (dBm).
+    };
+
+    void SaveHostConfig(HostConfig &aHostConfig) const;
+    void RestoreHostConfig(const HostConfig &aHostConfig);
+
     otInstance *mInstance;
 
     otPlatformConfig                       mConfig;


### PR DESCRIPTION
## Problem

`RcpHost::Reset()` re-creates the OpenThread instance (`otSysDeinit()` → `Init()` → reset handlers). This is the reset path used by the D-Bus `Reset`/`FactoryReset` methods and by the REST API (`DELETE /node`). It exists in this in-process form on purpose: unlike `otPlatReset()`, which re-executes (or exits) the whole process, it lets the D-Bus service stay on the bus and the REST server keep serving — the caller gets its reply and can immediately continue (e.g. Home Assistant follows a factory reset with `PUT /node/dataset/active` right away).

The downside: re-creating the instance clears *all* volatile state — not only the Thread network state a reset is meant to clear, but also configuration of the host that has nothing to do with the Thread network:

- vendor name / model set via `--vendor-name`/`--model-name` (applied once in `realmain` after `Init()`),
- feature flags applied via `ApplyFeatureFlagList()` (the list is cached, but only "for debugging purpose" — it is not re-applied),
- NAT64 / DNS upstream / DHCPv6-PD / TREL enablement (with `OTBR_FEATURE_FLAGS`, `Init()` resets TREL to the flag default and does not bring up the others),
- the transmit power,
- the mDNS module state: whether it was enabled explicitly and the local host name.

The mDNS case is how we found this. With `OTBR_MDNS=openthread` and `OPENTHREAD_CONFIG_MULTICAST_DNS_AUTO_ENABLE_ON_INFRA_IF=0`, the border router sets a custom local host name and enables mDNS at startup (the host name can only be set while mDNS is disabled, and the default `ot<extaddr>` name is not user friendly when several border routers are around). After Home Assistant's "Reset border router" (`DELETE /node`), the agent comes back with mDNS **disabled**: the border agent re-registers its `_meshcop._udp` service into a module that never transmits, and the border router silently disappears from the network until the service is restarted. Nothing in the process knows that mDNS is supposed to be enabled — that knowledge lives in the startup script, which already ran.

## Proposal

Draw the line as: **a reset erases the node, not the deployment.** Configuration that describes how this border router is deployed (as opposed to which Thread network it serves) should survive `RcpHost::Reset()`, the same way the command line arguments (interfaces, radio URLs, REST address) already do because `Init()` re-reads them.

This PR saves a `HostConfig` snapshot before `otSysDeinit()` and restores it after `Init()`:

- vendor name / model (when not compiled in),
- the applied feature flags (re-applied from the cached copy),
- NAT64 / DNS upstream / DHCPv6-PD / TREL enablement,
- transmit power (`otPlatRadioGet/SetTransmitPower`, as the CLI does),
- mDNS: enabled state, restored only if it was enabled explicitly (`otMdnsIsEnabled() && !otMdnsGetAutoEnableMode()`, so the auto-enable mode keeps following the infrastructure interface on its own), and the local host name, restored only if it differs from the auto-generated `ot<extaddr>` (so the identity-derived default is still regenerated for the new extended address after a factory reset).

Everything is guarded by the existing feature macros and is a no-op for configuration that was never applied.

## Open questions (hence RFC)

1. Is this the right line? Alternatives would be to make the D-Bus/REST reset use `otPlatReset()` (loses the reply / takes the service off the bus; with #3537 the supervisor would restart it, but D-Bus/REST clients would have to cope with the service going away) or to have every consumer re-apply its configuration after a reset (which today they cannot even observe).
2. Which items belong in `HostConfig`? I included everything I found that `Init()` does not re-apply; happy to trim (e.g. transmit power or DHCPv6-PD) if some of it is considered network state.
3. Detecting an explicitly set mDNS local host name currently compares against the auto-generated `ot<extaddr>` name. A core API exposing "host name was set explicitly" would be cleaner, but is a cross-repo change.

## Testing

- Built with the default configuration and with `OTBR_FEATURE_FLAGS=ON`, compile-time vendor name/model, NAT64, DNS upstream, TREL.
- End-to-end with an OpenThread simulation RCP: configured mDNS (custom host name, enabled), TREL, NAT64, DNS upstream, transmit power 6 dBm, formed a network, then `DELETE /node`. Afterwards the Thread state is `disabled` (node erased) while mDNS is enabled with the custom host name and TREL/NAT64/DNS upstream/6 dBm are preserved; the log shows `Restore transmit power: OK`, `Restore mDNS local host name: OK`, `Restore mDNS: OK`. Without this change mDNS ends up disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)