### PR TITLE
[host] stub MulticastRoutingManager on non-Linux so a Backbone Router build links

### DIFF
--- a/src/host/posix/multicast_routing_manager.cpp
+++ b/src/host/posix/multicast_routing_manager.cpp
@@ -661,4 +661,62 @@ bool MulticastRoutingManager::MatchesMeshLocalPrefix(const Ip6Address        &aA
 } // namespace otbr
 
 #endif // OTBR_ENABLE_BACKBONE_ROUTER
+#else  // __linux__
+#if OTBR_ENABLE_BACKBONE_ROUTER
+
+// Kernel multicast routing (MRT6) is Linux-only. Elsewhere the class exists so
+// that a Backbone Router build links, but it forwards nothing: the Backbone
+// Router will not relay multicast between the Thread network and the backbone
+// link on this platform.
+
+namespace otbr {
+
+MulticastRoutingManager::MulticastRoutingManager(const Netif                   &aNetif,
+                                                 const InfraIf                 &aInfraIf,
+                                                 const Host::NetworkProperties &aNetworkProperties)
+    : mNetif(aNetif)
+    , mInfraIf(aInfraIf)
+    , mNetworkProperties(aNetworkProperties)
+    , mLastExpireTime(otbr::Timepoint::min())
+    , mMulticastRouterSock(-1)
+    , mState(kStateDisabled)
+    , mRetryIntervalUs(kMinRetryIntervalUs)
+    , mNextRetryTime(otbr::Timepoint::min())
+{
+    OTBR_UNUSED_VARIABLE(mMulticastForwardingCacheTable);
+    OTBR_UNUSED_VARIABLE(mMulticastListeners);
+
+    otbrLogWarning(
+        "Multicast routing is not available on this platform; the Backbone Router will not forward multicast");
+}
+
+void MulticastRoutingManager::HandleStateChange(otBackboneRouterState aState)
+{
+    OTBR_UNUSED_VARIABLE(aState);
+}
+
+void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                                   const Ip6Address                      &aAddress)
+{
+    OTBR_UNUSED_VARIABLE(aEvent);
+    OTBR_UNUSED_VARIABLE(aAddress);
+}
+
+void MulticastRoutingManager::FinalizeMulticastRouterSock(void)
+{
+}
+
+void MulticastRoutingManager::Update(MainloopContext &aContext)
+{
+    OTBR_UNUSED_VARIABLE(aContext);
+}
+
+void MulticastRoutingManager::Process(const MainloopContext &aContext)
+{
+    OTBR_UNUSED_VARIABLE(aContext);
+}
+
+} // namespace otbr
+
+#endif // OTBR_ENABLE_BACKBONE_ROUTER
 #endif // __linux__


### PR DESCRIPTION
The NCP-mode `MulticastRoutingManager` (`src/host/posix/multicast_routing_manager.cpp`) is implemented on the Linux MRT6 socket and compiles to nothing elsewhere, so `OTBR_BACKBONE_ROUTER=ON` fails to link on macOS with three undefined symbols. This gives it a non-Linux body: the constructor logs a warning that multicast routing is not available on the platform, the other methods are no-ops. No change on Linux.

Enabling piece for #3590 (userspace Backbone Router multicast forwarding on macOS); the forwarder itself is in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
