### PR TITLE
[firewall] add an opt-in in-process pf backend for macOS

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -54,11 +54,18 @@ jobs:
           - name: "Minimal (mDNS OFF, Border Agent OFF)"
             mdns: "OFF"
             border_agent: "OFF"
+            pf: "OFF"
           # The border router configuration used on macOS hosts: native
           # mDNSResponder with the border agent (and border routing) on.
           - name: "Native (mDNSResponder, Border Agent ON)"
             mdns: "mDNSResponder"
             border_agent: "ON"
+            pf: "OFF"
+          # The same, with the in-process pf firewall backend.
+          - name: "Native + pf firewall (mDNSResponder, Border Agent ON, OTBR_PF ON)"
+            mdns: "mDNSResponder"
+            border_agent: "ON"
+            pf: "ON"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -72,9 +79,16 @@ jobs:
       run: |
         OTBR_OPTIONS="-DOTBR_MDNS=${{ matrix.mdns }} \
                       -DOTBR_BORDER_AGENT=${{ matrix.border_agent }} \
+                      -DOTBR_PF=${{ matrix.pf }} \
                       -DOTBR_BACKBONE_ROUTER=OFF \
                       -DOTBR_TREL=OFF \
                       -DOTBR_NAT64=OFF \
                       -DOTBR_DNS_UPSTREAM_QUERY=OFF \
                       -DOT_FIREWALL=OFF \
                       -DOTBR_DBUS=OFF" ./script/test build
+    # `script/test check` installs into /usr and runs the Linux-only suites;
+    # run the firewall unit tests directly (the pf tests only exist with
+    # OTBR_PF=ON, the FirewallManager tests in every configuration).
+    - name: Test
+      run: |
+        cd build/otbr && CTEST_OUTPUT_ON_FAILURE=1 ctest -R 'FirewallManagerTest|PfFirewall'

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -102,6 +102,24 @@ else()
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_NFTABLES=0)
 endif()
 
+# Opt-in, macOS-only: build the in-process pf firewall backend. otbr-agent then
+# owns the Thread ingress filter (and the NAT44 masquerade) in the pf anchor
+# "otbr", driven through pfctl(8), and produces the ingress prefix tables from
+# Thread network data. The main ruleset (/etc/pf.conf) has to reference the
+# anchor; script/_firewall adds the reference.
+option(OTBR_PF "Enable in-process pf firewall backend (pfctl)" OFF)
+if (OTBR_PF)
+    if (NOT APPLE)
+        message(FATAL_ERROR "OTBR_PF is only supported on macOS")
+    endif()
+    if (OTBR_NFTABLES)
+        message(FATAL_ERROR "OTBR_PF and OTBR_NFTABLES are mutually exclusive")
+    endif()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_PF=1)
+else()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_PF=0)
+endif()
+
 option(OTBR_OPENWRT "Enable OpenWrt support" OFF)
 if(OTBR_OPENWRT)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_OPENWRT=1)

--- a/script/_firewall
+++ b/script/_firewall
@@ -29,7 +29,9 @@
 
 FIREWALL_SERVICE=/etc/init.d/otbr-firewall
 
-sudo modprobe ip6table_filter || true
+if have modprobe; then
+    sudo modprobe ip6table_filter || true
+fi
 
 FIREWALL="${FIREWALL:-1}"
 
@@ -51,9 +53,85 @@ if [ -z "${OTBR_NFTABLES:-}" ]; then
     fi
 fi
 
+# The in-process pf backend (-DOTBR_PF=ON, macOS) installs its rules into the
+# pf anchor "otbr" itself, and pf only evaluates an anchor the main ruleset
+# (/etc/pf.conf) references. Installing on macOS therefore means adding that
+# reference; there is no legacy firewall service there. The lines are tagged
+# so uninstall can find them again. pf wants translation rules before filter
+# rules, so the nat-anchor goes next to the system's own nat-anchor and only
+# the filter anchor is appended.
+# /usr/share sits on the SIP-protected system volume on macOS, so installs
+# there use another prefix; look in the usual ones.
+OTBR_PF_MARKER="/usr/share/otbr/pf-backend"
+[ -r "${OTBR_PF_MARKER}" ] || OTBR_PF_MARKER="/usr/local/share/otbr/pf-backend"
+[ -r "${OTBR_PF_MARKER}" ] || OTBR_PF_MARKER="/opt/homebrew/share/otbr/pf-backend"
+if [ -z "${OTBR_PF:-}" ]; then
+    OTBR_PF=0
+    if [ -r "${OTBR_PF_MARKER}" ] && grep -qx '1' "${OTBR_PF_MARKER}"; then
+        OTBR_PF=1
+    fi
+fi
+PF_CONF=/etc/pf.conf
+PF_ANCHOR_TAG="# otbr-agent (managed by script/_firewall)"
+
+firewall_is_macos()
+{
+    [[ ${PLATFORM:-} == "macOS" || ${OSTYPE:-} == darwin* ]]
+}
+
+# Replaces the main ruleset with the rewritten copy at "${PF_CONF}.otbr",
+# but only once pfctl has parsed it: a broken /etc/pf.conf would otherwise
+# be left in place.
+firewall_replace_pf_conf()
+{
+    # An empty file parses, so check for content first: a failed rewrite must
+    # not become an empty main ruleset.
+    [ -s "${PF_CONF}.otbr" ] || die 'Rewritten pf.conf is empty; leaving the original in place!'
+    sudo pfctl -n -f "${PF_CONF}.otbr" || die 'Rewritten pf.conf does not parse; leaving the original in place!'
+    sudo mv "${PF_CONF}.otbr" "${PF_CONF}"
+    sudo pfctl -f "${PF_CONF}" || die 'Failed to reload pf.conf!'
+}
+
+firewall_uninstall_macos()
+{
+    if grep -qF "${PF_ANCHOR_TAG}" "${PF_CONF}" 2>/dev/null; then
+        # awk matches the tag literally; it contains characters sed would
+        # read as a delimiter or metacharacters.
+        sudo awk -v tag="${PF_ANCHOR_TAG}" 'index($0, tag) { next } { print }' "${PF_CONF}" \
+            | sudo tee "${PF_CONF}.otbr" >/dev/null
+        sudo pfctl -a otbr -F all 2>/dev/null || true
+        firewall_replace_pf_conf
+    fi
+}
+
+firewall_install_macos()
+{
+    if [ "${OTBR_PF}" != "1" ]; then
+        echo "OTBR_PF=0: otbr-agent was built without the pf backend; no firewall to install on macOS."
+        return 0
+    fi
+
+    # Idempotent: earlier tagged lines are dropped before the new ones go in,
+    # so re-running setup never duplicates them. This deliberately does not
+    # go through firewall_uninstall_macos, which flushes the anchor: a running
+    # agent would lose its live rules until restarted.
+    sudo awk -v tag="${PF_ANCHOR_TAG}" '
+        index($0, tag) { next }
+        { print }
+        /^nat-anchor / && !done { print "nat-anchor \"otbr\" " tag; done = 1 }
+        END { if (!done) print "nat-anchor \"otbr\" " tag; print "anchor \"otbr\" " tag }
+    ' "${PF_CONF}" | sudo tee "${PF_CONF}.otbr" >/dev/null
+    firewall_replace_pf_conf
+}
+
 firewall_uninstall()
 {
     with FIREWALL || return 0
+
+    if firewall_is_macos; then
+        firewall_uninstall_macos
+        return 0
+    fi
 
     firewall_stop
     if have systemctl; then
@@ -70,6 +148,11 @@ firewall_install()
 {
     with FIREWALL || return 0
 
+    if firewall_is_macos; then
+        firewall_install_macos
+        return 0
+    fi
+
     if [ "${OTBR_NFTABLES}" = "1" ]; then
         echo "OTBR_NFTABLES=1: OTBR ingress filter is managed in-process (nftables); skipping legacy firewall service."
         return 0
@@ -85,6 +168,11 @@ firewall_install()
 
 firewall_start()
 {
+    # On macOS the agent installs the firewall itself; nothing to start.
+    if firewall_is_macos; then
+        return 0
+    fi
+
     # Same gate as the install: with the in-process backend there is no
     # otbr-firewall service to start, and starting the legacy one would put
     # its chain alongside the agent's.
@@ -104,6 +192,10 @@ firewall_start()
 firewall_stop()
 {
     with FIREWALL || return 0
+
+    if firewall_is_macos; then
+        return 0
+    fi
 
     if with DOCKER; then
         service otbr-firewall stop || true

--- a/script/_otbr
+++ b/script/_otbr
@@ -122,6 +122,8 @@ otbr_install()
         # does and the marker this build writes is not there yet at that point,
         # so the shell variable, not the file, is what keeps them agreeing.
         "-DOTBR_NFTABLES=$([ "${OTBR_NFTABLES:-0}" = "1" ] && echo ON || echo OFF)"
+        # Likewise for the pf backend on macOS.
+        "-DOTBR_PF=$([ "${OTBR_PF:-0}" = "1" ] && echo ON || echo OFF)"
         # Force re-evaluation of version strings
         "-DOTBR_VERSION="
         "-DOT_PACKAGE_VERSION="

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(otbr-agent
 target_link_libraries(otbr-agent PRIVATE
     $<$<BOOL:${OTBR_BORDER_AGENT}>:otbr-border-agent>
     $<$<BOOL:${OTBR_BACKBONE_ROUTER}>:otbr-backbone-router>
-    $<$<BOOL:${OTBR_NFTABLES}>:otbr-firewall>
+    $<$<OR:$<BOOL:${OTBR_NFTABLES}>,$<BOOL:${OTBR_PF}>>:otbr-firewall>
     $<$<BOOL:${OTBR_DBUS}>:otbr-dbus-server>
     $<$<BOOL:${OTBR_MDNS}>:otbr-mdns>
     $<$<BOOL:${OTBR_OPENWRT}>:otbr-ubus>
@@ -125,6 +125,17 @@ else()
 endif()
 configure_file(nftables-backend.in nftables-backend @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/nftables-backend
+    DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/otbr
+)
+
+# Same arrangement for the pf backend on macOS.
+if(OTBR_PF)
+    set(OTBR_PF_MARKER_VALUE 1)
+else()
+    set(OTBR_PF_MARKER_VALUE 0)
+endif()
+configure_file(pf-backend.in pf-backend @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pf-backend
     DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/otbr
 )
 

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -51,13 +51,16 @@
 #include "host/posix/dnssd.hpp"
 #include "utils/infra_link_selector.hpp"
 
-#if OTBR_ENABLE_NFTABLES
+#if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
 #include <algorithm>
 #include <string.h>
 #include <vector>
 
 #include <openthread/netdata.h>
 #include <openthread/thread.h>
+#endif
+#if OTBR_ENABLE_PF
+#include <openthread/openthread-system.h>
 #endif
 
 namespace otbr {
@@ -400,18 +403,26 @@ void Application::InitRcpMode(const std::string &aRestListenAddress, int aRestLi
     });
 #endif
 #endif // OTBR_ENABLE_BORDER_AGENT
-#if OTBR_ENABLE_NFTABLES
-    // The firewall is a security control: if it was built in (OTBR_NFTABLES) but
-    // cannot be installed, abort rather than silently forward traffic unfiltered.
-    // This mirrors the legacy script path, which `die`d when the otbr-firewall /
-    // otbr-nat44 services failed to start.
+#if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
+    // The firewall is a security control: if it was built in (OTBR_NFTABLES or
+    // OTBR_PF) but cannot be installed, abort rather than silently forward
+    // traffic unfiltered. This mirrors the legacy script path, which `die`d when
+    // the otbr-firewall / otbr-nat44 services failed to start.
     // Each result is taken once: SuccessOrDie() names its argument twice, so a
     // call passed to it directly runs a second time on the failing path and the
     // fatal log reports what that second attempt returned.
     otbrError firewallError;
 
+#if OTBR_ENABLE_NFTABLES
     firewallError = mNftables->Init();
     SuccessOrDie(firewallError, "Failed to initialize the nftables firewall!");
+#else
+    // pf rules are scoped to the Thread interface by name, and on macOS the
+    // kernel picks that name (utunN) when mHost.Init() creates the interface,
+    // so the backend is created here rather than in CreateRcpMode().
+    mPfctl    = MakeUnique<Firewall::PfctlProcess>();
+    mFirewall = MakeUnique<Firewall::PfFirewall>(*mPfctl, otSysGetThreadNetifName());
+#endif
     firewallError = mFirewall->Init();
     SuccessOrDie(firewallError, "Failed to initialize the firewall manager!");
     firewallError = mFirewall->EnableIngressFilter();
@@ -457,7 +468,7 @@ void Application::InitRcpMode(const std::string &aRestListenAddress, int aRestLi
 #endif
 }
 
-#if OTBR_ENABLE_NFTABLES
+#if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
 void Application::UpdateIngressPrefixes(void)
 {
     otNetworkDataIterator    iterator = OT_NETWORK_DATA_ITERATOR_INIT;
@@ -505,7 +516,7 @@ void Application::UpdateIngressPrefixes(void)
 
     if (mFirewall->ReplaceIngressPrefixes(denySrc, allowDst) != OTBR_ERROR_NONE)
     {
-        otbrLogWarning("FirewallManager: failed to update ingress prefixes");
+        otbrLogWarning("Firewall: failed to update ingress prefixes");
     }
 
 exit:
@@ -515,23 +526,31 @@ exit:
 
 void Application::DeinitRcpMode(void)
 {
-#if OTBR_ENABLE_NFTABLES
-    // Tear down the OTBR nftables table while the netlink socket is still open
-    // (mNftables outlives mFirewall by member declaration order).
+#if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
+    // Tear down the OTBR firewall while its backend is still usable (the
+    // backend outlives mFirewall by member declaration order).
     if (mFirewall != nullptr)
     {
         otbrError firewallError = mFirewall->Deinit();
         if (firewallError != OTBR_ERROR_NONE)
         {
-            otbrLogWarning("FirewallManager: teardown failed (%d)", firewallError);
+            otbrLogWarning("Firewall: teardown failed (%d)", firewallError);
         }
     }
+#if OTBR_ENABLE_NFTABLES
     // Close the netlink socket too, or a later InitRcpMode() dies in
     // mNftables->Init() on the still-open socket.
     if (mNftables != nullptr)
     {
         mNftables->Deinit();
     }
+#endif
+#if OTBR_ENABLE_PF
+    // Both are recreated by InitRcpMode(); release them in reverse order of
+    // creation so mFirewall never outlives the pfctl runner it references.
+    mFirewall.reset();
+    mPfctl.reset();
+#endif
 #endif
 #if OTBR_ENABLE_DNSSD_PLAT
     mDnssdPlatform.Stop();

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -53,6 +53,9 @@
 #include "firewall/firewall_manager.hpp"
 #include "firewall/nftables_impl.hpp"
 #endif
+#if OTBR_ENABLE_PF
+#include "firewall/pf_firewall.hpp"
+#endif
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
 #include "sdp_proxy/advertising_proxy.hpp"
 #endif
@@ -263,7 +266,7 @@ private:
     void InitRcpMode(const std::string &aRestListenAddress, int aRestListenPort);
     void DeinitRcpMode(void);
 
-#if OTBR_ENABLE_NFTABLES
+#if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
     void UpdateIngressPrefixes(void);
 #endif
 
@@ -302,6 +305,10 @@ private:
 #if OTBR_ENABLE_NFTABLES
     std::unique_ptr<Firewall::Nftables>        mNftables;
     std::unique_ptr<Firewall::FirewallManager> mFirewall;
+#endif
+#if OTBR_ENABLE_PF
+    std::unique_ptr<Firewall::PfctlProcess> mPfctl;
+    std::unique_ptr<Firewall::PfFirewall>   mFirewall;
 #endif
 #if OTBR_ENABLE_BACKBONE_ROUTER
     std::unique_ptr<BackboneRouter::BackboneAgent> mBackboneAgent;

--- a/src/agent/pf-backend.in
+++ b/src/agent/pf-backend.in
@@ -1,0 +1,13 @@
+# Written by the build, and read by script/_firewall on macOS.
+#
+# 1 means otbr-agent was built with -DOTBR_PF=ON: it installs the Thread
+# ingress filter and the NAT44 masquerade in-process, into the pf anchor
+# "otbr", and the setup script's job is to reference that anchor from the
+# main ruleset. 0 means there is no firewall backend on this host.
+#
+# The value is written either way rather than the file standing for "on" by
+# existing, for the same reason as nftables-backend: installing does not
+# uninstall first.
+#
+# Setting OTBR_PF in the environment overrides this.
+@OTBR_PF_MARKER_VALUE@

--- a/src/firewall/CMakeLists.txt
+++ b/src/firewall/CMakeLists.txt
@@ -37,6 +37,13 @@ if(OTBR_NFTABLES)
     )
 endif()
 
+if(OTBR_PF)
+    list(APPEND OTBR_FIREWALL_SOURCES
+        pf_firewall.cpp
+        pfctl.cpp
+    )
+endif()
+
 add_library(otbr-firewall ${OTBR_FIREWALL_SOURCES})
 
 target_link_libraries(otbr-firewall PUBLIC

--- a/src/firewall/pf_firewall.cpp
+++ b/src/firewall/pf_firewall.cpp
@@ -1,0 +1,360 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "FIREWALL"
+
+#include "firewall/pf_firewall.hpp"
+
+#include <algorithm>
+#include <ctype.h>
+#include <sstream>
+#include <string.h>
+#include <utility>
+
+#include "common/logging.hpp"
+
+namespace otbr {
+namespace Firewall {
+
+const char *const PfFirewall::kAnchorName           = "otbr";
+const char *const PfFirewall::kIngressDenySrcTable  = "ingress_deny_src";
+const char *const PfFirewall::kIngressAllowDstTable = "ingress_allow_dst";
+const char *const PfFirewall::kThreadTag            = "otbr_thread";
+
+PfFirewall::PfFirewall(IPfctl &aPfctl, std::string aThreadInterfaceName)
+    : mPfctl(aPfctl)
+    , mThreadIfName(std::move(aThreadInterfaceName))
+    , mInitialized(false)
+    , mIngressFilterEnabled(false)
+    , mNat44Enabled(false)
+{
+}
+
+otbrError PfFirewall::RunPfctl(const std::vector<std::string> &aArgs, const std::string &aInput, std::string &aOutput)
+{
+    std::string stderrText;
+    otbrError   error = mPfctl.Run(aArgs, aInput, aOutput, stderrText);
+
+    if (error != OTBR_ERROR_NONE)
+    {
+        std::string command = "pfctl";
+
+        for (const std::string &arg : aArgs)
+        {
+            command += " ";
+            command += arg;
+        }
+        otbrLogWarning("`%s` failed: %s", command.c_str(), stderrText.c_str());
+    }
+
+    return error;
+}
+
+otbrError PfFirewall::EnablePf(void)
+{
+    // `pfctl -E` enables pf with a reference count and reports the reference
+    // as "Token : <n>", which `pfctl -X` needs to release it again. pf stays
+    // enabled while anyone holds a reference, so this neither disturbs nor
+    // depends on other users of pf on the host.
+    otbrError   error;
+    std::string output;
+    std::string stderrText;
+    std::string all;
+    size_t      pos;
+
+    error = mPfctl.Run({"-E"}, "", output, stderrText);
+    VerifyOrExit(error == OTBR_ERROR_NONE, otbrLogWarning("`pfctl -E` failed: %s", stderrText.c_str()));
+
+    // pfctl prints the reference as "Token : <n>"; only the digits after the
+    // word matter, whichever stream and spacing a given release uses. pf is
+    // enabled either way, so a token that cannot be found is not fatal: the
+    // reference just cannot be released on Deinit().
+    all = output + stderrText;
+    mEnableToken.clear();
+    pos = all.find("Token");
+    if (pos == std::string::npos)
+    {
+        pos = all.find("token");
+    }
+    if (pos != std::string::npos)
+    {
+        while (pos < all.size() && !isdigit(static_cast<unsigned char>(all[pos])) && all[pos] != '\n')
+        {
+            pos++;
+        }
+        for (; pos < all.size() && isdigit(static_cast<unsigned char>(all[pos])); pos++)
+        {
+            mEnableToken += all[pos];
+        }
+    }
+    if (mEnableToken.empty())
+    {
+        otbrLogWarning("`pfctl -E` did not report a reference token; pf stays enabled on exit: %s", all.c_str());
+    }
+
+exit:
+    return error;
+}
+
+void PfFirewall::DisablePf(void)
+{
+    std::string output;
+
+    if (!mEnableToken.empty())
+    {
+        // Failure only means the reference lingers; nothing to do about it.
+        RunPfctl({"-X", mEnableToken}, "", output);
+        mEnableToken.clear();
+    }
+}
+
+otbrError PfFirewall::VerifyAnchorReferenced(const char *aListFlag, const char *aDirective)
+{
+    // A referenced anchor shows up in the main ruleset listing as, for example,
+    // `anchor "otbr" all` (`pfctl -s rules`) or `nat-anchor "otbr" all`
+    // (`pfctl -s nat`).
+    otbrError          error;
+    std::string        output;
+    std::string        wanted = std::string(aDirective) + " \"" + kAnchorName + "\"";
+    std::istringstream lines;
+    std::string        line;
+    bool               found = false;
+
+    SuccessOrExit(error = RunPfctl({"-s", aListFlag}, "", output));
+
+    lines.str(output);
+    while (std::getline(lines, line))
+    {
+        size_t start = line.find_first_not_of(" \t");
+
+        if (start != std::string::npos && line.compare(start, wanted.size(), wanted) == 0)
+        {
+            found = true;
+            break;
+        }
+    }
+    VerifyOrExit(found, error = OTBR_ERROR_NOT_FOUND);
+
+exit:
+    if (error == OTBR_ERROR_NOT_FOUND)
+    {
+        otbrLogCrit("The main pf ruleset does not reference the OTBR anchor: add `%s` to /etc/pf.conf "
+                    "(script/_firewall does this) and reload it with `pfctl -f /etc/pf.conf`",
+                    wanted.c_str());
+    }
+    return error;
+}
+
+otbrError PfFirewall::FlushAnchor(void)
+{
+    std::string output;
+
+    return RunPfctl({"-a", kAnchorName, "-F", "all"}, "", output);
+}
+
+otbrError PfFirewall::Init(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(!mInitialized, error = OTBR_ERROR_INVALID_STATE);
+    VerifyOrExit(!mThreadIfName.empty(), error = OTBR_ERROR_INVALID_ARGS);
+
+    SuccessOrExit(error = EnablePf());
+    SuccessOrExit(error = VerifyAnchorReferenced("rules", "anchor"));
+    SuccessOrExit(error = FlushAnchor());
+
+    mInitialized = true;
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        DisablePf();
+    }
+    otbrLogResult(error, "PfFirewall: %s", __FUNCTION__);
+    return error;
+}
+
+otbrError PfFirewall::Deinit(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mInitialized);
+
+    error = FlushAnchor();
+    DisablePf();
+
+    mInitialized          = false;
+    mIngressFilterEnabled = false;
+    mNat44Enabled         = false;
+    mUpstreamIfName.clear();
+
+exit:
+    otbrLogResult(error, "PfFirewall: %s", __FUNCTION__);
+    return error;
+}
+
+std::string PfFirewall::GenerateRuleset(void) const
+{
+    // pf insists on section order: options (tables), translation, filtering.
+    const std::string &thread   = mThreadIfName;
+    const std::string  denySrc  = std::string("<") + kIngressDenySrcTable + ">";
+    const std::string  allowDst = std::string("<") + kIngressAllowDstTable + ">";
+    std::string        rules;
+
+    rules += "# Installed by otbr-agent; do not edit.\n";
+    rules += "table " + denySrc + " persist\n";
+    rules += "table " + allowDst + " persist\n";
+
+    if (mNat44Enabled)
+    {
+        // Masquerade IPv4 that arrived on the Thread interface (the NAT64 egress
+        // path) out the upstream interface. A nat rule cannot match the inbound
+        // interface, so the packets are tagged on the way in and the nat rule
+        // keys on the tag. `nat pass` lets the translated packets through
+        // without a matching filter rule (the host's own ruleset may filter
+        // outbound on the upstream interface) and keeps state for the replies.
+        rules += "nat pass on " + mUpstreamIfName + " inet tagged " + kThreadTag + " -> (" + mUpstreamIfName + ")\n";
+        rules += "pass in quick on " + thread + " inet tag " + kThreadTag + "\n";
+    }
+
+    if (mIngressFilterEnabled)
+    {
+        // The ip6tables FORWARD ingress chain, with one difference: pf also sees
+        // the host's own output on the Thread interface, so that is exempted
+        // first. `(<thread>)` tracks the interface's addresses as they change
+        // (the OMR address only arrives after the ruleset is loaded); `(self)`
+        // covers the host's other addresses as of load time.
+        rules += "pass out quick on " + thread + " inet6 from (" + thread + ") to any\n";
+        rules += "pass out quick on " + thread + " inet6 from (self) to any\n";
+        // Spoof protection: transit packets claiming an on-mesh source.
+        rules += "block out quick on " + thread + " inet6 from " + denySrc + " to any\n";
+        // Advertised on-mesh destinations are reachable by design.
+        rules += "pass out quick on " + thread + " inet6 from any to " + allowDst + "\n";
+        // Multicast toward the mesh stays allowed; anything else is unsolicited.
+        rules += "pass out quick on " + thread + " inet6 from any to ff00::/8\n";
+        rules += "block out quick on " + thread + " inet6 all\n";
+    }
+
+    return rules;
+}
+
+otbrError PfFirewall::LoadRuleset(void)
+{
+    std::string output;
+
+    return RunPfctl({"-a", kAnchorName, "-f", "-"}, GenerateRuleset(), output);
+}
+
+otbrError PfFirewall::EnableIngressFilter(void)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mInitialized, error = OTBR_ERROR_INVALID_STATE);
+    VerifyOrExit(!mIngressFilterEnabled);
+
+    mIngressFilterEnabled = true;
+    error                 = LoadRuleset();
+    if (error != OTBR_ERROR_NONE)
+    {
+        mIngressFilterEnabled = false;
+    }
+
+exit:
+    otbrLogResult(error, "PfFirewall: %s", __FUNCTION__);
+    return error;
+}
+
+otbrError PfFirewall::EnableNat44Masquerade(const std::string &aUpstreamInterfaceName)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mInitialized, error = OTBR_ERROR_INVALID_STATE);
+    VerifyOrExit(!aUpstreamInterfaceName.empty(), error = OTBR_ERROR_INVALID_ARGS);
+    VerifyOrExit(!mNat44Enabled);
+
+    SuccessOrExit(error = VerifyAnchorReferenced("nat", "nat-anchor"));
+
+    mUpstreamIfName = aUpstreamInterfaceName;
+    mNat44Enabled   = true;
+    error           = LoadRuleset();
+    if (error != OTBR_ERROR_NONE)
+    {
+        mNat44Enabled = false;
+        mUpstreamIfName.clear();
+    }
+
+exit:
+    otbrLogResult(error, "PfFirewall: %s", __FUNCTION__);
+    return error;
+}
+
+otbrError PfFirewall::ReplaceTable(const char *aTable, const std::vector<Ip6Prefix> &aPrefixes)
+{
+    std::vector<std::string> args = {"-a", kAnchorName, "-t", aTable, "-T"};
+    std::vector<std::string> addresses;
+    std::string              output;
+
+    for (const Ip6Prefix &prefix : aPrefixes)
+    {
+        addresses.push_back(prefix.ToString());
+    }
+    // A stable order keeps the pfctl invocation reproducible; duplicates would
+    // only make pfctl complain.
+    std::sort(addresses.begin(), addresses.end());
+    addresses.erase(std::unique(addresses.begin(), addresses.end()), addresses.end());
+
+    if (addresses.empty())
+    {
+        args.push_back("flush");
+    }
+    else
+    {
+        args.push_back("replace");
+        args.insert(args.end(), addresses.begin(), addresses.end());
+    }
+
+    return RunPfctl(args, "", output);
+}
+
+otbrError PfFirewall::ReplaceIngressPrefixes(const std::vector<Ip6Prefix> &aDenySrc,
+                                             const std::vector<Ip6Prefix> &aAllowDst)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(mIngressFilterEnabled, error = OTBR_ERROR_INVALID_STATE);
+
+    SuccessOrExit(error = ReplaceTable(kIngressDenySrcTable, aDenySrc));
+    SuccessOrExit(error = ReplaceTable(kIngressAllowDstTable, aAllowDst));
+
+exit:
+    otbrLogResult(error, "PfFirewall: %s", __FUNCTION__);
+    return error;
+}
+
+} // namespace Firewall
+} // namespace otbr

--- a/src/firewall/pf_firewall.hpp
+++ b/src/firewall/pf_firewall.hpp
@@ -1,0 +1,148 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   PfFirewall owns the OTBR firewall policy on macOS and installs it into a
+ *   pf anchor through pfctl(8). It is the pf counterpart of FirewallManager
+ *   (the nftables backend) and exposes the same surface to the agent.
+ */
+
+#ifndef OTBR_FIREWALL_PF_FIREWALL_HPP_
+#define OTBR_FIREWALL_PF_FIREWALL_HPP_
+
+#include "openthread-br/config.h"
+
+#include <string>
+#include <vector>
+
+#include "common/code_utils.hpp"
+#include "common/types.hpp"
+#include "firewall/pfctl.hpp"
+
+namespace otbr {
+namespace Firewall {
+
+/**
+ * The Thread ingress filter (and NAT44 masquerade) as a pf anchor.
+ *
+ * Everything lives in the anchor named `kAnchorName`. pf only evaluates an
+ * anchor the main ruleset references, so /etc/pf.conf must carry
+ * `anchor "otbr"` (and `nat-anchor "otbr"` for NAT44); script/_firewall adds
+ * them. Init() refuses to proceed without the reference, so a build that
+ * includes the firewall never runs unfiltered.
+ *
+ * The ruleset is regenerated and reloaded atomically whenever a feature is
+ * enabled. The two ingress prefix tables are declared `persist`, so a reload
+ * keeps their contents, and each is replaced atomically (`-T replace`) as
+ * Thread network data changes.
+ */
+class PfFirewall : private NonCopyable
+{
+public:
+    /**
+     * @param[in] aPfctl                Runs pfctl. Must outlive this object.
+     * @param[in] aThreadInterfaceName  The Thread interface (e.g. "utun5") the
+     *                                  rules are scoped to. On macOS the kernel
+     *                                  assigns it, so pass the name the platform
+     *                                  reports, not the one that was requested.
+     */
+    PfFirewall(IPfctl &aPfctl, std::string aThreadInterfaceName);
+
+    /**
+     * Takes a pf enable reference (`pfctl -E`), verifies the main ruleset
+     * references the anchor, and flushes any stale anchor contents.
+     */
+    otbrError Init(void);
+
+    /**
+     * Flushes the anchor and releases the pf enable reference.
+     */
+    otbrError Deinit(void);
+
+    /**
+     * Installs the Thread ingress filter rules. No-op if already enabled.
+     */
+    otbrError EnableIngressFilter(void);
+
+    /**
+     * Masquerades IPv4 traffic that arrived on the Thread interface out the
+     * upstream interface (the NAT64 egress path). Requires `nat-anchor "otbr"`
+     * in the main ruleset. No-op if already enabled.
+     *
+     * @param[in] aUpstreamInterfaceName  Upstream interface (e.g. "en0").
+     */
+    otbrError EnableNat44Masquerade(const std::string &aUpstreamInterfaceName);
+
+    /**
+     * Replaces the contents of both ingress tables. Each table is replaced
+     * atomically; pfctl cannot batch the two, so the window between them is
+     * one process run.
+     *
+     * @param[in] aDenySrc   Prefixes for the deny-source table (on-mesh + mesh-local).
+     * @param[in] aAllowDst  Prefixes for the allow-destination table (on-mesh).
+     */
+    otbrError ReplaceIngressPrefixes(const std::vector<Ip6Prefix> &aDenySrc, const std::vector<Ip6Prefix> &aAllowDst);
+
+    bool IsInitialized(void) const { return mInitialized; }
+    bool IsIngressFilterEnabled(void) const { return mIngressFilterEnabled; }
+    bool IsNat44Enabled(void) const { return mNat44Enabled; }
+
+    /**
+     * Renders the anchor ruleset for the currently enabled features, in the
+     * order pf requires (tables, translation, filtering).
+     */
+    std::string GenerateRuleset(void) const;
+
+    static const char *const kAnchorName;
+    static const char *const kIngressDenySrcTable;
+    static const char *const kIngressAllowDstTable;
+    static const char *const kThreadTag;
+
+private:
+    otbrError RunPfctl(const std::vector<std::string> &aArgs, const std::string &aInput, std::string &aOutput);
+    otbrError EnablePf(void);
+    void      DisablePf(void);
+    otbrError VerifyAnchorReferenced(const char *aListFlag, const char *aDirective);
+    otbrError FlushAnchor(void);
+    otbrError LoadRuleset(void);
+    otbrError ReplaceTable(const char *aTable, const std::vector<Ip6Prefix> &aPrefixes);
+
+    IPfctl     &mPfctl;
+    std::string mThreadIfName;
+    std::string mUpstreamIfName;
+    std::string mEnableToken; ///< Reference token from `pfctl -E`, released by Deinit().
+    bool        mInitialized;
+    bool        mIngressFilterEnabled;
+    bool        mNat44Enabled;
+};
+
+} // namespace Firewall
+} // namespace otbr
+
+#endif // OTBR_FIREWALL_PF_FIREWALL_HPP_

--- a/src/firewall/pfctl.cpp
+++ b/src/firewall/pfctl.cpp
@@ -1,0 +1,259 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "FIREWALL"
+
+#include "firewall/pfctl.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+extern char **environ;
+
+namespace otbr {
+namespace Firewall {
+
+const char PfctlProcess::kPfctlPath[] = "/sbin/pfctl";
+
+namespace {
+
+void ClosePipeEnd(int &aFd)
+{
+    if (aFd >= 0)
+    {
+        close(aFd);
+        aFd = -1;
+    }
+}
+
+bool CreatePipe(int aFds[2])
+{
+    bool ok = (pipe(aFds) == 0);
+
+    // The parent's ends must not leak into pfctl (or any other child); the
+    // ends pfctl needs are dup2'd onto 0/1/2 by the spawn file actions, which
+    // clears close-on-exec on the copies.
+    if (ok)
+    {
+        ok = (fcntl(aFds[0], F_SETFD, FD_CLOEXEC) == 0) && (fcntl(aFds[1], F_SETFD, FD_CLOEXEC) == 0);
+    }
+
+    return ok;
+}
+
+// Appends what is readable from @p aFd to @p aOut; returns false at EOF or on error.
+bool DrainPipe(int aFd, std::string &aOut)
+{
+    char    buf[1024];
+    ssize_t count;
+
+    do
+    {
+        count = read(aFd, buf, sizeof(buf));
+    } while (count < 0 && errno == EINTR);
+
+    if (count > 0)
+    {
+        aOut.append(buf, static_cast<size_t>(count));
+    }
+
+    return count > 0;
+}
+
+} // namespace
+
+otbrError PfctlProcess::Run(const std::vector<std::string> &aArgs,
+                            const std::string              &aInput,
+                            std::string                    &aOutput,
+                            std::string                    &aError)
+{
+    otbrError                  error      = OTBR_ERROR_NONE;
+    int                        inPipe[2]  = {-1, -1};
+    int                        outPipe[2] = {-1, -1};
+    int                        errPipe[2] = {-1, -1};
+    posix_spawn_file_actions_t actions;
+    bool                       hasActions = false;
+    pid_t                      pid        = -1;
+    int                        status     = 0;
+    int                        rc;
+    size_t                     written = 0;
+    std::vector<char *>        argv;
+
+    aOutput.clear();
+    aError.clear();
+
+    VerifyOrExit(CreatePipe(inPipe) && CreatePipe(outPipe) && CreatePipe(errPipe), error = OTBR_ERROR_ERRNO);
+
+    // The posix_spawn family returns the error number instead of setting errno.
+    rc = posix_spawn_file_actions_init(&actions);
+    VerifyOrExit(rc == 0, errno = rc; error = OTBR_ERROR_ERRNO);
+    hasActions = true;
+    rc         = posix_spawn_file_actions_adddup2(&actions, inPipe[0], STDIN_FILENO);
+    VerifyOrExit(rc == 0, errno = rc; error = OTBR_ERROR_ERRNO);
+    rc = posix_spawn_file_actions_adddup2(&actions, outPipe[1], STDOUT_FILENO);
+    VerifyOrExit(rc == 0, errno = rc; error = OTBR_ERROR_ERRNO);
+    rc = posix_spawn_file_actions_adddup2(&actions, errPipe[1], STDERR_FILENO);
+    VerifyOrExit(rc == 0, errno = rc; error = OTBR_ERROR_ERRNO);
+
+    argv.push_back(const_cast<char *>("pfctl"));
+    for (const std::string &arg : aArgs)
+    {
+        argv.push_back(const_cast<char *>(arg.c_str()));
+    }
+    argv.push_back(nullptr);
+
+    rc = posix_spawn(&pid, kPfctlPath, &actions, nullptr, argv.data(), environ);
+    VerifyOrExit(rc == 0, errno = rc; error = OTBR_ERROR_ERRNO);
+
+    ClosePipeEnd(inPipe[0]);
+    ClosePipeEnd(outPipe[1]);
+    ClosePipeEnd(errPipe[1]);
+
+#ifdef F_SETNOSIGPIPE
+    // If pfctl exits before it has read all of its input (a syntax error in
+    // the ruleset, say), the next write would raise SIGPIPE and take the
+    // agent down with it; ask for EPIPE instead so the failure is reported.
+    fcntl(inPipe[1], F_SETNOSIGPIPE, 1);
+#endif
+
+    // pfctl reads its whole input (a ruleset of a few hundred bytes) before it
+    // produces any output, so writing it all first cannot deadlock on the
+    // output pipes.
+    while (written < aInput.size())
+    {
+        ssize_t count = write(inPipe[1], aInput.data() + written, aInput.size() - written);
+
+        if (count < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            // pfctl is gone: stop writing, but still drain what it said on
+            // stderr and report its exit status below.
+            VerifyOrExit(errno == EPIPE, error = OTBR_ERROR_ERRNO);
+            break;
+        }
+        written += static_cast<size_t>(count);
+    }
+    ClosePipeEnd(inPipe[1]);
+
+    // Drain stdout and stderr together so neither can fill up and stall pfctl.
+    while (outPipe[0] >= 0 || errPipe[0] >= 0)
+    {
+        struct pollfd fds[2];
+        nfds_t        count = 0;
+
+        if (outPipe[0] >= 0)
+        {
+            fds[count].fd      = outPipe[0];
+            fds[count].events  = POLLIN;
+            fds[count].revents = 0;
+            count++;
+        }
+        if (errPipe[0] >= 0)
+        {
+            fds[count].fd      = errPipe[0];
+            fds[count].events  = POLLIN;
+            fds[count].revents = 0;
+            count++;
+        }
+
+        if (poll(fds, count, -1) < 0)
+        {
+            VerifyOrExit(errno == EINTR, error = OTBR_ERROR_ERRNO);
+            continue;
+        }
+
+        for (nfds_t i = 0; i < count; i++)
+        {
+            if (fds[i].revents == 0)
+            {
+                continue;
+            }
+            if (fds[i].fd == outPipe[0])
+            {
+                if (!DrainPipe(outPipe[0], aOutput))
+                {
+                    ClosePipeEnd(outPipe[0]);
+                }
+            }
+            else if (fds[i].fd == errPipe[0])
+            {
+                if (!DrainPipe(errPipe[0], aError))
+                {
+                    ClosePipeEnd(errPipe[0]);
+                }
+            }
+        }
+    }
+
+    while (waitpid(pid, &status, 0) < 0)
+    {
+        VerifyOrExit(errno == EINTR, error = OTBR_ERROR_ERRNO);
+    }
+    pid = -1;
+
+    VerifyOrExit(WIFEXITED(status) && WEXITSTATUS(status) == 0, error = OTBR_ERROR_ERRNO);
+
+exit:
+    // Our pipe ends go first, so a pfctl that is still reading stdin sees EOF
+    // rather than waiting on us while we wait on it.
+    ClosePipeEnd(inPipe[0]);
+    ClosePipeEnd(inPipe[1]);
+    ClosePipeEnd(outPipe[0]);
+    ClosePipeEnd(outPipe[1]);
+    ClosePipeEnd(errPipe[0]);
+    ClosePipeEnd(errPipe[1]);
+    if (pid > 0)
+    {
+        // Spawned but not reaped because something failed part-way: don't
+        // block on a child that may hang, and don't leave a zombie behind.
+        kill(pid, SIGKILL);
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR)
+        {
+        }
+    }
+    if (hasActions)
+    {
+        posix_spawn_file_actions_destroy(&actions);
+    }
+
+    return error;
+}
+
+} // namespace Firewall
+} // namespace otbr

--- a/src/firewall/pfctl.hpp
+++ b/src/firewall/pfctl.hpp
@@ -1,0 +1,96 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file declares the interface the pf firewall backend uses to run
+ *   pfctl(8), and its process-spawning implementation.
+ */
+
+#ifndef OTBR_FIREWALL_PFCTL_HPP_
+#define OTBR_FIREWALL_PFCTL_HPP_
+
+#include "openthread-br/config.h"
+
+#include <string>
+#include <vector>
+
+#include "common/types.hpp"
+
+namespace otbr {
+namespace Firewall {
+
+/**
+ * Runs pfctl(8) for the pf firewall backend.
+ *
+ * The backend drives pf exclusively through pfctl: Apple does not ship the
+ * pf ioctl interface (net/pfvar.h) in the public SDK, and pfctl is part of
+ * the base system, so no build-time dependency is needed. Tests substitute a
+ * fake.
+ */
+class IPfctl
+{
+public:
+    virtual ~IPfctl(void) = default;
+
+    /**
+     * Runs pfctl with the given arguments, feeding @p aInput on its stdin.
+     *
+     * @param[in]  aArgs    The arguments, not including the program name.
+     * @param[in]  aInput   Data written to pfctl's stdin (may be empty).
+     * @param[out] aOutput  What pfctl wrote to stdout.
+     * @param[out] aError   What pfctl wrote to stderr.
+     *
+     * @retval OTBR_ERROR_NONE   pfctl exited with status 0.
+     * @retval OTBR_ERROR_ERRNO  pfctl could not be run, or exited non-zero.
+     */
+    virtual otbrError Run(const std::vector<std::string> &aArgs,
+                          const std::string              &aInput,
+                          std::string                    &aOutput,
+                          std::string                    &aError) = 0;
+};
+
+/**
+ * Runs /sbin/pfctl as a child process, without a shell.
+ */
+class PfctlProcess : public IPfctl
+{
+public:
+    otbrError Run(const std::vector<std::string> &aArgs,
+                  const std::string              &aInput,
+                  std::string                    &aOutput,
+                  std::string                    &aError) override;
+
+private:
+    static const char kPfctlPath[];
+};
+
+} // namespace Firewall
+} // namespace otbr
+
+#endif // OTBR_FIREWALL_PFCTL_HPP_

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -103,6 +103,11 @@ if(OTBR_NFTABLES)
         PkgConfig::LIBMNL
     )
 endif()
+if(OTBR_PF)
+    target_sources(otbr-gtest-firewall PRIVATE
+        test_pf_firewall.cpp
+    )
+endif()
 gtest_discover_tests(otbr-gtest-firewall)
 
 add_executable(otbr-gtest-unit-dnssd

--- a/tests/gtest/test_pf_firewall.cpp
+++ b/tests/gtest/test_pf_firewall.cpp
@@ -1,0 +1,303 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "common/types.hpp"
+#include "firewall/pf_firewall.hpp"
+#include "firewall/pfctl.hpp"
+
+namespace {
+
+using otbr::Ip6Prefix;
+using otbr::Firewall::IPfctl;
+using otbr::Firewall::PfFirewall;
+
+struct PfctlCall
+{
+    std::vector<std::string> mArgs;
+    std::string              mInput;
+
+    std::string Command(void) const
+    {
+        std::string command = "pfctl";
+
+        for (const std::string &arg : mArgs)
+        {
+            command += " " + arg;
+        }
+
+        return command;
+    }
+};
+
+// Records every pfctl invocation and answers the listing/enable queries the
+// backend makes, so the tests can assert on exactly what would be run.
+class FakePfctl : public IPfctl
+{
+public:
+    otbrError Run(const std::vector<std::string> &aArgs,
+                  const std::string              &aInput,
+                  std::string                    &aOutput,
+                  std::string                    &aError) override
+    {
+        otbrError error = OTBR_ERROR_NONE;
+
+        mCalls.push_back({aArgs, aInput});
+        aOutput.clear();
+        aError.clear();
+
+        if (aArgs == std::vector<std::string>{"-E"})
+        {
+            aError = mEnableOutput;
+        }
+        else if (aArgs == std::vector<std::string>{"-s", "rules"})
+        {
+            aOutput = mRulesListing;
+        }
+        else if (aArgs == std::vector<std::string>{"-s", "nat"})
+        {
+            aOutput = mNatListing;
+        }
+        else if (mFailRulesetLoad && aArgs.size() >= 4 && aArgs[2] == "-f")
+        {
+            aError = "pfctl: Syntax error in config file: pf rules not loaded\n";
+            error  = OTBR_ERROR_ERRNO;
+        }
+
+        return error;
+    }
+
+    const PfctlCall &Last(void) const { return mCalls.back(); }
+
+    std::vector<PfctlCall> mCalls;
+    std::string            mEnableOutput    = "pf enabled\nToken : 4242\n";
+    std::string            mRulesListing    = "anchor \"com.apple/*\" all\nanchor \"otbr\" all\n";
+    std::string            mNatListing      = "nat-anchor \"com.apple/*\" all\nnat-anchor \"otbr\" all\n";
+    bool                   mFailRulesetLoad = false;
+};
+
+const char kIngressRuleset[] = "# Installed by otbr-agent; do not edit.\n"
+                               "table <ingress_deny_src> persist\n"
+                               "table <ingress_allow_dst> persist\n"
+                               "pass out quick on utun5 inet6 from (utun5) to any\n"
+                               "pass out quick on utun5 inet6 from (self) to any\n"
+                               "block out quick on utun5 inet6 from <ingress_deny_src> to any\n"
+                               "pass out quick on utun5 inet6 from any to <ingress_allow_dst>\n"
+                               "pass out quick on utun5 inet6 from any to ff00::/8\n"
+                               "block out quick on utun5 inet6 all\n";
+
+TEST(PfFirewall, InitEnablesPfVerifiesAnchorAndFlushes)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    EXPECT_TRUE(firewall.IsInitialized());
+
+    ASSERT_EQ(pfctl.mCalls.size(), 3u);
+    EXPECT_EQ(pfctl.mCalls[0].Command(), "pfctl -E");
+    EXPECT_EQ(pfctl.mCalls[1].Command(), "pfctl -s rules");
+    EXPECT_EQ(pfctl.mCalls[2].Command(), "pfctl -a otbr -F all");
+}
+
+TEST(PfFirewall, InitFailsWhenMainRulesetDoesNotReferenceAnchor)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    pfctl.mRulesListing = "anchor \"com.apple/*\" all\n";
+
+    EXPECT_EQ(firewall.Init(), OTBR_ERROR_NOT_FOUND);
+    EXPECT_FALSE(firewall.IsInitialized());
+    // The enable reference taken before the check is given back.
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -X 4242");
+}
+
+TEST(PfFirewall, InitSucceedsWithoutReferenceTokenAndDeinitSkipsRelease)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    // pf is enabled regardless of whether the token can be read back.
+    pfctl.mEnableOutput = "pf enabled\n";
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    EXPECT_TRUE(firewall.IsInitialized());
+
+    ASSERT_EQ(firewall.Deinit(), OTBR_ERROR_NONE);
+    // Nothing to release: the last call is the anchor flush, not `pfctl -X`.
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -a otbr -F all");
+}
+
+TEST(PfFirewall, InitRejectsEmptyInterfaceName)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "");
+
+    EXPECT_EQ(firewall.Init(), OTBR_ERROR_INVALID_ARGS);
+    EXPECT_TRUE(pfctl.mCalls.empty());
+}
+
+TEST(PfFirewall, EnableIngressFilterLoadsRulesetIntoAnchor)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    ASSERT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+    EXPECT_TRUE(firewall.IsIngressFilterEnabled());
+
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -a otbr -f -");
+    EXPECT_EQ(pfctl.Last().mInput, kIngressRuleset);
+
+    // Enabling again is a no-op.
+    size_t calls = pfctl.mCalls.size();
+    EXPECT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+    EXPECT_EQ(pfctl.mCalls.size(), calls);
+}
+
+TEST(PfFirewall, EnableIngressFilterRequiresInit)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    EXPECT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_INVALID_STATE);
+    EXPECT_FALSE(firewall.IsIngressFilterEnabled());
+}
+
+TEST(PfFirewall, FailedRulesetLoadLeavesFilterDisabled)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    pfctl.mFailRulesetLoad = true;
+
+    EXPECT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_ERRNO);
+    EXPECT_FALSE(firewall.IsIngressFilterEnabled());
+}
+
+TEST(PfFirewall, Nat44RequiresNatAnchorAndPrecedesFilterRules)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    ASSERT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+
+    pfctl.mNatListing = "nat-anchor \"com.apple/*\" all\n";
+    EXPECT_EQ(firewall.EnableNat44Masquerade("en0"), OTBR_ERROR_NOT_FOUND);
+    EXPECT_FALSE(firewall.IsNat44Enabled());
+
+    pfctl.mNatListing = "nat-anchor \"otbr\" all\n";
+    ASSERT_EQ(firewall.EnableNat44Masquerade("en0"), OTBR_ERROR_NONE);
+    EXPECT_TRUE(firewall.IsNat44Enabled());
+
+    {
+        const std::string &ruleset = pfctl.Last().mInput;
+        size_t             nat     = ruleset.find("nat pass on en0 inet tagged otbr_thread -> (en0)\n");
+        size_t             tag     = ruleset.find("pass in quick on utun5 inet tag otbr_thread\n");
+        size_t             filter  = ruleset.find("pass out quick on utun5 inet6 from (utun5) to any\n");
+
+        EXPECT_EQ(pfctl.Last().Command(), "pfctl -a otbr -f -");
+        ASSERT_NE(nat, std::string::npos);
+        ASSERT_NE(tag, std::string::npos);
+        ASSERT_NE(filter, std::string::npos);
+        // pf requires translation rules before filter rules.
+        EXPECT_LT(nat, tag);
+        EXPECT_LT(tag, filter);
+    }
+}
+
+TEST(PfFirewall, ReplaceIngressPrefixesReplacesTablesSortedAndDeduplicated)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    ASSERT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+
+    std::vector<Ip6Prefix> denySrc  = {Ip6Prefix("fd00:2::", 64), Ip6Prefix("fd00:1::", 64), Ip6Prefix("fd00:2::", 64)};
+    std::vector<Ip6Prefix> allowDst = {Ip6Prefix("fd00:1::", 64)};
+
+    ASSERT_EQ(firewall.ReplaceIngressPrefixes(denySrc, allowDst), OTBR_ERROR_NONE);
+
+    ASSERT_GE(pfctl.mCalls.size(), 2u);
+    EXPECT_EQ(pfctl.mCalls[pfctl.mCalls.size() - 2].Command(),
+              "pfctl -a otbr -t ingress_deny_src -T replace fd00:1::/64 fd00:2::/64");
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -a otbr -t ingress_allow_dst -T replace fd00:1::/64");
+}
+
+TEST(PfFirewall, ReplaceIngressPrefixesFlushesEmptyTable)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    ASSERT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+
+    ASSERT_EQ(firewall.ReplaceIngressPrefixes({Ip6Prefix("fd00:1::", 64)}, {}), OTBR_ERROR_NONE);
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -a otbr -t ingress_allow_dst -T flush");
+}
+
+TEST(PfFirewall, ReplaceIngressPrefixesRequiresIngressFilter)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    EXPECT_EQ(firewall.ReplaceIngressPrefixes({}, {}), OTBR_ERROR_INVALID_STATE);
+}
+
+TEST(PfFirewall, DeinitFlushesAnchorAndReleasesReference)
+{
+    FakePfctl  pfctl;
+    PfFirewall firewall(pfctl, "utun5");
+
+    ASSERT_EQ(firewall.Init(), OTBR_ERROR_NONE);
+    ASSERT_EQ(firewall.EnableIngressFilter(), OTBR_ERROR_NONE);
+
+    ASSERT_EQ(firewall.Deinit(), OTBR_ERROR_NONE);
+    EXPECT_FALSE(firewall.IsInitialized());
+    EXPECT_FALSE(firewall.IsIngressFilterEnabled());
+
+    ASSERT_GE(pfctl.mCalls.size(), 2u);
+    EXPECT_EQ(pfctl.mCalls[pfctl.mCalls.size() - 2].Command(), "pfctl -a otbr -F all");
+    EXPECT_EQ(pfctl.Last().Command(), "pfctl -X 4242");
+
+    // Deinit without Init is a no-op.
+    size_t calls = pfctl.mCalls.size();
+    EXPECT_EQ(firewall.Deinit(), OTBR_ERROR_NONE);
+    EXPECT_EQ(pfctl.mCalls.size(), calls);
+}
+
+} // namespace

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -50,10 +50,10 @@ set(OT_DNS_CLIENT_OVER_TCP OFF CACHE STRING "disable DNS query over TCP")
 set(OT_DNS_UPSTREAM_QUERY ${OTBR_DNS_UPSTREAM_QUERY} CACHE STRING "enable sending DNS queries to upstream" FORCE)
 set(OT_ECDSA ON CACHE STRING "enable ECDSA" FORCE)
 set(OT_EXTERNAL_HEAP ON CACHE STRING "enable external heap" FORCE)
-if (OTBR_NFTABLES)
-    # otbr-agent owns the OTBR ingress firewall in-process (nftables), including
-    # producing the ingress prefix sets from Thread network data, so the OT posix
-    # platform firewall (ipset/ip6tables producer) must be off.
+if (OTBR_NFTABLES OR OTBR_PF)
+    # otbr-agent owns the OTBR ingress firewall in-process (nftables or pf),
+    # including producing the ingress prefix sets from Thread network data, so
+    # the OT posix platform firewall (ipset/ip6tables producer) must be off.
     set(OT_FIREWALL OFF CACHE STRING "enable firewall feature" FORCE)
 else()
     set(OT_FIREWALL ON CACHE STRING "enable firewall feature")


### PR DESCRIPTION
macOS has no netfilter; its firewall is pf. This adds a pf counterpart of the in-process nftables backend from #3325, as the follow-up promised in #3469.

With `-DOTBR_PF=ON` (opt-in, macOS only, mutually exclusive with `OTBR_NFTABLES`), otbr-agent owns the Thread ingress filter and the NAT44 masquerade in the pf anchor `otbr`, and produces the ingress prefix tables from Thread network data on `OT_CHANGED_THREAD_NETDATA` / `OT_CHANGED_ACTIVE_DATASET`, replacing the OpenThread posix platform firewall (which has no macOS port; `OT_FIREWALL` is forced off, as for nftables).

### Shape

- `PfFirewall` implements the same surface the agent already uses from `FirewallManager` (`Init`/`Deinit`, `EnableIngressFilter`, `EnableNat44Masquerade`, `ReplaceIngressPrefixes`) rather than `INftables`, whose vocabulary (tables/chains/hooks) does not map onto pf's anchors and tables. `Application` picks the backend at build time; `UpdateIngressPrefixes()` is shared.
- pf is driven through `pfctl(8)`, spawned directly with `posix_spawn` (no shell): Apple does not ship the pf ioctl interface (`net/pfvar.h`) in the public SDK, and pfctl is part of the base system, so there is no build-time dependency. The invocation sits behind `IPfctl` so the policy is unit-tested against a fake (`tests/gtest/test_pf_firewall.cpp`, 12 tests).
- The ruleset is regenerated and reloaded atomically (`pfctl -a otbr -f -`) when a feature is enabled; the two prefix tables are `persist` (a reload keeps their contents) and are each replaced atomically with `-T replace` as network data changes.

```
table <ingress_deny_src> persist
table <ingress_allow_dst> persist
nat pass on <infra> inet tagged otbr_thread -> (<infra>) # NAT44
pass in quick on <thread> inet tag otbr_thread            # NAT44
pass out quick on <thread> inet6 from (<thread>) to any
pass out quick on <thread> inet6 from (self) to any
block out quick on <thread> inet6 from <ingress_deny_src> to any
pass out quick on <thread> inet6 from any to <ingress_allow_dst>
pass out quick on <thread> inet6 from any to ff00::/8
block out quick on <thread> inet6 all
```

The ingress rules match the ip6tables FORWARD chain 1:1, with one difference: pf also sees the host's own output on the Thread interface, so it is exempted first. `(<thread>)` tracks the interface's addresses dynamically — the OMR address only arrives after the ruleset is loaded — and `(self)` covers the host's other addresses. A pf nat rule cannot match the inbound interface, so IPv4 from the Thread interface is tagged on the way in and the nat rule keys on the tag.

### Setup

pf only evaluates an anchor the main ruleset references, so `script/_firewall` gains a macOS branch: install adds `nat-anchor "otbr"` (next to the system's nat-anchor — pf requires translation before filtering) and `anchor "otbr"` to `/etc/pf.conf` and reloads it; uninstall removes them. `Init()` verifies the reference (`pfctl -s rules` / `-s nat`) and fails otherwise, so a build with the firewall never runs unfiltered — the same policy as the nftables backend. The rules are scoped to the interface name the platform reports (`otSysGetThreadNetifName()`), since macOS assigns `utunN` itself and it differs from the requested name.

### Tested

Apple Silicon Mac mini (macOS 26), otbr-agent in RCP mode as a Matter-over-Thread border router, in a mesh with three routers (the border router attaches as a router, the Matter locks parent elsewhere). After startup the anchor held the rules above on `utun0` — the kernel picked a different utun number than on the previous boot, which the backend followed — with `ingress_deny_src` = {OMR prefix, mesh-local prefix} and `ingress_allow_dst` = {OMR prefix}, all produced from network data. Host→mesh traffic sourced from the OMR address reached the locks through the filter, and Matter availability was unchanged across the switch from the previous (template/script) firewall. Running as the household's production border router since. Formatted with the `script/make-pretty` tooling (clang-format 19, shfmt, shellcheck).

Part of #3469. Adds a third leg to the macOS CI matrix from #3577 that builds this configuration with `-DOTBR_PF=ON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
