### PR TITLE
[mdns] fix the mDNSResponder build on Apple platforms

### DIFF
--- a/src/mdns/CMakeLists.txt
+++ b/src/mdns/CMakeLists.txt
@@ -36,8 +36,13 @@ if(OTBR_MDNS STREQUAL "mDNSResponder")
             otbr-common
         PRIVATE
             otbr-utils
-            dns_sd
     )
+    if(NOT APPLE)
+        # On Apple platforms the dns_sd API is provided by libSystem; the
+        # standalone library only exists on other platforms (e.g. mDNSResponder
+        # compatibility packages on Linux).
+        target_link_libraries(otbr-mdns PRIVATE dns_sd)
+    endif()
 endif()
 
 if(OTBR_MDNS STREQUAL "openthread")

--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -52,6 +52,16 @@
 #include "utils/dns_utils.hpp"
 #include "utils/string_utils.hpp"
 
+// kDNSServiceErr_StaleData entered dns_sd.h with mDNSResponder 2559 (the
+// macOS 15 SDK); older Apple SDKs predate it, and Apple's header stamps its
+// build into _DNS_SD_H. The mDNSResponder builds used on other platforms are
+// recent enough to have it.
+#if defined(__APPLE__) && defined(_DNS_SD_H) && ((_DNS_SD_H + 0) < 2559000000LL)
+#define OTBR_MDNSSD_HAVE_STALE_DATA 0
+#else
+#define OTBR_MDNSSD_HAVE_STALE_DATA 1
+#endif
+
 namespace otbr {
 
 namespace Mdns {
@@ -214,8 +224,10 @@ static const char *DNSErrorToString(DNSServiceErrorType aError)
     case kDNSServiceErr_DefunctConnection:
         return "Defunct Connection";
 
+#if OTBR_MDNSSD_HAVE_STALE_DATA
     case kDNSServiceErr_StaleData:
         return "Stale Data";
+#endif
 
     default:
         return "Unhandled Error";
@@ -237,7 +249,9 @@ bool IsRetryableError(DNSServiceErrorType aError)
     case kDNSServiceErr_DoubleNAT:
     case kDNSServiceErr_Timeout:
     case kDNSServiceErr_DefunctConnection:
+#if OTBR_MDNSSD_HAVE_STALE_DATA
     case kDNSServiceErr_StaleData:
+#endif
     case kDNSServiceErr_BadTime:
     case kDNSServiceErr_Firewall:
     case kDNSServiceErr_NATPortMappingUnsupported:


### PR DESCRIPTION
Two things keep `-DOTBR_MDNS=mDNSResponder` from building on macOS:

- On Apple platforms the dns_sd API is part of libSystem; the standalone library only exists elsewhere (e.g. mDNSResponder compatibility packages on Linux). Linking `dns_sd` unconditionally fails the link with `ld: library 'dns_sd' not found`. Link it only on non-Apple platforms.
- `kDNSServiceErr_StaleData` entered `dns_sd.h` with mDNSResponder 2559 (the macOS 15 SDK). Against an older Apple SDK — such as the macOS 14 SDK the macos-14 CI runner ships — the build fails with `use of undeclared identifier 'kDNSServiceErr_StaleData'` (since #2971). Apple's header stamps its build into `_DNS_SD_H`, so the two uses are gated on it; on an older SDK the error falls through to the default cases.

Part of #3469, split into separate PRs as requested there. #3577 adds a macOS CI leg that builds this configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
