### PR TITLE
[script] enable IP forwarding on macOS in _ipforward

### DIFF
--- a/script/_ipforward
+++ b/script/_ipforward
@@ -32,8 +32,24 @@
 
 SYSCTL_IP_FORWARD=/etc/sysctl.d/60-otbr-ip-forward.conf
 
+# macOS has no sysctl.d, and /etc/sysctl.conf is not reliably applied on
+# recent releases, so the setting is persisted as a launchd daemon that
+# re-applies it at boot (the counterpart of the sysctl.d drop-in on Linux).
+LAUNCHD_IP_FORWARD_LABEL=io.openthread.otbr-ipforward
+LAUNCHD_IP_FORWARD_PLIST=/Library/LaunchDaemons/${LAUNCHD_IP_FORWARD_LABEL}.plist
+
+ipforward_is_macos()
+{
+    [[ ${PLATFORM:-} == "macOS" || ${OSTYPE:-} == darwin* ]]
+}
+
 ipforward_install()
 {
+    if ipforward_is_macos; then
+        ipforward_install_macos
+        return
+    fi
+
     sudo tee $SYSCTL_IP_FORWARD <<EOF
 net.ipv6.conf.all.forwarding = 1
 net.ipv4.ip_forward = 1
@@ -46,13 +62,55 @@ EOF
     fi
 }
 
+ipforward_install_macos()
+{
+    sudo tee "$LAUNCHD_IP_FORWARD_PLIST" >/dev/null <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LAUNCHD_IP_FORWARD_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/sbin/sysctl</string>
+        <string>net.inet6.ip6.forwarding=1</string>
+        <string>net.inet.ip.forwarding=1</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+    # launchd refuses daemons whose plist is not owned by root:wheel with 644.
+    sudo chown root:wheel "$LAUNCHD_IP_FORWARD_PLIST"
+    sudo chmod 644 "$LAUNCHD_IP_FORWARD_PLIST"
+    # Re-running setup must not trip over an instance that is already loaded,
+    # nor over one that was disabled on the host earlier.
+    sudo launchctl bootout "system/${LAUNCHD_IP_FORWARD_LABEL}" 2>/dev/null || true
+    sudo launchctl enable "system/${LAUNCHD_IP_FORWARD_LABEL}" 2>/dev/null || true
+    sudo launchctl bootstrap system "$LAUNCHD_IP_FORWARD_PLIST" || die 'Failed to load the IP forwarding launchd daemon!'
+    ipforward_enable
+}
+
 ipforward_uninstall()
 {
+    if ipforward_is_macos; then
+        sudo launchctl bootout "system/${LAUNCHD_IP_FORWARD_LABEL}" 2>/dev/null || true
+        test ! -f "$LAUNCHD_IP_FORWARD_PLIST" || sudo rm -v "$LAUNCHD_IP_FORWARD_PLIST"
+        return
+    fi
+
     test ! -f $SYSCTL_IP_FORWARD || sudo rm -v $SYSCTL_IP_FORWARD
 }
 
 ipforward_enable()
 {
+    if ipforward_is_macos; then
+        sudo sysctl net.inet6.ip6.forwarding=1 net.inet.ip.forwarding=1 || die 'Failed to enable IP forwarding!'
+        return
+    fi
+
     echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/forwarding || die 'Failed to enable IPv6 forwarding!'
     echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward || die 'Failed to enable IPv4 forwarding!'
 }


### PR DESCRIPTION
macOS defaults `net.inet6.ip6.forwarding` to 0. Without it the host neither forwards traffic between the infrastructure and Thread interfaces nor delivers packets arriving on the infrastructure interface for addresses owned by the Thread utun, so a border router on a macOS host does not work until the sysctl is set.

This mirrors the Linux implementation, as suggested in #3469: enable forwarding immediately with `sysctl` and persist it across reboots. macOS has no `sysctl.d` and `/etc/sysctl.conf` is not reliably applied on recent releases, so the setting is persisted as a launchd daemon (`io.openthread.otbr-ipforward`) that re-applies it at boot; `ipforward_uninstall` boots the daemon out and removes the plist. Linux behavior is unchanged.

Checked with `shfmt -i 4 -bn -ci -fn -s` and `shellcheck -x`.

Part of #3469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
