### PR TITLE
[host] implement the Backbone Router hooks in RCP mode

### DIFF
--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -265,6 +265,20 @@ void RcpHost::Init(void)
         VerifyOrExit(result == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
     }
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    // State set through the hooks before this (re)initialization must reach
+    // the new instance: a reset re-creates it with the Backbone Router
+    // disabled and no callback.
+    if (mBackboneRouterEnabled)
+    {
+        otBackboneRouterSetEnabled(mInstance, true);
+    }
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        RegisterBackboneRouterMulticastListenerCallback();
+    }
+#endif
+
 #if OTBR_ENABLE_FEATURE_FLAGS && OTBR_ENABLE_TREL
     // Enable/Disable trel according to feature flag default value.
     otTrelSetEnabled(mInstance, featureFlagList.enable_trel());
@@ -378,6 +392,13 @@ void RcpHost::HandleStateChanged(otChangedFlags aFlags)
 
     mThreadHelper->StateChangedCallback(aFlags);
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    if ((aFlags & OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE) && mBackboneRouterStateChangedCallback)
+    {
+        mBackboneRouterStateChangedCallback(otBackboneRouterGetState(mInstance));
+    }
+#endif
+
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {
         otDeviceRole role = GetDeviceRole();
@@ -455,20 +476,66 @@ void RcpHost::AddThreadRoleChangedCallback(ThreadRoleChangedCallback aCallback)
 #if OTBR_ENABLE_BACKBONE_ROUTER
 void RcpHost::SetBackboneRouterEnabled(bool aEnabled)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aEnabled);
+    mBackboneRouterEnabled = aEnabled;
+
+    VerifyOrExit(mInstance != nullptr);
+    otBackboneRouterSetEnabled(mInstance, aEnabled);
+
+exit:
+    return;
 }
 
 void RcpHost::SetBackboneRouterMulticastListenerCallback(BackboneRouterMulticastListenerCallback aCallback)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aCallback);
+    // The OpenThread instance has one slot for this callback. Where the posix
+    // platform does the multicast routing itself (Linux, MRT6) it registers
+    // its own handler there; a host-side consumer must only be installed on
+    // platforms where it does not.
+    mBackboneRouterMulticastListenerCallback = std::move(aCallback);
+
+    VerifyOrExit(mInstance != nullptr);
+    RegisterBackboneRouterMulticastListenerCallback();
+
+exit:
+    return;
 }
 
 void RcpHost::SetBackboneRouterStateChangedCallback(BackboneRouterStateChangedCallback aCallback)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aCallback);
+    mBackboneRouterStateChangedCallback = std::move(aCallback);
+}
+
+void RcpHost::RegisterBackboneRouterMulticastListenerCallback(void)
+{
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        otBackboneRouterSetMulticastListenerCallback(mInstance, &RcpHost::HandleBackboneRouterMulticastListenerEvent,
+                                                     this);
+    }
+    else
+    {
+        otBackboneRouterSetMulticastListenerCallback(mInstance, nullptr, nullptr);
+    }
+}
+
+void RcpHost::HandleBackboneRouterMulticastListenerEvent(void                                  *aContext,
+                                                         otBackboneRouterMulticastListenerEvent aEvent,
+                                                         const otIp6Address                    *aAddress)
+{
+    VerifyOrExit(aAddress != nullptr);
+    static_cast<RcpHost *>(aContext)->HandleBackboneRouterMulticastListenerEvent(aEvent, *aAddress);
+
+exit:
+    return;
+}
+
+void RcpHost::HandleBackboneRouterMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                         const otIp6Address                    &aAddress)
+{
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        mBackboneRouterMulticastListenerCallback(aEvent, Ip6Address(aAddress));
+    }
 }
 #endif
 

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -290,6 +290,19 @@ private:
     std::vector<std::function<void(void)>> mResetHandlers;
     TaskRunner                             mTaskRunner;
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    void        RegisterBackboneRouterMulticastListenerCallback(void);
+    static void HandleBackboneRouterMulticastListenerEvent(void                                  *aContext,
+                                                           otBackboneRouterMulticastListenerEvent aEvent,
+                                                           const otIp6Address                    *aAddress);
+    void        HandleBackboneRouterMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                           const otIp6Address                    &aAddress);
+
+    BackboneRouterMulticastListenerCallback mBackboneRouterMulticastListenerCallback;
+    BackboneRouterStateChangedCallback      mBackboneRouterStateChangedCallback;
+    bool                                    mBackboneRouterEnabled = false;
+#endif
+
     std::vector<ThreadStateChangedCallback>       mThreadStateChangedCallbacks;
     std::vector<ThreadEnabledStateCallback>       mThreadEnabledStateChangedCallbacks;
     std::vector<ThreadRoleChangedCallback>        mThreadRoleChangedCallbacks;


### PR DESCRIPTION
`RcpHost::SetBackboneRouterEnabled`, `SetBackboneRouterMulticastListenerCallback` and `SetBackboneRouterStateChangedCallback` are `TODO` stubs in RCP mode (NCP mode has them over spinel). This implements them on the in-process instance:

- `SetBackboneRouterEnabled` → `otBackboneRouterSetEnabled`.
- The multicast listener callback registers with `otBackboneRouterSetMulticastListenerCallback` (with a static trampoline converting `otIp6Address` to `Ip6Address`), and is re-registered in `Init()` so it survives a reset that re-creates the instance.
- The state callback fires from `HandleStateChanged` on `OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE` with `otBackboneRouterGetState`.

One caveat is documented in the code: the instance has a single slot for the listener callback, and on Linux the posix platform's own multicast routing registers its handler there, so a host-side consumer is only for platforms where the platform does not (the macOS userspace forwarder in the follow-up PR). Nothing calls these hooks in RCP mode on Linux, so behaviour there is unchanged.

Enabling piece for #3590 (userspace Backbone Router multicast forwarding on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
