### PR TITLE
[github-actions] build the mDNSResponder configuration on macOS

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -45,7 +45,20 @@ permissions:
 
 jobs:
   build-check:
+    name: build-check (${{ matrix.name }})
     runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Minimal (mDNS OFF, Border Agent OFF)"
+            mdns: "OFF"
+            border_agent: "OFF"
+          # The border router configuration used on macOS hosts: native
+          # mDNSResponder with the border agent (and border routing) on.
+          - name: "Native (mDNSResponder, Border Agent ON)"
+            mdns: "mDNSResponder"
+            border_agent: "ON"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -57,9 +70,9 @@ jobs:
         brew reinstall jsoncpp ninja protobuf@21 googletest
     - name: Build
       run: |
-        OTBR_OPTIONS="-DOTBR_BORDER_AGENT=OFF \
+        OTBR_OPTIONS="-DOTBR_MDNS=${{ matrix.mdns }} \
+                      -DOTBR_BORDER_AGENT=${{ matrix.border_agent }} \
                       -DOTBR_BACKBONE_ROUTER=OFF \
-                      -DOTBR_MDNS=OFF \
                       -DOTBR_TREL=OFF \
                       -DOTBR_NAT64=OFF \
                       -DOTBR_DNS_UPSTREAM_QUERY=OFF \


### PR DESCRIPTION
The macOS job only builds with `OTBR_MDNS=OFF` and the border agent off, so it does not cover the configuration a macOS host actually runs: native mDNSResponder with the border agent (and border routing) on. This turns the job into a two-leg matrix so the Apple-specific mDNS link path stays covered.

Builds on #3575 (merged), which the new leg needs to link.

Verified locally on macOS 26 / Apple Silicon with the exact `script/test build` invocation used by the new leg.

Part of #3469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
