### PR TITLE
[host] add a userspace Backbone Router multicast forwarder for macOS

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -59,6 +59,20 @@ if (OTBR_BACKBONE_ROUTER)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BACKBONE_ROUTER=1)
 endif()
 
+# Forwards multicast between the Thread network and the backbone in userspace
+# (BPF taps) where the kernel has no multicast routing. Replaces the OpenThread
+# posix platform's MRT6-based multicast routing, which is Linux-only.
+option(OTBR_USERSPACE_MCAST_FWD "Enable the userspace Backbone Router multicast forwarder (macOS)" OFF)
+if (OTBR_USERSPACE_MCAST_FWD)
+    if (NOT APPLE)
+        message(FATAL_ERROR "OTBR_USERSPACE_MCAST_FWD is only supported on macOS")
+    endif()
+    if (NOT OTBR_BACKBONE_ROUTER)
+        message(FATAL_ERROR "OTBR_USERSPACE_MCAST_FWD requires OTBR_BACKBONE_ROUTER")
+    endif()
+    target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_USERSPACE_MCAST_FWD=1)
+endif()
+
 option(OTBR_BORDER_ROUTING "Enable Border Routing Manager" ON)
 if (OTBR_BORDER_ROUTING)
     target_compile_definitions(otbr-config INTERFACE OTBR_ENABLE_BORDER_ROUTING=1)

--- a/src/agent/application.cpp
+++ b/src/agent/application.cpp
@@ -448,6 +448,21 @@ void Application::InitRcpMode(const std::string &aRestListenAddress, int aRestLi
 #if OTBR_ENABLE_BACKBONE_ROUTER
     mBackboneAgent->Init();
 #endif
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    // Created here rather than in CreateRcpMode(): the Thread interface name
+    // is only known once mHost.Init() has created the interface.
+    mMcastForwarder = MakeUnique<McastForwarder>(otSysGetThreadNetifName(), mBackboneInterfaceName);
+    mHost.SetBackboneRouterMulticastListenerCallback(
+        [this](otBackboneRouterMulticastListenerEvent aEvent, const Ip6Address &aAddress) {
+            mMcastForwarder->HandleBackboneMulticastListenerEvent(aEvent, aAddress);
+        });
+    mHost.SetBackboneRouterStateChangedCallback(
+        [this](otBackboneRouterState aState) { mMcastForwarder->HandleBackboneRouterStateChange(aState); });
+    mMcastForwarder->HandleBackboneRouterStateChange(otBackboneRouterGetState(rcpHost.GetInstance()));
+#if OTBR_ENABLE_REST_SERVER
+    mRestWebServer->SetMcastForwarder(mMcastForwarder.get());
+#endif
+#endif
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     mAdvertisingProxy->SetEnabled(true);
 #endif
@@ -526,6 +541,16 @@ exit:
 
 void Application::DeinitRcpMode(void)
 {
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    // The host callbacks and the REST resource refer to the forwarder; drop
+    // them before it goes.
+    mHost.SetBackboneRouterMulticastListenerCallback(nullptr);
+    mHost.SetBackboneRouterStateChangedCallback(nullptr);
+#if OTBR_ENABLE_REST_SERVER
+    mRestWebServer->SetMcastForwarder(nullptr);
+#endif
+    mMcastForwarder.reset();
+#endif
 #if OTBR_ENABLE_NFTABLES || OTBR_ENABLE_PF
     // Tear down the OTBR firewall while its backend is still usable (the
     // backend outlives mFirewall by member declaration order).

--- a/src/agent/application.hpp
+++ b/src/agent/application.hpp
@@ -80,6 +80,9 @@
 #if OTBR_ENABLE_TREL_DNSSD
 #include "trel_dnssd/trel_dnssd.hpp"
 #endif
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+#include "host/posix/mcast_forwarder.hpp"
+#endif
 #include "host/posix/multicast_routing_manager.hpp"
 #include "host/posix/netif.hpp"
 #include "utils/infra_link_selector.hpp"
@@ -313,6 +316,9 @@ private:
 #if OTBR_ENABLE_BACKBONE_ROUTER
     std::unique_ptr<BackboneRouter::BackboneAgent> mBackboneAgent;
     std::unique_ptr<MulticastRoutingManager>       mMulticastRoutingManager;
+#endif
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    std::unique_ptr<McastForwarder> mMcastForwarder;
 #endif
 #if OTBR_ENABLE_SRP_ADVERTISING_PROXY
     std::unique_ptr<AdvertisingProxy> mAdvertisingProxy;

--- a/src/host/posix/CMakeLists.txt
+++ b/src/host/posix/CMakeLists.txt
@@ -45,6 +45,17 @@ add_library(otbr-posix
     udp_proxy.hpp
 )
 
+if(OTBR_USERSPACE_MCAST_FWD)
+    target_sources(otbr-posix PRIVATE
+        bpf_tap.hpp
+        bpf_tap.cpp
+        mcast_forwarder.hpp
+        mcast_forwarder.cpp
+        mcast_policy.hpp
+        mcast_policy.cpp
+    )
+endif()
+
 target_link_libraries(otbr-posix
     otbr-common
     otbr-utils

--- a/src/host/posix/bpf_tap.cpp
+++ b/src/host/posix/bpf_tap.cpp
@@ -1,0 +1,204 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "BPF"
+
+#include "host/posix/bpf_tap.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <net/bpf.h>
+#include <net/if.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "common/logging.hpp"
+
+namespace otbr {
+
+BpfTap::BpfTap(void)
+    : mFd(-1)
+    , mDlt(0)
+    , mBufLen(0)
+{
+}
+
+BpfTap::~BpfTap(void)
+{
+    Close();
+}
+
+otbrError BpfTap::Open(const std::string &aIfName, bool aSeeSent)
+{
+    otbrError    error = OTBR_ERROR_NONE;
+    int          savedErrno;
+    struct ifreq ifr;
+    unsigned int value;
+
+    VerifyOrExit(!IsOpen(), error = OTBR_ERROR_INVALID_STATE);
+
+    // The BPF device does not clone on every platform: take the first free unit.
+    for (int unit = 0; unit < kMaxUnits && mFd < 0; unit++)
+    {
+        std::string path = "/dev/bpf" + std::to_string(unit);
+
+        mFd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+        if (mFd < 0 && errno != EBUSY)
+        {
+            break;
+        }
+    }
+    VerifyOrExit(mFd >= 0, error = OTBR_ERROR_ERRNO);
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, aIfName.c_str(), sizeof(ifr.ifr_name) - 1);
+    VerifyOrExit(ioctl(mFd, BIOCSETIF, &ifr) == 0, error = OTBR_ERROR_ERRNO);
+
+    // Deliver frames as they arrive rather than when the buffer fills.
+    value = 1;
+    VerifyOrExit(ioctl(mFd, BIOCIMMEDIATE, &value) == 0, error = OTBR_ERROR_ERRNO);
+
+    // Frames written to the tap carry their own link-layer header.
+    value = 1;
+    VerifyOrExit(ioctl(mFd, BIOCSHDRCMPLT, &value) == 0, error = OTBR_ERROR_ERRNO);
+
+    value = aSeeSent ? 1 : 0;
+    VerifyOrExit(ioctl(mFd, BIOCSSEESENT, &value) == 0, error = OTBR_ERROR_ERRNO);
+
+    VerifyOrExit(ioctl(mFd, BIOCGDLT, &mDlt) == 0, error = OTBR_ERROR_ERRNO);
+    VerifyOrExit(mDlt == DLT_NULL || mDlt == DLT_EN10MB, error = OTBR_ERROR_NOT_IMPLEMENTED);
+
+    VerifyOrExit(ioctl(mFd, BIOCGBLEN, &mBufLen) == 0, error = OTBR_ERROR_ERRNO);
+    mBuffer.resize(mBufLen);
+
+    otbrLogInfo("Attached to %s (dlt %u, see sent %d)", aIfName.c_str(), mDlt, aSeeSent);
+
+exit:
+    if (error != OTBR_ERROR_NONE && error != OTBR_ERROR_INVALID_STATE)
+    {
+        savedErrno = errno;
+        otbrLogWarning("Failed to attach to %s: %s", aIfName.c_str(),
+                       error == OTBR_ERROR_ERRNO ? strerror(savedErrno) : "unsupported link type");
+        Close();
+        errno = savedErrno;
+    }
+    return error;
+}
+
+void BpfTap::Close(void)
+{
+    if (mFd >= 0)
+    {
+        close(mFd);
+        mFd = -1;
+    }
+    mDlt    = 0;
+    mBufLen = 0;
+    mBuffer.clear();
+}
+
+size_t BpfTap::GetLinkHeaderLength(void) const
+{
+    size_t length;
+
+    switch (mDlt)
+    {
+    case DLT_NULL:
+        length = 4;
+        break;
+    case DLT_EN10MB:
+        length = 14;
+        break;
+    default:
+        length = 0;
+        break;
+    }
+
+    return length;
+}
+
+otbrError BpfTap::SetFilter(const struct bpf_insn *aInsns, size_t aCount)
+{
+    otbrError          error = OTBR_ERROR_NONE;
+    struct bpf_program program;
+
+    VerifyOrExit(IsOpen(), error = OTBR_ERROR_INVALID_STATE);
+
+    program.bf_len   = static_cast<u_int>(aCount);
+    program.bf_insns = const_cast<struct bpf_insn *>(aInsns);
+    VerifyOrExit(ioctl(mFd, BIOCSETF, &program) == 0, error = OTBR_ERROR_ERRNO);
+
+exit:
+    return error;
+}
+
+otbrError BpfTap::Read(const FrameHandler &aHandler)
+{
+    otbrError error = OTBR_ERROR_NONE;
+    ssize_t   count;
+    size_t    offset = 0;
+
+    VerifyOrExit(IsOpen(), error = OTBR_ERROR_INVALID_STATE);
+
+    count = read(mFd, mBuffer.data(), mBuffer.size());
+    if (count < 0)
+    {
+        VerifyOrExit(errno == EAGAIN || errno == EINTR, error = OTBR_ERROR_ERRNO);
+        ExitNow();
+    }
+
+    while (offset + sizeof(struct bpf_hdr) <= static_cast<size_t>(count))
+    {
+        struct bpf_hdr header;
+        size_t         frameOffset;
+
+        memcpy(&header, mBuffer.data() + offset, sizeof(header));
+        frameOffset = offset + header.bh_hdrlen;
+        VerifyOrExit(frameOffset + header.bh_caplen <= static_cast<size_t>(count), error = OTBR_ERROR_PARSE);
+
+        aHandler(mBuffer.data() + frameOffset, header.bh_caplen);
+        offset += BPF_WORDALIGN(header.bh_hdrlen + header.bh_caplen);
+    }
+
+exit:
+    return error;
+}
+
+otbrError BpfTap::Write(const uint8_t *aFrame, size_t aLength)
+{
+    otbrError error = OTBR_ERROR_NONE;
+
+    VerifyOrExit(IsOpen(), error = OTBR_ERROR_INVALID_STATE);
+    VerifyOrExit(write(mFd, aFrame, aLength) == static_cast<ssize_t>(aLength), error = OTBR_ERROR_ERRNO);
+
+exit:
+    return error;
+}
+
+} // namespace otbr

--- a/src/host/posix/bpf_tap.hpp
+++ b/src/host/posix/bpf_tap.hpp
@@ -1,0 +1,136 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a packet tap on a network interface
+ *   through the BSD Packet Filter.
+ */
+
+#ifndef OTBR_HOST_POSIX_BPF_TAP_HPP_
+#define OTBR_HOST_POSIX_BPF_TAP_HPP_
+
+#include "openthread-br/config.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "common/code_utils.hpp"
+#include "common/types.hpp"
+
+struct bpf_insn;
+
+namespace otbr {
+
+/**
+ * A packet tap on one network interface through the BSD Packet Filter.
+ *
+ * The tap delivers the frames the kernel receives on the interface, and
+ * optionally the ones it transmits, and can inject frames into the
+ * interface's transmit path. For a utun interface the transmit path is the
+ * userspace client that owns the tunnel, so writing to the tap hands the
+ * frame to that client.
+ */
+class BpfTap : private NonCopyable
+{
+public:
+    /**
+     * Receives one captured frame, link-layer header included.
+     *
+     * @param[in] aFrame   The frame.
+     * @param[in] aLength  The captured length of the frame.
+     */
+    using FrameHandler = std::function<void(const uint8_t *aFrame, size_t aLength)>;
+
+    BpfTap(void);
+    ~BpfTap(void);
+
+    /**
+     * Attaches the tap to an interface.
+     *
+     * @param[in] aIfName   The interface name.
+     * @param[in] aSeeSent  Whether frames transmitted by this host are delivered too.
+     *
+     * @retval OTBR_ERROR_NONE             The tap is attached.
+     * @retval OTBR_ERROR_INVALID_STATE    The tap is already attached.
+     * @retval OTBR_ERROR_NOT_IMPLEMENTED  The interface's link type is not supported.
+     * @retval OTBR_ERROR_ERRNO            A BPF device could not be opened or configured.
+     */
+    otbrError Open(const std::string &aIfName, bool aSeeSent);
+
+    /**
+     * Detaches the tap.
+     */
+    void Close(void);
+
+    bool     IsOpen(void) const { return mFd >= 0; }
+    int      GetFd(void) const { return mFd; }
+    uint32_t GetDataLinkType(void) const { return mDlt; }
+
+    /**
+     * Returns the length of the link-layer header the interface's frames carry.
+     */
+    size_t GetLinkHeaderLength(void) const;
+
+    /**
+     * Installs a packet filter program.
+     *
+     * @param[in] aInsns  The program.
+     * @param[in] aCount  The number of instructions.
+     */
+    otbrError SetFilter(const struct bpf_insn *aInsns, size_t aCount);
+
+    /**
+     * Reads every frame currently buffered and hands each to @p aHandler.
+     */
+    otbrError Read(const FrameHandler &aHandler);
+
+    /**
+     * Injects a frame into the interface's transmit path.
+     *
+     * @param[in] aFrame   The frame, link-layer header included.
+     * @param[in] aLength  The frame length.
+     */
+    otbrError Write(const uint8_t *aFrame, size_t aLength);
+
+private:
+    static constexpr int kMaxUnits = 256;
+
+    int                  mFd;
+    uint32_t             mDlt;
+    uint32_t             mBufLen;
+    std::vector<uint8_t> mBuffer;
+};
+
+} // namespace otbr
+
+#endif // OTBR_HOST_POSIX_BPF_TAP_HPP_

--- a/src/host/posix/mcast_forwarder.cpp
+++ b/src/host/posix/mcast_forwarder.cpp
@@ -1,0 +1,789 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define OTBR_LOG_TAG "MCAST"
+
+#include "host/posix/mcast_forwarder.hpp"
+
+#include <errno.h>
+#include <ifaddrs.h>
+#include <net/bpf.h>
+#include <net/if_dl.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "common/logging.hpp"
+
+namespace otbr {
+
+namespace {
+
+// ICMPv6 types (RFC 2710, RFC 3810)
+constexpr uint8_t kMldv1Report = 131;
+constexpr uint8_t kMldv1Done   = 132;
+constexpr uint8_t kMldv2Report = 143;
+
+// MLDv2 multicast address record types (RFC 3810 §5.2.12)
+constexpr uint8_t kModeIsInclude   = 1;
+constexpr uint8_t kModeIsExclude   = 2;
+constexpr uint8_t kChangeToInclude = 3;
+constexpr uint8_t kChangeToExclude = 4;
+constexpr uint8_t kAllowNewSources = 5;
+constexpr uint8_t kBlockOldSources = 6;
+
+constexpr size_t kIp6HeaderSize       = 40;
+constexpr size_t kIp6ExtHeaderUnit    = 8;
+constexpr size_t kMldv1Size           = 24; // ICMPv6 header (8) + multicast address (16)
+constexpr size_t kMldv2HeaderSize     = 8;  // ICMPv6 header (4) + reserved (2) + number of records (2)
+constexpr size_t kMldv2RecordHeadSize = 20; // type (1) + aux data len (1) + number of sources (2) + address (16)
+constexpr size_t kIp6AddressSize      = 16;
+constexpr size_t kMldv2AuxDataUnit    = 4;
+constexpr size_t kTunnelHeaderSize    = 4; // BSD tunnel interfaces prefix packets with the address family
+
+// Rate limits for forwarded multicast. Thread group traffic (Matter
+// groupcast) is a few packets per second at most; these leave headroom
+// while keeping a storm from either side well below what a mesh can absorb.
+// Into the mesh is tighter: every injected packet is flooded (MPL) to every
+// router.
+constexpr McastRateLimiter::Config kThreadToBackboneLimits = {
+    /* mPerGroupRatePerSecond */ 20,
+    /* mPerGroupBurst */ 40,
+    /* mTotalRatePerSecond */ 100,
+    /* mTotalBurst */ 200,
+    /* mMaxGroups */ 32,
+};
+
+constexpr McastRateLimiter::Config kBackboneToThreadLimits = {
+    /* mPerGroupRatePerSecond */ 10,
+    /* mPerGroupBurst */ 20,
+    /* mTotalRatePerSecond */ 30,
+    /* mTotalBurst */ 60,
+    /* mMaxGroups */ 32,
+};
+
+uint16_t ReadUint16(const uint8_t *aBuffer)
+{
+    return static_cast<uint16_t>((aBuffer[0] << 8) | aBuffer[1]);
+}
+
+Ip6Address ReadAddress(const uint8_t *aBuffer)
+{
+    Ip6Address address;
+
+    memcpy(address.m8, aBuffer, kIp6AddressSize);
+    return address;
+}
+
+// Accepts IPv6 packets whose transport is ICMPv6, directly or behind the
+// Hop-by-Hop header MLD messages carry for the Router Alert option. The
+// ICMPv6 type is checked in userspace.
+const struct bpf_insn kIcmp6FilterNull[] = {
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4),                      // IPv6 version nibble
+    BPF_STMT(BPF_ALU | BPF_AND | BPF_K, 0xf0),                  //
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0x60, 0, 6),            // not IPv6 -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4 + 6),                  // next header
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 3, 0),  // ICMPv6 -> accept
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_HOPOPTS, 0, 3), // not Hop-by-Hop -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4 + 40),                 // Hop-by-Hop next header
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 0, 1),  //
+    BPF_STMT(BPF_RET | BPF_K, 0xffffffff),                      // accept
+    BPF_STMT(BPF_RET | BPF_K, 0),                               // drop
+};
+
+const struct bpf_insn kIcmp6FilterEthernet[] = {
+    BPF_STMT(BPF_LD | BPF_H | BPF_ABS, 12),                     // EtherType
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0x86dd, 0, 6),          // not IPv6 -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 14 + 6),                 // next header
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 3, 0),  // ICMPv6 -> accept
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_HOPOPTS, 0, 3), // not Hop-by-Hop -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 14 + 40),                // Hop-by-Hop next header
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, IPPROTO_ICMPV6, 0, 1),  //
+    BPF_STMT(BPF_RET | BPF_K, 0xffffffff),                      // accept
+    BPF_STMT(BPF_RET | BPF_K, 0),                               // drop
+};
+
+// Accept IPv6 packets to a multicast destination of admin-local scope or
+// larger, the only ones a Backbone Router carries: one program for tunnel
+// interfaces (DLT_NULL, 4-byte family header), one for Ethernet.
+const struct bpf_insn kForwardableMulticastFilterNull[] = {
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4),           // IPv6 version nibble
+    BPF_STMT(BPF_ALU | BPF_AND | BPF_K, 0xf0),       //
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0x60, 0, 6), // not IPv6 -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4 + 24),      // destination[0]
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0xff, 0, 4), // not multicast -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 4 + 25),      // destination[1]: flags | scope
+    BPF_STMT(BPF_ALU | BPF_AND | BPF_K, 0x0f),       //
+    BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, 0x04, 0, 1), // scope < admin-local -> drop
+    BPF_STMT(BPF_RET | BPF_K, 0xffffffff),           // accept
+    BPF_STMT(BPF_RET | BPF_K, 0),                    // drop
+};
+
+const struct bpf_insn kForwardableMulticastFilterEthernet[] = {
+    BPF_STMT(BPF_LD | BPF_H | BPF_ABS, 12),            // EtherType
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0x86dd, 0, 6), // not IPv6 -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 14 + 24),       // destination[0]
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0xff, 0, 4),   // not multicast -> drop
+    BPF_STMT(BPF_LD | BPF_B | BPF_ABS, 14 + 25),       // destination[1]: flags | scope
+    BPF_STMT(BPF_ALU | BPF_AND | BPF_K, 0x0f),         //
+    BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, 0x04, 0, 1),   // scope < admin-local -> drop
+    BPF_STMT(BPF_RET | BPF_K, 0xffffffff),             // accept
+    BPF_STMT(BPF_RET | BPF_K, 0),                      // drop
+};
+
+template <size_t N> otbrError SetFilter(BpfTap &aTap, const struct bpf_insn (&aInsns)[N])
+{
+    return aTap.SetFilter(aInsns, N);
+}
+
+} // namespace
+
+// Odr-used (chrono takes them by reference); C++11 needs the definitions.
+constexpr uint32_t McastForwarder::kBackboneListenerTimeoutSec;
+constexpr uint32_t McastForwarder::kExpireIntervalSec;
+constexpr uint32_t McastForwarder::kReportIntervalSec;
+constexpr uint32_t McastForwarder::kDedupWindowMs;
+constexpr size_t   McastForwarder::kDedupEntries;
+constexpr size_t   McastForwarder::kMaxFrameSize;
+
+McastForwarder::McastForwarder(const std::string &aThreadIfName, const std::string &aBackboneIfName)
+    : mThreadIfName(aThreadIfName)
+    , mBackboneIfName(aBackboneIfName)
+    , mEnabled(false)
+    , mHasBackboneMac(false)
+    , mDedup(kDedupWindowMs, kDedupEntries)
+    , mThreadToBackboneLimiter(kThreadToBackboneLimits)
+    , mBackboneToThreadLimiter(kBackboneToThreadLimits)
+    , mNextExpire(Clock::now())
+    , mNextReport(Clock::now())
+{
+    memset(mBackboneMac, 0, sizeof(mBackboneMac));
+}
+
+McastForwarder::~McastForwarder(void)
+{
+    Disable();
+}
+
+void McastForwarder::HandleBackboneRouterStateChange(otBackboneRouterState aState)
+{
+    otbrLogInfo("Backbone Router state: %d", aState);
+
+    if (aState == OT_BACKBONE_ROUTER_STATE_PRIMARY)
+    {
+        Enable();
+    }
+    else
+    {
+        Disable();
+    }
+}
+
+void McastForwarder::HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                          const Ip6Address                      &aAddress)
+{
+    switch (aEvent)
+    {
+    case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED:
+        mThreadListeners.insert(aAddress);
+        otbrLogInfo("Thread listener added: %s (%zu groups)", aAddress.ToString().c_str(), mThreadListeners.size());
+        break;
+    case OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED:
+        mThreadListeners.erase(aAddress);
+        otbrLogInfo("Thread listener removed: %s (%zu groups)", aAddress.ToString().c_str(), mThreadListeners.size());
+        break;
+    }
+}
+
+void McastForwarder::Enable(void)
+{
+    VerifyOrExit(!mEnabled);
+    mEnabled = true;
+    otbrLogNotice("Enabled: thread %s, backbone %s", mThreadIfName.c_str(),
+                  mBackboneIfName.empty() ? "(none)" : mBackboneIfName.c_str());
+
+    if (mBackboneIfName.empty())
+    {
+        otbrLogWarning("No backbone interface; nothing is forwarded and backbone listeners are unknown");
+    }
+    else if (!ReadBackboneMac())
+    {
+        otbrLogWarning("No link address on %s; nothing is forwarded", mBackboneIfName.c_str());
+    }
+    else
+    {
+        OpenBackboneMldTap();
+        OpenBackboneDataTap();
+        OpenThreadTap();
+    }
+
+exit:
+    return;
+}
+
+void McastForwarder::OpenBackboneMldTap(void)
+{
+    otbrError error;
+
+    // The host itself may be a listener, so its own MLD reports count too.
+    error = mBackboneMldTap.Open(mBackboneIfName, /* aSeeSent */ true);
+    VerifyOrExit(error == OTBR_ERROR_NONE, otbrLogWarning("Cannot attach to %s for MLD", mBackboneIfName.c_str()));
+
+    error = mBackboneMldTap.GetDataLinkType() == DLT_NULL ? SetFilter(mBackboneMldTap, kIcmp6FilterNull)
+                                                          : SetFilter(mBackboneMldTap, kIcmp6FilterEthernet);
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Cannot install the MLD filter on %s: %s", mBackboneIfName.c_str(), strerror(errno));
+        mBackboneMldTap.Close();
+    }
+
+exit:
+    return;
+}
+
+void McastForwarder::OpenBackboneDataTap(void)
+{
+    otbrError error;
+
+    // Frames this host sends are included so applications on the Backbone
+    // Router itself can reach the mesh. That also shows the forwarder its
+    // own emissions; those are in the duplicate cache from when they were
+    // forwarded, and the Thread stack refuses on-mesh sources anyway.
+    error = mBackboneDataTap.Open(mBackboneIfName, /* aSeeSent */ true);
+    VerifyOrExit(error == OTBR_ERROR_NONE,
+                 otbrLogWarning("Cannot attach to %s; nothing is forwarded from it", mBackboneIfName.c_str()));
+
+    error = mBackboneDataTap.GetDataLinkType() == DLT_NULL
+                ? SetFilter(mBackboneDataTap, kForwardableMulticastFilterNull)
+                : SetFilter(mBackboneDataTap, kForwardableMulticastFilterEthernet);
+    if (error != OTBR_ERROR_NONE)
+    {
+        otbrLogWarning("Cannot install the multicast filter on %s: %s", mBackboneIfName.c_str(), strerror(errno));
+        mBackboneDataTap.Close();
+    }
+
+exit:
+    return;
+}
+
+void McastForwarder::OpenThreadTap(void)
+{
+    otbrError error;
+
+    // Inbound only: the packets the Thread stack hands to the host, which
+    // is everything it received from the mesh (it runs the interface in
+    // multicast-promiscuous mode), never what the host sent it. The same tap
+    // is written to for injecting packets into the mesh.
+    error = mThreadTap.Open(mThreadIfName, /* aSeeSent */ false);
+    VerifyOrExit(error == OTBR_ERROR_NONE,
+                 otbrLogWarning("Cannot attach to %s; nothing is forwarded to or from it", mThreadIfName.c_str()));
+    VerifyOrExit(mThreadTap.GetDataLinkType() == DLT_NULL,
+                 otbrLogWarning("%s is not a tunnel interface (dlt %u); nothing is forwarded to or from it",
+                                mThreadIfName.c_str(), mThreadTap.GetDataLinkType()));
+
+    error = SetFilter(mThreadTap, kForwardableMulticastFilterNull);
+    VerifyOrExit(error == OTBR_ERROR_NONE, otbrLogWarning("Cannot install the multicast filter on %s: %s",
+                                                          mThreadIfName.c_str(), strerror(errno)));
+    ExitNow();
+
+exit:
+    if (error != OTBR_ERROR_NONE)
+    {
+        mThreadTap.Close();
+    }
+}
+
+void McastForwarder::Disable(void)
+{
+    VerifyOrExit(mEnabled);
+    mEnabled = false;
+    mThreadTap.Close();
+    mBackboneDataTap.Close();
+    mBackboneMldTap.Close();
+    mBackboneListeners.clear();
+    ReportCounters(/* aForce */ true);
+    otbrLogNotice("Disabled");
+
+exit:
+    return;
+}
+
+bool McastForwarder::ReadBackboneMac(void)
+{
+    struct ifaddrs *addresses = nullptr;
+
+    mHasBackboneMac = false;
+    VerifyOrExit(getifaddrs(&addresses) == 0);
+
+    for (struct ifaddrs *ifa = addresses; ifa != nullptr; ifa = ifa->ifa_next)
+    {
+        const struct sockaddr_dl *link;
+
+        if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_LINK || mBackboneIfName != ifa->ifa_name)
+        {
+            continue;
+        }
+        link = reinterpret_cast<const struct sockaddr_dl *>(ifa->ifa_addr);
+        if (link->sdl_alen == McastForwardPolicy::kMacSize)
+        {
+            memcpy(mBackboneMac, LLADDR(link), McastForwardPolicy::kMacSize);
+            mHasBackboneMac = true;
+            break;
+        }
+    }
+    freeifaddrs(addresses);
+
+exit:
+    return mHasBackboneMac;
+}
+
+bool McastForwarder::IsTrackedGroup(const Ip6Address &aGroup)
+{
+    return aGroup.IsMulticast() && aGroup.GetScope() > Ip6Address::kLinkLocalScope;
+}
+
+bool McastForwarder::ParseMld(const uint8_t *aPacket, size_t aLength, std::vector<MldRecord> &aRecords)
+{
+    bool           isMld  = false;
+    size_t         offset = kIp6HeaderSize;
+    uint8_t        nextHeader;
+    const uint8_t *icmp;
+    size_t         icmpLength;
+
+    aRecords.clear();
+
+    VerifyOrExit(aLength >= kIp6HeaderSize && (aPacket[0] >> 4) == 6);
+    nextHeader = aPacket[6];
+
+    // MLD messages carry a Hop-by-Hop header with the Router Alert option.
+    while (nextHeader == IPPROTO_HOPOPTS || nextHeader == IPPROTO_DSTOPTS || nextHeader == IPPROTO_ROUTING)
+    {
+        VerifyOrExit(offset + kIp6ExtHeaderUnit <= aLength);
+        nextHeader = aPacket[offset];
+        offset += (static_cast<size_t>(aPacket[offset + 1]) + 1) * kIp6ExtHeaderUnit;
+    }
+    VerifyOrExit(nextHeader == IPPROTO_ICMPV6 && offset + 4 <= aLength);
+
+    icmp       = aPacket + offset;
+    icmpLength = aLength - offset;
+
+    switch (icmp[0])
+    {
+    case kMldv1Report:
+    case kMldv1Done:
+        VerifyOrExit(icmpLength >= kMldv1Size);
+        aRecords.push_back({ReadAddress(icmp + 8), icmp[0] == kMldv1Report});
+        isMld = true;
+        break;
+
+    case kMldv2Report:
+    {
+        uint16_t count;
+        size_t   pos = kMldv2HeaderSize;
+
+        VerifyOrExit(icmpLength >= kMldv2HeaderSize);
+        count = ReadUint16(icmp + 6);
+
+        for (uint16_t i = 0; i < count; i++)
+        {
+            uint8_t    type;
+            uint8_t    auxLength;
+            uint16_t   sources;
+            Ip6Address group;
+
+            VerifyOrExit(pos + kMldv2RecordHeadSize <= icmpLength);
+            type      = icmp[pos];
+            auxLength = icmp[pos + 1];
+            sources   = ReadUint16(icmp + pos + 2);
+            group     = ReadAddress(icmp + pos + 4);
+
+            // Source-specific detail is folded into "any source": a record that
+            // leaves the listener interested in some source is a join, one that
+            // leaves it interested in none is a leave.
+            switch (type)
+            {
+            case kModeIsExclude:
+            case kChangeToExclude:
+                aRecords.push_back({group, true});
+                break;
+            case kModeIsInclude:
+            case kAllowNewSources:
+                if (sources > 0)
+                {
+                    aRecords.push_back({group, true});
+                }
+                break;
+            case kChangeToInclude:
+                if (sources == 0)
+                {
+                    aRecords.push_back({group, false});
+                }
+                break;
+            case kBlockOldSources:
+                // An empty BLOCK record has no meaning in RFC 3810, but it is
+                // how macOS reports the last socket leaving a group.
+                if (sources == 0)
+                {
+                    aRecords.push_back({group, false});
+                }
+                break;
+            default:
+                break;
+            }
+
+            pos += kMldv2RecordHeadSize + sources * kIp6AddressSize + auxLength * kMldv2AuxDataUnit;
+        }
+        isMld = true;
+        break;
+    }
+
+    default:
+        break;
+    }
+
+exit:
+    if (!isMld)
+    {
+        aRecords.clear();
+    }
+    return isMld;
+}
+
+void McastForwarder::HandleMldFrame(const uint8_t *aFrame, size_t aLength)
+{
+    size_t                 linkHeader = mBackboneMldTap.GetLinkHeaderLength();
+    std::vector<MldRecord> records;
+
+    VerifyOrExit(aLength > linkHeader);
+    VerifyOrExit(ParseMld(aFrame + linkHeader, aLength - linkHeader, records));
+    HandleMldRecords(records);
+
+exit:
+    return;
+}
+
+void McastForwarder::HandleMldRecords(const std::vector<MldRecord> &aRecords)
+{
+    for (const MldRecord &record : aRecords)
+    {
+        otbrLogDebug("MLD %s %s", record.mIsJoin ? "join" : "leave", record.mGroup.ToString().c_str());
+
+        // A report batches records for every group whose state changed,
+        // link-local ones included; skip those without giving up on the rest.
+        if (!IsTrackedGroup(record.mGroup))
+        {
+            continue;
+        }
+
+        if (record.mIsJoin)
+        {
+            bool isNew = mBackboneListeners.find(record.mGroup) == mBackboneListeners.end();
+
+            mBackboneListeners[record.mGroup] = Clock::now();
+            if (isNew)
+            {
+                otbrLogInfo("Backbone listener added: %s (%zu groups)", record.mGroup.ToString().c_str(),
+                            mBackboneListeners.size());
+            }
+        }
+        else if (mBackboneListeners.erase(record.mGroup) > 0)
+        {
+            otbrLogInfo("Backbone listener removed: %s (%zu groups)", record.mGroup.ToString().c_str(),
+                        mBackboneListeners.size());
+        }
+    }
+}
+
+void McastForwarder::HandleThreadFrame(const uint8_t *aFrame, size_t aLength)
+{
+    size_t linkHeader = mThreadTap.GetLinkHeaderLength();
+
+    VerifyOrExit(aLength > linkHeader);
+    HandleThreadPacket(aFrame + linkHeader, aLength - linkHeader, Clock::now());
+
+exit:
+    return;
+}
+
+void McastForwarder::HandleBackboneDataFrame(const uint8_t *aFrame, size_t aLength)
+{
+    size_t linkHeader = mBackboneDataTap.GetLinkHeaderLength();
+
+    VerifyOrExit(aLength > linkHeader);
+    HandleBackbonePacket(aFrame + linkHeader, aLength - linkHeader, Clock::now());
+
+exit:
+    return;
+}
+
+void McastForwarder::HandleThreadPacket(const uint8_t *aPacket, size_t aLength, Timepoint aNow)
+{
+    McastForwardPolicy::Verdict verdict;
+    Ip6Address                  group;
+    uint8_t                     frame[kMaxFrameSize];
+    size_t                      frameLength;
+    otbrError                   error;
+
+    mThreadToBackbone.mReceived++;
+
+    verdict = McastForwardPolicy::Check(aPacket, aLength);
+    if (verdict != McastForwardPolicy::kForward)
+    {
+        mThreadToBackbone.mRejected++;
+        otbrLogDebug("thread->backbone: %s: %s", McastForwardPolicy::VerdictToString(verdict),
+                     McastForwardPolicy::GetDestination(aPacket).ToString().c_str());
+        ExitNow();
+    }
+
+    if (mDedup.Check(McastDedupCache::Fingerprint(aPacket, aLength), aNow))
+    {
+        mThreadToBackbone.mDuplicates++;
+        ExitNow();
+    }
+
+    group = McastForwardPolicy::GetDestination(aPacket);
+    if (!mThreadToBackboneLimiter.Allow(group, aNow))
+    {
+        mThreadToBackbone.mRateLimited++;
+        ExitNow();
+    }
+
+    // Build the frame with the hop limit already decremented.
+    frameLength = McastForwardPolicy::BuildEthernetFrame(aPacket, aLength, mBackboneMac, frame, sizeof(frame));
+    VerifyOrExit(frameLength > 0, mThreadToBackbone.mRejected++);
+    McastForwardPolicy::DecrementHopLimit(frame + McastForwardPolicy::kEthernetHeaderSize);
+
+    error = mBackboneDataTap.Write(frame, frameLength);
+    if (error != OTBR_ERROR_NONE)
+    {
+        mThreadToBackbone.mErrors++;
+        otbrLogDebug("thread->backbone: write to %s failed: %s", mBackboneIfName.c_str(),
+                     error == OTBR_ERROR_INVALID_STATE ? "not attached" : strerror(errno));
+        ExitNow();
+    }
+
+    mThreadToBackbone.mForwarded++;
+    otbrLogDebug("thread->backbone: forwarded %s -> %s (%zu bytes)",
+                 McastForwardPolicy::GetSource(aPacket).ToString().c_str(), group.ToString().c_str(), aLength);
+
+exit:
+    return;
+}
+
+void McastForwarder::HandleBackbonePacket(const uint8_t *aPacket, size_t aLength, Timepoint aNow)
+{
+    McastForwardPolicy::Verdict verdict;
+    Ip6Address                  group;
+    uint8_t                     frame[kMaxFrameSize];
+    uint32_t                    family = AF_INET6;
+    otbrError                   error;
+
+    mBackboneToThread.mReceived++;
+
+    verdict = McastForwardPolicy::Check(aPacket, aLength);
+    if (verdict != McastForwardPolicy::kForward)
+    {
+        mBackboneToThread.mRejected++;
+        otbrLogDebug("backbone->thread: %s: %s", McastForwardPolicy::VerdictToString(verdict),
+                     McastForwardPolicy::GetDestination(aPacket).ToString().c_str());
+        ExitNow();
+    }
+
+    // Into the mesh only for groups a Thread device registered for (MLR),
+    // as the Linux path's inbound forwarding cache does: an injected packet
+    // is flooded to every router, so unrequested groups stay out.
+    group = McastForwardPolicy::GetDestination(aPacket);
+    if (!HasThreadListener(group))
+    {
+        mBackboneToThread.mNoListener++;
+        ExitNow();
+    }
+
+    if (mDedup.Check(McastDedupCache::Fingerprint(aPacket, aLength), aNow))
+    {
+        mBackboneToThread.mDuplicates++;
+        ExitNow();
+    }
+
+    if (!mBackboneToThreadLimiter.Allow(group, aNow))
+    {
+        mBackboneToThread.mRateLimited++;
+        ExitNow();
+    }
+
+    VerifyOrExit(kTunnelHeaderSize + aLength <= sizeof(frame), mBackboneToThread.mRejected++);
+
+    // A BPF write to a tunnel interface skips the framer and lands in the
+    // driver's output path, which converts the family header to the byte
+    // order the tunnel's client expects; so it goes in host order here.
+    memcpy(frame, &family, kTunnelHeaderSize);
+    memcpy(frame + kTunnelHeaderSize, aPacket, aLength);
+    McastForwardPolicy::DecrementHopLimit(frame + kTunnelHeaderSize);
+
+    error = mThreadTap.Write(frame, kTunnelHeaderSize + aLength);
+    if (error != OTBR_ERROR_NONE)
+    {
+        mBackboneToThread.mErrors++;
+        otbrLogDebug("backbone->thread: write to %s failed: %s", mThreadIfName.c_str(),
+                     error == OTBR_ERROR_INVALID_STATE ? "not attached" : strerror(errno));
+        ExitNow();
+    }
+
+    mBackboneToThread.mForwarded++;
+    otbrLogDebug("backbone->thread: forwarded %s -> %s (%zu bytes)",
+                 McastForwardPolicy::GetSource(aPacket).ToString().c_str(), group.ToString().c_str(), aLength);
+
+exit:
+    return;
+}
+
+void McastForwarder::ExpireBackboneListeners(void)
+{
+    Timepoint now = Clock::now();
+
+    for (auto it = mBackboneListeners.begin(); it != mBackboneListeners.end();)
+    {
+        if (now - it->second > Seconds(kBackboneListenerTimeoutSec))
+        {
+            otbrLogInfo("Backbone listener expired: %s", it->first.ToString().c_str());
+            it = mBackboneListeners.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+// Periodic reports are skipped while nothing changes; the report on disable
+// is always written so a shutdown leaves the final numbers in the log.
+void McastForwarder::ReportCounters(bool aForce)
+{
+    ReportCounters("thread->backbone", mThreadToBackbone, mReportedThreadToBackbone, aForce);
+    ReportCounters("backbone->thread", mBackboneToThread, mReportedBackboneToThread, aForce);
+}
+
+void McastForwarder::ReportCounters(const char *aDirection, const Counters &aCounters, Counters &aReported, bool aForce)
+{
+    VerifyOrExit(aForce || memcmp(&aCounters, &aReported, sizeof(Counters)) != 0);
+    otbrLogInfo(
+        "%s: received %llu forwarded %llu rejected %llu no-listener %llu duplicates %llu rate-limited %llu "
+        "errors %llu",
+        aDirection, static_cast<unsigned long long>(aCounters.mReceived),
+        static_cast<unsigned long long>(aCounters.mForwarded), static_cast<unsigned long long>(aCounters.mRejected),
+        static_cast<unsigned long long>(aCounters.mNoListener), static_cast<unsigned long long>(aCounters.mDuplicates),
+        static_cast<unsigned long long>(aCounters.mRateLimited), static_cast<unsigned long long>(aCounters.mErrors));
+    aReported = aCounters;
+
+exit:
+    return;
+}
+
+void McastForwarder::Update(MainloopContext &aMainloop)
+{
+    VerifyOrExit(mEnabled);
+
+    for (BpfTap *tap : {&mBackboneMldTap, &mBackboneDataTap, &mThreadTap})
+    {
+        if (tap->IsOpen())
+        {
+            aMainloop.AddFdToReadSet(tap->GetFd());
+        }
+    }
+
+    {
+        Timepoint      now         = Clock::now();
+        Timepoint      next        = mNextExpire < mNextReport ? mNextExpire : mNextReport;
+        uint64_t       remainingMs = now >= next ? 0 : std::chrono::duration_cast<Milliseconds>(next - now).count();
+        struct timeval timeout;
+
+        timeout.tv_sec  = static_cast<time_t>(remainingMs / 1000);
+        timeout.tv_usec = static_cast<suseconds_t>((remainingMs % 1000) * 1000);
+        if (timercmp(&timeout, &aMainloop.mTimeout, <))
+        {
+            aMainloop.mTimeout = timeout;
+        }
+    }
+
+exit:
+    return;
+}
+
+void McastForwarder::Process(const MainloopContext &aMainloop)
+{
+    VerifyOrExit(mEnabled);
+
+    if (mBackboneMldTap.IsOpen() && FD_ISSET(mBackboneMldTap.GetFd(), &aMainloop.mReadFdSet))
+    {
+        otbrError error =
+            mBackboneMldTap.Read([this](const uint8_t *aFrame, size_t aLength) { HandleMldFrame(aFrame, aLength); });
+
+        if (error != OTBR_ERROR_NONE)
+        {
+            otbrLogWarning("Reading MLD from %s failed: %s", mBackboneIfName.c_str(), strerror(errno));
+        }
+    }
+
+    if (mBackboneDataTap.IsOpen() && FD_ISSET(mBackboneDataTap.GetFd(), &aMainloop.mReadFdSet))
+    {
+        otbrError error = mBackboneDataTap.Read(
+            [this](const uint8_t *aFrame, size_t aLength) { HandleBackboneDataFrame(aFrame, aLength); });
+
+        if (error != OTBR_ERROR_NONE)
+        {
+            otbrLogWarning("Reading from %s failed: %s", mBackboneIfName.c_str(), strerror(errno));
+        }
+    }
+
+    if (mThreadTap.IsOpen() && FD_ISSET(mThreadTap.GetFd(), &aMainloop.mReadFdSet))
+    {
+        otbrError error =
+            mThreadTap.Read([this](const uint8_t *aFrame, size_t aLength) { HandleThreadFrame(aFrame, aLength); });
+
+        if (error != OTBR_ERROR_NONE)
+        {
+            otbrLogWarning("Reading from %s failed: %s", mThreadIfName.c_str(), strerror(errno));
+        }
+    }
+
+    if (Clock::now() >= mNextExpire)
+    {
+        ExpireBackboneListeners();
+        mNextExpire = Clock::now() + Seconds(kExpireIntervalSec);
+    }
+    if (Clock::now() >= mNextReport)
+    {
+        ReportCounters(/* aForce */ false);
+        mNextReport = Clock::now() + Seconds(kReportIntervalSec);
+    }
+
+exit:
+    return;
+}
+
+} // namespace otbr

--- a/src/host/posix/mcast_forwarder.hpp
+++ b/src/host/posix/mcast_forwarder.hpp
@@ -1,0 +1,229 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the userspace Backbone Router
+ *   multicast forwarder.
+ */
+
+#ifndef OTBR_HOST_POSIX_MCAST_FORWARDER_HPP_
+#define OTBR_HOST_POSIX_MCAST_FORWARDER_HPP_
+
+#include "openthread-br/config.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <openthread/backbone_router_ftd.h>
+
+#include "common/code_utils.hpp"
+#include "common/mainloop.hpp"
+#include "common/time.hpp"
+#include "common/types.hpp"
+#include "host/posix/bpf_tap.hpp"
+#include "host/posix/mcast_policy.hpp"
+
+namespace otbr {
+
+/**
+ * Userspace multicast forwarder for a Backbone Router.
+ *
+ * The OpenThread posix platform forwards multicast between the Thread
+ * network and the backbone through the kernel's multicast routing (MRT6),
+ * which only Linux offers. This class takes that role on platforms without
+ * it. It tracks the groups that have listeners on each side — the Thread
+ * side from the core's Multicast Listener Registration table, the backbone
+ * side by snooping MLD reports on the backbone interface — and moves
+ * packets between the Thread interface and the backbone through BPF taps,
+ * applying the same rules as the Linux path:
+ *
+ * - Thread -> backbone: every multicast packet the Thread stack hands to
+ *   the host with a scope beyond realm-local is forwarded, whether or not
+ *   a backbone listener is known.
+ * - Backbone -> Thread: only packets to groups with a registered Thread
+ *   listener are injected into the mesh, where they are flooded (MPL).
+ *
+ * Both directions forward each packet once (duplicate suppression), within
+ * per-group and overall rate limits, with the hop limit decremented.
+ */
+class McastForwarder : public MainloopProcessor, private NonCopyable
+{
+public:
+    /**
+     * A group membership change carried by an MLD message.
+     */
+    struct MldRecord
+    {
+        Ip6Address mGroup;
+        bool       mIsJoin;
+    };
+
+    /**
+     * Forwarding statistics for one direction.
+     */
+    struct Counters
+    {
+        uint64_t mReceived    = 0; ///< Packets taken from the tap.
+        uint64_t mForwarded   = 0; ///< Packets written to the other side.
+        uint64_t mRejected    = 0; ///< Not forwardable (policy).
+        uint64_t mNoListener  = 0; ///< No listener for the group on the other side.
+        uint64_t mDuplicates  = 0; ///< Copies of a packet already forwarded.
+        uint64_t mRateLimited = 0; ///< Dropped by the rate limiter.
+        uint64_t mErrors      = 0; ///< Write failures.
+    };
+
+    /**
+     * Constructor.
+     *
+     * @param[in] aThreadIfName    The Thread network interface name.
+     * @param[in] aBackboneIfName  The backbone interface name; may be empty.
+     */
+    McastForwarder(const std::string &aThreadIfName, const std::string &aBackboneIfName);
+
+    ~McastForwarder(void) override;
+
+    /**
+     * Handles a Backbone Router state change. Forwarding runs only while this
+     * device is the Primary Backbone Router.
+     */
+    void HandleBackboneRouterStateChange(otBackboneRouterState aState);
+
+    /**
+     * Handles a change of the core's Multicast Listener Registration table.
+     */
+    void HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                              const Ip6Address                      &aAddress);
+
+    bool IsEnabled(void) const { return mEnabled; }
+    bool HasThreadListener(const Ip6Address &aGroup) const { return mThreadListeners.count(aGroup) != 0; }
+    bool HasBackboneListener(const Ip6Address &aGroup) const { return mBackboneListeners.count(aGroup) != 0; }
+
+    const Counters &GetThreadToBackboneCounters(void) const { return mThreadToBackbone; }
+    const Counters &GetBackboneToThreadCounters(void) const { return mBackboneToThread; }
+
+    const std::string                     &GetThreadIfName(void) const { return mThreadIfName; }
+    const std::string                     &GetBackboneIfName(void) const { return mBackboneIfName; }
+    const std::set<Ip6Address>            &GetThreadListeners(void) const { return mThreadListeners; }
+    const std::map<Ip6Address, Timepoint> &GetBackboneListeners(void) const { return mBackboneListeners; }
+
+    /**
+     * Extracts the group membership changes an MLD message carries.
+     *
+     * @param[in]  aPacket   An IPv6 packet, starting at the IPv6 header.
+     * @param[in]  aLength   The packet length.
+     * @param[out] aRecords  The membership changes, in message order.
+     *
+     * @returns true if the packet is a well-formed MLD report or done message, false otherwise.
+     */
+    static bool ParseMld(const uint8_t *aPacket, size_t aLength, std::vector<MldRecord> &aRecords);
+
+    /**
+     * Applies the membership changes of one MLD message to the backbone
+     * listener table. Groups the forwarder does not track are ignored.
+     */
+    void HandleMldRecords(const std::vector<MldRecord> &aRecords);
+
+    /**
+     * Runs one IPv6 packet from the Thread side through the forwarding
+     * pipeline (policy, duplicate suppression, rate limit) and, if it
+     * passes, writes it to the backbone. Public so the pipeline can be
+     * exercised without a tap; the counters record the outcome.
+     *
+     * @param[in] aPacket  The IPv6 packet, starting at the IPv6 header.
+     * @param[in] aLength  The packet length.
+     * @param[in] aNow     The current time.
+     */
+    void HandleThreadPacket(const uint8_t *aPacket, size_t aLength, Timepoint aNow);
+
+    /**
+     * Runs one IPv6 packet from the backbone through the forwarding pipeline
+     * (policy, Thread listener check, duplicate suppression, rate limit)
+     * and, if it passes, injects it into the Thread network. Public for the
+     * same reason as HandleThreadPacket().
+     */
+    void HandleBackbonePacket(const uint8_t *aPacket, size_t aLength, Timepoint aNow);
+
+    /**
+     * Indicates whether a group is one the forwarder tracks: multicast with a
+     * scope beyond link-local, the only scopes a Backbone Router carries.
+     */
+    static bool IsTrackedGroup(const Ip6Address &aGroup);
+
+    void Update(MainloopContext &aMainloop) override;
+    void Process(const MainloopContext &aMainloop) override;
+
+private:
+    // RFC 3810 §9.4: Multicast Listener Interval = Robustness Variable (2) *
+    // Query Interval (125 s) + Query Response Interval (10 s).
+    static constexpr uint32_t kBackboneListenerTimeoutSec = 260;
+    static constexpr uint32_t kExpireIntervalSec          = 30;
+    static constexpr uint32_t kReportIntervalSec          = 60;
+    static constexpr uint32_t kDedupWindowMs              = 5000;
+    static constexpr size_t   kDedupEntries               = 512;
+    static constexpr size_t   kMaxFrameSize               = 1514;
+
+    void Enable(void);
+    void Disable(void);
+    void OpenBackboneMldTap(void);
+    void OpenBackboneDataTap(void);
+    void OpenThreadTap(void);
+    void HandleMldFrame(const uint8_t *aFrame, size_t aLength);
+    void HandleBackboneDataFrame(const uint8_t *aFrame, size_t aLength);
+    void HandleThreadFrame(const uint8_t *aFrame, size_t aLength);
+    void ExpireBackboneListeners(void);
+    void ReportCounters(bool aForce);
+    void ReportCounters(const char *aDirection, const Counters &aCounters, Counters &aReported, bool aForce);
+    bool ReadBackboneMac(void);
+
+    std::string                     mThreadIfName;
+    std::string                     mBackboneIfName;
+    bool                            mEnabled;
+    BpfTap                          mBackboneMldTap;
+    BpfTap                          mBackboneDataTap;
+    BpfTap                          mThreadTap;
+    uint8_t                         mBackboneMac[McastForwardPolicy::kMacSize];
+    bool                            mHasBackboneMac;
+    std::set<Ip6Address>            mThreadListeners;
+    std::map<Ip6Address, Timepoint> mBackboneListeners;
+    McastDedupCache                 mDedup;
+    McastRateLimiter                mThreadToBackboneLimiter;
+    McastRateLimiter                mBackboneToThreadLimiter;
+    Counters                        mThreadToBackbone;
+    Counters                        mBackboneToThread;
+    Counters                        mReportedThreadToBackbone;
+    Counters                        mReportedBackboneToThread;
+    Timepoint                       mNextExpire;
+    Timepoint                       mNextReport;
+};
+
+} // namespace otbr
+
+#endif // OTBR_HOST_POSIX_MCAST_FORWARDER_HPP_

--- a/src/host/posix/mcast_policy.cpp
+++ b/src/host/posix/mcast_policy.cpp
@@ -1,0 +1,289 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "host/posix/mcast_policy.hpp"
+
+#include <string.h>
+
+#include "common/code_utils.hpp"
+
+namespace otbr {
+
+namespace {
+
+constexpr size_t  kHopLimitOffset    = 7;
+constexpr size_t  kSourceOffset      = 8;
+constexpr size_t  kDestinationOffset = 24;
+constexpr uint8_t kMinForwardedScope = Ip6Address::kAdminLocalScope;
+constexpr uint8_t kMinHopLimit       = 2;
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// McastForwardPolicy
+
+McastForwardPolicy::Verdict McastForwardPolicy::Check(const uint8_t *aPacket, size_t aLength)
+{
+    Verdict    verdict = kForward;
+    Ip6Address destination;
+    Ip6Address source;
+    uint16_t   payloadLength;
+
+    VerifyOrExit(aLength >= kIp6HeaderSize && (aPacket[0] >> 4) == 6, verdict = kNotIp6);
+    payloadLength = static_cast<uint16_t>((aPacket[4] << 8) | aPacket[5]);
+    VerifyOrExit(kIp6HeaderSize + payloadLength <= aLength, verdict = kNotIp6);
+
+    destination = GetDestination(aPacket);
+    VerifyOrExit(destination.IsMulticast(), verdict = kNotMulticast);
+    VerifyOrExit(destination.GetScope() >= kMinForwardedScope, verdict = kScopeTooSmall);
+
+    source = GetSource(aPacket);
+    VerifyOrExit(!source.IsMulticast() && !source.IsUnspecified() && !source.IsLinkLocal(), verdict = kBadSource);
+
+    VerifyOrExit(aPacket[kHopLimitOffset] >= kMinHopLimit, verdict = kHopLimitExceeded);
+
+exit:
+    return verdict;
+}
+
+void McastForwardPolicy::DecrementHopLimit(uint8_t *aPacket)
+{
+    if (aPacket[kHopLimitOffset] > 0)
+    {
+        aPacket[kHopLimitOffset]--;
+    }
+}
+
+size_t McastForwardPolicy::BuildEthernetFrame(const uint8_t *aPacket,
+                                              size_t         aLength,
+                                              const uint8_t *aSourceMac,
+                                              uint8_t       *aFrame,
+                                              size_t         aFrameCapacity)
+{
+    size_t length = 0;
+
+    VerifyOrExit(aLength >= kIp6HeaderSize && kEthernetHeaderSize + aLength <= aFrameCapacity);
+
+    // RFC 2464 §7: the multicast MAC is 33:33 followed by the group's low 32 bits.
+    aFrame[0] = 0x33;
+    aFrame[1] = 0x33;
+    memcpy(aFrame + 2, aPacket + kDestinationOffset + 12, 4);
+    memcpy(aFrame + kMacSize, aSourceMac, kMacSize);
+    aFrame[12] = 0x86;
+    aFrame[13] = 0xdd;
+    memcpy(aFrame + kEthernetHeaderSize, aPacket, aLength);
+    length = kEthernetHeaderSize + aLength;
+
+exit:
+    return length;
+}
+
+Ip6Address McastForwardPolicy::GetDestination(const uint8_t *aPacket)
+{
+    Ip6Address address;
+
+    memcpy(address.m8, aPacket + kDestinationOffset, sizeof(address.m8));
+    return address;
+}
+
+Ip6Address McastForwardPolicy::GetSource(const uint8_t *aPacket)
+{
+    Ip6Address address;
+
+    memcpy(address.m8, aPacket + kSourceOffset, sizeof(address.m8));
+    return address;
+}
+
+const char *McastForwardPolicy::VerdictToString(Verdict aVerdict)
+{
+    const char *str = "unknown";
+
+    switch (aVerdict)
+    {
+    case kForward:
+        str = "forward";
+        break;
+    case kNotIp6:
+        str = "not IPv6";
+        break;
+    case kNotMulticast:
+        str = "not multicast";
+        break;
+    case kScopeTooSmall:
+        str = "scope too small";
+        break;
+    case kBadSource:
+        str = "bad source";
+        break;
+    case kHopLimitExceeded:
+        str = "hop limit exceeded";
+        break;
+    }
+
+    return str;
+}
+
+// ---------------------------------------------------------------------------
+// McastDedupCache
+
+McastDedupCache::McastDedupCache(uint32_t aWindowMs, size_t aMaxEntries)
+    : mWindowMs(aWindowMs)
+    , mMaxEntries(aMaxEntries)
+{
+}
+
+uint64_t McastDedupCache::Fingerprint(const uint8_t *aPacket, size_t aLength)
+{
+    // FNV-1a, 64-bit.
+    uint64_t hash = 0xcbf29ce484222325ULL;
+
+    for (size_t i = 0; i < aLength; i++)
+    {
+        uint8_t byte = (i == kHopLimitOffset) ? 0 : aPacket[i];
+
+        hash ^= byte;
+        hash *= 0x100000001b3ULL;
+    }
+
+    return hash;
+}
+
+bool McastDedupCache::Check(uint64_t aFingerprint, Timepoint aNow)
+{
+    bool isDuplicate = false;
+    auto it          = mSeen.find(aFingerprint);
+
+    if (it != mSeen.end())
+    {
+        isDuplicate = aNow - it->second->second <= Milliseconds(mWindowMs);
+        // Seen again: it becomes the most recent entry.
+        it->second->second = aNow;
+        mOrder.splice(mOrder.end(), mOrder, it->second);
+        ExitNow();
+    }
+
+    // The list is ordered by last sighting, so expired entries are at the
+    // front; drop them, and if the cache is still full, the least recent one.
+    while (!mOrder.empty() && aNow - mOrder.front().second > Milliseconds(mWindowMs))
+    {
+        mSeen.erase(mOrder.front().first);
+        mOrder.pop_front();
+    }
+    if (mOrder.size() >= mMaxEntries)
+    {
+        mSeen.erase(mOrder.front().first);
+        mOrder.pop_front();
+    }
+    mOrder.emplace_back(aFingerprint, aNow);
+    mSeen.emplace(aFingerprint, std::prev(mOrder.end()));
+
+exit:
+    return isDuplicate;
+}
+
+// ---------------------------------------------------------------------------
+// TokenBucket
+
+TokenBucket::TokenBucket(uint32_t aRatePerSecond, uint32_t aBurst)
+    : mRatePerSecond(aRatePerSecond)
+    , mBurst(aBurst)
+    , mTokens(aBurst)
+    , mLastRefill(Timepoint::min())
+{
+}
+
+bool TokenBucket::Take(Timepoint aNow)
+{
+    bool taken = false;
+
+    if (mLastRefill != Timepoint::min() && aNow > mLastRefill)
+    {
+        double elapsedSec = std::chrono::duration_cast<std::chrono::duration<double>>(aNow - mLastRefill).count();
+
+        mTokens += elapsedSec * mRatePerSecond;
+        if (mTokens > mBurst)
+        {
+            mTokens = mBurst;
+        }
+    }
+    mLastRefill = aNow;
+
+    if (mTokens >= 1.0)
+    {
+        mTokens -= 1.0;
+        taken = true;
+    }
+
+    return taken;
+}
+
+// ---------------------------------------------------------------------------
+// McastRateLimiter
+
+McastRateLimiter::McastRateLimiter(const Config &aConfig)
+    : mConfig(aConfig)
+    , mTotal(aConfig.mTotalRatePerSecond, aConfig.mTotalBurst)
+{
+}
+
+bool McastRateLimiter::Allow(const Ip6Address &aGroup, Timepoint aNow)
+{
+    bool allowed = false;
+    auto it      = mGroups.find(aGroup);
+
+    if (it == mGroups.end())
+    {
+        if (mGroups.size() >= mConfig.mMaxGroups)
+        {
+            auto idlest = mGroups.begin();
+
+            for (auto candidate = mGroups.begin(); candidate != mGroups.end(); ++candidate)
+            {
+                if (candidate->second.mLastUse < idlest->second.mLastUse)
+                {
+                    idlest = candidate;
+                }
+            }
+            mGroups.erase(idlest);
+        }
+        it = mGroups.emplace(aGroup, GroupState(mConfig, aNow)).first;
+    }
+
+    it->second.mLastUse = aNow;
+
+    // Take from the group first: a group over its own limit must not drain
+    // the shared budget for the others.
+    VerifyOrExit(it->second.mBucket.Take(aNow));
+    VerifyOrExit(mTotal.Take(aNow));
+    allowed = true;
+
+exit:
+    return allowed;
+}
+
+} // namespace otbr

--- a/src/host/posix/mcast_policy.hpp
+++ b/src/host/posix/mcast_policy.hpp
@@ -1,0 +1,213 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the forwarding policy pieces of the
+ *   userspace multicast forwarder: what may be forwarded, duplicate
+ *   suppression and rate limiting.
+ */
+
+#ifndef OTBR_HOST_POSIX_MCAST_POLICY_HPP_
+#define OTBR_HOST_POSIX_MCAST_POLICY_HPP_
+
+#include "openthread-br/config.h"
+
+#include <list>
+#include <map>
+#include <unordered_map>
+#include <utility>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/time.hpp"
+#include "common/types.hpp"
+
+namespace otbr {
+
+/**
+ * Decides whether an IPv6 packet is one a Backbone Router forwards between
+ * the Thread network and the backbone, and prepares it for the other side.
+ */
+class McastForwardPolicy
+{
+public:
+    static constexpr size_t kIp6HeaderSize      = 40;
+    static constexpr size_t kEthernetHeaderSize = 14;
+    static constexpr size_t kMacSize            = 6;
+
+    enum Verdict : uint8_t
+    {
+        kForward,          ///< The packet may be forwarded.
+        kNotIp6,           ///< Not a well-formed IPv6 packet.
+        kNotMulticast,     ///< Unicast destination.
+        kScopeTooSmall,    ///< Multicast scope realm-local or smaller; never crosses a Backbone Router.
+        kBadSource,        ///< Multicast, unspecified or link-local source.
+        kHopLimitExceeded, ///< Hop limit 1 or less: forwarding would expire it.
+    };
+
+    /**
+     * Checks whether an IPv6 packet may be forwarded to the other side.
+     *
+     * @param[in] aPacket  The IPv6 packet, starting at the IPv6 header.
+     * @param[in] aLength  Its length.
+     */
+    static Verdict Check(const uint8_t *aPacket, size_t aLength);
+
+    /**
+     * Decrements the hop limit, as a router forwarding the packet would.
+     */
+    static void DecrementHopLimit(uint8_t *aPacket);
+
+    /**
+     * Wraps an IPv6 multicast packet in an Ethernet frame for the backbone:
+     * the group's multicast MAC as destination, @p aSourceMac as source.
+     *
+     * @returns The frame length, or 0 if @p aFrame is too small.
+     */
+    static size_t BuildEthernetFrame(const uint8_t *aPacket,
+                                     size_t         aLength,
+                                     const uint8_t *aSourceMac,
+                                     uint8_t       *aFrame,
+                                     size_t         aFrameCapacity);
+
+    static Ip6Address GetDestination(const uint8_t *aPacket);
+    static Ip6Address GetSource(const uint8_t *aPacket);
+
+    static const char *VerdictToString(Verdict aVerdict);
+};
+
+/**
+ * Remembers recently forwarded packets so a copy that comes back — through
+ * another Backbone Router, a looped switch port, or the mesh flooding it a
+ * second time — is not forwarded again.
+ */
+class McastDedupCache
+{
+public:
+    /**
+     * @param[in] aWindowMs    How long a packet is remembered.
+     * @param[in] aMaxEntries  Upper bound on remembered packets; the oldest go first.
+     */
+    McastDedupCache(uint32_t aWindowMs, size_t aMaxEntries);
+
+    /**
+     * Fingerprints an IPv6 packet. The hop limit is left out so a copy that
+     * travelled a different path still matches.
+     */
+    static uint64_t Fingerprint(const uint8_t *aPacket, size_t aLength);
+
+    /**
+     * Records a packet and reports whether it was already known.
+     *
+     * @returns true if the packet was seen within the window, false if it is new (and is now recorded).
+     */
+    bool Check(uint64_t aFingerprint, Timepoint aNow);
+
+    size_t GetSize(void) const { return mSeen.size(); }
+
+private:
+    using Entry = std::pair<uint64_t, Timepoint>;
+    using Order = std::list<Entry>; // least recently seen first
+
+    uint32_t                                      mWindowMs;
+    size_t                                        mMaxEntries;
+    Order                                         mOrder;
+    std::unordered_map<uint64_t, Order::iterator> mSeen;
+};
+
+/**
+ * A token bucket: @p aRatePerSecond tokens arrive per second, at most
+ * @p aBurst accumulate.
+ */
+class TokenBucket
+{
+public:
+    TokenBucket(uint32_t aRatePerSecond, uint32_t aBurst);
+
+    /**
+     * Takes one token if available.
+     *
+     * @returns true if a token was taken, false if the bucket is empty.
+     */
+    bool Take(Timepoint aNow);
+
+private:
+    uint32_t  mRatePerSecond;
+    uint32_t  mBurst;
+    double    mTokens;
+    Timepoint mLastRefill;
+};
+
+/**
+ * Rate limits forwarded multicast per group and overall, so one chatty
+ * group or a storm cannot saturate either side.
+ */
+class McastRateLimiter
+{
+public:
+    struct Config
+    {
+        uint32_t mPerGroupRatePerSecond;
+        uint32_t mPerGroupBurst;
+        uint32_t mTotalRatePerSecond;
+        uint32_t mTotalBurst;
+        size_t   mMaxGroups; ///< Groups tracked at once; an idle group's bucket is dropped for a new one.
+    };
+
+    explicit McastRateLimiter(const Config &aConfig);
+
+    /**
+     * Accounts one packet for @p aGroup.
+     *
+     * @returns true if the packet is within both limits, false if it must be dropped.
+     */
+    bool Allow(const Ip6Address &aGroup, Timepoint aNow);
+
+private:
+    struct GroupState
+    {
+        GroupState(const Config &aConfig, Timepoint aNow)
+            : mBucket(aConfig.mPerGroupRatePerSecond, aConfig.mPerGroupBurst)
+            , mLastUse(aNow)
+        {
+        }
+
+        TokenBucket mBucket;
+        Timepoint   mLastUse;
+    };
+
+    Config                           mConfig;
+    TokenBucket                      mTotal;
+    std::map<Ip6Address, GroupState> mGroups;
+};
+
+} // namespace otbr
+
+#endif // OTBR_HOST_POSIX_MCAST_POLICY_HPP_

--- a/src/host/posix/multicast_routing_manager.cpp
+++ b/src/host/posix/multicast_routing_manager.cpp
@@ -661,4 +661,62 @@ bool MulticastRoutingManager::MatchesMeshLocalPrefix(const Ip6Address        &aA
 } // namespace otbr
 
 #endif // OTBR_ENABLE_BACKBONE_ROUTER
+#else  // __linux__
+#if OTBR_ENABLE_BACKBONE_ROUTER
+
+// Kernel multicast routing (MRT6) is Linux-only. Elsewhere the class exists so
+// that a Backbone Router build links, but it forwards nothing: the Backbone
+// Router will not relay multicast between the Thread network and the backbone
+// link on this platform.
+
+namespace otbr {
+
+MulticastRoutingManager::MulticastRoutingManager(const Netif                   &aNetif,
+                                                 const InfraIf                 &aInfraIf,
+                                                 const Host::NetworkProperties &aNetworkProperties)
+    : mNetif(aNetif)
+    , mInfraIf(aInfraIf)
+    , mNetworkProperties(aNetworkProperties)
+    , mLastExpireTime(otbr::Timepoint::min())
+    , mMulticastRouterSock(-1)
+    , mState(kStateDisabled)
+    , mRetryIntervalUs(kMinRetryIntervalUs)
+    , mNextRetryTime(otbr::Timepoint::min())
+{
+    OTBR_UNUSED_VARIABLE(mMulticastForwardingCacheTable);
+    OTBR_UNUSED_VARIABLE(mMulticastListeners);
+
+    otbrLogWarning(
+        "Multicast routing is not available on this platform; the Backbone Router will not forward multicast");
+}
+
+void MulticastRoutingManager::HandleStateChange(otBackboneRouterState aState)
+{
+    OTBR_UNUSED_VARIABLE(aState);
+}
+
+void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                                   const Ip6Address                      &aAddress)
+{
+    OTBR_UNUSED_VARIABLE(aEvent);
+    OTBR_UNUSED_VARIABLE(aAddress);
+}
+
+void MulticastRoutingManager::FinalizeMulticastRouterSock(void)
+{
+}
+
+void MulticastRoutingManager::Update(MainloopContext &aContext)
+{
+    OTBR_UNUSED_VARIABLE(aContext);
+}
+
+void MulticastRoutingManager::Process(const MainloopContext &aContext)
+{
+    OTBR_UNUSED_VARIABLE(aContext);
+}
+
+} // namespace otbr
+
+#endif // OTBR_ENABLE_BACKBONE_ROUTER
 #endif // __linux__

--- a/src/host/rcp_host.cpp
+++ b/src/host/rcp_host.cpp
@@ -265,6 +265,20 @@ void RcpHost::Init(void)
         VerifyOrExit(result == OT_ERROR_NONE, error = OTBR_ERROR_OPENTHREAD);
     }
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    // State set through the hooks before this (re)initialization must reach
+    // the new instance: a reset re-creates it with the Backbone Router
+    // disabled and no callback.
+    if (mBackboneRouterEnabled)
+    {
+        otBackboneRouterSetEnabled(mInstance, true);
+    }
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        RegisterBackboneRouterMulticastListenerCallback();
+    }
+#endif
+
 #if OTBR_ENABLE_FEATURE_FLAGS && OTBR_ENABLE_TREL
     // Enable/Disable trel according to feature flag default value.
     otTrelSetEnabled(mInstance, featureFlagList.enable_trel());
@@ -378,6 +392,13 @@ void RcpHost::HandleStateChanged(otChangedFlags aFlags)
 
     mThreadHelper->StateChangedCallback(aFlags);
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    if ((aFlags & OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE) && mBackboneRouterStateChangedCallback)
+    {
+        mBackboneRouterStateChangedCallback(otBackboneRouterGetState(mInstance));
+    }
+#endif
+
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {
         otDeviceRole role = GetDeviceRole();
@@ -455,20 +476,66 @@ void RcpHost::AddThreadRoleChangedCallback(ThreadRoleChangedCallback aCallback)
 #if OTBR_ENABLE_BACKBONE_ROUTER
 void RcpHost::SetBackboneRouterEnabled(bool aEnabled)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aEnabled);
+    mBackboneRouterEnabled = aEnabled;
+
+    VerifyOrExit(mInstance != nullptr);
+    otBackboneRouterSetEnabled(mInstance, aEnabled);
+
+exit:
+    return;
 }
 
 void RcpHost::SetBackboneRouterMulticastListenerCallback(BackboneRouterMulticastListenerCallback aCallback)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aCallback);
+    // The OpenThread instance has one slot for this callback. Where the posix
+    // platform does the multicast routing itself (Linux, MRT6) it registers
+    // its own handler there; a host-side consumer must only be installed on
+    // platforms where it does not.
+    mBackboneRouterMulticastListenerCallback = std::move(aCallback);
+
+    VerifyOrExit(mInstance != nullptr);
+    RegisterBackboneRouterMulticastListenerCallback();
+
+exit:
+    return;
 }
 
 void RcpHost::SetBackboneRouterStateChangedCallback(BackboneRouterStateChangedCallback aCallback)
 {
-    // TODO: Implement this in RCP mode.
-    OTBR_UNUSED_VARIABLE(aCallback);
+    mBackboneRouterStateChangedCallback = std::move(aCallback);
+}
+
+void RcpHost::RegisterBackboneRouterMulticastListenerCallback(void)
+{
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        otBackboneRouterSetMulticastListenerCallback(mInstance, &RcpHost::HandleBackboneRouterMulticastListenerEvent,
+                                                     this);
+    }
+    else
+    {
+        otBackboneRouterSetMulticastListenerCallback(mInstance, nullptr, nullptr);
+    }
+}
+
+void RcpHost::HandleBackboneRouterMulticastListenerEvent(void                                  *aContext,
+                                                         otBackboneRouterMulticastListenerEvent aEvent,
+                                                         const otIp6Address                    *aAddress)
+{
+    VerifyOrExit(aAddress != nullptr);
+    static_cast<RcpHost *>(aContext)->HandleBackboneRouterMulticastListenerEvent(aEvent, *aAddress);
+
+exit:
+    return;
+}
+
+void RcpHost::HandleBackboneRouterMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                         const otIp6Address                    &aAddress)
+{
+    if (mBackboneRouterMulticastListenerCallback)
+    {
+        mBackboneRouterMulticastListenerCallback(aEvent, Ip6Address(aAddress));
+    }
 }
 #endif
 

--- a/src/host/rcp_host.hpp
+++ b/src/host/rcp_host.hpp
@@ -290,6 +290,19 @@ private:
     std::vector<std::function<void(void)>> mResetHandlers;
     TaskRunner                             mTaskRunner;
 
+#if OTBR_ENABLE_BACKBONE_ROUTER
+    void        RegisterBackboneRouterMulticastListenerCallback(void);
+    static void HandleBackboneRouterMulticastListenerEvent(void                                  *aContext,
+                                                           otBackboneRouterMulticastListenerEvent aEvent,
+                                                           const otIp6Address                    *aAddress);
+    void        HandleBackboneRouterMulticastListenerEvent(otBackboneRouterMulticastListenerEvent aEvent,
+                                                           const otIp6Address                    &aAddress);
+
+    BackboneRouterMulticastListenerCallback mBackboneRouterMulticastListenerCallback;
+    BackboneRouterStateChangedCallback      mBackboneRouterStateChangedCallback;
+    bool                                    mBackboneRouterEnabled = false;
+#endif
+
     std::vector<ThreadStateChangedCallback>       mThreadStateChangedCallbacks;
     std::vector<ThreadEnabledStateCallback>       mThreadEnabledStateChangedCallbacks;
     std::vector<ThreadRoleChangedCallback>        mThreadRoleChangedCallbacks;

--- a/src/rest/openapi.yaml
+++ b/src/rest/openapi.yaml
@@ -1338,6 +1338,45 @@ paths:
                 type: string
                 description: 8-byte IEEE 802.15.4 Extended Address of this node as hex string.
                 example: "C21F906BE0352A4C"
+  /node/mcast-forwarder:
+    get:
+      tags:
+        - node
+      summary: Get the state of the userspace multicast forwarder.
+      description: |-
+        Present only when the border router was built with the userspace
+        Backbone Router multicast forwarder (OTBR_USERSPACE_MCAST_FWD). Reports
+        whether forwarding is active (the device is Primary Backbone Router),
+        the interfaces it bridges, the groups with listeners on each side and
+        the forwarding counters per direction.
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  threadInterface:
+                    type: string
+                  backboneInterface:
+                    type: string
+                  threadListeners:
+                    type: array
+                    items:
+                      type: string
+                  backboneListeners:
+                    type: array
+                    items:
+                      type: string
+                  threadToBackbone:
+                    $ref: '#/components/schemas/McastForwarderCounters'
+                  backboneToThread:
+                    $ref: '#/components/schemas/McastForwarderCounters'
+        '404':
+          description: The forwarder is not built in.
   /node/state:
     get:
       tags:
@@ -1801,6 +1840,31 @@ components:
   ### Schemas #################################################################
   #############################################################################
   schemas:
+    McastForwarderCounters:
+      type: object
+      description: Forwarding statistics for one direction of the userspace multicast forwarder.
+      properties:
+        received:
+          type: integer
+          description: Packets taken from the interface tap.
+        forwarded:
+          type: integer
+          description: Packets written to the other side.
+        rejected:
+          type: integer
+          description: Packets a Backbone Router must not forward (scope, source, hop limit).
+        noListener:
+          type: integer
+          description: Packets to a group without a listener on the other side.
+        duplicates:
+          type: integer
+          description: Copies of a packet already forwarded.
+        rateLimited:
+          type: integer
+          description: Packets dropped by the rate limiter.
+        errors:
+          type: integer
+          description: Write failures.
     ### Actions #################################################################
     Actions_addThreadDeviceTask:
       type: object

--- a/src/rest/rest_web_server.cpp
+++ b/src/rest/rest_web_server.cpp
@@ -63,6 +63,9 @@
 #include "rest/services.hpp"
 #include "rest/version.hpp"
 #include "utils/string_utils.hpp"
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+#include "host/posix/mcast_forwarder.hpp"
+#endif
 
 #include <cJSON.h>
 
@@ -86,6 +89,7 @@
 #define OT_REST_RESOURCE_PATH_NODE_RLOC16 "/node/rloc16"
 #define OT_REST_RESOURCE_PATH_NODE_EXTADDRESS "/node/ext-address"
 #define OT_REST_RESOURCE_PATH_NODE_STATE "/node/state"
+#define OT_REST_RESOURCE_PATH_NODE_MCAST_FORWARDER "/node/mcast-forwarder"
 #define OT_REST_RESOURCE_PATH_NODE_NETWORKNAME "/node/network-name"
 #define OT_REST_RESOURCE_PATH_NODE_LEADERDATA "/node/leader-data"
 #define OT_REST_RESOURCE_PATH_NODE_NUMOFROUTER "/node/num-of-router"
@@ -163,6 +167,11 @@ RestWebServer::RestWebServer(Host::RcpHost &aHost)
     RegisterGet(OT_REST_RESOURCE_PATH_NODE_BAID, MakeHandler(&RestWebServer::BaId));
     RegisterGet(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
     RegisterPut(OT_REST_RESOURCE_PATH_NODE_STATE, MakeHandler(&RestWebServer::State));
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    // The forwarder lives on the main loop; read it there.
+    RegisterGet(OT_REST_RESOURCE_PATH_NODE_MCAST_FORWARDER,
+                MakeHandlerInMainLoop(&RestWebServer::McastForwarderStatus));
+#endif
     RegisterGet(OT_REST_RESOURCE_PATH_NODE_EXTADDRESS, MakeHandler(&RestWebServer::ExtendedAddr));
     RegisterGet(OT_REST_RESOURCE_PATH_NODE_NETWORKNAME, MakeHandler(&RestWebServer::NetworkName));
     RegisterGet(OT_REST_RESOURCE_PATH_NODE_RLOC16, MakeHandler(&RestWebServer::Rloc16));
@@ -605,6 +614,63 @@ void RestWebServer::State(const Request &aRequest, Response &aResponse) const
         break;
     }
 }
+
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+void RestWebServer::McastForwarderStatus(const Request &aRequest, Response &aResponse)
+{
+    cJSON      *root = nullptr;
+    cJSON      *list;
+    char       *printed;
+    std::string body;
+
+    OTBR_UNUSED_VARIABLE(aRequest);
+
+    VerifyOrExit(mMcastForwarder != nullptr, ErrorHandler(aResponse, StatusCode::NotFound_404));
+
+    root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "enabled", mMcastForwarder->IsEnabled());
+    cJSON_AddStringToObject(root, "threadInterface", mMcastForwarder->GetThreadIfName().c_str());
+    cJSON_AddStringToObject(root, "backboneInterface", mMcastForwarder->GetBackboneIfName().c_str());
+
+    list = cJSON_AddArrayToObject(root, "threadListeners");
+    for (const Ip6Address &group : mMcastForwarder->GetThreadListeners())
+    {
+        cJSON_AddItemToArray(list, cJSON_CreateString(group.ToString().c_str()));
+    }
+    list = cJSON_AddArrayToObject(root, "backboneListeners");
+    for (const auto &entry : mMcastForwarder->GetBackboneListeners())
+    {
+        cJSON_AddItemToArray(list, cJSON_CreateString(entry.first.ToString().c_str()));
+    }
+
+    for (const auto &direction : {std::make_pair("threadToBackbone", &mMcastForwarder->GetThreadToBackboneCounters()),
+                                  std::make_pair("backboneToThread", &mMcastForwarder->GetBackboneToThreadCounters())})
+    {
+        const McastForwarder::Counters &c        = *direction.second;
+        cJSON                          *counters = cJSON_AddObjectToObject(root, direction.first);
+
+        cJSON_AddNumberToObject(counters, "received", static_cast<double>(c.mReceived));
+        cJSON_AddNumberToObject(counters, "forwarded", static_cast<double>(c.mForwarded));
+        cJSON_AddNumberToObject(counters, "rejected", static_cast<double>(c.mRejected));
+        cJSON_AddNumberToObject(counters, "noListener", static_cast<double>(c.mNoListener));
+        cJSON_AddNumberToObject(counters, "duplicates", static_cast<double>(c.mDuplicates));
+        cJSON_AddNumberToObject(counters, "rateLimited", static_cast<double>(c.mRateLimited));
+        cJSON_AddNumberToObject(counters, "errors", static_cast<double>(c.mErrors));
+    }
+
+    printed = cJSON_PrintUnformatted(root);
+    body    = printed;
+    free(printed);
+    aResponse.set_content(body, OT_REST_CONTENT_TYPE_JSON);
+    aResponse.status = StatusCode::OK_200;
+
+exit:
+    if (root != nullptr)
+    {
+        cJSON_Delete(root);
+    }
+}
+#endif // OTBR_ENABLE_USERSPACE_MCAST_FWD
 
 void RestWebServer::GetDataNetworkName(Response &aResponse) const
 {

--- a/src/rest/rest_web_server.hpp
+++ b/src/rest/rest_web_server.hpp
@@ -59,6 +59,11 @@
 #include "rest/types.hpp"
 
 namespace otbr {
+
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+class McastForwarder;
+#endif
+
 namespace rest {
 
 /**
@@ -83,6 +88,14 @@ public:
      * This method initializes the REST server.
      */
     void Init(const std::string &aRestListenAddress, int aRestListenPort);
+
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    /**
+     * Sets the multicast forwarder whose state GET /node/mcast-forwarder
+     * reports; nullptr (the default) makes the resource 404.
+     */
+    void SetMcastForwarder(const McastForwarder *aForwarder) { mMcastForwarder = aForwarder; }
+#endif
 
 private:
     using Request    = httplib::Request;
@@ -159,6 +172,9 @@ private:
     void BaId(const Request &aRequest, Response &aResponse) const;
     void ExtendedAddr(const Request &aRequest, Response &aResponse) const;
     void State(const Request &aRequest, Response &aResponse) const;
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    void McastForwarderStatus(const Request &aRequest, Response &aResponse);
+#endif
     void NetworkName(const Request &aRequest, Response &aResponse) const;
     void LeaderData(const Request &aRequest, Response &aResponse) const;
     void NumOfRoute(const Request &aRequest, Response &aResponse) const;
@@ -279,6 +295,9 @@ private:
     }
 
     Host::RcpHost &mHost;
+#if OTBR_ENABLE_USERSPACE_MCAST_FWD
+    const McastForwarder *mMcastForwarder = nullptr;
+#endif
 
     httplib::Server mServer;
     std::thread     mServerThread;

--- a/tests/gtest/CMakeLists.txt
+++ b/tests/gtest/CMakeLists.txt
@@ -152,6 +152,20 @@ if(OTBR_MDNS AND NOT OTBR_MDNS STREQUAL "openthread")
     gtest_discover_tests(otbr-gtest-mdns-subscribe)
 endif()
 
+if(OTBR_USERSPACE_MCAST_FWD)
+    add_executable(otbr-gtest-mcast-forwarder
+        test_mcast_forwarder.cpp
+        test_mcast_policy.cpp
+    )
+    target_link_libraries(otbr-gtest-mcast-forwarder
+        otbr-config
+        otbr-posix
+        otbr-common
+        GTest::gmock_main
+    )
+    gtest_discover_tests(otbr-gtest-mcast-forwarder)
+endif()
+
 add_executable(otbr-posix-gtest-unit
     ${OPENTHREAD_PROJECT_DIRECTORY}/tests/gtest/fake_platform.cpp
     fake_posix_platform.cpp

--- a/tests/gtest/test_mcast_forwarder.cpp
+++ b/tests/gtest/test_mcast_forwarder.cpp
@@ -1,0 +1,355 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string.h>
+#include <string>
+#include <vector>
+
+#include "host/posix/mcast_forwarder.hpp"
+
+namespace {
+
+using otbr::Ip6Address;
+using otbr::McastForwarder;
+
+// Builds an IPv6 packet from fe80::1 to aDestination carrying aPayload behind a
+// Hop-by-Hop header with the Router Alert option, the way MLD messages travel.
+std::vector<uint8_t> MakeMldPacket(const char                 *aDestination,
+                                   const std::vector<uint8_t> &aPayload,
+                                   bool                        aRouterAlert = true)
+{
+    std::vector<uint8_t> packet(40, 0);
+    uint16_t             payloadLength = static_cast<uint16_t>(aPayload.size() + (aRouterAlert ? 8 : 0));
+
+    packet[0]  = 0x60;
+    packet[4]  = static_cast<uint8_t>(payloadLength >> 8);
+    packet[5]  = static_cast<uint8_t>(payloadLength & 0xff);
+    packet[6]  = aRouterAlert ? 0 : 58; // Hop-by-Hop or ICMPv6
+    packet[7]  = 1;
+    packet[8]  = 0xfe;
+    packet[9]  = 0x80;
+    packet[23] = 1;
+    memcpy(&packet[24], Ip6Address(aDestination).m8, 16);
+
+    if (aRouterAlert)
+    {
+        // next header ICMPv6, length 0 (8 bytes), Router Alert (5,2,0) + PadN(1,0)
+        const uint8_t hopByHop[8] = {58, 0, 5, 2, 0, 0, 1, 0};
+
+        packet.insert(packet.end(), hopByHop, hopByHop + 8);
+    }
+    packet.insert(packet.end(), aPayload.begin(), aPayload.end());
+
+    return packet;
+}
+
+std::vector<uint8_t> Address(const char *aString)
+{
+    Ip6Address address(aString);
+
+    return std::vector<uint8_t>(address.m8, address.m8 + 16);
+}
+
+void Append(std::vector<uint8_t> &aTo, const std::vector<uint8_t> &aBytes)
+{
+    aTo.insert(aTo.end(), aBytes.begin(), aBytes.end());
+}
+
+// One MLDv2 multicast address record.
+std::vector<uint8_t> Record(uint8_t aType, const char *aGroup, const std::vector<const char *> &aSources = {})
+{
+    std::vector<uint8_t> record = {aType, 0, 0, static_cast<uint8_t>(aSources.size())};
+
+    Append(record, Address(aGroup));
+    for (const char *source : aSources)
+    {
+        Append(record, Address(source));
+    }
+
+    return record;
+}
+
+std::vector<uint8_t> Mldv2Report(const std::vector<std::vector<uint8_t>> &aRecords)
+{
+    std::vector<uint8_t> report = {143, 0, 0, 0, 0, 0, 0, static_cast<uint8_t>(aRecords.size())};
+
+    for (const auto &record : aRecords)
+    {
+        Append(report, record);
+    }
+
+    return report;
+}
+
+TEST(McastForwarder, ParsesMldv1ReportAndDone)
+{
+    std::vector<McastForwarder::MldRecord> records;
+    std::vector<uint8_t>                   report = {131, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<uint8_t>                   done   = {132, 0, 0, 0, 0, 0, 0, 0};
+
+    Append(report, Address("ff05::abcd"));
+    Append(done, Address("ff05::abcd"));
+
+    EXPECT_TRUE(McastForwarder::ParseMld(MakeMldPacket("ff05::abcd", report).data(),
+                                         MakeMldPacket("ff05::abcd", report).size(), records));
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].mGroup, Ip6Address("ff05::abcd"));
+    EXPECT_TRUE(records[0].mIsJoin);
+
+    std::vector<uint8_t> packet = MakeMldPacket("ff02::2", done);
+
+    EXPECT_TRUE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].mGroup, Ip6Address("ff05::abcd"));
+    EXPECT_FALSE(records[0].mIsJoin);
+}
+
+TEST(McastForwarder, ParsesMldv2ReportRecordTypes)
+{
+    std::vector<McastForwarder::MldRecord> records;
+    std::vector<uint8_t>                   packet =
+        MakeMldPacket("ff02::16", Mldv2Report({
+                                      Record(4, "ff05::1"),                  // CHANGE_TO_EXCLUDE: join
+                                      Record(2, "ff05::2"),                  // MODE_IS_EXCLUDE: join
+                                      Record(3, "ff05::3"),                  // CHANGE_TO_INCLUDE, no sources: leave
+                                      Record(1, "ff05::4", {"2001:db8::1"}), // MODE_IS_INCLUDE with a source: join
+                                      Record(1, "ff05::5"),                  // MODE_IS_INCLUDE, no sources: nothing
+                                      Record(5, "ff05::6", {"2001:db8::2"}), // ALLOW_NEW_SOURCES: join
+                                      Record(6, "ff05::7", {"2001:db8::3"}), // BLOCK_OLD_SOURCES: nothing
+                                      Record(6, "ff05::a"),                  // empty BLOCK: leave (macOS)
+                                      Record(4, "ff0e::8"),                  // global scope join
+                                  }));
+
+    EXPECT_TRUE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+    ASSERT_EQ(records.size(), 7u);
+    EXPECT_EQ(records[0].mGroup, Ip6Address("ff05::1"));
+    EXPECT_TRUE(records[0].mIsJoin);
+    EXPECT_EQ(records[1].mGroup, Ip6Address("ff05::2"));
+    EXPECT_TRUE(records[1].mIsJoin);
+    EXPECT_EQ(records[2].mGroup, Ip6Address("ff05::3"));
+    EXPECT_FALSE(records[2].mIsJoin);
+    EXPECT_EQ(records[3].mGroup, Ip6Address("ff05::4"));
+    EXPECT_TRUE(records[3].mIsJoin);
+    EXPECT_EQ(records[4].mGroup, Ip6Address("ff05::6"));
+    EXPECT_TRUE(records[4].mIsJoin);
+    EXPECT_EQ(records[5].mGroup, Ip6Address("ff05::a"));
+    EXPECT_FALSE(records[5].mIsJoin);
+    EXPECT_EQ(records[6].mGroup, Ip6Address("ff0e::8"));
+    EXPECT_TRUE(records[6].mIsJoin);
+}
+
+TEST(McastForwarder, ParsesMldWithoutRouterAlert)
+{
+    std::vector<McastForwarder::MldRecord> records;
+    std::vector<uint8_t>                   packet =
+        MakeMldPacket("ff02::16", Mldv2Report({Record(4, "ff05::9")}), /* aRouterAlert */ false);
+
+    EXPECT_TRUE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+    ASSERT_EQ(records.size(), 1u);
+    EXPECT_EQ(records[0].mGroup, Ip6Address("ff05::9"));
+}
+
+TEST(McastForwarder, RejectsNonMldAndTruncatedPackets)
+{
+    std::vector<McastForwarder::MldRecord> records;
+    std::vector<uint8_t>                   echo = {128, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<uint8_t>                   packet;
+
+    packet = MakeMldPacket("ff02::1", echo);
+    EXPECT_FALSE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+    EXPECT_TRUE(records.empty());
+
+    // A UDP packet
+    packet    = MakeMldPacket("ff05::abcd", {0, 0, 0, 0, 0, 8, 0, 0}, false);
+    packet[6] = 17;
+    EXPECT_FALSE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+
+    // An MLDv2 report announcing two records but carrying one
+    packet             = MakeMldPacket("ff02::16", Mldv2Report({Record(4, "ff05::1")}));
+    packet[40 + 8 + 7] = 2;
+    EXPECT_FALSE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+    EXPECT_TRUE(records.empty());
+
+    // Truncated MLDv1 report
+    packet = MakeMldPacket("ff05::abcd", {131, 0, 0, 0, 0, 0, 0, 0, 0xff, 0x05});
+    EXPECT_FALSE(McastForwarder::ParseMld(packet.data(), packet.size(), records));
+
+    // Too short for an IPv6 header
+    EXPECT_FALSE(McastForwarder::ParseMld(packet.data(), 20, records));
+}
+
+TEST(McastForwarder, AppliesEveryTrackedRecordOfAReport)
+{
+    McastForwarder forwarder("utun0", "");
+
+    // A state-change report batches link-local groups with the interesting ones.
+    forwarder.HandleMldRecords({{Ip6Address("ff02::1:ff00:1"), true},
+                                {Ip6Address("ff05::beef"), true},
+                                {Ip6Address("ff02::fb"), true},
+                                {Ip6Address("ff0e::1"), true}});
+    EXPECT_TRUE(forwarder.HasBackboneListener(Ip6Address("ff05::beef")));
+    EXPECT_TRUE(forwarder.HasBackboneListener(Ip6Address("ff0e::1")));
+    EXPECT_FALSE(forwarder.HasBackboneListener(Ip6Address("ff02::fb")));
+
+    forwarder.HandleMldRecords({{Ip6Address("ff02::1:ff00:1"), false}, {Ip6Address("ff05::beef"), false}});
+    EXPECT_FALSE(forwarder.HasBackboneListener(Ip6Address("ff05::beef")));
+    EXPECT_TRUE(forwarder.HasBackboneListener(Ip6Address("ff0e::1")));
+}
+
+TEST(McastForwarder, TracksOnlyMulticastBeyondLinkLocal)
+{
+    EXPECT_TRUE(McastForwarder::IsTrackedGroup(Ip6Address("ff05::abcd")));
+    EXPECT_TRUE(McastForwarder::IsTrackedGroup(Ip6Address("ff03::fc")));
+    EXPECT_TRUE(McastForwarder::IsTrackedGroup(Ip6Address("ff0e::1")));
+    EXPECT_FALSE(McastForwarder::IsTrackedGroup(Ip6Address("ff02::1")));
+    EXPECT_FALSE(McastForwarder::IsTrackedGroup(Ip6Address("ff01::1")));
+    EXPECT_FALSE(McastForwarder::IsTrackedGroup(Ip6Address("fd00::1")));
+}
+
+// A minimal IPv6/UDP packet from the mesh.
+std::vector<uint8_t> MeshPacket(const char *aSource, const char *aGroup, uint8_t aHopLimit, const char *aPayload)
+{
+    std::vector<uint8_t> packet(40, 0);
+    size_t               payloadLength = 8 + strlen(aPayload);
+
+    packet[0] = 0x60;
+    packet[4] = static_cast<uint8_t>(payloadLength >> 8);
+    packet[5] = static_cast<uint8_t>(payloadLength & 0xff);
+    packet[6] = 17;
+    packet[7] = aHopLimit;
+    memcpy(&packet[8], Ip6Address(aSource).m8, 16);
+    memcpy(&packet[24], Ip6Address(aGroup).m8, 16);
+    packet.resize(40 + payloadLength, 0);
+    memcpy(&packet[48], aPayload, strlen(aPayload));
+
+    return packet;
+}
+
+TEST(McastForwarder, ThreadPacketPipelineCountsEveryOutcome)
+{
+    McastForwarder                  forwarder("utun0", "");
+    otbr::Timepoint                 now = otbr::Clock::now();
+    std::vector<uint8_t>            packet;
+    const McastForwarder::Counters &c = forwarder.GetThreadToBackboneCounters();
+
+    // Not forwardable: link-local destination, link-local source, exhausted hop limit.
+    packet = MeshPacket("fd12::1", "ff02::1", 64, "a");
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now);
+    packet = MeshPacket("fe80::1", "ff05::1", 64, "a");
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now);
+    packet = MeshPacket("fd12::1", "ff05::1", 1, "a");
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now);
+    EXPECT_EQ(c.mReceived, 3u);
+    EXPECT_EQ(c.mRejected, 3u);
+
+    // Forwardable, but no backbone tap is attached: reaches the write and fails there.
+    packet = MeshPacket("fd12::1", "ff05::abcd", 64, "hello");
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now);
+    EXPECT_EQ(c.mErrors, 1u);
+    EXPECT_EQ(c.mForwarded, 0u);
+
+    // The same packet again (even with another hop limit) is a duplicate, not another write.
+    packet[7] = 60;
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now + otbr::Milliseconds(100));
+    EXPECT_EQ(c.mDuplicates, 1u);
+    EXPECT_EQ(c.mErrors, 1u);
+
+    // A flood of distinct packets to one group hits the per-group limit (40 burst).
+    for (int i = 0; i < 100; i++)
+    {
+        std::string payload = "flood-" + std::to_string(i);
+
+        packet = MeshPacket("fd12::1", "ff05::abcd", 64, payload.c_str());
+        forwarder.HandleThreadPacket(packet.data(), packet.size(), now + otbr::Milliseconds(200));
+    }
+    EXPECT_EQ(c.mRateLimited, 100u - 40u); // burst 40: the 200 ms since the first packet refilled the token it spent
+    EXPECT_EQ(c.mErrors, 1u + 40u);
+    EXPECT_EQ(c.mReceived, 105u);
+}
+
+TEST(McastForwarder, BackbonePacketPipelineInjectsOnlyForThreadListeners)
+{
+    McastForwarder                  forwarder("utun0", "");
+    otbr::Timepoint                 now = otbr::Clock::now();
+    std::vector<uint8_t>            packet;
+    const McastForwarder::Counters &c = forwarder.GetBackboneToThreadCounters();
+
+    // Policy first: a link-local group never enters the mesh.
+    packet = MeshPacket("fd00:1::1", "ff02::1", 64, "a");
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now);
+    EXPECT_EQ(c.mRejected, 1u);
+
+    // No Thread device registered for the group: nothing is injected.
+    packet = MeshPacket("fd00:1::1", "ff05::abcd", 64, "hello");
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now);
+    EXPECT_EQ(c.mNoListener, 1u);
+    EXPECT_EQ(c.mErrors, 0u);
+
+    // With a listener the packet reaches the write (and fails there: no tap).
+    forwarder.HandleBackboneMulticastListenerEvent(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ADDED,
+                                                   Ip6Address("ff05::abcd"));
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now);
+    EXPECT_EQ(c.mErrors, 1u);
+    EXPECT_EQ(c.mForwarded, 0u);
+
+    // The same packet again is a duplicate.
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now + otbr::Milliseconds(100));
+    EXPECT_EQ(c.mDuplicates, 1u);
+
+    // A packet the forwarder itself just emitted towards the backbone comes
+    // back through the backbone tap (see-sent): the duplicate cache catches
+    // it, so the mesh never sees its own traffic again.
+    packet = MeshPacket("fd12::1", "ff05::abcd", 64, "from-the-mesh");
+    forwarder.HandleThreadPacket(packet.data(), packet.size(), now + otbr::Milliseconds(200));
+    packet[7] = 63;
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now + otbr::Milliseconds(201));
+    EXPECT_EQ(c.mDuplicates, 2u);
+    EXPECT_EQ(c.mErrors, 1u);
+
+    // A flood of distinct packets is held to the tighter mesh-bound limit (20 burst).
+    for (int i = 0; i < 100; i++)
+    {
+        std::string payload = "flood-" + std::to_string(i);
+
+        packet = MeshPacket("fd00:1::1", "ff05::abcd", 64, payload.c_str());
+        forwarder.HandleBackbonePacket(packet.data(), packet.size(), now + otbr::Milliseconds(300));
+    }
+    EXPECT_EQ(c.mRateLimited, 100u - 20u);
+    EXPECT_EQ(c.mErrors, 1u + 20u);
+
+    // Once the listener is gone, the group is closed again.
+    forwarder.HandleBackboneMulticastListenerEvent(OT_BACKBONE_ROUTER_MULTICAST_LISTENER_REMOVED,
+                                                   Ip6Address("ff05::abcd"));
+    packet = MeshPacket("fd00:1::1", "ff05::abcd", 64, "late");
+    forwarder.HandleBackbonePacket(packet.data(), packet.size(), now + otbr::Milliseconds(400));
+    EXPECT_EQ(c.mNoListener, 2u);
+}
+
+} // namespace

--- a/tests/gtest/test_mcast_policy.cpp
+++ b/tests/gtest/test_mcast_policy.cpp
@@ -1,0 +1,226 @@
+/*
+ *    Copyright (c) 2026, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string.h>
+#include <vector>
+
+#include "host/posix/mcast_policy.hpp"
+
+namespace {
+
+using otbr::Ip6Address;
+using otbr::McastDedupCache;
+using otbr::McastForwardPolicy;
+using otbr::McastRateLimiter;
+using otbr::Milliseconds;
+using otbr::Seconds;
+using otbr::Timepoint;
+using otbr::TokenBucket;
+
+// A minimal IPv6/UDP packet: src -> dst, hop limit, payload.
+std::vector<uint8_t> MakePacket(const char *aSource, const char *aDestination, uint8_t aHopLimit, const char *aPayload)
+{
+    std::vector<uint8_t> packet(40, 0);
+    size_t               payloadLength = 8 + strlen(aPayload);
+
+    packet[0] = 0x60;
+    packet[4] = static_cast<uint8_t>(payloadLength >> 8);
+    packet[5] = static_cast<uint8_t>(payloadLength & 0xff);
+    packet[6] = 17;
+    packet[7] = aHopLimit;
+    memcpy(&packet[8], Ip6Address(aSource).m8, 16);
+    memcpy(&packet[24], Ip6Address(aDestination).m8, 16);
+
+    std::vector<uint8_t> udp = {
+        0x10, 0xe1, 0x04, 0xd2, static_cast<uint8_t>(payloadLength >> 8), static_cast<uint8_t>(payloadLength & 0xff),
+        0,    0};
+
+    packet.insert(packet.end(), udp.begin(), udp.end());
+    packet.insert(packet.end(), aPayload, aPayload + strlen(aPayload));
+
+    return packet;
+}
+
+Timepoint At(uint32_t aMs)
+{
+    return Timepoint() + Milliseconds(aMs);
+}
+
+TEST(McastForwardPolicy, ForwardsSiteAndGlobalScopeFromRoutableSources)
+{
+    std::vector<uint8_t> packet = MakePacket("fd12::1", "ff05::abcd", 64, "hi");
+
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kForward);
+
+    packet = MakePacket("2001:db8::1", "ff0e::1", 2, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kForward);
+
+    packet = MakePacket("fd12::1", "ff04::1", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kForward);
+}
+
+TEST(McastForwardPolicy, RejectsWhatABackboneRouterMustNotForward)
+{
+    std::vector<uint8_t> packet;
+
+    packet = MakePacket("fd12::1", "ff02::1", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kScopeTooSmall);
+
+    packet = MakePacket("fd12::1", "ff03::fc", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kScopeTooSmall);
+
+    packet = MakePacket("fd12::1", "fd12::2", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kNotMulticast);
+
+    packet = MakePacket("fe80::1", "ff05::abcd", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kBadSource);
+
+    packet = MakePacket("::", "ff05::abcd", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kBadSource);
+
+    packet = MakePacket("fd12::1", "ff05::abcd", 1, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kHopLimitExceeded);
+
+    packet = MakePacket("fd12::1", "ff05::abcd", 64, "hi");
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), 39), McastForwardPolicy::kNotIp6);
+    packet[0] = 0x45;
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kNotIp6);
+
+    // Payload length claims more than the packet carries
+    packet    = MakePacket("fd12::1", "ff05::abcd", 64, "hi");
+    packet[5] = 0xff;
+    EXPECT_EQ(McastForwardPolicy::Check(packet.data(), packet.size()), McastForwardPolicy::kNotIp6);
+}
+
+TEST(McastForwardPolicy, BuildsTheEthernetFrame)
+{
+    std::vector<uint8_t> packet = MakePacket("fd12::1", "ff05::1234:abcd", 64, "hi");
+    const uint8_t        mac[6] = {0x02, 0x11, 0x22, 0x33, 0x44, 0x55};
+    uint8_t              frame[1514];
+    size_t               length;
+
+    McastForwardPolicy::DecrementHopLimit(packet.data());
+    EXPECT_EQ(packet[7], 63);
+
+    length = McastForwardPolicy::BuildEthernetFrame(packet.data(), packet.size(), mac, frame, sizeof(frame));
+    ASSERT_EQ(length, 14 + packet.size());
+    const uint8_t expectedDst[6] = {0x33, 0x33, 0x12, 0x34, 0xab, 0xcd};
+    EXPECT_EQ(memcmp(frame, expectedDst, 6), 0);
+    EXPECT_EQ(memcmp(frame + 6, mac, 6), 0);
+    EXPECT_EQ(frame[12], 0x86);
+    EXPECT_EQ(frame[13], 0xdd);
+    EXPECT_EQ(memcmp(frame + 14, packet.data(), packet.size()), 0);
+
+    EXPECT_EQ(McastForwardPolicy::BuildEthernetFrame(packet.data(), packet.size(), mac, frame, 20), 0u);
+}
+
+TEST(McastDedupCache, SuppressesCopiesWithinTheWindow)
+{
+    McastDedupCache      cache(1000, 16);
+    std::vector<uint8_t> packet = MakePacket("fd12::1", "ff05::abcd", 64, "hello");
+    std::vector<uint8_t> other  = MakePacket("fd12::1", "ff05::abcd", 64, "hellp");
+    uint64_t             fp     = McastDedupCache::Fingerprint(packet.data(), packet.size());
+
+    EXPECT_FALSE(cache.Check(fp, At(0)));
+    EXPECT_TRUE(cache.Check(fp, At(500)));
+    EXPECT_NE(fp, McastDedupCache::Fingerprint(other.data(), other.size()));
+    EXPECT_FALSE(cache.Check(McastDedupCache::Fingerprint(other.data(), other.size()), At(500)));
+
+    // The same packet after the window is new again.
+    EXPECT_FALSE(cache.Check(fp, At(1600)));
+}
+
+TEST(McastDedupCache, IgnoresTheHopLimit)
+{
+    std::vector<uint8_t> a = MakePacket("fd12::1", "ff05::abcd", 64, "hello");
+    std::vector<uint8_t> b = MakePacket("fd12::1", "ff05::abcd", 63, "hello");
+
+    EXPECT_EQ(McastDedupCache::Fingerprint(a.data(), a.size()), McastDedupCache::Fingerprint(b.data(), b.size()));
+}
+
+TEST(McastDedupCache, EvictsTheOldestWhenFull)
+{
+    McastDedupCache cache(10000, 4);
+
+    for (uint64_t fp = 1; fp <= 4; fp++)
+    {
+        EXPECT_FALSE(cache.Check(fp, At(static_cast<uint32_t>(fp))));
+    }
+    EXPECT_EQ(cache.GetSize(), 4u);
+    EXPECT_FALSE(cache.Check(5, At(10)));
+    EXPECT_EQ(cache.GetSize(), 4u);
+    EXPECT_FALSE(cache.Check(1, At(11))); // the oldest was evicted, so it is new again
+    EXPECT_TRUE(cache.Check(5, At(12)));
+}
+
+TEST(TokenBucket, BurstsThenRefills)
+{
+    TokenBucket bucket(10, 3);
+
+    EXPECT_TRUE(bucket.Take(At(0)));
+    EXPECT_TRUE(bucket.Take(At(0)));
+    EXPECT_TRUE(bucket.Take(At(0)));
+    EXPECT_FALSE(bucket.Take(At(0)));
+    EXPECT_FALSE(bucket.Take(At(50))); // half a token
+    EXPECT_TRUE(bucket.Take(At(100)));
+    EXPECT_FALSE(bucket.Take(At(100)));
+    // Long idle: refills to the burst, not beyond.
+    EXPECT_TRUE(bucket.Take(At(5000)));
+    EXPECT_TRUE(bucket.Take(At(5000)));
+    EXPECT_TRUE(bucket.Take(At(5000)));
+    EXPECT_FALSE(bucket.Take(At(5000)));
+}
+
+TEST(McastRateLimiter, LimitsPerGroupAndOverall)
+{
+    McastRateLimiter::Config config;
+
+    config.mPerGroupRatePerSecond = 10;
+    config.mPerGroupBurst         = 2;
+    config.mTotalRatePerSecond    = 100;
+    config.mTotalBurst            = 3;
+    config.mMaxGroups             = 2;
+
+    McastRateLimiter limiter(config);
+    Ip6Address       a("ff05::a");
+    Ip6Address       b("ff05::b");
+    Ip6Address       c("ff05::c");
+
+    EXPECT_TRUE(limiter.Allow(a, At(0)));
+    EXPECT_TRUE(limiter.Allow(a, At(0)));
+    EXPECT_FALSE(limiter.Allow(a, At(0))); // group a exhausted; the total still has one left
+    EXPECT_TRUE(limiter.Allow(b, At(0)));
+    EXPECT_FALSE(limiter.Allow(b, At(0))); // total exhausted
+    EXPECT_TRUE(limiter.Allow(b, At(100)));
+    // A third group evicts the idlest tracked one and starts with a full bucket.
+    EXPECT_TRUE(limiter.Allow(c, At(200)));
+}
+
+} // namespace

--- a/third_party/openthread/CMakeLists.txt
+++ b/third_party/openthread/CMakeLists.txt
@@ -166,6 +166,15 @@ if (NOT OT_THREAD_VERSION STREQUAL "1.1")
     )
 endif()
 
+if (OTBR_USERSPACE_MCAST_FWD)
+    # The userspace forwarder replaces the posix platform's kernel multicast
+    # routing; the core keeps its multicast listener table, which the
+    # forwarder consumes.
+    target_compile_definitions(ot-config INTERFACE
+        "-DOPENTHREAD_POSIX_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE=0"
+    )
+endif()
+
 if (OTBR_MDNS STREQUAL "openthread")
     target_compile_definitions(ot-config INTERFACE
         "-DOPENTHREAD_CONFIG_MULTICAST_DNS_PUBLIC_API_ENABLE=1"


### PR DESCRIPTION
Implements #3590. Stacked on the two enabling PRs, #3591 (non-Linux `MulticastRoutingManager` stub) and #3592 (RCP-mode Backbone Router hooks): the first two commits here are theirs and drop out once they merge.

The OpenThread posix platform forwards multicast between the Thread network and the backbone through the kernel's multicast routing (MRT6), which only Linux offers — the last piece missing for a full-functionality border router on macOS. This adds a userspace forwarder behind a new build option, `OTBR_USERSPACE_MCAST_FWD` (default OFF, macOS only), that takes the MRT6 role in RCP mode. The Linux path is untouched; the OpenThread core is untouched (only the posix multicast-routing knob is forced off while the core keeps its multicast listener table).

**Data plane** — `BpfTap` (`src/host/posix/bpf_tap.*`) wraps the BSD Packet Filter; `McastForwarder` (`src/host/posix/mcast_forwarder.*`) runs while the device is Primary Backbone Router:

- Thread → backbone: an inbound-only tap on the Thread tunnel interface (what the stack hands to the host, i.e. everything received from the mesh) picks up multicast of admin-local scope or larger; it is written to the backbone as an Ethernet frame (RFC 2464 multicast MAC), forwarded regardless of backbone listeners as the Linux path does.
- Backbone → Thread: a tap on the backbone interface (frames this host sends included, so applications on the border router itself reach the mesh); a packet is injected — written to the tunnel with the family header in host order, which the driver's output path converts — only for a group with a registered Thread listener, as the Linux inbound forwarding cache does.
- Both directions (`src/host/posix/mcast_policy.*`): policy (IPv6 multicast of admin-local scope or larger, routable non-link-local source, hop limit above 1), duplicate cache keyed by a hop-limit-agnostic fingerprint (5 s window; it also catches the forwarder's own emissions coming back through the backbone tap), per-group and overall token buckets (20/s per group and 100/s total towards the backbone; 10/s and 30/s into the mesh, since every injected packet is MPL-flooded), hop limit decremented.

**Control plane** — Thread listeners from the core's MLR events via the RcpHost hooks; backbone listeners by snooping MLD reports (MLDv1 report/done, MLDv2 records; an empty `BLOCK_OLD_SOURCES` record is treated as a leave — that is how macOS reports the last socket leaving a group), aged out after the RFC 3810 listener interval. Per-direction counters are logged every minute and on disable, and `GET /node/mcast-forwarder` (openapi.yaml updated) reports state, interfaces, listener tables and counters; 404 when not built in.

**Tests** — `otbr-gtest-mcast-forwarder`: MLD parsing (v1, v2 record types, with/without Router Alert, truncation), policy, dedup cache, token bucket, rate limiter, and both pipelines including the flood and own-emission cases. Runs in the macOS CI `Test` step.

**Evidence** — on a Mac mini (macOS 26) with a SONOFF MG24 RCP: acceptance on the OpenThread simulation platform (mesh→LAN 10/10 once each, flood of 300 → 172 forwarded / 168 rate-limited, 10-minute soak 298/298 with zero duplicates; LAN→mesh listener gate, flood held to the limit, no loop through the backbone tap), and on real radio with a second MG24 running as an FTD on the production mesh (both directions 10/10, 5-minute soak 13/13 each way, zero duplicates, production border router and its pf firewall unaffected). Running as the production border router since 2026-09-11.

Tracking issue: #3590 (design, questions for the maintainers). Context: the macOS host support in #3469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
