### PR TITLE
[mdns] treat mDNSResponder timeout as terminal error

### DIFF
--- a/src/mdns/mdns_mdnssd.cpp
+++ b/src/mdns/mdns_mdnssd.cpp
@@ -247,7 +247,6 @@ bool IsRetryableError(DNSServiceErrorType aError)
     case kDNSServiceErr_NoRouter:
     case kDNSServiceErr_NATTraversal:
     case kDNSServiceErr_DoubleNAT:
-    case kDNSServiceErr_Timeout:
     case kDNSServiceErr_DefunctConnection:
 #if OTBR_MDNSSD_HAVE_STALE_DATA
     case kDNSServiceErr_StaleData:
@@ -583,8 +582,6 @@ otbrError PublisherMDnsSd::DnssdServiceRegistration::Register(void)
 
     // Note: If the mDNSResponder service is in some bad state, `DNSServiceRegister` may block here for 60 seconds at
     // most.
-    // TODO: Abort on `Timeout` error, as it indicates an unresponsive mDNSResponder. This may require removing
-    // `kDNSServiceErr_Timeout` from `IsRetryableError` and adding specific handling for it.
     dnsError = DNSServiceRegister(&mServiceRef, kDNSServiceFlagsNoAutoRename, kDNSServiceInterfaceIndexAny,
                                   serviceNameCString, regType.c_str(),
                                   /* domain */ nullptr, hostNameCString, htons(mPort), mTxtData.size(), mTxtData.data(),

--- a/tests/gtest/test_mdns_mdnssd.cpp
+++ b/tests/gtest/test_mdns_mdnssd.cpp
@@ -65,3 +65,12 @@ TEST(MdnsSd, TestDNSErrorToString)
     EXPECT_NE(otbr::Mdns::DNSErrorToString(kDNSServiceErr_PollingMode), nullptr);
     EXPECT_NE(otbr::Mdns::DNSErrorToString(kDNSServiceErr_Timeout), nullptr);
 }
+
+TEST(MdnsSd, TestIsRetryableError)
+{
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_Transient));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_ServiceNotRunning));
+    EXPECT_TRUE(otbr::Mdns::IsRetryableError(kDNSServiceErr_DefunctConnection));
+    EXPECT_FALSE(otbr::Mdns::IsRetryableError(kDNSServiceErr_Timeout));
+    EXPECT_FALSE(otbr::Mdns::IsRetryableError(kDNSServiceErr_BadParam));
+}


### PR DESCRIPTION
In src/mdns/mdns_mdnssd.cpp, kDNSServiceErr_Timeout was previously classified as a retryable error in IsRetryableError(). This caused two severe issues:

1. During service, host, and key registrations, DNSServiceRegister blocks synchronously for up to 60 seconds when mDNSResponder is unresponsive before returning kDNSServiceErr_Timeout. Because Timeout was marked retryable, HandleRegisterResult scheduled a retry in 5 seconds, causing otbr-agent to hang in an indefinite 60-second blocking loop and starving other operations.

2. During service and host resolution, DNSServiceResolve passes kDNSServiceFlagsTimeout so mDNSResponder returns a Timeout error if the query cannot be answered on the network. Treating Timeout as retryable led to endless resolution retry loops instead of reporting failure back to OpenThread / discovery proxy.

This commit fixes the issue by:
- Removing kDNSServiceErr_Timeout from IsRetryableError() so that timeouts during registration or resolution are treated as terminal failures rather than retryable.
- Removing the outdated TODO comment in DnssdServiceRegistration.
- Adding unit tests in tests/gtest/test_mdns_mdnssd.cpp verifying the expected behavior of IsRetryableError().

Resolves #3242