### PR TITLE
[dbus] handle failing and uncompiled properties in GetAll (#2754)

### DIFF
--- a/src/dbus/common/dbus_message_helper.cpp
+++ b/src/dbus/common/dbus_message_helper.cpp
@@ -199,5 +199,155 @@ bool IsDBusMessageEmpty(DBusMessage &aMessage)
     return dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_INVALID;
 }
 
+otbrError DBusMessageCopy(DBusMessageIter *aDest, DBusMessageIter *aSrc)
+{
+    otbrError error   = OTBR_ERROR_NONE;
+    int       argType = dbus_message_iter_get_arg_type(aSrc);
+    char     *sig     = nullptr;
+
+    VerifyOrExit(argType != DBUS_TYPE_INVALID, error = OTBR_ERROR_DBUS);
+
+    if (dbus_type_is_basic(argType))
+    {
+        switch (argType)
+        {
+        case DBUS_TYPE_BYTE:
+        {
+            uint8_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_BOOLEAN:
+        {
+            dbus_bool_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_INT16:
+        {
+            int16_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_UINT16:
+        {
+            uint16_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_INT32:
+        {
+            int32_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_UINT32:
+        {
+            uint32_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_INT64:
+        {
+            int64_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_UINT64:
+        {
+            uint64_t val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_DOUBLE:
+        {
+            double val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_STRING:
+        case DBUS_TYPE_OBJECT_PATH:
+        case DBUS_TYPE_SIGNATURE:
+        {
+            const char *val = nullptr;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        case DBUS_TYPE_UNIX_FD:
+        {
+            int val;
+
+            dbus_message_iter_get_basic(aSrc, &val);
+            VerifyOrExit(dbus_message_iter_append_basic(aDest, argType, &val), error = OTBR_ERROR_DBUS);
+            break;
+        }
+        default:
+            ExitNow(error = OTBR_ERROR_DBUS);
+        }
+    }
+    else if (dbus_type_is_container(argType))
+    {
+        DBusMessageIter subSrc;
+        DBusMessageIter subDest;
+        const char     *containedSig = nullptr;
+
+        dbus_message_iter_recurse(aSrc, &subSrc);
+
+        if (argType == DBUS_TYPE_ARRAY)
+        {
+            sig = dbus_message_iter_get_signature(aSrc);
+            VerifyOrExit(sig != nullptr, error = OTBR_ERROR_DBUS);
+            containedSig = sig + 1;
+        }
+        else if (argType == DBUS_TYPE_VARIANT)
+        {
+            sig = dbus_message_iter_get_signature(&subSrc);
+            VerifyOrExit(sig != nullptr, error = OTBR_ERROR_DBUS);
+            containedSig = sig;
+        }
+
+        VerifyOrExit(dbus_message_iter_open_container(aDest, argType, containedSig, &subDest), error = OTBR_ERROR_DBUS);
+
+        while (dbus_message_iter_get_arg_type(&subSrc) != DBUS_TYPE_INVALID)
+        {
+            SuccessOrExit(error = DBusMessageCopy(&subDest, &subSrc));
+            dbus_message_iter_next(&subSrc);
+        }
+
+        VerifyOrExit(dbus_message_iter_close_container(aDest, &subDest), error = OTBR_ERROR_DBUS);
+    }
+    else
+    {
+        ExitNow(error = OTBR_ERROR_DBUS);
+    }
+
+exit:
+    if (sig != nullptr)
+    {
+        dbus_free(sig);
+    }
+    return error;
+}
+
 } // namespace DBus
 } // namespace otbr

--- a/src/dbus/common/dbus_message_helper.hpp
+++ b/src/dbus/common/dbus_message_helper.hpp
@@ -846,6 +846,17 @@ otbrError DBusMessageToTuple(UniqueDBusMessage const &aMessage, std::tuple<Field
 
 bool IsDBusMessageEmpty(DBusMessage &aMessage);
 
+/**
+ * This function copies a single D-Bus element from source iterator to destination iterator.
+ *
+ * @param[in,out] aDest  The destination message iterator to append to.
+ * @param[in,out] aSrc   The source message iterator to copy from.
+ *
+ * @retval OTBR_ERROR_NONE  Successfully copied the element.
+ * @retval OTBR_ERROR_DBUS  Failed to copy the element.
+ */
+otbrError DBusMessageCopy(DBusMessageIter *aDest, DBusMessageIter *aSrc);
+
 } // namespace DBus
 } // namespace otbr
 

--- a/src/dbus/server/dbus_object.cpp
+++ b/src/dbus/server/dbus_object.cpp
@@ -238,7 +238,7 @@ exit:
 void DBusObject::GetAllPropertiesMethodHandler(DBusRequest &aRequest)
 {
     UniqueDBusMessage reply{dbus_message_new_method_return(aRequest.GetMessage())};
-    DBusMessageIter   iter, subIter, dictEntryIter;
+    DBusMessageIter   iter, arrayIter;
     std::string       interfaceName;
     auto              args  = std::tie(interfaceName);
     otError           error = OT_ERROR_NONE;
@@ -248,25 +248,54 @@ void DBusObject::GetAllPropertiesMethodHandler(DBusRequest &aRequest)
     VerifyOrExit(mGetPropertyHandlers.find(interfaceName) != mGetPropertyHandlers.end(), error = OT_ERROR_NOT_FOUND);
     dbus_message_iter_init_append(reply.get(), &iter);
 
-    for (auto &p : mGetPropertyHandlers.at(interfaceName))
+    VerifyOrExit(dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY,
+                                                  "{" DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING "}",
+                                                  &arrayIter),
+                 error = OT_ERROR_FAILED);
+
+    for (const auto &p : mGetPropertyHandlers.at(interfaceName))
     {
-        VerifyOrExit(dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY,
-                                                      "{" DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING "}",
-                                                      &subIter),
-                     error = OT_ERROR_FAILED);
-        VerifyOrExit(dbus_message_iter_open_container(&subIter, DBUS_TYPE_DICT_ENTRY, nullptr, &dictEntryIter),
+        UniqueDBusMessage propMsg{dbus_message_new(DBUS_MESSAGE_TYPE_METHOD_RETURN)};
+        DBusMessageIter   propAppendIter;
+        DBusMessageIter   propReadIter;
+        DBusMessageIter   dictEntryIter;
+        otError           propError;
+
+        VerifyOrExit(propMsg != nullptr, error = OT_ERROR_NO_BUFS);
+        dbus_message_iter_init_append(propMsg.get(), &propAppendIter);
+        propError = p.second(propAppendIter);
+        if (propError != OT_ERROR_NONE)
+        {
+            otbrLogDebug("GetAllProperties: property %s failed with %s, omitting", p.first.c_str(),
+                         ConvertToDBusErrorName(propError));
+            continue;
+        }
+
+        if (!dbus_message_iter_init(propMsg.get(), &propReadIter) ||
+            dbus_message_iter_get_arg_type(&propReadIter) == DBUS_TYPE_INVALID)
+        {
+            otbrLogWarning("GetAllProperties: property %s returned empty message, omitting", p.first.c_str());
+            continue;
+        }
+
+        VerifyOrExit(dbus_message_iter_open_container(&arrayIter, DBUS_TYPE_DICT_ENTRY, nullptr, &dictEntryIter),
                      error = OT_ERROR_FAILED);
         VerifyOrExit(DBusMessageEncode(&dictEntryIter, p.first) == OTBR_ERROR_NONE, error = OT_ERROR_FAILED);
-
-        SuccessOrExit(error = p.second(dictEntryIter));
-
-        VerifyOrExit(dbus_message_iter_close_container(&subIter, &dictEntryIter), error = OT_ERROR_FAILED);
-        VerifyOrExit(dbus_message_iter_close_container(&iter, &subIter));
+        VerifyOrExit(DBusMessageCopy(&dictEntryIter, &propReadIter) == OTBR_ERROR_NONE, error = OT_ERROR_FAILED);
+        VerifyOrExit(dbus_message_iter_close_container(&arrayIter, &dictEntryIter), error = OT_ERROR_FAILED);
     }
+
+    VerifyOrExit(dbus_message_iter_close_container(&iter, &arrayIter), error = OT_ERROR_FAILED);
 
 exit:
     if (error == OT_ERROR_NONE)
     {
+        if (otbrLogGetLevel() >= OTBR_LOG_DEBUG)
+        {
+            otbrLogDebug("GetAllProperties %s reply:", interfaceName.c_str());
+            DumpDBusMessage(*reply);
+        }
+
         dbus_connection_send(aRequest.GetConnection(), reply.get(), nullptr);
     }
     else

--- a/src/dbus/server/dbus_thread_object_rcp.cpp
+++ b/src/dbus/server/dbus_thread_object_rcp.cpp
@@ -182,14 +182,18 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::SetLinkModeHandler, this, _1));
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_ACTIVE_DATASET_TLVS,
                                std::bind(&DBusThreadObjectRcp::SetActiveDatasetTlvsHandler, this, _1));
+#if OTBR_ENABLE_FEATURE_FLAGS
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_FEATURE_FLAG_LIST_DATA,
                                std::bind(&DBusThreadObjectRcp::SetFeatureFlagListDataHandler, this, _1));
+#endif
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_RADIO_REGION,
                                std::bind(&DBusThreadObjectRcp::SetRadioRegionHandler, this, _1));
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DNS_UPSTREAM_QUERY_STATE,
                                std::bind(&DBusThreadObjectRcp::SetDnsUpstreamQueryState, this, _1));
+#if OTBR_ENABLE_NAT64
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NAT64_CIDR,
                                std::bind(&DBusThreadObjectRcp::SetNat64Cidr, this, _1));
+#endif
 #if OTBR_ENABLE_EPSKC
     RegisterSetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_EPHEMERAL_KEY_ENABLED,
                                std::bind(&DBusThreadObjectRcp::SetEphemeralKeyEnabled, this, _1));
@@ -262,16 +266,22 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::GetActiveDatasetTlvsHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_PENDING_DATASET_TLVS,
                                std::bind(&DBusThreadObjectRcp::GetPendingDatasetTlvsHandler, this, _1));
+#if OTBR_ENABLE_FEATURE_FLAGS
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_FEATURE_FLAG_LIST_DATA,
                                std::bind(&DBusThreadObjectRcp::GetFeatureFlagListDataHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_RADIO_REGION,
                                std::bind(&DBusThreadObjectRcp::GetRadioRegionHandler, this, _1));
+#if OTBR_ENABLE_SRP_SERVER
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_SRP_SERVER_INFO,
                                std::bind(&DBusThreadObjectRcp::GetSrpServerInfoHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_MDNS_TELEMETRY_INFO,
                                std::bind(&DBusThreadObjectRcp::GetMdnsTelemetryInfoHandler, this, _1));
+#if OTBR_ENABLE_DNSSD_DISCOVERY_PROXY
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DNSSD_COUNTERS,
                                std::bind(&DBusThreadObjectRcp::GetDnssdCountersHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_OTBR_VERSION,
                                std::bind(&DBusThreadObjectRcp::GetOtbrVersionHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_OT_HOST_VERSION,
@@ -288,8 +298,11 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::GetUptimeHandler, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_RADIO_COEX_METRICS,
                                std::bind(&DBusThreadObjectRcp::GetRadioCoexMetrics, this, _1));
+#if OTBR_ENABLE_BORDER_ROUTING_COUNTERS
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_BORDER_ROUTING_COUNTERS,
                                std::bind(&DBusThreadObjectRcp::GetBorderRoutingCountersHandler, this, _1));
+#endif
+#if OTBR_ENABLE_NAT64
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NAT64_STATE,
                                std::bind(&DBusThreadObjectRcp::GetNat64State, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NAT64_MAPPINGS,
@@ -300,20 +313,29 @@ otbrError DBusThreadObjectRcp::Init(void)
                                std::bind(&DBusThreadObjectRcp::GetNat64ErrorCounters, this, _1));
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_NAT64_CIDR,
                                std::bind(&DBusThreadObjectRcp::GetNat64Cidr, this, _1));
+#endif
 #if OTBR_ENABLE_EPSKC
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_EPHEMERAL_KEY_ENABLED,
                                std::bind(&DBusThreadObjectRcp::GetEphemeralKeyEnabled, this, _1));
 #endif
+#if OTBR_ENABLE_BORDER_ROUTING
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_INFRA_LINK_INFO,
                                std::bind(&DBusThreadObjectRcp::GetInfraLinkInfo, this, _1));
+#endif
+#if OTBR_ENABLE_TREL
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_TREL_INFO,
                                std::bind(&DBusThreadObjectRcp::GetTrelInfoHandler, this, _1));
+#endif
+#if OTBR_ENABLE_MULTI_AIL
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_MULTI_AIL_DETECTED,
                                std::bind(&DBusThreadObjectRcp::GetMultiAilDetectedHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_DNS_UPSTREAM_QUERY_STATE,
                                std::bind(&DBusThreadObjectRcp::GetDnsUpstreamQueryState, this, _1));
+#if OTBR_ENABLE_TELEMETRY_DATA_API
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_TELEMETRY_DATA,
                                std::bind(&DBusThreadObjectRcp::GetTelemetryDataHandler, this, _1));
+#endif
     RegisterGetPropertyHandler(OTBR_DBUS_THREAD_INTERFACE, OTBR_DBUS_PROPERTY_CAPABILITIES,
                                std::bind(&DBusThreadObjectRcp::GetCapabilitiesHandler, this, _1));
 

--- a/tests/dbus/test-server
+++ b/tests/dbus/test-server
@@ -54,6 +54,7 @@ main()
     dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj io.openthread.Ping uint32:1 string:"Ping" | grep 'PingPong"'
     dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj org.freedesktop.DBus.Properties.Set string:io.openthread string:Count variant:int32:3
     dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj org.freedesktop.DBus.Properties.GetAll string:io.openthread | grep 'int32 3'
+    dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj org.freedesktop.DBus.Properties.GetAll string:io.openthread | grep 'string "Test"'
     dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj org.freedesktop.DBus.Properties.Get string:io.openthread string:Count | grep 'int32 3'
     dbus-send --system --dest=io.openthread.TestServer --type=method_call --print-reply /io/openthread/testobj io.openthread.Ping | grep '"hello"'
     wait

--- a/tests/dbus/test_dbus_server.cpp
+++ b/tests/dbus/test_dbus_server.cpp
@@ -47,6 +47,9 @@ public:
         RegisterMethod("io.openthread", "Ping", std::bind(&TestObject::PingHandler, this, _1));
         RegisterGetPropertyHandler("io.openthread", "Count", std::bind(&TestObject::CountGetHandler, this, _1));
         RegisterSetPropertyHandler("io.openthread", "Count", std::bind(&TestObject::CountSetHandler, this, _1));
+        RegisterGetPropertyHandler("io.openthread", "Unimplemented",
+                                   std::bind(&TestObject::UnimplementedGetHandler, this, _1));
+        RegisterGetPropertyHandler("io.openthread", "Name", std::bind(&TestObject::NameGetHandler, this, _1));
     }
 
     bool IsEnded(void) const { return mEnded; }
@@ -55,6 +58,20 @@ private:
     otError CountGetHandler(DBusMessageIter &aIter)
     {
         DBusMessageEncodeToVariant(&aIter, mCount);
+        return OT_ERROR_NONE;
+    }
+
+    otError UnimplementedGetHandler(DBusMessageIter &aIter)
+    {
+        OTBR_UNUSED_VARIABLE(aIter);
+        return OT_ERROR_NOT_IMPLEMENTED;
+    }
+
+    otError NameGetHandler(DBusMessageIter &aIter)
+    {
+        std::string name = "Test";
+
+        DBusMessageEncodeToVariant(&aIter, name);
         return OT_ERROR_NONE;
     }
 


### PR DESCRIPTION
When invoking org.freedesktop.DBus.Properties.GetAll, if any registered property getter failed (e.g., returning OT_ERROR_NOT_IMPLEMENTED when a feature is not compiled or supported), DBusObject terminated GetAll immediately with an error. In addition, the D-Bus array container was previously opened and closed inside the property iteration loop rather than once around the loop, which produced malformed D-Bus responses when multiple properties were present.

According to the D-Bus specification for
org.freedesktop.DBus.Properties.GetAll: "If one or more of the properties cannot be accessed, they may simply be omitted from the result."

This commit resolves these issues:
1. Implements DBusMessageCopy in dbus_message_helper to copy D-Bus elements across message iterators recursively.
2. Updates DBusObject::GetAllPropertiesMethodHandler to:
   - Open a single a{sv} array container around the property loop.
   - Evaluate each property getter in an isolated temporary message.
   - Omit any property whose getter returns an error.
   - Copy successful property variants into the result dictionary using DBusMessageCopy.
3. Adds #if compile-time feature guards in DBusThreadObjectRcp::Init around property registrations for features that can be disabled at compile time.
4. Updates DBus server tests to verify that GetAll correctly handles multiple properties and omits unimplemented properties.

Resolves #2754, #2414