### PR TITLE
[script] detect Raspberry Pi OS via `/etc/rpi-issue` (#3579)

### DIFF
--- a/script/_initrc
+++ b/script/_initrc
@@ -124,8 +124,12 @@ if [[ ! ${PLATFORM+x} ]]; then
             PLATFORM=macOS
             ;;
         *)
-            have_or_die lsb_release
-            PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+            if [[ -f /etc/rpi-issue ]]; then
+                PLATFORM=raspbian
+            else
+                have_or_die lsb_release
+                PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+            fi
             ;;
     esac
 fi


### PR DESCRIPTION
Modern 64-bit Raspberry Pi OS images are built on upstream Debian aarch64 packages and do not modify `/etc/os-release`. Consequently, `lsb_release -i` reports `Debian` rather than `Raspbian`, causing `script/_initrc` to set `PLATFORM=debian` instead of `PLATFORM=raspbian`.

When `PLATFORM=debian` is selected on Raspberry Pi OS:
- `examples/platforms/debian/default` only enables `REST_API=1`, whereas `examples/platforms/raspbian/default` enables both `WEB_GUI=1` and `REST_API=1`.
- Platform hooks under `examples/platforms/raspbian/` are skipped.

Since official 32-bit and 64-bit Raspberry Pi OS images generated by `pi-gen` always include `/etc/rpi-issue`, check for `/etc/rpi-issue` in `script/_initrc` before falling back to `lsb_release -i`.

Closes #3579