### PR TITLE
[rest] register the pending dataset via MGMT_PENDING_SET

### DIFF
--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: BSD 3-Clause
     url: https://github.com/openthread/ot-br-posix/blob/main/LICENSE
-  version: 0.5.0
+  version: 0.6.0
 servers:
   - url: "{protocol}://{host}:{port}"
     description: Configurable Border Router destination.
@@ -1517,13 +1517,27 @@ paths:
       description: |-
         Creates or updates the pending operational dataset on the current node. Delay needs to be set to let
         the pending dataset apply as active dataset in the near future.
+
+        The request is applied on top of the current pending dataset, or on top of the current active dataset
+        when none is pending: fields the request leaves out keep their current value, so a partial request
+        (for example only a new channel plus a newer active timestamp) describes a change to the current
+        network.
+
+        The dataset is registered with the Thread leader (MGMT_PENDING_SET), so leader-side validation applies:
+        the pending timestamp must be newer than that of any pending dataset already known to the network, the
+        active timestamp must be newer than that of the current active dataset unless the network key changes,
+        the delay timer is raised to the allowed minimum (default 30 s, or the default delay when the network
+        key changes), and the node must be attached to a Thread network. A JSON request that omits the pending
+        timestamp gets one generated from the current time, advanced past the pending timestamp of the dataset
+        it replaces if necessary.
       parameters:
         - $ref: "#/components/parameters/IfNoneMatchStar"
       requestBody:
         description: |-
           Operational dataset that will be stored as pending operational dataset. Supports request body Content-Type
           `text/plain` (dataset in TLV format as hex string) or `application/json` (dataset in JSON format). In both
-          cases keys which are not set will be initialized with defaults.
+          cases keys which are not set are taken from the current pending dataset, or from the current active
+          dataset when none is pending. A delay timer is required in either format.
         content:
           application/json:
             schema:
@@ -1540,10 +1554,22 @@ paths:
           $ref: "#/components/responses/PreconditionFailedError"
         "400":
           description: |-
-            Invalid request body, or an `If-None-Match` header value other
-            than `*`.
+            Invalid request body (including a pending dataset without a delay timer), or an `If-None-Match`
+            header value other than `*`.
+        "409":
+          description: |-
+            The leader rejected the dataset (for example, the pending or active timestamp does not advance), the
+            node is not attached to a Thread network (also when it detaches while the registration is in
+            flight), or another dataset update is still in progress.
         "500":
           $ref: "#/components/responses/InternalServerError"
+        "504":
+          description: |-
+            The leader did not answer the dataset registration in time: this node gateways the request
+            to the leader over CoAP (MGMT_PENDING_SET), and that exchange timed out. The outcome is
+            unknown - the leader may or may not have applied the dataset. Read back the pending dataset
+            and compare its pending timestamp to learn what happened; a retry needs a newer pending
+            timestamp.
   /node/commissioner/state:
     get:
       tags:

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -33,6 +33,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <future>
+#include <memory>
 #include <utility>
 
 #include <arpa/inet.h>
@@ -40,6 +42,7 @@
 #include <fcntl.h>
 #include <httplib.h>
 #include <string.h>
+#include <time.h>
 
 #include <openthread/commissioner.h>
 
@@ -834,6 +837,43 @@ static std::string TrimOws(const std::string &aValue)
     return begin == std::string::npos ? "" : aValue.substr(begin, end - begin + 1);
 }
 
+static void HandleMgmtPendingSetResponse(otError aResult, void *aContext)
+{
+    std::unique_ptr<std::promise<otError>> result(static_cast<std::promise<otError> *>(aContext));
+
+    result->set_value(aResult);
+}
+
+// Generates a Pending Timestamp from the current time. The leader rejects a
+// MGMT_PENDING_SET whose Pending Timestamp does not advance the one it holds,
+// and the clock may lag that value (not yet synchronized, or the dataset was
+// registered by a commissioner with a faster clock), so the result is made to
+// strictly advance the Pending Timestamp in @p aBaseTlvs when there is one.
+static otbrError GeneratePendingTimestamp(const otOperationalDatasetTlvs &aBaseTlvs, otTimestamp &aTimestamp)
+{
+    otbrError            error = OTBR_ERROR_NONE;
+    otOperationalDataset base;
+    timespec             now;
+
+    VerifyOrExit(clock_gettime(CLOCK_REALTIME, &now) == 0, error = OTBR_ERROR_REST);
+
+    aTimestamp.mSeconds = static_cast<uint64_t>(now.tv_sec) & 0xffffffffffff;
+    aTimestamp.mTicks   = static_cast<uint16_t>((static_cast<uint64_t>(now.tv_nsec) * 32768 / 1000000000) & 0x7fff);
+    aTimestamp.mAuthoritative = false;
+
+    if (otDatasetParseTlvs(&aBaseTlvs, &base) == OT_ERROR_NONE && base.mComponents.mIsPendingTimestampPresent &&
+        (aTimestamp.mSeconds < base.mPendingTimestamp.mSeconds ||
+         (aTimestamp.mSeconds == base.mPendingTimestamp.mSeconds &&
+          aTimestamp.mTicks <= base.mPendingTimestamp.mTicks)))
+    {
+        aTimestamp.mSeconds = (base.mPendingTimestamp.mSeconds + 1) & 0xffffffffffff;
+        aTimestamp.mTicks   = 0;
+    }
+
+exit:
+    return error;
+}
+
 void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest, Response &aResponse) const
 {
     otbrError       error = OTBR_ERROR_NONE;
@@ -841,13 +881,16 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
     std::string     body;
     StatusCode      errorCode = StatusCode::OK_200;
 
+    std::unique_ptr<std::promise<otError>> mgmtSetResult;
+    std::future<otError>                   mgmtSetFuture;
+    bool                                   mgmtSetSent = false;
+
     // RFC 9110 section 13.1.2: If-None-Match with "*" makes the write
-    // conditional on no dataset being in place. A pending dataset that is
-    // not newer than the one already held is silently ignored by the mesh
-    // while this handler accepts the write, so a client that does not intend
-    // to supersede an in-flight dataset can turn that collision into an
-    // error it sees. Other forms of the header (entity tags) have nothing to
-    // match against here and are rejected rather than mistaken for an
+    // conditional on no dataset being in place, so a client that does not
+    // intend to supersede an in-flight pending dataset can turn that
+    // collision into an error it sees, before anything is sent to the
+    // leader. Other forms of the header (entity tags) have nothing to match
+    // against here and are rejected rather than mistaken for an
     // unconditional write.
     const std::string ifNoneMatch  = TrimOws(aRequest.get_header_value(OT_REST_IF_NONE_MATCH_HEADER));
     const bool        onlyIfAbsent = ifNoneMatch == "*";
@@ -855,7 +898,8 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
     VerifyOrExit(ifNoneMatch.empty() || onlyIfAbsent, error = OTBR_ERROR_INVALID_ARGS);
 
     SuccessOrExit(
-        error = RunInMainLoop([this, aDatasetType, onlyIfAbsent, &errorCode, &aRequest]() {
+        error = RunInMainLoop([this, aDatasetType, onlyIfAbsent, &errorCode, &aRequest, &mgmtSetResult, &mgmtSetFuture,
+                               &mgmtSetSent]() {
             bool                     isTlv;
             otOperationalDataset     dataset = {};
             otOperationalDatasetTlvs datasetTlvs;
@@ -869,21 +913,38 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
             }
             else if (aDatasetType == DatasetType::kPending)
             {
+                // The Pending Dataset is registered with the leader (see below), which
+                // requires the device to be attached.
+                VerifyOrReturn(otThreadGetDeviceRole(GetInstance()) >= OT_DEVICE_ROLE_CHILD, OTBR_ERROR_INVALID_STATE);
                 errorOt = otDatasetGetPendingTlvs(GetInstance(), &datasetTlvs);
             }
 
             // RFC 9110 section 13.2.1: the precondition is evaluated after the
-            // request checks (the role check above still answers 409 first, the
+            // request checks (the role checks above still answer 409 first, the
             // header cannot downgrade that to a 412) and before the content is
-            // processed; evaluated in this main-loop task, it is atomic with
-            // the write below.
+            // processed. Evaluated in this main-loop task, it is atomic with
+            // the write below for the Active Dataset; for the Pending Dataset
+            // it is atomic with the MGMT_PENDING_SET send, and the leader's
+            // Pending Timestamp ordering arbitrates concurrent registrations.
             VerifyOrReturn(!onlyIfAbsent || errorOt != OT_ERROR_NONE, OTBR_ERROR_DUPLICATED);
 
-            // Create a new operational dataset if it doesn't exist.
             if (errorOt == OT_ERROR_NOT_FOUND)
             {
-                VerifyOrReturn(otDatasetCreateNewNetwork(GetInstance(), &dataset) == OT_ERROR_NONE, OTBR_ERROR_REST);
-                otDatasetConvertToTlvs(&dataset, &datasetTlvs);
+                if (aDatasetType == DatasetType::kPending)
+                {
+                    // A Pending Dataset describes a change to the network this node is
+                    // attached to, so a new one starts from the current Active Dataset:
+                    // fields the request leaves out keep their current value.
+                    VerifyOrReturn(otDatasetGetActiveTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE,
+                                   OTBR_ERROR_REST);
+                }
+                else
+                {
+                    // Create a new operational dataset if it doesn't exist.
+                    VerifyOrReturn(otDatasetCreateNewNetwork(GetInstance(), &dataset) == OT_ERROR_NONE,
+                                   OTBR_ERROR_REST);
+                    otDatasetConvertToTlvs(&dataset, &datasetTlvs);
+                }
                 errorCode = StatusCode::Created_201;
             }
 
@@ -914,8 +975,27 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
                     VerifyOrReturn(Json::JsonPendingDatasetString2Dataset(aRequest.body, dataset),
                                    OTBR_ERROR_INVALID_ARGS);
                     VerifyOrReturn(dataset.mComponents.mIsDelayPresent, OTBR_ERROR_INVALID_ARGS);
+
+                    if (!dataset.mComponents.mIsPendingTimestampPresent)
+                    {
+                        VerifyOrReturn(GeneratePendingTimestamp(datasetTlvs, dataset.mPendingTimestamp) ==
+                                           OTBR_ERROR_NONE,
+                                       OTBR_ERROR_REST);
+                        dataset.mComponents.mIsPendingTimestampPresent = true;
+                    }
                 }
                 VerifyOrReturn(otDatasetUpdateTlvs(&dataset, &datasetTlvs) == OT_ERROR_NONE, OTBR_ERROR_REST);
+            }
+
+            if (aDatasetType == DatasetType::kPending)
+            {
+                otOperationalDataset merged;
+
+                // Without a Delay Timer the leader accepts the dataset but it never
+                // applies. The JSON path requires one in the request; this also
+                // covers the TLV path, whose merge result may lack one.
+                VerifyOrReturn(otDatasetParseTlvs(&datasetTlvs, &merged) == OT_ERROR_NONE, OTBR_ERROR_REST);
+                VerifyOrReturn(merged.mComponents.mIsDelayPresent, OTBR_ERROR_INVALID_ARGS);
             }
 
             if (aDatasetType == DatasetType::kActive)
@@ -924,10 +1004,65 @@ void RestWebServer::SetDataset(DatasetType aDatasetType, const Request &aRequest
             }
             else if (aDatasetType == DatasetType::kPending)
             {
-                VerifyOrReturn(otDatasetSetPendingTlvs(GetInstance(), &datasetTlvs) == OT_ERROR_NONE, OTBR_ERROR_REST);
+                // Register the Pending Dataset with the leader via MGMT_PENDING_SET
+                // rather than writing it locally, so that leader-side validation
+                // (Pending Timestamp ordering, minimum delay timer) applies even
+                // when this device is the leader.
+                otOperationalDataset emptyDataset = {};
+
+                mgmtSetResult.reset(new std::promise<otError>());
+                mgmtSetFuture = mgmtSetResult->get_future();
+
+                errorOt =
+                    otDatasetSendMgmtPendingSet(GetInstance(), &emptyDataset, datasetTlvs.mTlvs, datasetTlvs.mLength,
+                                                HandleMgmtPendingSetResponse, mgmtSetResult.get());
+                VerifyOrReturn(errorOt != OT_ERROR_ALREADY && errorOt != OT_ERROR_BUSY &&
+                                   errorOt != OT_ERROR_INVALID_STATE,
+                               OTBR_ERROR_INVALID_STATE);
+                VerifyOrReturn(errorOt == OT_ERROR_NONE, OTBR_ERROR_REST);
+
+                // On success the response callback owns (and frees) the promise.
+                mgmtSetResult.release();
+                mgmtSetSent = true;
             }
             return OTBR_ERROR_NONE;
         }));
+
+    if (mgmtSetSent)
+    {
+        otError mgmtError = OT_ERROR_RESPONSE_TIMEOUT;
+
+        // The callback is invoked on response reception, timeout, or abort.
+        // With OpenThread's default CoAP parameters the exchange can run for
+        // up to MAX_TRANSMIT_WAIT (62 to 93 s, RFC 7252 section 4.8.2) before
+        // it times out; answering earlier keeps the HTTP worker available.
+        // The client then learns the outcome is unknown (504), a late
+        // callback is absorbed by the heap-owned promise, and further
+        // registrations answer 409 (busy) until the exchange finalizes.
+        if (mgmtSetFuture.wait_for(std::chrono::seconds(30)) == std::future_status::ready)
+        {
+            mgmtError = mgmtSetFuture.get();
+        }
+
+        switch (mgmtError)
+        {
+        case OT_ERROR_NONE:
+            break;
+        case OT_ERROR_REJECTED:
+            ErrorHandler(aResponse, StatusCode::Conflict_409, "rejected by leader");
+            ExitNow();
+        case OT_ERROR_ABORT:
+            // Thread was stopped or the node detached while the request was in flight.
+            ErrorHandler(aResponse, StatusCode::Conflict_409, "no longer attached");
+            ExitNow();
+        case OT_ERROR_RESPONSE_TIMEOUT:
+            ErrorHandler(aResponse, StatusCode::GatewayTimeout_504, "no response from leader");
+            ExitNow();
+        default:
+            ErrorHandler(aResponse, StatusCode::InternalServerError_500);
+            ExitNow();
+        }
+    }
 
     aResponse.status = errorCode;
 

--- a/src/rest/version.hpp
+++ b/src/rest/version.hpp
@@ -40,6 +40,6 @@
  * - MINOR: New features (backward compatible) or breaking changes during 0.x
  * - PATCH: Bug fixes (backward compatible)
  */
-#define OTBR_REST_API_VERSION "0.5.0"
+#define OTBR_REST_API_VERSION "0.6.0"
 
 #endif // OTBR_REST_VERSION_HPP_

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -870,6 +870,71 @@ def node_dataset_if_none_match_test():
     print(" /node/dataset If-None-Match : OK")
 
 
+def node_dataset_pending_put_test():
+    url = rest_api_addr + "/node/dataset/pending"
+
+    def put(body_dict):
+        req = urllib.request.Request(url,
+                                     data=json.dumps(body_dict).encode(),
+                                     method='PUT',
+                                     headers={'Content-Type': 'application/json'})
+        return urllib.request.urlopen(req)
+
+    def get_json(target):
+        with urllib.request.urlopen(urllib.request.Request(target, headers={'Accept': 'application/json'})) as response:
+            assert response.status == 200
+            return json.loads(response.read())
+
+    # The pending dataset is registered with the leader via MGMT_PENDING_SET,
+    # so the leader raises the delay timer to the allowed minimum (30 s; the
+    # network key is unchanged, so not the 5 min key-change default) rather
+    # than applying a 1 ms delay verbatim (which, written locally, would
+    # migrate this node alone almost immediately).
+    body = {"activeDataset": {"activeTimestamp": {"seconds": 20}}, "delay": 1}
+    with put(body) as response:
+        assert response.status in (200, 201)
+
+    pending = get_json(url)
+    assert 1000 < pending["delay"] <= 30000
+
+    # A partial request describes a change to the current network: the fields
+    # it leaves out come from the active dataset, not from a freshly generated
+    # random one.
+    active = get_json(rest_api_addr + "/node/dataset/active")
+    assert pending["activeDataset"]["networkKey"] == active["networkKey"]
+    assert pending["activeDataset"]["panId"] == active["panId"]
+
+    # A pending timestamp that does not advance is rejected by the leader and
+    # reported, not silently accepted.
+    body = {
+        "activeDataset": {"activeTimestamp": {"seconds": 30}},
+        "pendingTimestamp": {"seconds": 1},
+        "delay": 3600000,
+    }
+    expect_http_error(409, lambda: put(body))
+
+    # A request without a pending timestamp gets one generated that advances,
+    # even past a pending timestamp ahead of this node's clock.
+    body = {
+        "activeDataset": {"activeTimestamp": {"seconds": 30}},
+        "pendingTimestamp": {"seconds": 1000000000000},
+        "delay": 3600000,
+    }
+    with put(body) as response:
+        assert response.status == 200
+
+    body = {"activeDataset": {"activeTimestamp": {"seconds": 30}}, "delay": 3600000}
+    with put(body) as response:
+        assert response.status == 200
+    assert get_json(url)["pendingTimestamp"]["seconds"] > 1000000000000
+
+    # A pending dataset without a delay timer would never apply.
+    body = {"activeDataset": {"activeTimestamp": {"seconds": 30}}}
+    expect_http_error(400, lambda: put(body))
+
+    print(" /node/dataset/pending PUT : OK")
+
+
 def main():
     node_test(200)
     node_rloc_test(200)
@@ -894,8 +959,12 @@ def main():
     # diagnostics_test(20)  # partly replaced with restjsonapi tests
     error_test(10)
     well_known_thread_test(20)
-    epskc_test()
+    # Pending dataset writes require an attached node. epskc_test disables
+    # Thread and the node only comes back through auto-attach, so these run
+    # before it, while the attached state is deterministic.
     node_dataset_if_none_match_test()
+    node_dataset_pending_put_test()
+    epskc_test()
 
     return 0
 


### PR DESCRIPTION
`PUT /node/dataset/pending` commits the dataset with `otDatasetSetPendingTlvs`, a plain local write. That bypasses every check the TMF MGMT_PENDING_SET handler performs when the border router is the leader, and worse when it is not attached:

- A pending timestamp that does not advance is accepted locally and then silently ignored by the mesh — the client reports success for a change that never happens (the collision #3552 lets a client opt out of; here the mandatory arbitration applies again).
- A delay timer below the allowed minimum is applied verbatim: a 1 ms delay migrates the network with effectively zero warning time, bypassing the 30 s minimum (and the default-delay floor for network key changes) that `MGMT_PENDING_SET` enforces.
- On a disabled or detached border router the dataset is applied to that node alone when the delay expires; no other device ever sees it, and in the worst case the border router migrates by itself and leaves the mesh. This is the failure mode home-assistant-libs/python-otbr-api#278 adds client-side detection for; this change removes it at the source.

**What this does**

Send the dataset to the leader with `otDatasetSendMgmtPendingSet` and report the leader's verdict to the client. When the border router is the leader itself the request goes through the same TMF handler (leader ALOC), so validation applies uniformly.

Behavior changes on `PUT /node/dataset/pending`:

- A rejected registration answers **409** instead of a phantom success; no response from the leader answers **504**. An accepted dataset (200/201) has actually been registered with the leader.
- The node must be attached, otherwise **409**. The check runs with the other request checks, so a failing `If-None-Match` precondition still answers in the order RFC 9110 section 13.2.1 prescribes (409 before 412).
- A JSON request without a `pendingTimestamp` gets one generated from the current time: the previous behavior of inheriting the timestamp from the dataset being replaced now amounts to a guaranteed rejection.
- Raw TLV requests are passed through unchanged — expert callers get exactly the leader's verdict.

**Tests**

The new test drives the full path against the test node (a leader): a 1 ms delay is raised to the leader-enforced minimum instead of migrating the node, a stale pending timestamp answers 409, and an omitted pending timestamp is generated so a subsequent write advances. Verified locally: the full `tests/rest/test_rest.py` suite passes with this change (and without it, on current main, as a baseline).

`node_dataset_if_none_match_test` moves before `epskc_test`: pending writes now require an attached node, and after `epskc_test` disables Thread the node only comes back through auto-attach, so its attach state at that point is racy rather than guaranteed.

**Notes**

- **Seeding (review follow-up):** when no pending dataset exists, the request is now applied on top of the current **active** dataset instead of an `otDatasetCreateNewNetwork()` base. Digging through the history, the random seed was never a decision taken for the pending endpoint: it came from folding POST's "create like `dataset init new`" semantics into PUT for the *active* dataset in #1682 (see the `openapi.yaml:197` thread there), and the pending endpoint shared the code path. Now that the dataset reaches the whole mesh, a partial request (e.g. only a new channel) would otherwise rotate the network to a random key and PAN ID. The pending JSON shape (active dataset + pending timestamp + delay) was defined in #1682 precisely to express that a pending dataset is a change to the current network. Consequence: with no key change, the leader requires the request's `activeTimestamp` to advance (documented in the spec; python-otbr-api's `set_channel` already does this).
- A merged pending dataset must carry a delay timer in either request format (the TLV path could previously produce one without, which the leader accepts but never applies).
- The REST API version reported by `/.well-known/thread/br-rest` is bumped to 0.6.0 so clients can feature-detect the new behavior; it also covers the If-None-Match support from #3552, which did not bump it.
- The REST worker blocks on the MGMT response (the callback fires on response or CoAP timeout; a 30 s wait is a safety net only) while the main loop keeps running.

cc @LorbusChris — this is the server-side enforcement half of what #3552 (concurrency guard) and home-assistant-libs/python-otbr-api#278 (client-side role check) address; a client on a new OTBR now gets a 409 instead of a silent local-only apply even if it skips the role check.


