### PR TITLE
[netif] verify unicast netlink ACKs and gate cache updates

### DIFF
--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -481,7 +481,12 @@ public:
     bool         mPreferred : 1;
     bool         mMeshLocal : 1;
 
-    bool operator==(const Ip6AddressInfo &aOther) const { return memcmp(this, &aOther, sizeof(Ip6AddressInfo)) == 0; }
+    bool operator==(const Ip6AddressInfo &aOther) const
+    {
+        return memcmp(&mAddress, &aOther.mAddress, sizeof(mAddress)) == 0 && mPrefixLength == aOther.mPrefixLength &&
+               mScope == aOther.mScope && mPreferred == aOther.mPreferred && mMeshLocal == aOther.mMeshLocal;
+    }
+    bool operator!=(const Ip6AddressInfo &aOther) const { return !(*this == aOther); }
 };
 
 /**

--- a/src/host/posix/netif.cpp
+++ b/src/host/posix/netif.cpp
@@ -57,6 +57,15 @@
 
 namespace otbr {
 
+namespace {
+
+bool HasSameIp6Address(const Ip6AddressInfo &aFirst, const Ip6AddressInfo &aSecond)
+{
+    return Ip6Address(aFirst.mAddress) == Ip6Address(aSecond.mAddress);
+}
+
+} // namespace
+
 otbrError Netif::Dependencies::Ip6Send(const uint8_t *aData, uint16_t aLength)
 {
     OTBR_UNUSED_VARIABLE(aData);
@@ -154,29 +163,108 @@ void Netif::Deinit(void)
 
 void Netif::UpdateIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aAddrInfos)
 {
-    // Remove stale addresses
-    for (const Ip6AddressInfo &addrInfo : mIp6UnicastAddresses)
+    mIp6UnicastAddresses = ReconcileIp6UnicastAddresses(
+        mIp6UnicastAddresses, aAddrInfos,
+        [this](const std::vector<UnicastAddressChange> &aChanges) { return ProcessUnicastAddressChanges(aChanges); });
+}
+
+std::vector<Ip6AddressInfo> Netif::ReconcileIp6UnicastAddresses(const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+                                                                const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+                                                                const UnicastAddressChangeHandler &aChangeHandler)
+{
+    std::vector<UnicastAddressChange> changes;
+    std::vector<Ip6AddressInfo>       updatedAddresses;
+    std::vector<otbrError>            errors;
+
+    changes.reserve(aCachedAddrInfos.size() + aDesiredAddrInfos.size());
+    updatedAddresses.reserve(std::max(aCachedAddrInfos.size(), aDesiredAddrInfos.size()));
+
+    for (const Ip6AddressInfo &cached : aCachedAddrInfos)
     {
-        if (std::find(aAddrInfos.begin(), aAddrInfos.end(), addrInfo) == aAddrInfos.end())
+        auto it = std::find_if(aDesiredAddrInfos.begin(), aDesiredAddrInfos.end(),
+                               [&](const Ip6AddressInfo &aDesired) { return HasSameIp6Address(cached, aDesired); });
+
+        if (it == aDesiredAddrInfos.end())
         {
-            otbrLogInfo("Remove address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            // TODO: Verify success of the addition or deletion in Netlink response.
-            ProcessUnicastAddressChange(addrInfo, false);
+            otbrLogInfo("Remove address: %s/%u", Ip6Address(cached.mAddress).ToString().c_str(), cached.mPrefixLength);
+            changes.push_back({cached, UnicastAddressAction::kRemove});
+        }
+        else if (*it != cached)
+        {
+            otbrLogInfo("Replace address: %s/%u", Ip6Address(it->mAddress).ToString().c_str(), it->mPrefixLength);
+            changes.push_back({*it, UnicastAddressAction::kReplace});
+        }
+        else
+        {
+            updatedAddresses.push_back(cached);
         }
     }
 
-    // Add new addresses
-    for (const Ip6AddressInfo &addrInfo : aAddrInfos)
+    for (const Ip6AddressInfo &desired : aDesiredAddrInfos)
     {
-        if (std::find(mIp6UnicastAddresses.begin(), mIp6UnicastAddresses.end(), addrInfo) == mIp6UnicastAddresses.end())
+        auto it = std::find_if(aCachedAddrInfos.begin(), aCachedAddrInfos.end(),
+                               [&](const Ip6AddressInfo &aCached) { return HasSameIp6Address(desired, aCached); });
+
+        if (it == aCachedAddrInfos.end())
         {
-            otbrLogInfo("Add address: %s", Ip6Address(addrInfo.mAddress).ToString().c_str());
-            // TODO: Verify success of the addition or deletion in Netlink response.
-            ProcessUnicastAddressChange(addrInfo, true);
+            otbrLogInfo("Add address: %s/%u", Ip6Address(desired.mAddress).ToString().c_str(), desired.mPrefixLength);
+            changes.push_back({desired, UnicastAddressAction::kAdd});
         }
     }
 
-    mIp6UnicastAddresses.assign(aAddrInfos.begin(), aAddrInfos.end());
+    VerifyOrExit(!changes.empty());
+
+    errors = aChangeHandler(changes);
+
+    if (errors.size() != changes.size())
+    {
+        otbrLogWarning("Netlink results count mismatch (expected %zu, got %zu)", changes.size(), errors.size());
+        errors.assign(changes.size(), OTBR_ERROR_INVALID_STATE);
+    }
+
+    for (size_t i = 0; i < changes.size(); ++i)
+    {
+        const UnicastAddressChange &change = changes[i];
+        otbrError                   error  = errors[i];
+
+        switch (change.mAction)
+        {
+        case UnicastAddressAction::kRemove:
+            if (error != OTBR_ERROR_NONE)
+            {
+                updatedAddresses.push_back(change.mAddressInfo);
+            }
+            break;
+
+        case UnicastAddressAction::kReplace:
+            if (error == OTBR_ERROR_NONE)
+            {
+                updatedAddresses.push_back(change.mAddressInfo);
+            }
+            else
+            {
+                auto it =
+                    std::find_if(aCachedAddrInfos.begin(), aCachedAddrInfos.end(), [&](const Ip6AddressInfo &aCached) {
+                        return HasSameIp6Address(change.mAddressInfo, aCached);
+                    });
+                if (it != aCachedAddrInfos.end())
+                {
+                    updatedAddresses.push_back(*it);
+                }
+            }
+            break;
+
+        case UnicastAddressAction::kAdd:
+            if (error == OTBR_ERROR_NONE)
+            {
+                updatedAddresses.push_back(change.mAddressInfo);
+            }
+            break;
+        }
+    }
+
+exit:
+    return updatedAddresses;
 }
 
 otbrError Netif::UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs)

--- a/src/host/posix/netif.hpp
+++ b/src/host/posix/netif.hpp
@@ -74,11 +74,29 @@ public:
     otbrError UpdateIp6MulticastAddresses(const std::vector<Ip6Address> &aAddrs);
     void      SetNetifState(bool aState);
 
+    enum class UnicastAddressAction : uint8_t
+    {
+        kAdd,     ///< Add a new address.
+        kRemove,  ///< Remove an existing address.
+        kReplace, ///< Replace metadata of an existing address in-place.
+    };
+
+    struct UnicastAddressChange
+    {
+        Ip6AddressInfo       mAddressInfo;
+        UnicastAddressAction mAction;
+    };
+
+    using UnicastAddressChangeHandler =
+        std::function<std::vector<otbrError>(const std::vector<UnicastAddressChange> &)>;
+
     void Ip6Receive(const uint8_t *aBuf, uint16_t aLen);
 
     unsigned int GetIfIndex(void) const { return mNetifIndex; }
 
 private:
+    friend class NetifTestPeer;
+
     // TODO: Retrieve the Maximum Ip6 size from the coprocessor.
     static constexpr size_t kIp6Mtu = 1280;
 
@@ -88,12 +106,17 @@ private:
     otbrError InitNetlink(void);
     otbrError InitMldListener(void);
 
-    void      PlatformSpecificInit(void);
-    void      SetAddrGenModeToNone(void);
-    void      ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded);
-    otbrError ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
-    void      ProcessIp6Send(void);
-    void      ProcessMldEvent(void);
+    void PlatformSpecificInit(void);
+    void SetAddrGenModeToNone(void);
+
+    static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(
+        const std::vector<Ip6AddressInfo> &aCachedAddrInfos,
+        const std::vector<Ip6AddressInfo> &aDesiredAddrInfos,
+        const UnicastAddressChangeHandler &aChangeHandler);
+    std::vector<otbrError> ProcessUnicastAddressChanges(const std::vector<UnicastAddressChange> &aChanges);
+    otbrError              ProcessMulticastAddressChange(const Ip6Address &aAddress, bool aIsAdded);
+    void                   ProcessIp6Send(void);
+    void                   ProcessMldEvent(void);
 #if OTBR_ENABLE_DHCP6_PD && OTBR_ENABLE_BORDER_ROUTING
     otbrError TryProcessIcmp6RaMessage(const uint8_t *aData, uint16_t aLength);
 #endif

--- a/src/host/posix/netif_linux.cpp
+++ b/src/host/posix/netif_linux.cpp
@@ -41,8 +41,12 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <net/if_arp.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
 
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
@@ -141,7 +145,9 @@ otbrError Netif::InitNetlink(void)
 
         memset(&sa, 0, sizeof(sa));
         sa.nl_family = AF_NETLINK;
-        sa.nl_groups = RTMGRP_LINK | RTMGRP_IPV6_IFADDR;
+        // Do not subscribe to multicast groups because mNetlinkFd is only used for synchronous
+        // request/ACK communication and is not polled for asynchronous link or address events.
+        sa.nl_groups = 0;
         VerifyOrExit(bind(mNetlinkFd, reinterpret_cast<sockaddr *>(&sa), sizeof(sa)) == 0, error = OTBR_ERROR_ERRNO);
     }
 
@@ -152,6 +158,41 @@ exit:
 void Netif::PlatformSpecificInit(void)
 {
     SetAddrGenModeToNone();
+}
+
+static ssize_t SendNetlinkMessage(int aFd, const void *aBuffer, size_t aLength)
+{
+    ssize_t sendLen;
+
+    while ((sendLen = send(aFd, aBuffer, aLength, 0)) == -1)
+    {
+        if (errno == EINTR)
+        {
+            continue;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            struct pollfd pfd;
+            int           pollResult;
+
+            pfd.fd      = aFd;
+            pfd.events  = POLLOUT;
+            pfd.revents = 0;
+
+            while ((pollResult = poll(&pfd, 1, 10)) == -1 && errno == EINTR)
+            {
+                continue;
+            }
+
+            if (pollResult > 0 && (pfd.revents & POLLOUT))
+            {
+                continue;
+            }
+        }
+        break;
+    }
+
+    return sendLen;
 }
 
 void Netif::SetAddrGenModeToNone(void)
@@ -168,7 +209,7 @@ void Netif::SetAddrGenModeToNone(void)
     memset(&req, 0, sizeof(req));
 
     req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifinfomsg));
-    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    req.nh.nlmsg_flags = NLM_F_REQUEST;
     req.nh.nlmsg_type  = RTM_NEWLINK;
     req.nh.nlmsg_pid   = 0;
     req.nh.nlmsg_seq   = ++mNetlinkSequence;
@@ -186,7 +227,7 @@ void Netif::SetAddrGenModeToNone(void)
         afSpec->rta_len += afInet6->rta_len;
     }
 
-    if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1)
+    if (SendNetlinkMessage(mNetlinkFd, &req, req.nh.nlmsg_len) != -1)
     {
         otbrLogInfo("Sent request#%u to set addr_gen_mode to %d", mNetlinkSequence, mode);
     }
@@ -196,52 +237,250 @@ void Netif::SetAddrGenModeToNone(void)
     }
 }
 
-void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+static const char *ActionToString(Netif::UnicastAddressAction aAction)
 {
-    struct
+    const char *str;
+
+    switch (aAction)
     {
-        nlmsghdr  nh;
-        ifaddrmsg ifa;
-        char      buf[512];
-    } req;
-
-    assert(mIpFd >= 0);
-    memset(&req, 0, sizeof(req));
-
-    req.nh.nlmsg_len   = NLMSG_LENGTH(sizeof(ifaddrmsg));
-    req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | (aIsAdded ? (NLM_F_CREATE | NLM_F_EXCL) : 0);
-    req.nh.nlmsg_type  = aIsAdded ? RTM_NEWADDR : RTM_DELADDR;
-    req.nh.nlmsg_pid   = 0;
-    req.nh.nlmsg_seq   = ++mNetlinkSequence;
-
-    req.ifa.ifa_family    = AF_INET6;
-    req.ifa.ifa_prefixlen = aAddressInfo.mPrefixLength;
-    req.ifa.ifa_flags     = IFA_F_NODAD;
-    req.ifa.ifa_scope     = aAddressInfo.mScope;
-    req.ifa.ifa_index     = mNetifIndex;
-
-    AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, &aAddressInfo.mAddress, sizeof(aAddressInfo.mAddress));
-
-    if (!aAddressInfo.mPreferred || aAddressInfo.mMeshLocal)
-    {
-        ifa_cacheinfo cacheinfo;
-
-        memset(&cacheinfo, 0, sizeof(cacheinfo));
-        cacheinfo.ifa_valid = UINT32_MAX;
-
-        AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
+    case Netif::UnicastAddressAction::kAdd:
+        str = "add";
+        break;
+    case Netif::UnicastAddressAction::kRemove:
+        str = "remove";
+        break;
+    case Netif::UnicastAddressAction::kReplace:
+        str = "replace";
+        break;
+    default:
+        str = "unknown";
+        break;
     }
 
-    if (send(mNetlinkFd, &req, req.nh.nlmsg_len, 0) != -1)
+    return str;
+}
+
+static bool ParseAckResponse(const nlmsghdr &aHeader, Netif::UnicastAddressAction aAction, int &aKernelErr)
+{
+    bool isSuccess = false;
+
+    VerifyOrExit(aHeader.nlmsg_type == NLMSG_ERROR, aKernelErr = EPROTO);
+    VerifyOrExit(aHeader.nlmsg_len >= NLMSG_LENGTH(sizeof(int)), aKernelErr = EBADMSG);
+
     {
-        otbrLogInfo("Sent request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
-                    Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+        const int *err = reinterpret_cast<const int *>(NLMSG_DATA(&aHeader));
+
+        aKernelErr = (*err < 0) ? -*err : *err;
     }
-    else
+
+    isSuccess =
+        (aKernelErr == 0 || (aAction == Netif::UnicastAddressAction::kAdd && aKernelErr == EEXIST) ||
+         (aAction == Netif::UnicastAddressAction::kRemove && (aKernelErr == ENOENT || aKernelErr == EADDRNOTAVAIL)));
+
+exit:
+    return isSuccess;
+}
+
+std::vector<otbrError> Netif::ProcessUnicastAddressChanges(const std::vector<UnicastAddressChange> &aChanges)
+{
+    constexpr int kNetlinkAckTimeoutMs = 50;
+
+    struct PendingAck
     {
-        otbrLogWarning("Failed to send request#%u to %s %s/%u", mNetlinkSequence, (aIsAdded ? "add" : "remove"),
-                       Ip6Address(aAddressInfo.mAddress).ToString().c_str(), aAddressInfo.mPrefixLength);
+        uint32_t mSequence;
+        size_t   mChangeIndex;
+        bool     mIsDone;
+    };
+
+    std::vector<otbrError>  errors(aChanges.size(), OTBR_ERROR_ERRNO);
+    std::vector<PendingAck> pendingAcks;
+    size_t                  pendingAckCount = 0;
+
+    VerifyOrExit(mNetlinkFd >= 0 && mIpFd >= 0, errors.assign(aChanges.size(), OTBR_ERROR_INVALID_STATE));
+
+    pendingAcks.reserve(aChanges.size());
+
+    for (size_t i = 0; i < aChanges.size(); ++i)
+    {
+        const UnicastAddressChange &change   = aChanges[i];
+        const Ip6AddressInfo       &addrInfo = change.mAddressInfo;
+        struct
+        {
+            nlmsghdr  nh;
+            ifaddrmsg ifa;
+            char      buf[512];
+        } req;
+
+        memset(&req, 0, sizeof(req));
+
+        req.nh.nlmsg_len = NLMSG_LENGTH(sizeof(ifaddrmsg));
+        req.nh.nlmsg_pid = 0;
+        req.nh.nlmsg_seq = ++mNetlinkSequence;
+
+        switch (change.mAction)
+        {
+        case UnicastAddressAction::kAdd:
+            req.nh.nlmsg_type  = RTM_NEWADDR;
+            req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL;
+            break;
+        case UnicastAddressAction::kRemove:
+            req.nh.nlmsg_type  = RTM_DELADDR;
+            req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+            break;
+        case UnicastAddressAction::kReplace:
+            req.nh.nlmsg_type  = RTM_NEWADDR;
+            req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE;
+            break;
+        }
+
+        req.ifa.ifa_family    = AF_INET6;
+        req.ifa.ifa_prefixlen = addrInfo.mPrefixLength;
+        req.ifa.ifa_flags     = IFA_F_NODAD;
+        req.ifa.ifa_scope     = addrInfo.mScope;
+        req.ifa.ifa_index     = mNetifIndex;
+
+        AddRtAttr(&req.nh, sizeof(req), IFA_LOCAL, &addrInfo.mAddress, sizeof(addrInfo.mAddress));
+
+        if (change.mAction != UnicastAddressAction::kRemove)
+        {
+            ifa_cacheinfo cacheinfo;
+
+            memset(&cacheinfo, 0, sizeof(cacheinfo));
+            cacheinfo.ifa_valid    = UINT32_MAX;
+            cacheinfo.ifa_prefered = (addrInfo.mPreferred && !addrInfo.mMeshLocal) ? UINT32_MAX : 0;
+
+            AddRtAttr(&req.nh, sizeof(req), IFA_CACHEINFO, &cacheinfo, sizeof(cacheinfo));
+        }
+
+        if (SendNetlinkMessage(mNetlinkFd, &req, req.nh.nlmsg_len) == -1)
+        {
+            otbrLogWarning("Failed to send request#%u to %s %s/%u: %s", req.nh.nlmsg_seq,
+                           ActionToString(change.mAction), Ip6Address(addrInfo.mAddress).ToString().c_str(),
+                           addrInfo.mPrefixLength, strerror(errno));
+            continue;
+        }
+
+        otbrLogInfo("Sent request#%u to %s %s/%u", req.nh.nlmsg_seq, ActionToString(change.mAction),
+                    Ip6Address(addrInfo.mAddress).ToString().c_str(), addrInfo.mPrefixLength);
+
+        pendingAcks.push_back({req.nh.nlmsg_seq, i, false});
+        ++pendingAckCount;
     }
+
+    VerifyOrExit(pendingAckCount > 0);
+
+    {
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(static_cast<int>(kNetlinkAckTimeoutMs));
+        int failureErrno = ETIMEDOUT;
+        union
+        {
+            nlmsghdr mHeader;
+            uint8_t  mBuffer[8192];
+        } response;
+
+        while (pendingAckCount > 0)
+        {
+            auto now = std::chrono::steady_clock::now();
+            if (now >= deadline)
+            {
+                break;
+            }
+
+            int pollTimeoutMs = std::max(
+                static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count()), 1);
+
+            struct pollfd pfd;
+            pfd.fd      = mNetlinkFd;
+            pfd.events  = POLLIN;
+            pfd.revents = 0;
+
+            int pollResult = poll(&pfd, 1, pollTimeoutMs);
+            if (pollResult == 0)
+            {
+                break;
+            }
+
+            if (pollResult < 0)
+            {
+                if (errno == EINTR)
+                {
+                    continue;
+                }
+                failureErrno = errno;
+                break;
+            }
+
+            if ((pfd.revents & POLLIN) == 0)
+            {
+                failureErrno = EIO;
+                break;
+            }
+
+            ssize_t length = recv(mNetlinkFd, response.mBuffer, sizeof(response.mBuffer), MSG_TRUNC);
+            if (length <= 0)
+            {
+                if (length < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK))
+                {
+                    continue;
+                }
+                failureErrno = (length < 0) ? errno : EIO;
+                break;
+            }
+
+            if (length > static_cast<ssize_t>(sizeof(response.mBuffer)))
+            {
+                otbrLogWarning("Netlink response truncated (received %zd, buffer size %zu)", length,
+                               sizeof(response.mBuffer));
+            }
+
+            ssize_t msgLen = std::min(length, static_cast<ssize_t>(sizeof(response.mBuffer)));
+
+            for (nlmsghdr *header = &response.mHeader;
+                 msgLen >= static_cast<ssize_t>(sizeof(nlmsghdr)) && NLMSG_OK(header, static_cast<size_t>(msgLen));
+                 header = NLMSG_NEXT(header, msgLen))
+            {
+                auto it = std::find_if(pendingAcks.begin(), pendingAcks.end(), [&](const PendingAck &aPending) {
+                    return !aPending.mIsDone && aPending.mSequence == header->nlmsg_seq;
+                });
+
+                if (it != pendingAcks.end())
+                {
+                    const UnicastAddressChange &change    = aChanges[it->mChangeIndex];
+                    int                         kernelErr = 0;
+
+                    if (ParseAckResponse(*header, change.mAction, kernelErr))
+                    {
+                        errors[it->mChangeIndex] = OTBR_ERROR_NONE;
+                    }
+                    else
+                    {
+                        otbrLogWarning("Failed to %s address %s/%u: %s", ActionToString(change.mAction),
+                                       Ip6Address(change.mAddressInfo.mAddress).ToString().c_str(),
+                                       change.mAddressInfo.mPrefixLength, strerror(kernelErr));
+                    }
+
+                    it->mIsDone = true;
+                    --pendingAckCount;
+                }
+            }
+        }
+
+        for (const PendingAck &pendingAck : pendingAcks)
+        {
+            if (!pendingAck.mIsDone)
+            {
+                const UnicastAddressChange &change = aChanges[pendingAck.mChangeIndex];
+
+                otbrLogWarning("Failed to %s address %s/%u: %s", ActionToString(change.mAction),
+                               Ip6Address(change.mAddressInfo.mAddress).ToString().c_str(),
+                               change.mAddressInfo.mPrefixLength, strerror(failureErrno));
+            }
+        }
+    }
+
+exit:
+    return errors;
 }
 
 } // namespace otbr

--- a/src/host/posix/netif_unix.cpp
+++ b/src/host/posix/netif_unix.cpp
@@ -58,10 +58,9 @@ void Netif::PlatformSpecificInit(void)
     /* Empty */
 }
 
-void Netif::ProcessUnicastAddressChange(const Ip6AddressInfo &aAddressInfo, bool aIsAdded)
+std::vector<otbrError> Netif::ProcessUnicastAddressChanges(const std::vector<UnicastAddressChange> &aChanges)
 {
-    OTBR_UNUSED_VARIABLE(aAddressInfo);
-    OTBR_UNUSED_VARIABLE(aIsAdded);
+    return std::vector<otbrError>(aChanges.size(), OTBR_ERROR_NONE);
 }
 
 } // namespace otbr

--- a/tests/gtest/test_netif.cpp
+++ b/tests/gtest/test_netif.cpp
@@ -62,6 +62,196 @@
 #include "host/posix/netif.hpp"
 #include "utils/socket_utils.hpp"
 
+namespace otbr {
+
+class NetifTestPeer
+{
+public:
+    static std::vector<Ip6AddressInfo> ReconcileIp6UnicastAddresses(
+        const std::vector<Ip6AddressInfo>        &aCachedAddrInfos,
+        const std::vector<Ip6AddressInfo>        &aDesiredAddrInfos,
+        const Netif::UnicastAddressChangeHandler &aChangeHandler)
+    {
+        return Netif::ReconcileIp6UnicastAddresses(aCachedAddrInfos, aDesiredAddrInfos, aChangeHandler);
+    }
+};
+
+} // namespace otbr
+
+TEST(Netif, ReconcileUnicastAddresses_AddSuccess)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, true, false);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {}, {kDesired}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            if (!aChanges.empty())
+            {
+                EXPECT_EQ(aChanges[0].mAction, otbr::Netif::UnicastAddressAction::kAdd);
+                EXPECT_EQ(aChanges[0].mAddressInfo, kDesired);
+            }
+            return std::vector<otbrError>{OTBR_ERROR_NONE};
+        });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kDesired);
+}
+
+TEST(Netif, ReconcileUnicastAddresses_AddFailure)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, true, false);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {}, {kDesired}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            return std::vector<otbrError>{OTBR_ERROR_ERRNO};
+        });
+
+    EXPECT_TRUE(updated.empty());
+}
+
+TEST(Netif, ReconcileUnicastAddresses_RemoveSuccess)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kCached}, {}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            if (!aChanges.empty())
+            {
+                EXPECT_EQ(aChanges[0].mAction, otbr::Netif::UnicastAddressAction::kRemove);
+                EXPECT_EQ(aChanges[0].mAddressInfo, kCached);
+            }
+            return std::vector<otbrError>{OTBR_ERROR_NONE};
+        });
+
+    EXPECT_TRUE(updated.empty());
+}
+
+TEST(Netif, ReconcileUnicastAddresses_RemoveFailure)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kCached}, {}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            return std::vector<otbrError>{OTBR_ERROR_ERRNO};
+        });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kCached);
+}
+
+TEST(Netif, ReconcileUnicastAddresses_ReplaceSuccess)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, false, true);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kCached}, {kDesired}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            if (!aChanges.empty())
+            {
+                EXPECT_EQ(aChanges[0].mAction, otbr::Netif::UnicastAddressAction::kReplace);
+                EXPECT_EQ(aChanges[0].mAddressInfo, kDesired);
+            }
+            return std::vector<otbrError>{OTBR_ERROR_NONE};
+        });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kDesired);
+}
+
+TEST(Netif, ReconcileUnicastAddresses_ReplaceFailure)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kCached(kAddress, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired(kAddress, 64, 0, false, true);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kCached}, {kDesired}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 1U);
+            return std::vector<otbrError>{OTBR_ERROR_ERRNO};
+        });
+
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kCached);
+}
+
+TEST(Netif, ReconcileUnicastAddresses_UnchangedNoHandlerCall)
+{
+    const otIp6Address kAddress = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otbr::Ip6AddressInfo kAddr(kAddress, 64, 0, true, false);
+    size_t                     handlerCalls = 0;
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kAddr}, {kAddr}, [&](const std::vector<otbr::Netif::UnicastAddressChange> &) {
+            ++handlerCalls;
+            return std::vector<otbrError>{};
+        });
+
+    EXPECT_EQ(handlerCalls, 0U);
+    ASSERT_EQ(updated.size(), 1U);
+    EXPECT_EQ(updated[0], kAddr);
+}
+
+TEST(Netif, ReconcileUnicastAddresses_BatchedChanges)
+{
+    const otIp6Address kAddr1 = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}};
+    const otIp6Address kAddr2 = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}};
+    const otIp6Address kAddr3 = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03}};
+    const otIp6Address kAddr4 = {
+        {0xfd, 0x0d, 0x07, 0xfc, 0xa1, 0xb9, 0xf0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04}};
+
+    const otbr::Ip6AddressInfo kCached1(kAddr1, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kCached2(kAddr2, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kCached3(kAddr3, 64, 0, true, false);
+
+    const otbr::Ip6AddressInfo kDesired2(kAddr2, 64, 0, true, false);
+    const otbr::Ip6AddressInfo kDesired3(kAddr3, 64, 0, false, true);
+    const otbr::Ip6AddressInfo kDesired4(kAddr4, 64, 0, true, false);
+
+    std::vector<otbr::Ip6AddressInfo> updated = otbr::NetifTestPeer::ReconcileIp6UnicastAddresses(
+        {kCached1, kCached2, kCached3}, {kDesired2, kDesired3, kDesired4},
+        [&](const std::vector<otbr::Netif::UnicastAddressChange> &aChanges) {
+            EXPECT_EQ(aChanges.size(), 3U);
+            if (aChanges.size() == 3U)
+            {
+                EXPECT_EQ(aChanges[0].mAction, otbr::Netif::UnicastAddressAction::kRemove);
+                EXPECT_EQ(aChanges[0].mAddressInfo, kCached1);
+
+                EXPECT_EQ(aChanges[1].mAction, otbr::Netif::UnicastAddressAction::kReplace);
+                EXPECT_EQ(aChanges[1].mAddressInfo, kDesired3);
+
+                EXPECT_EQ(aChanges[2].mAction, otbr::Netif::UnicastAddressAction::kAdd);
+                EXPECT_EQ(aChanges[2].mAddressInfo, kDesired4);
+            }
+            return std::vector<otbrError>{
+                OTBR_ERROR_NONE,
+                OTBR_ERROR_NONE,
+                OTBR_ERROR_NONE,
+            };
+        });
+
+    ASSERT_EQ(updated.size(), 3U);
+    EXPECT_THAT(updated, ::testing::UnorderedElementsAre(kDesired2, kDesired3, kDesired4));
+}
+
 // Only Test on linux platform for now.
 #ifdef __linux__
 


### PR DESCRIPTION
Previously, Netif::UpdateIp6UnicastAddresses updated its internal mIp6UnicastAddresses cache optimistically without confirming whether the Linux kernel accepted or rejected netlink requests (RTM_NEWADDR / RTM_DELADDR). If the kernel rejected an address addition or deletion, OTBR's local cache diverged from the kernel interface state. Because subsequent updates diff against the local cache, failed operations were never retried, leaving interface addresses desynchronized.

This commit resolves the issue:
1. Categorizes address reconciliation into removals, in-place replaces, and additions.
2. Gates mutations of mIp6UnicastAddresses on confirmed netlink ACK outcomes.
3. Uses NLM_F_REPLACE for address metadata modifications (e.g., preferred lifetime changes) to update attributes in-place without a racy delete-then-add cycle.
4. Binds mNetlinkFd with sa.nl_groups = 0 so the socket receives only unicast ACKs/replies and avoids buffer exhaustion (ENOBUFS) from unhandled system-wide multicast link/address events.
5. Removes NLM_F_ACK from SetAddrGenModeToNone to avoid generating unhandled netlink ACKs on initialization.
6. Implements netlink ACK sequence verification bounded by a tight 50 ms timeout, handling EAGAIN/EWOULDBLOCK on non-blocking sends and correctly parsing ACKs when NETLINK_CAP_ACK is enabled.
7. Treats idempotent outcomes (EEXIST for add, ENOENT/EADDRNOTAVAIL for remove) as success.
8. Fixes Ip6AddressInfo constructor and operator== to avoid comparing uninitialized bitfield padding.
9. Adds unit tests in test_netif.cpp verifying address reconciliation caching behavior under success, failure, and batched changes.

Resolves #3244